### PR TITLE
Send doc attributes to LLM in search results

### DIFF
--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -154,21 +154,29 @@ class SearchToolHandler:
             doc_content_text_blocks = [
                 TextBlockParam(type="text", text=h) for h in result.highlights
             ]
+
+            metadata_blocks = [
+                TextBlockParam(type="text", text=f"[Document ID: {doc.id}]"),
+                TextBlockParam(type="text", text=f"[Document Name: {doc.title}]"),
+                TextBlockParam(
+                    type="text",
+                    text=f"[Source: {result.source_type or 'unknown'}]",
+                ),
+                TextBlockParam(type="text", text=f"[URL: {doc.url or '<unknown>'}]"),
+            ]
+
+            if doc.attributes:
+                attrs_str = ", ".join(f"{k}: {v}" for k, v in doc.attributes.items())
+                metadata_blocks.append(
+                    TextBlockParam(type="text", text=f"[Attributes: {attrs_str}]")
+                )
+
             content_blocks.append(
                 SearchResultBlockParam(
                     type="search_result",
                     title=doc.title,
                     source=doc.url or "<unknown>",
-                    content=[
-                        TextBlockParam(type="text", text=f"[Document ID: {doc.id}]"),
-                        TextBlockParam(
-                            type="text", text=f"[Document Name: {doc.title}]"
-                        ),
-                        TextBlockParam(
-                            type="text", text=f"[URL: {doc.url or '<unknown>'}]"
-                        ),
-                        *doc_content_text_blocks,
-                    ],
+                    content=[*metadata_blocks, *doc_content_text_blocks],
                     citations=CitationsConfigParam(enabled=True),
                 )
             )

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -171,6 +171,13 @@ class SearchToolHandler:
                     TextBlockParam(type="text", text=f"[Attributes: {attrs_str}]")
                 )
 
