### PR TITLE
Fix timestamp serialization format in document metadata

### DIFF
--- a/connectors/atlassian/src/models.rs
+++ b/connectors/atlassian/src/models.rs
@@ -136,7 +136,7 @@ pub struct ConfluencePage {
     #[serde(rename = "lastOwnerId")]
     pub last_owner_id: Option<String>,
     pub subtype: Option<String>,
-    #[serde(rename = "createdAt", with = "time::serde::iso8601")]
+    #[serde(rename = "createdAt", with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
     pub version: ConfluenceVersion,
     pub body: Option<ConfluencePageBody>,
@@ -154,7 +154,7 @@ pub struct ConfluenceSpace {
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ConfluenceVersion {
-    #[serde(rename = "createdAt", with = "time::serde::iso8601")]
+    #[serde(rename = "createdAt", with = "time::serde::rfc3339")]
     pub created_at: OffsetDateTime,
     pub message: String,
     pub number: i32,

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -248,9 +248,9 @@ pub struct JiraSourceConfig {
 pub struct DocumentMetadata {
     pub title: Option<String>,
     pub author: Option<String>,
-    #[serde(default, with = "time::serde::iso8601::option")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
     pub created_at: Option<OffsetDateTime>,
-    #[serde(default, with = "time::serde::iso8601::option")]
+    #[serde(default, with = "time::serde::rfc3339::option")]
     pub updated_at: Option<OffsetDateTime>,
     pub content_type: Option<String>,
     pub mime_type: Option<String>,


### PR DESCRIPTION
- Switch `DocumentMetadata` timestamp fields from `time::serde::iso8601` to `time::serde::rfc3339` to produce standard `2026-03-02T17:51:16Z` format instead of `+002026-03-02T17:51:16.000000000Z`
- Fix the same iso8601→rfc3339 in Atlassian connector's Confluence models for consistency
- Fixes broken Postgres string comparisons on `metadata->>'updated_at'`