### PR TITLE
Impl email send tool

### DIFF
--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -36,6 +36,7 @@ from tools import (
     DocumentToolHandler,
 )
 from tools.connector_handler import ConnectorAction
+from tools.email_handler import EmailToolHandler
 from tools.sandbox_handler import SandboxToolHandler
 
 from .models import Agent, AgentRun
@@ -140,6 +141,14 @@ async def _build_agent_registry(
     # Sandbox tools
     if SANDBOX_URL:
         registry.register(SandboxToolHandler(sandbox_url=SANDBOX_URL))
+
+    # Email tool — only for org agents with send_email in allowed_actions
+    if (
+        agent.agent_type == "org"
+        and action_whitelist
+        and "send_email" in action_whitelist
+    ):
+        registry.register(EmailToolHandler())
 
     return registry, connector_actions
 

--- a/services/ai/email_service/repository.py
+++ b/services/ai/email_service/repository.py
@@ -1,0 +1,92 @@
+"""Read-only DB access for email provider configuration."""
+
+import json
+import logging
+from dataclasses import dataclass
+from typing import Literal, Optional, Union
+
+from asyncpg import Pool
+
+from db.connection import get_db_pool
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ACSConfig:
+    type: Literal["acs"]
+    connection_string: str
+    sender_address: str
+
+
+@dataclass
+class ResendConfig:
+    type: Literal["resend"]
+    api_key: str
+    from_email: str
+
+
+@dataclass
+class SMTPConfig:
+    type: Literal["smtp"]
+    host: str
+    from_email: str
+    port: int = 587
+    user: Optional[str] = None
+    password: Optional[str] = None
+    secure: bool = False
+
+
+EmailProviderConfig = Union[ACSConfig, ResendConfig, SMTPConfig]
+
+
+def _parse_config(provider_type: str, config: dict) -> EmailProviderConfig:
+    if provider_type == "acs":
+        return ACSConfig(
+            type="acs",
+            connection_string=config["connectionString"],
+            sender_address=config["senderAddress"],
+        )
+    elif provider_type == "resend":
+        return ResendConfig(
+            type="resend",
+            api_key=config["apiKey"],
+            from_email=config["fromEmail"],
+        )
+    elif provider_type == "smtp":
+        return SMTPConfig(
+            type="smtp",
+            host=config["host"],
+            from_email=config["fromEmail"],
+            port=config.get("port", 587),
+            user=config.get("user"),
+            password=config.get("password"),
+            secure=config.get("secure", False),
+        )
+    else:
+        raise ValueError(f"Unknown email provider type: {provider_type}")
+
+
+async def get_current_email_provider(
+    pool: Optional[Pool] = None,
+) -> Optional[EmailProviderConfig]:
+    if not pool:
+        pool = await get_db_pool()
+
+    row = await pool.fetchrow(
+        """
+        SELECT provider_type, config
+        FROM email_providers
+        WHERE is_current = true AND is_deleted = false
+        LIMIT 1
+        """
+    )
+
+    if not row:
+        return None
+
+    config = row["config"]
+    if isinstance(config, str):
+        config = json.loads(config)
+
+    return _parse_config(row["provider_type"], config)

--- a/services/ai/email_service/sender.py
+++ b/services/ai/email_service/sender.py
@@ -1,0 +1,171 @@
+"""Email sending with pluggable providers."""
+
+import logging
+from abc import ABC, abstractmethod
+from dataclasses import dataclass
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+from typing import Optional
+
+import aiosmtplib
+import httpx
+from asyncpg import Pool
+from azure.communication.email import EmailClient
+
+from .repository import (
+    ACSConfig,
+    EmailProviderConfig,
+    ResendConfig,
+    SMTPConfig,
+    get_current_email_provider,
+)
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SendResult:
+    success: bool
+    message_id: Optional[str] = None
+    error: Optional[str] = None
+
+
+class EmailProvider(ABC):
+    @abstractmethod
+    async def send(
+        self, to: str, subject: str, html: str, text: Optional[str] = None
+    ) -> SendResult: ...
+
+
+class ACSEmailProvider(EmailProvider):
+    def __init__(self, config: ACSConfig):
+        self._client = EmailClient.from_connection_string(config.connection_string)
+        self._sender_address = config.sender_address
+
+    async def send(
+        self, to: str, subject: str, html: str, text: Optional[str] = None
+    ) -> SendResult:
+        try:
+            message = {
+                "senderAddress": self._sender_address,
+                "content": {"subject": subject, "html": html, "plainText": text or ""},
+                "recipients": {"to": [{"address": to}]},
+            }
+
+            poller = self._client.begin_send(message)
+            result = poller.result()
+
+            if result["status"] == "Succeeded":
+                return SendResult(success=True, message_id=result.get("id"))
+
+            logger.error("ACS send failed: status=%s", result["status"])
+            return SendResult(success=False, error=f"Send failed: {result['status']}")
+        except Exception as e:
+            logger.error("ACS send error: %s", e)
+            return SendResult(success=False, error="Failed to send email via ACS")
+
+
+class ResendEmailProvider(EmailProvider):
+    def __init__(self, config: ResendConfig):
+        self._api_key = config.api_key
+        self._from_email = config.from_email
+
+    async def send(
+        self, to: str, subject: str, html: str, text: Optional[str] = None
+    ) -> SendResult:
+        try:
+            async with httpx.AsyncClient() as client:
+                resp = await client.post(
+                    "https://api.resend.com/emails",
+                    headers={
+                        "Authorization": f"Bearer {self._api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json={
+                        "from": self._from_email,
+                        "to": [to],
+                        "subject": subject,
+                        "html": html,
+                    },
+                    timeout=30,
+                )
+
+            if resp.status_code == 200:
+                data = resp.json()
+                return SendResult(success=True, message_id=data.get("id"))
+
+            logger.error("Resend error: status=%d body=%s", resp.status_code, resp.text)
+            return SendResult(success=False, error="Failed to send email via Resend")
+        except Exception as e:
+            logger.error("Resend send error: %s", e)
+            return SendResult(success=False, error="Failed to send email via Resend")
+
+
+class SMTPEmailProvider(EmailProvider):
+    def __init__(self, config: SMTPConfig):
+        self._host = config.host
+        self._port = config.port
+        self._user = config.user
+        self._password = config.password
+        self._secure = config.secure
+        self._from_email = config.from_email
+
+    async def send(
+        self, to: str, subject: str, html: str, text: Optional[str] = None
+    ) -> SendResult:
+        try:
+            msg = MIMEMultipart("alternative")
+            msg["Subject"] = subject
+            msg["From"] = self._from_email
+            msg["To"] = to
+
+            if text:
+                msg.attach(MIMEText(text, "plain"))
+            msg.attach(MIMEText(html, "html"))
+
+            await aiosmtplib.send(
+                msg,
+                hostname=self._host,
+                port=self._port,
+                username=self._user,
+                password=self._password,
+                use_tls=self._secure,
+                start_tls=not self._secure,
+            )
+
+            return SendResult(success=True)
+        except Exception as e:
+            logger.error("SMTP send error: %s", e)
+            return SendResult(success=False, error="Failed to send email via SMTP")
+
+
+def _build_provider(config: EmailProviderConfig) -> EmailProvider:
+    match config:
+        case ACSConfig():
+            return ACSEmailProvider(config)
+        case ResendConfig():
+            return ResendEmailProvider(config)
+        case SMTPConfig():
+            return SMTPEmailProvider(config)
+
+
+class EmailSender:
+    """Reads provider config from DB and delegates to the appropriate EmailProvider."""
+
+    def __init__(self, pool: Optional[Pool] = None):
+        self._pool = pool
+        self._provider: Optional[EmailProvider] = None
+
+    async def send(
+        self, to: str, subject: str, html: str, text: Optional[str] = None
+    ) -> SendResult:
+        if not self._provider:
+            config = await get_current_email_provider(self._pool)
+            if not config:
+                return SendResult(success=False, error="No email provider configured")
+            self._provider = _build_provider(config)
+
+        return await self._provider.send(to, subject, html, text)
+
+    def reset(self):
+        self._provider = None

--- a/services/ai/pyproject.toml
+++ b/services/ai/pyproject.toml
@@ -33,6 +33,8 @@ dependencies = [
     "cohere>=5.20.4",
     "google-genai>=1.0.0",
     "azure-identity>=1.19.0",
+    "azure-communication-email>=1.0.0",
+    "aiosmtplib>=3.0.0",
     "croniter>=2.0.0",
 ]
 
@@ -93,6 +95,7 @@ include = [
     "models*",
     "logger*",
     "agents*",
+    "email_service*",
 ]
 
 [dependency-groups]

--- a/services/ai/tools/email_handler.py
+++ b/services/ai/tools/email_handler.py
@@ -1,0 +1,112 @@
+"""EmailToolHandler: send_email tool for org agents."""
+
+from __future__ import annotations
+
+import html
+import logging
+
+from email_service.sender import EmailSender
+from tools.registry import ToolContext, ToolResult
+
+logger = logging.getLogger(__name__)
+
+TOOL_NAME = "send_email"
+
+
+def _body_to_html(body: str) -> str:
+    """Convert plain text body to simple HTML email."""
+    escaped = html.escape(body)
+    paragraphs = escaped.split("\n\n")
+    html_parts = []
+    for p in paragraphs:
+        lines = p.replace("\n", "<br>")
+        html_parts.append(f"<p>{lines}</p>")
+
+    return f"""<!DOCTYPE html>
+<html>
+<head><meta charset="utf-8"></head>
+<body style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; line-height: 1.6; color: #1a1a1a; max-width: 600px; margin: 0 auto; padding: 20px;">
+{''.join(html_parts)}
+</body>
+</html>"""
+
+
+class EmailToolHandler:
+    def __init__(self):
+        self._sender = EmailSender()
+
+    def get_tools(self) -> list[dict]:
+        return [
+            {
+                "name": TOOL_NAME,
+                "description": (
+                    "Send an email to a recipient. Use this to send reports, summaries, "
+                    "notifications, or other content via email."
+                ),
+                "input_schema": {
+                    "type": "object",
+                    "properties": {
+                        "to": {
+                            "type": "string",
+                            "description": "Recipient email address",
+                        },
+                        "subject": {
+                            "type": "string",
+                            "description": "Email subject line",
+                        },
+                        "body": {
+                            "type": "string",
+                            "description": "Email body content in plain text",
+                        },
+                    },
+                    "required": ["to", "subject", "body"],
+                },
+            }
+        ]
+
+    def can_handle(self, tool_name: str) -> bool:
+        return tool_name == TOOL_NAME
+
+    def requires_approval(self, tool_name: str) -> bool:
+        return True
+
+    async def execute(
+        self, tool_name: str, tool_input: dict, context: ToolContext
+    ) -> ToolResult:
+        to = tool_input.get("to", "").strip()
+        subject = tool_input.get("subject", "").strip()
+        body = tool_input.get("body", "").strip()
+
+        if not to:
+            return ToolResult(
+                content=[{"type": "text", "text": "Error: 'to' is required"}],
+                is_error=True,
+            )
+        if not subject:
+            return ToolResult(
+                content=[{"type": "text", "text": "Error: 'subject' is required"}],
+                is_error=True,
+            )
+        if not body:
+            return ToolResult(
+                content=[{"type": "text", "text": "Error: 'body' is required"}],
+                is_error=True,
+            )
+
+        html_body = _body_to_html(body)
+        result = await self._sender.send(
+            to=to, subject=subject, html=html_body, text=body
+        )
+
+        if result.success:
+            msg = f"Email sent to {to}"
+            if result.message_id:
+                msg += f" (ID: {result.message_id})"
+            return ToolResult(content=[{"type": "text", "text": msg}])
+        else:
+            return ToolResult(
+                content=[
+                    {"type": "text", "text": f"Failed to send email: {result.error}"}
+                ],
+                is_error=True,
+            )

--- a/services/ai/uv.lock
+++ b/services/ai/uv.lock
@@ -114,6 +114,15 @@ wheels = [
 ]
 
 [[package]]
+name = "aiosmtplib"
+version = "5.1.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/e7/ad/240a7ce4e50713b111dff8b781a898d8d4770e5d6ad4899103f84c86005c/aiosmtplib-5.1.0.tar.gz", hash = "sha256:2504a23b2b63c9de6bc4ea719559a38996dba68f73f6af4eb97be20ee4c5e6c4", size = 66176, upload-time = "2026-01-25T01:51:11.408Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/37/82/70f2c452acd7ed18c558c8ace9a8cf4fdcc70eae9a41749b5bdc53eb6f45/aiosmtplib-5.1.0-py3-none-any.whl", hash = "sha256:368029440645b486b69db7029208a7a78c6691b90d24a5332ddba35d9109d55b", size = 27778, upload-time = "2026-01-25T01:51:10.026Z" },
+]
+
+[[package]]
 name = "annotated-doc"
 version = "0.0.4"
 source = { registry = "https://pypi.org/simple" }
