### PR TITLE
Refactor Google connector test suite

### DIFF
--- a/connectors/google/tests/common/mod.rs
+++ b/connectors/google/tests/common/mod.rs
@@ -1,0 +1,126 @@
+use anyhow::Result;
+use redis::Client as RedisClient;
+use shared::db::repositories::SyncRunRepository;
+use shared::test_environment::TestEnvironment;
+use sqlx::PgPool;
+
+/// Test fixture for Google connector integration tests
+pub struct GoogleConnectorTestFixture {
+    pub test_env: TestEnvironment,
+}
+
+impl GoogleConnectorTestFixture {
+    /// Create a new test fixture with all dependencies
+    pub async fn new() -> Result<Self> {
+        let test_env = TestEnvironment::new().await?;
+        Ok(Self { test_env })
+    }
+
+    /// Get the database pool
+    pub fn pool(&self) -> &PgPool {
+        self.test_env.db_pool.pool()
+    }
+
+    /// Get the Redis client
+    pub fn redis_client(&self) -> RedisClient {
+        self.test_env.redis_client.clone()
+    }
+
+    /// Get the SyncRunRepository for testing sync operations
+    pub fn sync_run_repo(&self) -> SyncRunRepository {
+        SyncRunRepository::new(self.pool())
+    }
+
+    /// Create a test user and return the user ID
+    pub async fn create_test_user(&self, email: &str) -> Result<String> {
+        let user_id = shared::utils::generate_ulid();
+
+        sqlx::query(
+            "INSERT INTO users (id, email, full_name, role, password_hash) VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(&user_id)
+        .bind(email)
+        .bind("Test User")
+        .bind("admin")
+        .bind("hashed_password")
+        .execute(self.pool())
+        .await?;
+
+        Ok(user_id)
+    }
+
+    /// Create a test source and return the source ID
+    pub async fn create_test_source(
+        &self,
+        name: &str,
+        source_type: shared::models::SourceType,
+        user_id: &str,
+    ) -> Result<String> {
+        let source_id = shared::utils::generate_ulid();
+
+        sqlx::query(
+            "INSERT INTO sources (id, name, source_type, is_active, created_by) VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(&source_id)
+        .bind(name)
+        .bind(source_type)
+        .bind(true)
+        .bind(user_id)
+        .execute(self.pool())
+        .await?;
+
+        Ok(source_id)
+    }
+
+    /// Create a sync run with specific status and timing
+    pub async fn create_sync_run(
+        &self,
+        source_id: &str,
+        sync_type: shared::models::SyncType,
+        status: shared::models::SyncStatus,
+        started_at: sqlx::types::time::OffsetDateTime,
+    ) -> Result<String> {
+        let sync_run_id = shared::utils::generate_ulid();
+
+        sqlx::query(
+            "INSERT INTO sync_runs (id, source_id, sync_type, status, started_at) VALUES ($1, $2, $3, $4, $5)",
+        )
+        .bind(&sync_run_id)
+        .bind(source_id)
+        .bind(sync_type)
+        .bind(status)
+        .bind(started_at)
+        .execute(self.pool())
+        .await?;
+
+        Ok(sync_run_id)
+    }
+
+    /// Create a completed sync run
+    pub async fn create_completed_sync_run(
+        &self,
+        source_id: &str,
+        sync_type: shared::models::SyncType,
+        completed_at: sqlx::types::time::OffsetDateTime,
+        documents_processed: i32,
+        documents_updated: i32,
+    ) -> Result<String> {
+        let sync_run_id = shared::utils::generate_ulid();
+
+        sqlx::query(
+            "INSERT INTO sync_runs (id, source_id, sync_type, status, completed_at, documents_processed, documents_updated)
+             VALUES ($1, $2, $3, $4, $5, $6, $7)",
+        )
+        .bind(&sync_run_id)
+        .bind(source_id)
+        .bind(sync_type)
+        .bind(shared::models::SyncStatus::Completed)
+        .bind(completed_at)
+        .bind(documents_processed)
+        .bind(documents_updated)
+        .execute(self.pool())
+        .await?;
+
+        Ok(sync_run_id)
+    }
+}

--- a/connectors/google/tests/sync_run_test.rs
+++ b/connectors/google/tests/sync_run_test.rs
@@ -1,119 +1,232 @@
+mod common;
+
 use anyhow::Result;
-use chrono::{Duration, Utc};
-use shared::models::{SyncStatus, SyncType};
-use shared::test_environment::TestEnvironment;
+use shared::models::{SourceType, SyncStatus, SyncType};
+
+use common::GoogleConnectorTestFixture;
 
 #[tokio::test]
-async fn test_sync_run_tracking() -> Result<()> {
-    let test_env = TestEnvironment::new().await?;
-    let pool = test_env.db_pool.pool();
-    let redis_client = test_env.redis_client.clone();
+async fn test_sync_run_creation() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
 
-    // Create a test source
-    let source_id = shared::utils::generate_ulid();
-    let user_id = shared::utils::generate_ulid();
+    // Create test user and source
+    let user_id = fixture.create_test_user("test_creation@example.com").await?;
+    let source_id = fixture
+        .create_test_source("Test Source", SourceType::GoogleDrive, &user_id)
+        .await?;
 
-    // Insert test user first
-    sqlx::query(
-        "INSERT INTO users (id, email, full_name, role) VALUES ($1, 'test@example.com', 'Test User', 'admin')"
-    )
-    .bind(&user_id)
-    .execute(pool)
-    .await?;
+    // Create a sync run
+    let sync_run = sync_run_repo.create(&source_id, SyncType::Full).await?;
 
-    // Insert test source
-    sqlx::query(
-        "INSERT INTO sources (id, name, source_type, config, created_by) VALUES ($1, 'Test Source', 'google_drive', '{}', $2)"
-    )
-    .bind(&source_id)
-    .bind(&user_id)
-    .execute(pool)
-    .await?;
+    assert_eq!(sync_run.source_id, source_id);
+    assert_eq!(sync_run.sync_type, SyncType::Full);
+    assert_eq!(sync_run.status, SyncStatus::Running);
+    assert_eq!(sync_run.documents_scanned, 0);
+    assert_eq!(sync_run.documents_processed, 0);
+    assert_eq!(sync_run.documents_updated, 0);
 
-    // Create sync manager
-    use omni_google_connector::admin::AdminClient;
-    use omni_google_connector::sync::SyncManager;
-    use shared::RateLimiter;
-    use std::sync::Arc;
+    Ok(())
+}
 
-    let rate_limiter = Arc::new(RateLimiter::new(180, 5));
-    let admin_client = Arc::new(AdminClient::with_rate_limiter(rate_limiter));
-    let ai_service_url = "http://localhost:8003".to_string();
+#[tokio::test]
+async fn test_sync_run_completion() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
 
-    let sync_manager =
-        SyncManager::new(pool.clone(), redis_client, ai_service_url, admin_client).await?;
+    // Create test user and source
+    let user_id = fixture.create_test_user("test_completion@example.com").await?;
+    let source_id = fixture
+        .create_test_source("Test Source Completion", SourceType::GoogleDrive, &user_id)
+        .await?;
 
-    // Test that should_run_full_sync returns true for new source (no previous sync)
-    let should_sync = sync_manager.should_run_full_sync(&source_id).await?;
-    assert!(
-        should_sync,
-        "Should run full sync for source with no previous sync"
-    );
+    // Create and complete a sync run
+    let sync_run = sync_run_repo.create(&source_id, SyncType::Full).await?;
+    sync_run_repo.mark_completed(&sync_run.id, 100, 50).await?;
 
-    // Create a completed sync run from 30 minutes ago
-    let sync_run_id = shared::utils::generate_ulid();
-    let completed_at = Utc::now() - Duration::minutes(30);
+    // Verify the sync run was updated
+    let updated = sync_run_repo.find_by_id(&sync_run.id).await?;
+    assert!(updated.is_some());
 
-    sqlx::query(
-        "INSERT INTO sync_runs (id, source_id, sync_type, status, completed_at, documents_processed, documents_updated) 
-         VALUES ($1, $2, $3, $4, $5, 10, 5)"
-    )
-    .bind(&sync_run_id)
-    .bind(&source_id)
-    .bind(SyncType::Full)
-    .bind(SyncStatus::Completed)
-    .bind(completed_at)
-    .execute(pool)
-    .await?;
+    let updated = updated.unwrap();
+    assert_eq!(updated.status, SyncStatus::Completed);
+    assert_eq!(updated.documents_scanned, 100);
+    assert_eq!(updated.documents_updated, 50);
+    assert!(updated.completed_at.is_some());
 
-    // Test that should_run_full_sync returns false for recent sync (default interval is 24 hours)
-    let should_sync = sync_manager.should_run_full_sync(&source_id).await?;
-    assert!(
-        !should_sync,
-        "Should not run full sync for source with recent sync"
-    );
+    Ok(())
+}
 
-    // TODO: Test creating a new sync run - method is currently private
-    // let new_sync_run_id = sync_manager
-    //     .create_sync_run(&source_id, SyncType::Full)
-    //     .await?;
-    // assert!(
-    //     !new_sync_run_id.is_empty(),
-    //     "Should return valid sync run ID"
-    // );
+#[tokio::test]
+async fn test_sync_run_failure() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
 
-    // // Verify the sync run was created
-    // let sync_run: Option<SyncRun> = sqlx::query_as("SELECT * FROM sync_runs WHERE id = $1")
-    //     .bind(&new_sync_run_id)
-    //     .fetch_optional(pool)
-    //     .await?;
+    // Create test user and source
+    let user_id = fixture.create_test_user("test_failure@example.com").await?;
+    let source_id = fixture
+        .create_test_source("Test Source Failure", SourceType::GoogleDrive, &user_id)
+        .await?;
 
-    // assert!(sync_run.is_some(), "Sync run should be created in database");
-    // let sync_run = sync_run.unwrap();
-    // assert_eq!(sync_run.source_id, source_id);
-    // assert_eq!(sync_run.sync_type, SyncType::Full);
-    // assert_eq!(sync_run.status, SyncStatus::Running);
+    // Create and fail a sync run
+    let sync_run = sync_run_repo.create(&source_id, SyncType::Full).await?;
+    let error_message = "Test error: connection timeout";
+    sync_run_repo.mark_failed(&sync_run.id, error_message).await?;
 
-    // TODO: Test completing the sync run - method is currently private
-    // sync_manager
-    //     .update_sync_run_completed(&new_sync_run_id, 100, 50)
-    //     .await?;
+    // Verify the sync run was updated
+    let updated = sync_run_repo.find_by_id(&sync_run.id).await?;
+    assert!(updated.is_some());
 
-    // // Verify the sync run was updated
-    // let updated_sync_run: Option<SyncRun> = sqlx::query_as("SELECT * FROM sync_runs WHERE id = $1")
-    //     .bind(&new_sync_run_id)
-    //     .fetch_optional(pool)
-    //     .await?;
+    let updated = updated.unwrap();
+    assert_eq!(updated.status, SyncStatus::Failed);
+    assert_eq!(updated.error_message.as_deref(), Some(error_message));
+    assert!(updated.completed_at.is_some());
 
-    // assert!(updated_sync_run.is_some(), "Updated sync run should exist");
-    // let updated_sync_run = updated_sync_run.unwrap();
-    // assert_eq!(updated_sync_run.status, SyncStatus::Completed);
-    // assert_eq!(updated_sync_run.documents_processed, 100);
-    // assert_eq!(updated_sync_run.documents_updated, 50);
-    // assert!(
-    //     updated_sync_run.completed_at.is_some(),
-    //     "Should have completed_at timestamp"
-    // );
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_last_completed_sync() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
+
+    // Create test user and source
+    let user_id = fixture.create_test_user("test_last_completed@example.com").await?;
+    let source_id = fixture
+        .create_test_source("Test Source Last Completed", SourceType::GoogleDrive, &user_id)
+        .await?;
+
+    // Initially, no completed sync should exist
+    let last_sync = sync_run_repo
+        .get_last_completed_for_source(&source_id, SyncType::Full)
+        .await?;
+    assert!(last_sync.is_none());
+
+    // Create and complete a sync run
+    let sync_run = sync_run_repo.create(&source_id, SyncType::Full).await?;
+    sync_run_repo.mark_completed(&sync_run.id, 10, 5).await?;
+
+    // Now we should have a completed sync
+    let last_sync = sync_run_repo
+        .get_last_completed_for_source(&source_id, SyncType::Full)
+        .await?;
+    assert!(last_sync.is_some());
+    assert_eq!(last_sync.unwrap().id, sync_run.id);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_running_sync_for_source() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
+
+    // Create test user and source
+    let user_id = fixture.create_test_user("test_running@example.com").await?;
+    let source_id = fixture
+        .create_test_source("Test Source Running", SourceType::GoogleDrive, &user_id)
+        .await?;
+
+    // Initially, no running sync should exist
+    let running_sync = sync_run_repo.get_running_for_source(&source_id).await?;
+    assert!(running_sync.is_none());
+
+    // Create a running sync
+    let sync_run = sync_run_repo.create(&source_id, SyncType::Full).await?;
+
+    // Now we should have a running sync
+    let running_sync = sync_run_repo.get_running_for_source(&source_id).await?;
+    assert!(running_sync.is_some());
+    assert_eq!(running_sync.unwrap().id, sync_run.id);
+
+    // Complete the sync
+    sync_run_repo.mark_completed(&sync_run.id, 10, 5).await?;
+
+    // No longer running
+    let running_sync = sync_run_repo.get_running_for_source(&source_id).await?;
+    assert!(running_sync.is_none());
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_find_all_running_syncs() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
+
+    // Create test user and multiple sources
+    let user_id = fixture.create_test_user("test_all_running@example.com").await?;
+    let source_id_1 = fixture
+        .create_test_source("Test Source 1", SourceType::GoogleDrive, &user_id)
+        .await?;
+    let source_id_2 = fixture
+        .create_test_source("Test Source 2", SourceType::Gmail, &user_id)
+        .await?;
+
+    // Create running syncs for both sources
+    let sync_1 = sync_run_repo.create(&source_id_1, SyncType::Full).await?;
+    let sync_2 = sync_run_repo.create(&source_id_2, SyncType::Incremental).await?;
+
+    // Find all running syncs
+    let running_syncs = sync_run_repo.find_all_running().await?;
+
+    // Should find at least our 2 syncs (might be more from other tests)
+    let our_sync_ids: Vec<&str> = running_syncs
+        .iter()
+        .filter(|s| s.id == sync_1.id || s.id == sync_2.id)
+        .map(|s| s.id.as_str())
+        .collect();
+    assert_eq!(our_sync_ids.len(), 2);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_increment_scanned_count() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
+
+    // Create test user and source
+    let user_id = fixture.create_test_user("test_increment@example.com").await?;
+    let source_id = fixture
+        .create_test_source("Test Source Increment", SourceType::GoogleDrive, &user_id)
+        .await?;
+
+    // Create a sync run
+    let sync_run = sync_run_repo.create(&source_id, SyncType::Full).await?;
+
+    // Increment scanned count
+    sync_run_repo.increment_scanned(&sync_run.id, 25).await?;
+    sync_run_repo.increment_scanned(&sync_run.id, 15).await?;
+
+    // Verify count
+    let updated = sync_run_repo.find_by_id(&sync_run.id).await?.unwrap();
+    assert_eq!(updated.documents_scanned, 40);
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_increment_progress() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_run_repo = fixture.sync_run_repo();
+
+    // Create test user and source
+    let user_id = fixture.create_test_user("test_progress@example.com").await?;
+    let source_id = fixture
+        .create_test_source("Test Source Progress", SourceType::GoogleDrive, &user_id)
+        .await?;
+
+    // Create a sync run
+    let sync_run = sync_run_repo.create(&source_id, SyncType::Full).await?;
+
+    // Increment progress
+    sync_run_repo.increment_progress(&sync_run.id).await?;
+    sync_run_repo.increment_progress_by(&sync_run.id, 5).await?;
+
+    // Verify count
+    let updated = sync_run_repo.find_by_id(&sync_run.id).await?.unwrap();
+    assert_eq!(updated.documents_processed, 6);
 
     Ok(())
 }

