### PR TITLE
Fix connector manifest issues

### DIFF
--- a/connectors/atlassian/src/api.rs
+++ b/connectors/atlassian/src/api.rs
@@ -97,12 +97,16 @@ async fn manifest() -> impl IntoResponse {
             name: "search_spaces".to_string(),
             description: "Search Confluence spaces or Jira projects".to_string(),
             parameters: json!({
-                "type": "object",
-                "properties": {
-                    "query": { "type": "string", "description": "Search query to filter by name or key" },
-                    "type": { "type": "string", "enum": ["confluence", "jira"], "description": "Whether to search Confluence spaces or Jira projects" }
+                "query": {
+                    "type": "string",
+                    "required": false,
+                    "description": "Search query to filter by name or key"
                 },
-                "required": ["type"]
+                "type": {
+                    "type": "string",
+                    "required": true,
+                    "description": "Whether to search Confluence spaces or Jira projects"
+                }
             }),
         }],
     };

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -155,9 +155,14 @@ class ConnectorToolHandler:
         self._actions.clear()
         self._tools.clear()
 
+        seen_tools: set[str] = set()
         for action in actions:
             # Namespace: {source_type}__{action_name}
             tool_name = f"{action['source_type']}__{action['action_name']}"
+
+            if tool_name in seen_tools:
+                continue
+            seen_tools.add(tool_name)
 
             self._actions[tool_name] = ConnectorAction(
                 source_id=action["source_id"],


### PR DESCRIPTION
- The Atlassian connector was not using the proper manifest format
- If we have multiple sources connected of the same type, we get duplicate tools, which we need to skip 