+            extra = (doc.metadata or {}).get("extra")
+            if extra and isinstance(extra, dict):
+                extra_str = ", ".join(f"{k}: {v}" for k, v in extra.items())
+                metadata_blocks.append(
+                    TextBlockParam(type="text", text=f"[Extra: {extra_str}]")
+                )
+
             content_blocks.append(
                 SearchResultBlockParam(
                     type="search_result",

--- a/services/ai/tools/searcher_client.py
+++ b/services/ai/tools/searcher_client.py
@@ -43,6 +43,7 @@ class Document(BaseModel):
 class SearchResult(BaseModel):
     document: Document
     highlights: list[str]
+    source_type: str | None = None
 
 
 class SearchResponse(BaseModel):

--- a/services/ai/tools/searcher_client.py
+++ b/services/ai/tools/searcher_client.py
@@ -38,6 +38,7 @@ class Document(BaseModel):
     url: str | None
     source_type: str | None = None
     attributes: dict | None = None
+    metadata: dict | None = None
 
 
 class SearchResult(BaseModel):

--- a/services/searcher/src/models.rs
+++ b/services/searcher/src/models.rs
@@ -87,6 +87,8 @@ pub struct SearchResult {
     pub match_type: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub content: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub source_type: Option<String>,
 }
 
 #[derive(Debug, Deserialize)]

--- a/services/searcher/src/search.rs
+++ b/services/searcher/src/search.rs
@@ -7,7 +7,7 @@ use crate::query_parser;
 use crate::search_repository::SearchDocumentRepository;
 use anyhow::Result;
 use redis::{AsyncCommands, Client as RedisClient};
-use shared::db::repositories::{DocumentRepository, EmbeddingRepository};
+use shared::db::repositories::{DocumentRepository, EmbeddingRepository, SourceRepository};
 use shared::models::{ChunkResult, Document};
 use shared::utils::safe_str_slice;
 use shared::{
@@ -56,6 +56,27 @@ impl SearchEngine {
         })
     }
 
+    async fn populate_source_types(&self, results: &mut [SearchResult]) {
+        let source_ids: Vec<String> = results
+            .iter()
+            .map(|r| r.document.source_id.clone())
+            .collect::<std::collections::HashSet<_>>()
+            .into_iter()
+            .collect();
+
+        let source_repo = SourceRepository::new(self.db_pool.pool());
+        match source_repo.fetch_source_type_map(&source_ids).await {
+            Ok(type_map) => {
+                for result in results.iter_mut() {
+                    result.source_type = type_map.get(&result.document.source_id).cloned();
+                }
+            }
+            Err(e) => {
+                info!("Failed to fetch source types: {}", e);
+            }
+        }
+    }
+
     fn prepare_document_for_response(&self, mut doc: Document) -> Document {
         doc.content_id = None;
 
@@ -63,8 +84,6 @@ impl SearchEngine {
         if let Some(url_str) = &doc.url {
             if doc.content_type.is_some() {
                 let mut metadata_parts = Vec::new();
-                // Note: source_type would go here if we had it
-                // For now, we only add content_type
                 if let Some(ref ct) = doc.content_type {
                     metadata_parts.push(ct.clone());
                 }
@@ -300,6 +319,8 @@ impl SearchEngine {
         let has_more = total_count >= limit;
         let query_time = start_time.elapsed().as_millis() as u64;
 
+        self.populate_source_types(&mut results).await;
+
         info!(
             "Search completed in {}ms, found {} results",
             query_time,
@@ -383,6 +404,7 @@ impl SearchEngine {
                 highlights,
                 match_type: "fulltext".to_string(),
                 content: None,
+                source_type: None,
             });
         }
 
@@ -489,7 +511,8 @@ impl SearchEngine {
                     score: max_score,
                     highlights: all_highlights,
                     match_type: "semantic".to_string(),
-                    content: None, // Using highlights instead of single content snippet
+                    content: None,
+                    source_type: None,
                 });
             }
         }
@@ -537,7 +560,7 @@ impl SearchEngine {
             .ok_or_else(|| anyhow::anyhow!("Document not found: {}", document_id))?;
 
         // Get actual content size (extracted text, not original file)
-        let results = if let Some(content_id) = &doc.content_id {
+        let mut results = if let Some(content_id) = &doc.content_id {
             match self.content_storage.get_text(content_id).await {
                 Ok(content) => {
                     let content_size = content.len();
@@ -553,6 +576,7 @@ impl SearchEngine {
                             highlights: vec![content],
                             match_type: "full_content".to_string(),
                             content: None,
+                            source_type: None,
                         }]
                     } else {
                         // Check if specific line range is requested
@@ -614,6 +638,7 @@ impl SearchEngine {
                                     highlights: vec![selected_content],
                                     match_type: "line_range".to_string(),
                                     content: None,
+                                    source_type: None,
                                 }]
                             }
                             _ => {
@@ -640,6 +665,8 @@ impl SearchEngine {
             info!("No content_id available for document");
             vec![]
         };
+
+        self.populate_source_types(&mut results).await;
 
         let total_count = results.len() as i64;
         let query_time = start_time.elapsed().as_millis() as u64;
@@ -700,6 +727,7 @@ impl SearchEngine {
                     highlights: vec![truncated],
                     match_type: "fulltext".to_string(),
                     content: None,
+                    source_type: None,
                 }]
             } else {
                 error!(
@@ -834,6 +862,7 @@ impl SearchEngine {
                     },
                     match_type: "semantic".to_string(),
                     content: None,
+                    source_type: None,
                 });
             }
         }
@@ -914,6 +943,7 @@ impl SearchEngine {
                     highlights: result.highlights,
                     match_type: "fulltext".to_string(),
                     content: result.content,
+                    source_type: None,
                 },
             );
         }
@@ -942,6 +972,7 @@ impl SearchEngine {
                         highlights: result.highlights,
                         match_type: "semantic".to_string(),
                         content: result.content,
+                        source_type: None,
                     }
                 });
         }

--- a/shared/src/db/repositories/source.rs
+++ b/shared/src/db/repositories/source.rs
@@ -1,6 +1,7 @@
 use crate::{db::error::DatabaseError, models::Source, traits::Repository};
 use async_trait::async_trait;
 use sqlx::PgPool;
+use std::collections::HashMap;
 use time::OffsetDateTime;
 
 #[derive(Clone)]
@@ -152,6 +153,22 @@ impl SourceRepository {
                 .fetch_all(&self.pool)
                 .await?;
         Ok(results)
+    }
+
+    pub async fn fetch_source_type_map(
+        &self,
+        source_ids: &[String],
+    ) -> Result<HashMap<String, String>, DatabaseError> {
+        if source_ids.is_empty() {
+            return Ok(HashMap::new());
+        }
+        let rows: Vec<(String, String)> =
+            sqlx::query_as("SELECT id, source_type::text FROM sources WHERE id = ANY($1)")
+                .bind(source_ids)
+                .fetch_all(&self.pool)
+                .await?;
+
+        Ok(rows.into_iter().collect())
     }
 
     pub async fn find_due_for_sync(


### PR DESCRIPTION
Currently search results do not include the doc attributes (which contain important source specific information). We add them to give the LLM more context about the search results.