@@ -219,6 +228,20 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/6b/5c/685e6633917e101e5dcb62b9dd76946cbb57c26e133bae9e0cd36033c0a9/attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11", size = 934251, upload-time = "2025-10-06T13:54:44.725Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/3a/2a/7cc015f5b9f5db42b7d48157e23356022889fc354a2813c15934b7cb5c0e/attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373", size = 67615, upload-time = "2025-10-06T13:54:43.17Z" },
+]
+
+[[package]]
+name = "azure-communication-email"
+version = "1.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/97/de/f71191ead5e778a7d8939744977a049f796f6fb6549847c667fad373605e/azure_communication_email-1.1.0.tar.gz", hash = "sha256:6a4af8281024327c3ab18a4996919069a99a69aad3a19c40f7852a6682493327", size = 55546, upload-time = "2025-10-17T20:30:23.349Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/97/fe/9bd1028853c4b351c756ba4acc39ef5b5914a3452ebe2df0b8ddd6051114/azure_communication_email-1.1.0-py3-none-any.whl", hash = "sha256:9212153f21cf7e68734c32ebfe8702b43398bd01df2dddb0ca52cd5a8bbd5024", size = 64170, upload-time = "2025-10-17T20:30:24.829Z" },
 ]
 
 [[package]]
@@ -1043,6 +1066,15 @@ wheels = [
 ]
 
 [[package]]