--- a/connectors/google/tests/sync_state_test.rs
+++ b/connectors/google/tests/sync_state_test.rs
@@ -1,170 +1,189 @@
+mod common;
+
+use anyhow::Result;
 use omni_google_connector::sync::SyncState;
-use redis::Client as RedisClient;
 use std::collections::HashSet;
 
-// Note: These tests require a Redis instance to run
-// You can start one with: docker run -d -p 6379:6379 redis:alpine
-// Or skip these tests with: cargo test -- --skip sync_state
+use common::GoogleConnectorTestFixture;
 
-#[cfg(test)]
-mod tests {
-    use super::*;
+#[tokio::test]
+async fn test_sync_state_set_and_get() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_state = SyncState::new(fixture.redis_client());
 
-    fn create_test_redis_client() -> anyhow::Result<RedisClient> {
-        let redis_url = std::env::var("TEST_REDIS_URL")
-            .unwrap_or_else(|_| "redis://localhost:6379".to_string());
-        Ok(RedisClient::open(redis_url)?)
-    }
+    let source_id = "test_source";
+    let file_id = "test_file";
+    let modified_time = "2023-01-01T12:00:00Z";
 
-    #[tokio::test]
-    #[ignore] // Remove this to run with Redis
-    async fn test_sync_state_set_and_get() -> anyhow::Result<()> {
-        let redis_client = create_test_redis_client()?;
-        let sync_state = SyncState::new(redis_client);
+    // Initially, no state should exist
+    assert_eq!(
+        sync_state.get_file_sync_state(source_id, file_id).await?,
+        None
+    );
 
-        let source_id = "test_source";
-        let file_id = "test_file";
-        let modified_time = "2023-01-01T12:00:00Z";
+    // Set the state
+    sync_state
+        .set_file_sync_state_with_expiry(source_id, file_id, modified_time, 60)
+        .await?;
 
-        // Initially, no state should exist
-        assert_eq!(
-            sync_state.get_file_sync_state(source_id, file_id).await?,
-            None
-        );
+    // State should now exist
+    assert_eq!(
+        sync_state.get_file_sync_state(source_id, file_id).await?,
+        Some(modified_time.to_string())
+    );
 
-        // Set the state
+    // Clean up
+    sync_state
+        .delete_file_sync_state(source_id, file_id)
+        .await?;
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_sync_state_delete() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_state = SyncState::new(fixture.redis_client());
+
+    let source_id = "test_source_delete";
+    let file_id = "test_file_delete";
+    let modified_time = "2023-01-01T12:00:00Z";
+
+    // Set the state
+    sync_state
+        .set_file_sync_state(source_id, file_id, modified_time)
+        .await?;
+
+    // Verify it exists
+    assert!(sync_state
+        .get_file_sync_state(source_id, file_id)
+        .await?
+        .is_some());
+
+    // Delete it
+    sync_state
+        .delete_file_sync_state(source_id, file_id)
+        .await?;
+
+    // Verify it's gone
+    assert_eq!(
+        sync_state.get_file_sync_state(source_id, file_id).await?,
+        None
+    );
+
+    Ok(())
+}
+
+#[tokio::test]
+async fn test_get_all_synced_file_ids() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_state = SyncState::new(fixture.redis_client());
+
+    let source_id = "test_source_all_files";
+    let files = vec![
+        ("file1", "2023-01-01T12:00:00Z"),
+        ("file2", "2023-01-02T12:00:00Z"),
+        ("file3", "2023-01-03T12:00:00Z"),
+    ];
+
+    // Set multiple file states
+    for (file_id, modified_time) in &files {
         sync_state
             .set_file_sync_state_with_expiry(source_id, file_id, modified_time, 60)
             .await?;
+    }
 
-        // State should now exist
-        assert_eq!(
-            sync_state.get_file_sync_state(source_id, file_id).await?,
-            Some(modified_time.to_string())
-        );
+    // Get all synced file IDs
+    let synced_files = sync_state.get_all_synced_file_ids(source_id).await?;
 
-        // Clean up
+    // Should contain all file IDs
+    let expected: HashSet<String> = files.iter().map(|(id, _)| id.to_string()).collect();
+    assert_eq!(synced_files, expected);
+
+    // Clean up
+    for (file_id, _) in &files {
         sync_state
             .delete_file_sync_state(source_id, file_id)
             .await?;
-
-        Ok(())
     }
 
-    #[tokio::test]
-    #[ignore] // Remove this to run with Redis
-    async fn test_sync_state_delete() -> anyhow::Result<()> {
-        let redis_client = create_test_redis_client()?;
-        let sync_state = SyncState::new(redis_client);
+    Ok(())
+}
 
-        let source_id = "test_source";
-        let file_id = "test_file";
-        let modified_time = "2023-01-01T12:00:00Z";
+#[tokio::test]
+async fn test_thread_sync_state() -> Result<()> {
+    let fixture = GoogleConnectorTestFixture::new().await?;
+    let sync_state = SyncState::new(fixture.redis_client());
 
-        // Set the state
+    let source_id = "test_gmail_source";
+    let thread_id = "thread123";
+    let latest_date = "1704067200000"; // Unix timestamp in ms
+
+    // Initially, no state should exist
+    assert_eq!(
         sync_state
-            .set_file_sync_state(source_id, file_id, modified_time)
-            .await?;
+            .get_thread_sync_state(source_id, thread_id)
+            .await?,
+        None
+    );
 
-        // Verify it exists
-        assert!(sync_state
-            .get_file_sync_state(source_id, file_id)
-            .await?
-            .is_some());
+    // Set the state
+    sync_state
+        .set_thread_sync_state(source_id, thread_id, latest_date)
+        .await?;
 
-        // Delete it
+    // State should now exist
+    assert_eq!(
         sync_state
-            .delete_file_sync_state(source_id, file_id)
-            .await?;
+            .get_thread_sync_state(source_id, thread_id)
+            .await?,
+        Some(latest_date.to_string())
+    );
 
-        // Verify it's gone
+    Ok(())
+}
+
+/// Pure unit test for modification time comparison logic
+#[test]
+fn test_modification_time_comparison_logic() {
+    struct TestCase {
+        stored_time: Option<&'static str>,
+        current_time: &'static str,
+        should_process: bool,
+        description: &'static str,
+    }
+
+    let test_cases = vec![
+        TestCase {
+            stored_time: None,
+            current_time: "2023-01-01T12:00:00Z",
+            should_process: true,
+            description: "New file should be processed",
+        },
+        TestCase {
+            stored_time: Some("2023-01-01T12:00:00Z"),
+            current_time: "2023-01-01T12:00:00Z",
+            should_process: false,
+            description: "Unchanged file should be skipped",
+        },
+        TestCase {
+            stored_time: Some("2023-01-01T12:00:00Z"),
+            current_time: "2023-01-01T13:00:00Z",
+            should_process: true,
+            description: "Modified file should be processed",
+        },
+    ];
+
+    for test_case in test_cases {
+        let should_process = match test_case.stored_time {
+            Some(stored) => stored != test_case.current_time,
+            None => true,
+        };
+
         assert_eq!(
-            sync_state.get_file_sync_state(source_id, file_id).await?,
-            None
+            should_process, test_case.should_process,
+            "Failed: {}",
+            test_case.description
         );
-
-        Ok(())
-    }
-
-    #[tokio::test]
-    #[ignore] // Remove this to run with Redis
-    async fn test_get_all_synced_file_ids() -> anyhow::Result<()> {
-        let redis_client = create_test_redis_client()?;
-        let sync_state = SyncState::new(redis_client);
-
-        let source_id = "test_source";
-        let files = vec![
-            ("file1", "2023-01-01T12:00:00Z"),
-            ("file2", "2023-01-02T12:00:00Z"),
-            ("file3", "2023-01-03T12:00:00Z"),
-        ];
-
-        // Set multiple file states
-        for (file_id, modified_time) in &files {
-            sync_state
-                .set_file_sync_state_with_expiry(source_id, file_id, modified_time, 60)
-                .await?;
-        }
-
-        // Get all synced file IDs
-        let synced_files = sync_state.get_all_synced_file_ids(source_id).await?;
-
-        // Should contain all file IDs
-        let expected: HashSet<String> = files.iter().map(|(id, _)| id.to_string()).collect();
-        assert_eq!(synced_files, expected);
-
-        // Clean up
-        for (file_id, _) in &files {
-            sync_state
-                .delete_file_sync_state(source_id, file_id)
-                .await?;
-        }
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_modification_time_comparison_logic() {
-        // Test the logic for determining if a file should be processed
-        struct TestCase {
-            stored_time: Option<&'static str>,
-            current_time: &'static str,
-            should_process: bool,
-            description: &'static str,
-        }
-
-        let test_cases = vec![
-            TestCase {
-                stored_time: None,
-                current_time: "2023-01-01T12:00:00Z",
-                should_process: true,
-                description: "New file should be processed",
-            },
-            TestCase {
-                stored_time: Some("2023-01-01T12:00:00Z"),
-                current_time: "2023-01-01T12:00:00Z",
-                should_process: false,
-                description: "Unchanged file should be skipped",
-            },
-            TestCase {
-                stored_time: Some("2023-01-01T12:00:00Z"),
-                current_time: "2023-01-01T13:00:00Z",
-                should_process: true,
-                description: "Modified file should be processed",
-            },
-        ];
-
-        for test_case in test_cases {
-            let should_process = match test_case.stored_time {
-                Some(stored) => stored != test_case.current_time,
-                None => true,
-            };
-
-            assert_eq!(
-                should_process, test_case.should_process,
-                "Failed: {}",
-                test_case.description
-            );
-        }
     }
 }


### PR DESCRIPTION
- Create tests/common/mod.rs with GoogleConnectorTestFixture for shared test infrastructure
- Refactor sync_state_test.rs to use TestEnvironment instead of manual Redis setup
- Refactor sync_run_test.rs and stale_sync_recovery_test.rs to test at repository level
- Add unit tests to src/models.rs for ConnectorEvent conversion and model types
- Add unit tests to src/auth.rs for scope selection, auth errors, and key validation
- All tests now follow the same patterns as the searcher module tests