+name = "isodate"
+version = "0.7.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/54/4d/e940025e2ce31a8ce1202635910747e5a87cc3a6a6bb2d00973375014749/isodate-0.7.2.tar.gz", hash = "sha256:4cd1aa0f43ca76f4a6c6c0292a85f40b35ec2e43e315b59f06e6d32171a953e6", size = 29705, upload-time = "2024-10-08T23:04:11.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/aa/0aca39a37d3c7eb941ba736ede56d689e7be91cab5d9ca846bde3999eba6/isodate-0.7.2-py3-none-any.whl", hash = "sha256:28009937d8031054830160fce6d409ed342816b543597cece116d966c6d99e15", size = 22320, upload-time = "2024-10-08T23:04:09.501Z" },
+]
+
+[[package]]
 name = "jiter"
 version = "0.12.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1404,8 +1436,10 @@ name = "omni-ai"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
+    { name = "aiosmtplib" },
     { name = "anthropic" },
     { name = "asyncpg" },
+    { name = "azure-communication-email" },
     { name = "azure-identity" },
     { name = "boto3" },
     { name = "cohere" },
@@ -1444,8 +1478,10 @@ dev = [
 
 [package.metadata]
 requires-dist = [
+    { name = "aiosmtplib", specifier = ">=3.0.0" },
     { name = "anthropic", specifier = ">=0.68.0" },
     { name = "asyncpg", specifier = ">=0.30.0" },
+    { name = "azure-communication-email", specifier = ">=1.0.0" },
     { name = "azure-identity", specifier = ">=1.19.0" },
     { name = "boto3", specifier = ">=1.40.0" },
     { name = "cohere", specifier = ">=5.20.4" },


### PR DESCRIPTION
Implement an email sending tool that will be available only to org-level agents.

We already have an email sending service in omni-web, which we could have simply exposed via an API like `/api/email/send` that this service omni-ai could have invoked. But that would lead to a circular call pattern which I'd like to avoid (omni-web already invokes omni-ai). We duplicate part of the email sending logic instead. IMO accepting this duplication is a better option than adding a circular dependency.