### PR TITLE
Bring Terraform configs to parity with Docker Compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -31,6 +31,7 @@ FIREFLIES_CONNECTOR_PORT=4009
 IMAP_CONNECTOR_PORT=4010
 CLICKUP_CONNECTOR_PORT=4011
 LINEAR_CONNECTOR_PORT=4012
+FILESYSTEM_CONNECTOR_PORT=4013
 
 # Sandbox Port
 SANDBOX_PORT=8090
@@ -47,7 +48,7 @@ LOCAL_EMBEDDINGS_PORT=8001 # For local embedding models via TEI
 #
 # Enable connectors you want to run by adding their profile to ENABLED_CONNECTORS (comma-separated).
 # Available connector names:
-# 	google, slack, atlassian, web, github, notion, hubspot, fireflies, microsoft, filesystem, imap, linear
+# 	google, slack, atlassian, web, github, notion, hubspot, fireflies, microsoft, filesystem, imap, linear, clickup
 #
 # Example: ENABLED_CONNECTORS=google,slack
 #
@@ -80,6 +81,7 @@ SESSION_COOKIE_NAME=auth-session
 SESSION_DURATION_DAYS=7
 
 # Application Configuration
+OMNI_VERSION=latest
 APP_URL=http://localhost:3000
 OMNI_DOMAIN=localhost
 ACME_EMAIL=admin@yourcompany.com

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -560,6 +560,26 @@ services:
     restart: unless-stopped
     logging: *default-logging
 
+  filesystem-connector:
+    image: ghcr.io/getomnico/omni/omni-filesystem-connector:${OMNI_VERSION:-latest}
+    container_name: omni-filesystem-connector
+    profiles:
+      - filesystem
+    expose:
+      - "${FILESYSTEM_CONNECTOR_PORT}"
+    environment:
+      <<: *otel-config
+      PORT: ${FILESYSTEM_CONNECTOR_PORT}
+      CONNECTOR_MANAGER_URL: ${CONNECTOR_MANAGER_URL}
+      CONNECTOR_HOST_NAME: filesystem-connector
+    networks:
+      - omni-network
+    depends_on:
+      connector-manager:
+        condition: service_started
+    restart: unless-stopped
+    logging: *default-logging
+
   # Web Application (SvelteKit frontend + backend)
   web:
     image: ghcr.io/getomnico/omni/omni-web:${OMNI_VERSION:-latest}

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -184,8 +184,6 @@ module "compute" {
   stale_sync_timeout_minutes      = var.stale_sync_timeout_minutes
 
   # Google connector configuration
-  google_webhook_url                     = var.google_webhook_url
-  google_sync_interval_seconds           = var.google_sync_interval_seconds
   google_max_age_days                    = var.google_max_age_days
   webhook_renewal_check_interval_seconds = var.webhook_renewal_check_interval_seconds
 

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -198,6 +198,11 @@ module "compute" {
   ai_answer_enabled          = var.ai_answer_enabled
   agents_enabled             = var.agents_enabled
 
+  enabled_connectors       = var.enabled_connectors
+  sandbox_url              = var.sandbox_url
+  agent_max_iterations     = var.agent_max_iterations
+  approval_timeout_seconds = var.approval_timeout_seconds
+
   # Storage resources for S3 and batch inference
   content_bucket_arn     = module.storage.content_bucket_arn
   content_bucket_name    = module.storage.content_bucket_name

--- a/infra/aws/terraform/modules/compute/iam.tf
+++ b/infra/aws/terraform/modules/compute/iam.tf
@@ -27,7 +27,6 @@ resource "aws_iam_role" "ecs_task_execution" {
         ]
         Resource = [
           var.database_password_arn,
-          var.embedding_api_key_arn,
           var.encryption_key_arn,
           var.encryption_salt_arn
         ]

--- a/infra/aws/terraform/modules/compute/outputs.tf
+++ b/infra/aws/terraform/modules/compute/outputs.tf
@@ -30,7 +30,7 @@ output "ai_service_name" {
 
 output "google_connector_service_name" {
   description = "Google connector service name"
-  value       = aws_ecs_service.google_connector.name
+  value       = try(aws_ecs_service.google_connector[0].name, null)
 }
 
 output "migrator_task_definition_arn" {
@@ -60,40 +60,55 @@ output "connector_manager_service_name" {
 
 output "slack_connector_service_name" {
   description = "Slack connector service name"
-  value       = aws_ecs_service.slack_connector.name
+  value       = try(aws_ecs_service.slack_connector[0].name, null)
 }
 
 output "atlassian_connector_service_name" {
   description = "Atlassian connector service name"
-  value       = aws_ecs_service.atlassian_connector.name
+  value       = try(aws_ecs_service.atlassian_connector[0].name, null)
 }
 
 output "web_connector_service_name" {
   description = "Web connector service name"
-  value       = aws_ecs_service.web_connector.name
+  value       = try(aws_ecs_service.web_connector[0].name, null)
 }
 
 output "github_connector_service_name" {
   description = "GitHub connector service name"
-  value       = aws_ecs_service.github_connector.name
+  value       = try(aws_ecs_service.github_connector[0].name, null)
 }
 
 output "hubspot_connector_service_name" {
   description = "HubSpot connector service name"
-  value       = aws_ecs_service.hubspot_connector.name
+  value       = try(aws_ecs_service.hubspot_connector[0].name, null)
 }
 
 output "microsoft_connector_service_name" {
   description = "Microsoft connector service name"
-  value       = aws_ecs_service.microsoft_connector.name
+  value       = try(aws_ecs_service.microsoft_connector[0].name, null)
 }
 
 output "notion_connector_service_name" {
   description = "Notion connector service name"
-  value       = aws_ecs_service.notion_connector.name
+  value       = try(aws_ecs_service.notion_connector[0].name, null)
 }
 
 output "fireflies_connector_service_name" {
   description = "Fireflies connector service name"
-  value       = aws_ecs_service.fireflies_connector.name
+  value       = try(aws_ecs_service.fireflies_connector[0].name, null)
+}
+
+output "imap_connector_service_name" {
+  description = "IMAP connector service name"
+  value       = try(aws_ecs_service.imap_connector[0].name, null)
+}
+
+output "linear_connector_service_name" {
+  description = "Linear connector service name"
+  value       = try(aws_ecs_service.linear_connector[0].name, null)
+}
+
+output "clickup_connector_service_name" {
+  description = "ClickUp connector service name"
+  value       = try(aws_ecs_service.clickup_connector[0].name, null)
 }

--- a/infra/aws/terraform/modules/compute/outputs.tf
+++ b/infra/aws/terraform/modules/compute/outputs.tf
@@ -112,3 +112,8 @@ output "clickup_connector_service_name" {
   description = "ClickUp connector service name"
   value       = try(aws_ecs_service.clickup_connector[0].name, null)
 }
+
+output "filesystem_connector_service_name" {
+  description = "Filesystem connector service name"
+  value       = try(aws_ecs_service.filesystem_connector[0].name, null)
+}

--- a/infra/aws/terraform/modules/compute/service_discovery.tf
+++ b/infra/aws/terraform/modules/compute/service_discovery.tf
@@ -310,3 +310,22 @@ resource "aws_service_discovery_service" "clickup_connector" {
     failure_threshold = 1
   }
 }
+
+resource "aws_service_discovery_service" "filesystem_connector" {
+  count = contains(var.enabled_connectors, "filesystem") ? 1 : 0
+
+  name = "filesystem-connector"
+
+  dns_config {
+    namespace_id = var.service_discovery_namespace_id
+
+    dns_records {
+      ttl  = 300
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}

--- a/infra/aws/terraform/modules/compute/service_discovery.tf
+++ b/infra/aws/terraform/modules/compute/service_discovery.tf
@@ -67,6 +67,8 @@ resource "aws_service_discovery_service" "ai" {
 }
 
 resource "aws_service_discovery_service" "google_connector" {
+  count = contains(var.enabled_connectors, "google") ? 1 : 0
+
   name = "google-connector"
 
   dns_config {
@@ -84,6 +86,8 @@ resource "aws_service_discovery_service" "google_connector" {
 }
 
 resource "aws_service_discovery_service" "atlassian_connector" {
+  count = contains(var.enabled_connectors, "atlassian") ? 1 : 0
+
   name = "atlassian-connector"
 
   dns_config {
@@ -101,6 +105,8 @@ resource "aws_service_discovery_service" "atlassian_connector" {
 }
 
 resource "aws_service_discovery_service" "web_connector" {
+  count = contains(var.enabled_connectors, "web") ? 1 : 0
+
   name = "web-connector"
 
   dns_config {
@@ -135,6 +141,8 @@ resource "aws_service_discovery_service" "connector_manager" {
 }
 
 resource "aws_service_discovery_service" "slack_connector" {
+  count = contains(var.enabled_connectors, "slack") ? 1 : 0
+
   name = "slack-connector"
 
   dns_config {
@@ -152,6 +160,8 @@ resource "aws_service_discovery_service" "slack_connector" {
 }
 
 resource "aws_service_discovery_service" "github_connector" {
+  count = contains(var.enabled_connectors, "github") ? 1 : 0
+
   name = "github-connector"
 
   dns_config {
@@ -169,6 +179,8 @@ resource "aws_service_discovery_service" "github_connector" {
 }
 
 resource "aws_service_discovery_service" "hubspot_connector" {
+  count = contains(var.enabled_connectors, "hubspot") ? 1 : 0
+
   name = "hubspot-connector"
 
   dns_config {
@@ -186,6 +198,8 @@ resource "aws_service_discovery_service" "hubspot_connector" {
 }
 
 resource "aws_service_discovery_service" "microsoft_connector" {
+  count = contains(var.enabled_connectors, "microsoft") ? 1 : 0
+
   name = "microsoft-connector"
 
   dns_config {
@@ -203,6 +217,8 @@ resource "aws_service_discovery_service" "microsoft_connector" {
 }
 
 resource "aws_service_discovery_service" "notion_connector" {
+  count = contains(var.enabled_connectors, "notion") ? 1 : 0
+
   name = "notion-connector"
 
   dns_config {
@@ -220,7 +236,66 @@ resource "aws_service_discovery_service" "notion_connector" {
 }
 
 resource "aws_service_discovery_service" "fireflies_connector" {
+  count = contains(var.enabled_connectors, "fireflies") ? 1 : 0
+
   name = "fireflies-connector"
+
+  dns_config {
+    namespace_id = var.service_discovery_namespace_id
+
+    dns_records {
+      ttl  = 300
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_service_discovery_service" "imap_connector" {
+  count = contains(var.enabled_connectors, "imap") ? 1 : 0
+
+  name = "imap-connector"
+
+  dns_config {
+    namespace_id = var.service_discovery_namespace_id
+
+    dns_records {
+      ttl  = 300
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_service_discovery_service" "linear_connector" {
+  count = contains(var.enabled_connectors, "linear") ? 1 : 0
+
+  name = "linear-connector"
+
+  dns_config {
+    namespace_id = var.service_discovery_namespace_id
+
+    dns_records {
+      ttl  = 300
+      type = "A"
+    }
+  }
+
+  health_check_custom_config {
+    failure_threshold = 1
+  }
+}
+
+resource "aws_service_discovery_service" "clickup_connector" {
+  count = contains(var.enabled_connectors, "clickup") ? 1 : 0
+
+  name = "clickup-connector"
 
   dns_config {
     namespace_id = var.service_discovery_namespace_id

--- a/infra/aws/terraform/modules/compute/services.tf
+++ b/infra/aws/terraform/modules/compute/services.tf
@@ -106,9 +106,11 @@ resource "aws_ecs_service" "ai" {
 
 # Google Connector Service
 resource "aws_ecs_service" "google_connector" {
+  count = contains(var.enabled_connectors, "google") ? 1 : 0
+
   name            = "omni-${var.customer_name}-google-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.google_connector.arn
+  task_definition = aws_ecs_task_definition.google_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -121,7 +123,7 @@ resource "aws_ecs_service" "google_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.google_connector.arn
+    registry_arn = aws_service_discovery_service.google_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -131,9 +133,11 @@ resource "aws_ecs_service" "google_connector" {
 
 # Atlassian Connector Service
 resource "aws_ecs_service" "atlassian_connector" {
+  count = contains(var.enabled_connectors, "atlassian") ? 1 : 0
+
   name            = "omni-${var.customer_name}-atlassian-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.atlassian_connector.arn
+  task_definition = aws_ecs_task_definition.atlassian_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -146,7 +150,7 @@ resource "aws_ecs_service" "atlassian_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.atlassian_connector.arn
+    registry_arn = aws_service_discovery_service.atlassian_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -156,9 +160,11 @@ resource "aws_ecs_service" "atlassian_connector" {
 
 # Web Connector Service
 resource "aws_ecs_service" "web_connector" {
+  count = contains(var.enabled_connectors, "web") ? 1 : 0
+
   name            = "omni-${var.customer_name}-web-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.web_connector.arn
+  task_definition = aws_ecs_task_definition.web_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -171,7 +177,7 @@ resource "aws_ecs_service" "web_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.web_connector.arn
+    registry_arn = aws_service_discovery_service.web_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -206,9 +212,11 @@ resource "aws_ecs_service" "connector_manager" {
 
 # Slack Connector Service
 resource "aws_ecs_service" "slack_connector" {
+  count = contains(var.enabled_connectors, "slack") ? 1 : 0
+
   name            = "omni-${var.customer_name}-slack-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.slack_connector.arn
+  task_definition = aws_ecs_task_definition.slack_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -221,7 +229,7 @@ resource "aws_ecs_service" "slack_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.slack_connector.arn
+    registry_arn = aws_service_discovery_service.slack_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -231,9 +239,11 @@ resource "aws_ecs_service" "slack_connector" {
 
 # GitHub Connector Service
 resource "aws_ecs_service" "github_connector" {
+  count = contains(var.enabled_connectors, "github") ? 1 : 0
+
   name            = "omni-${var.customer_name}-github-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.github_connector.arn
+  task_definition = aws_ecs_task_definition.github_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -246,7 +256,7 @@ resource "aws_ecs_service" "github_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.github_connector.arn
+    registry_arn = aws_service_discovery_service.github_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -256,9 +266,11 @@ resource "aws_ecs_service" "github_connector" {
 
 # HubSpot Connector Service
 resource "aws_ecs_service" "hubspot_connector" {
+  count = contains(var.enabled_connectors, "hubspot") ? 1 : 0
+
   name            = "omni-${var.customer_name}-hubspot-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.hubspot_connector.arn
+  task_definition = aws_ecs_task_definition.hubspot_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -271,7 +283,7 @@ resource "aws_ecs_service" "hubspot_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.hubspot_connector.arn
+    registry_arn = aws_service_discovery_service.hubspot_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -281,9 +293,11 @@ resource "aws_ecs_service" "hubspot_connector" {
 
 # Microsoft Connector Service
 resource "aws_ecs_service" "microsoft_connector" {
+  count = contains(var.enabled_connectors, "microsoft") ? 1 : 0
+
   name            = "omni-${var.customer_name}-microsoft-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.microsoft_connector.arn
+  task_definition = aws_ecs_task_definition.microsoft_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -296,7 +310,7 @@ resource "aws_ecs_service" "microsoft_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.microsoft_connector.arn
+    registry_arn = aws_service_discovery_service.microsoft_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -306,9 +320,11 @@ resource "aws_ecs_service" "microsoft_connector" {
 
 # Notion Connector Service
 resource "aws_ecs_service" "notion_connector" {
+  count = contains(var.enabled_connectors, "notion") ? 1 : 0
+
   name            = "omni-${var.customer_name}-notion-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.notion_connector.arn
+  task_definition = aws_ecs_task_definition.notion_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -321,7 +337,7 @@ resource "aws_ecs_service" "notion_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.notion_connector.arn
+    registry_arn = aws_service_discovery_service.notion_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
@@ -331,9 +347,11 @@ resource "aws_ecs_service" "notion_connector" {
 
 # Fireflies Connector Service
 resource "aws_ecs_service" "fireflies_connector" {
+  count = contains(var.enabled_connectors, "fireflies") ? 1 : 0
+
   name            = "omni-${var.customer_name}-fireflies-connector"
   cluster         = var.cluster_arn
-  task_definition = aws_ecs_task_definition.fireflies_connector.arn
+  task_definition = aws_ecs_task_definition.fireflies_connector[0].arn
   launch_type     = "FARGATE"
   desired_count   = var.desired_count
 
@@ -346,10 +364,91 @@ resource "aws_ecs_service" "fireflies_connector" {
   }
 
   service_registries {
-    registry_arn = aws_service_discovery_service.fireflies_connector.arn
+    registry_arn = aws_service_discovery_service.fireflies_connector[0].arn
   }
 
   tags = merge(local.common_tags, {
     Name = "omni-${var.customer_name}-fireflies-connector"
+  })
+}
+
+# IMAP Connector Service
+resource "aws_ecs_service" "imap_connector" {
+  count = contains(var.enabled_connectors, "imap") ? 1 : 0
+
+  name            = "omni-${var.customer_name}-imap-connector"
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.imap_connector[0].arn
+  launch_type     = "FARGATE"
+  desired_count   = var.desired_count
+
+  enable_execute_command = true
+
+  network_configuration {
+    security_groups  = [var.security_group_id]
+    subnets          = var.subnet_ids
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.imap_connector[0].arn
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-imap-connector"
+  })
+}
+
+# Linear Connector Service
+resource "aws_ecs_service" "linear_connector" {
+  count = contains(var.enabled_connectors, "linear") ? 1 : 0
+
+  name            = "omni-${var.customer_name}-linear-connector"
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.linear_connector[0].arn
+  launch_type     = "FARGATE"
+  desired_count   = var.desired_count
+
+  enable_execute_command = true
+
+  network_configuration {
+    security_groups  = [var.security_group_id]
+    subnets          = var.subnet_ids
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.linear_connector[0].arn
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-linear-connector"
+  })
+}
+
+# ClickUp Connector Service
+resource "aws_ecs_service" "clickup_connector" {
+  count = contains(var.enabled_connectors, "clickup") ? 1 : 0
+
+  name            = "omni-${var.customer_name}-clickup-connector"
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.clickup_connector[0].arn
+  launch_type     = "FARGATE"
+  desired_count   = var.desired_count
+
+  enable_execute_command = true
+
+  network_configuration {
+    security_groups  = [var.security_group_id]
+    subnets          = var.subnet_ids
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.clickup_connector[0].arn
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-clickup-connector"
   })
 }

--- a/infra/aws/terraform/modules/compute/services.tf
+++ b/infra/aws/terraform/modules/compute/services.tf
@@ -452,3 +452,30 @@ resource "aws_ecs_service" "clickup_connector" {
     Name = "omni-${var.customer_name}-clickup-connector"
   })
 }
+
+# Filesystem Connector Service
+resource "aws_ecs_service" "filesystem_connector" {
+  count = contains(var.enabled_connectors, "filesystem") ? 1 : 0
+
+  name            = "omni-${var.customer_name}-filesystem-connector"
+  cluster         = var.cluster_arn
+  task_definition = aws_ecs_task_definition.filesystem_connector[0].arn
+  launch_type     = "FARGATE"
+  desired_count   = var.desired_count
+
+  enable_execute_command = true
+
+  network_configuration {
+    security_groups  = [var.security_group_id]
+    subnets          = var.subnet_ids
+    assign_public_ip = false
+  }
+
+  service_registries {
+    registry_arn = aws_service_discovery_service.filesystem_connector[0].arn
+  }
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-filesystem-connector"
+  })
+}

--- a/infra/aws/terraform/modules/compute/task_definitions.tf
+++ b/infra/aws/terraform/modules/compute/task_definitions.tf
@@ -370,8 +370,6 @@ resource "aws_ecs_task_definition" "google_connector" {
       { name = "PORT", value = "4001" },
       { name = "CONNECTOR_HOST_NAME", value = "google-connector" },
       { name = "AI_SERVICE_URL", value = "http://ai.omni-${var.customer_name}.local:3003" },
-      { name = "GOOGLE_WEBHOOK_URL", value = var.google_webhook_url },
-      { name = "GOOGLE_SYNC_INTERVAL_SECONDS", value = var.google_sync_interval_seconds },
       { name = "GOOGLE_MAX_AGE_DAYS", value = var.google_max_age_days },
       { name = "OMNI_DOMAIN", value = var.custom_domain },
       { name = "WEBHOOK_RENEWAL_CHECK_INTERVAL_SECONDS", value = var.webhook_renewal_check_interval_seconds }

--- a/infra/aws/terraform/modules/compute/task_definitions.tf
+++ b/infra/aws/terraform/modules/compute/task_definitions.tf
@@ -104,10 +104,6 @@ resource "aws_ecs_task_definition" "web" {
       { name = "INDEXER_URL", value = "http://indexer.omni-${var.customer_name}.local:3002" },
       { name = "AI_SERVICE_URL", value = "http://ai.omni-${var.customer_name}.local:3003" },
       { name = "CONNECTOR_MANAGER_URL", value = local.connector_manager_url },
-      { name = "GOOGLE_CONNECTOR_URL", value = "http://google-connector.omni-${var.customer_name}.local:4001" },
-      { name = "SLACK_CONNECTOR_URL", value = "http://slack-connector.omni-${var.customer_name}.local:4002" },
-      { name = "ATLASSIAN_CONNECTOR_URL", value = "http://atlassian-connector.omni-${var.customer_name}.local:4003" },
-      { name = "WEB_CONNECTOR_URL", value = "http://web-connector.omni-${var.customer_name}.local:4004" },
       { name = "SESSION_COOKIE_NAME", value = var.session_cookie_name },
       { name = "SESSION_DURATION_DAYS", value = var.session_duration_days },
       { name = "OMNI_DOMAIN", value = var.custom_domain },
@@ -256,6 +252,8 @@ resource "aws_ecs_task_definition" "ai" {
     environment = concat(local.common_environment, [
       { name = "PORT", value = "3003" },
       { name = "SEARCHER_URL", value = "http://searcher.omni-${var.customer_name}.local:3001" },
+      { name = "CONNECTOR_MANAGER_URL", value = local.connector_manager_url },
+      { name = "SANDBOX_URL", value = var.sandbox_url },
       { name = "MODEL_PATH", value = "/models" },
       { name = "EMBEDDING_MODEL", value = var.embedding_model },
       { name = "EMBEDDING_MAX_MODEL_LEN", value = var.embedding_max_model_len },
@@ -272,6 +270,8 @@ resource "aws_ecs_task_definition" "ai" {
       { name = "EMBEDDING_BATCH_ACCUMULATION_TIMEOUT_SECONDS", value = var.embedding_batch_accumulation_timeout_seconds },
       { name = "EMBEDDING_BATCH_ACCUMULATION_POLL_INTERVAL", value = var.embedding_batch_accumulation_poll_interval },
       { name = "EMBEDDING_BATCH_MONITOR_POLL_INTERVAL", value = var.embedding_batch_monitor_poll_interval },
+      { name = "AGENT_MAX_ITERATIONS", value = var.agent_max_iterations },
+      { name = "APPROVAL_TIMEOUT_SECONDS", value = var.approval_timeout_seconds },
       { name = "AGENTS_ENABLED", value = var.agents_enabled }
     ])
 
@@ -314,15 +314,6 @@ resource "aws_ecs_task_definition" "connector_manager" {
 
     environment = concat(local.common_environment, [
       { name = "PORT", value = "3004" },
-      { name = "GOOGLE_CONNECTOR_URL", value = "http://google-connector.omni-${var.customer_name}.local:4001" },
-      { name = "SLACK_CONNECTOR_URL", value = "http://slack-connector.omni-${var.customer_name}.local:4002" },
-      { name = "ATLASSIAN_CONNECTOR_URL", value = "http://atlassian-connector.omni-${var.customer_name}.local:4003" },
-      { name = "WEB_CONNECTOR_URL", value = "http://web-connector.omni-${var.customer_name}.local:4004" },
-      { name = "GITHUB_CONNECTOR_URL", value = "http://github-connector.omni-${var.customer_name}.local:4005" },
-      { name = "HUBSPOT_CONNECTOR_URL", value = "http://hubspot-connector.omni-${var.customer_name}.local:4006" },
-      { name = "MICROSOFT_CONNECTOR_URL", value = "http://microsoft-connector.omni-${var.customer_name}.local:4007" },
-      { name = "NOTION_CONNECTOR_URL", value = "http://notion-connector.omni-${var.customer_name}.local:4008" },
-      { name = "FIREFLIES_CONNECTOR_URL", value = "http://fireflies-connector.omni-${var.customer_name}.local:4009" },
       { name = "MAX_CONCURRENT_SYNCS", value = var.max_concurrent_syncs },
       { name = "MAX_CONCURRENT_SYNCS_PER_TYPE", value = var.max_concurrent_syncs_per_type },
       { name = "SCHEDULER_POLL_INTERVAL_SECONDS", value = var.scheduler_poll_interval_seconds },
@@ -346,6 +337,8 @@ resource "aws_ecs_task_definition" "connector_manager" {
 
 # Google Connector Task Definition
 resource "aws_ecs_task_definition" "google_connector" {
+  count = contains(var.enabled_connectors, "google") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-google-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -375,10 +368,12 @@ resource "aws_ecs_task_definition" "google_connector" {
 
     environment = concat(local.connector_base_environment, local.redis_environment, [
       { name = "PORT", value = "4001" },
+      { name = "CONNECTOR_HOST_NAME", value = "google-connector" },
       { name = "AI_SERVICE_URL", value = "http://ai.omni-${var.customer_name}.local:3003" },
       { name = "GOOGLE_WEBHOOK_URL", value = var.google_webhook_url },
       { name = "GOOGLE_SYNC_INTERVAL_SECONDS", value = var.google_sync_interval_seconds },
       { name = "GOOGLE_MAX_AGE_DAYS", value = var.google_max_age_days },
+      { name = "OMNI_DOMAIN", value = var.custom_domain },
       { name = "WEBHOOK_RENEWAL_CHECK_INTERVAL_SECONDS", value = var.webhook_renewal_check_interval_seconds }
     ])
 
@@ -395,6 +390,8 @@ resource "aws_ecs_task_definition" "google_connector" {
 
 # Atlassian Connector Task Definition
 resource "aws_ecs_task_definition" "atlassian_connector" {
+  count = contains(var.enabled_connectors, "atlassian") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-atlassian-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -423,7 +420,8 @@ resource "aws_ecs_task_definition" "atlassian_connector" {
     }
 
     environment = concat(local.connector_base_environment, local.redis_environment, [
-      { name = "PORT", value = "4003" }
+      { name = "PORT", value = "4003" },
+      { name = "CONNECTOR_HOST_NAME", value = "atlassian-connector" }
     ])
 
     secrets = []
@@ -436,6 +434,8 @@ resource "aws_ecs_task_definition" "atlassian_connector" {
 
 # Web Connector Task Definition
 resource "aws_ecs_task_definition" "web_connector" {
+  count = contains(var.enabled_connectors, "web") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-web-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -464,7 +464,8 @@ resource "aws_ecs_task_definition" "web_connector" {
     }
 
     environment = concat(local.connector_base_environment, local.redis_environment, [
-      { name = "PORT", value = "4004" }
+      { name = "PORT", value = "4004" },
+      { name = "CONNECTOR_HOST_NAME", value = "web-connector" }
     ])
 
     secrets = []
@@ -477,6 +478,8 @@ resource "aws_ecs_task_definition" "web_connector" {
 
 # Slack Connector Task Definition
 resource "aws_ecs_task_definition" "slack_connector" {
+  count = contains(var.enabled_connectors, "slack") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-slack-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -505,7 +508,8 @@ resource "aws_ecs_task_definition" "slack_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4002" }
+      { name = "PORT", value = "4002" },
+      { name = "CONNECTOR_HOST_NAME", value = "slack-connector" }
     ])
 
     secrets = []
@@ -518,6 +522,8 @@ resource "aws_ecs_task_definition" "slack_connector" {
 
 # GitHub Connector Task Definition
 resource "aws_ecs_task_definition" "github_connector" {
+  count = contains(var.enabled_connectors, "github") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-github-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -546,7 +552,8 @@ resource "aws_ecs_task_definition" "github_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4005" }
+      { name = "PORT", value = "4005" },
+      { name = "CONNECTOR_HOST_NAME", value = "github-connector" }
     ])
 
     secrets = []
@@ -559,6 +566,8 @@ resource "aws_ecs_task_definition" "github_connector" {
 
 # HubSpot Connector Task Definition
 resource "aws_ecs_task_definition" "hubspot_connector" {
+  count = contains(var.enabled_connectors, "hubspot") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-hubspot-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -587,7 +596,8 @@ resource "aws_ecs_task_definition" "hubspot_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4006" }
+      { name = "PORT", value = "4006" },
+      { name = "CONNECTOR_HOST_NAME", value = "hubspot-connector" }
     ])
 
     secrets = []
@@ -600,6 +610,8 @@ resource "aws_ecs_task_definition" "hubspot_connector" {
 
 # Microsoft Connector Task Definition
 resource "aws_ecs_task_definition" "microsoft_connector" {
+  count = contains(var.enabled_connectors, "microsoft") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-microsoft-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -628,7 +640,8 @@ resource "aws_ecs_task_definition" "microsoft_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4007" }
+      { name = "PORT", value = "4007" },
+      { name = "CONNECTOR_HOST_NAME", value = "microsoft-connector" }
     ])
 
     secrets = []
@@ -641,6 +654,8 @@ resource "aws_ecs_task_definition" "microsoft_connector" {
 
 # Notion Connector Task Definition
 resource "aws_ecs_task_definition" "notion_connector" {
+  count = contains(var.enabled_connectors, "notion") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-notion-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -669,7 +684,8 @@ resource "aws_ecs_task_definition" "notion_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4008" }
+      { name = "PORT", value = "4008" },
+      { name = "CONNECTOR_HOST_NAME", value = "notion-connector" }
     ])
 
     secrets = []
@@ -682,6 +698,8 @@ resource "aws_ecs_task_definition" "notion_connector" {
 
 # Fireflies Connector Task Definition
 resource "aws_ecs_task_definition" "fireflies_connector" {
+  count = contains(var.enabled_connectors, "fireflies") ? 1 : 0
+
   family                   = "omni-${var.customer_name}-fireflies-connector"
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
@@ -710,7 +728,8 @@ resource "aws_ecs_task_definition" "fireflies_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4009" }
+      { name = "PORT", value = "4009" },
+      { name = "CONNECTOR_HOST_NAME", value = "fireflies-connector" }
     ])
 
     secrets = []
@@ -718,5 +737,137 @@ resource "aws_ecs_task_definition" "fireflies_connector" {
 
   tags = merge(local.common_tags, {
     Name = "omni-${var.customer_name}-fireflies-connector"
+  })
+}
+
+# IMAP Connector Task Definition
+resource "aws_ecs_task_definition" "imap_connector" {
+  count = contains(var.enabled_connectors, "imap") ? 1 : 0
+
+  family                   = "omni-${var.customer_name}-imap-connector"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "omni-imap-connector"
+    image     = "ghcr.io/${var.github_org}/omni/omni-imap-connector:latest"
+    essential = true
+
+    portMappings = [{
+      containerPort = 4010
+      protocol      = "tcp"
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = var.log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "imap-connector"
+      }
+    }
+
+    environment = concat(local.connector_base_environment, [
+      { name = "PORT", value = "4010" },
+      { name = "CONNECTOR_HOST_NAME", value = "imap-connector" }
+    ])
+
+    secrets = []
+  }])
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-imap-connector"
+  })
+}
+
+# Linear Connector Task Definition
+resource "aws_ecs_task_definition" "linear_connector" {
+  count = contains(var.enabled_connectors, "linear") ? 1 : 0
+
+  family                   = "omni-${var.customer_name}-linear-connector"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "omni-linear-connector"
+    image     = "ghcr.io/${var.github_org}/omni/omni-linear-connector:latest"
+    essential = true
+
+    portMappings = [{
+      containerPort = 4011
+      protocol      = "tcp"
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = var.log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "linear-connector"
+      }
+    }
+
+    environment = concat(local.connector_base_environment, [
+      { name = "PORT", value = "4011" },
+      { name = "CONNECTOR_HOST_NAME", value = "linear-connector" }
+    ])
+
+    secrets = []
+  }])
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-linear-connector"
+  })
+}
+
+# ClickUp Connector Task Definition
+resource "aws_ecs_task_definition" "clickup_connector" {
+  count = contains(var.enabled_connectors, "clickup") ? 1 : 0
+
+  family                   = "omni-${var.customer_name}-clickup-connector"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "omni-clickup-connector"
+    image     = "ghcr.io/${var.github_org}/omni/omni-clickup-connector:latest"
+    essential = true
+
+    portMappings = [{
+      containerPort = 4012
+      protocol      = "tcp"
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = var.log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "clickup-connector"
+      }
+    }
+
+    environment = concat(local.connector_base_environment, [
+      { name = "PORT", value = "4012" },
+      { name = "CONNECTOR_HOST_NAME", value = "clickup-connector" }
+    ])
+
+    secrets = []
+  }])
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-clickup-connector"
   })
 }

--- a/infra/aws/terraform/modules/compute/task_definitions.tf
+++ b/infra/aws/terraform/modules/compute/task_definitions.tf
@@ -802,7 +802,7 @@ resource "aws_ecs_task_definition" "linear_connector" {
     essential = true
 
     portMappings = [{
-      containerPort = 4011
+      containerPort = 4012
       protocol      = "tcp"
     }]
 
@@ -816,7 +816,7 @@ resource "aws_ecs_task_definition" "linear_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4011" },
+      { name = "PORT", value = "4012" },
       { name = "CONNECTOR_HOST_NAME", value = "linear-connector" }
     ])
 
@@ -846,7 +846,7 @@ resource "aws_ecs_task_definition" "clickup_connector" {
     essential = true
 
     portMappings = [{
-      containerPort = 4012
+      containerPort = 4011
       protocol      = "tcp"
     }]
 
@@ -860,7 +860,7 @@ resource "aws_ecs_task_definition" "clickup_connector" {
     }
 
     environment = concat(local.connector_base_environment, [
-      { name = "PORT", value = "4012" },
+      { name = "PORT", value = "4011" },
       { name = "CONNECTOR_HOST_NAME", value = "clickup-connector" }
     ])
 
@@ -869,5 +869,49 @@ resource "aws_ecs_task_definition" "clickup_connector" {
 
   tags = merge(local.common_tags, {
     Name = "omni-${var.customer_name}-clickup-connector"
+  })
+}
+
+# Filesystem Connector Task Definition
+resource "aws_ecs_task_definition" "filesystem_connector" {
+  count = contains(var.enabled_connectors, "filesystem") ? 1 : 0
+
+  family                   = "omni-${var.customer_name}-filesystem-connector"
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  cpu                      = var.task_cpu
+  memory                   = var.task_memory
+  execution_role_arn       = aws_iam_role.ecs_task_execution.arn
+  task_role_arn            = aws_iam_role.ecs_task.arn
+
+  container_definitions = jsonencode([{
+    name      = "omni-filesystem-connector"
+    image     = "ghcr.io/${var.github_org}/omni/omni-filesystem-connector:latest"
+    essential = true
+
+    portMappings = [{
+      containerPort = 4013
+      protocol      = "tcp"
+    }]
+
+    logConfiguration = {
+      logDriver = "awslogs"
+      options = {
+        "awslogs-group"         = var.log_group_name
+        "awslogs-region"        = var.region
+        "awslogs-stream-prefix" = "filesystem-connector"
+      }
+    }
+
+    environment = concat(local.connector_base_environment, [
+      { name = "PORT", value = "4013" },
+      { name = "CONNECTOR_HOST_NAME", value = "filesystem-connector" }
+    ])
+
+    secrets = []
+  }])
+
+  tags = merge(local.common_tags, {
+    Name = "omni-${var.customer_name}-filesystem-connector"
   })
 }

--- a/infra/aws/terraform/modules/compute/variables.tf
+++ b/infra/aws/terraform/modules/compute/variables.tf
@@ -259,18 +259,6 @@ variable "stale_sync_timeout_minutes" {
 }
 
 # Google Connector Configuration
-variable "google_webhook_url" {
-  description = "Google webhook URL for push notifications"
-  type        = string
-  default     = ""
-}
-
-variable "google_sync_interval_seconds" {
-  description = "Google connector sync interval in seconds"
-  type        = string
-  default     = ""
-}
-
 variable "google_max_age_days" {
   description = "Maximum age in days for Google documents"
   type        = string

--- a/infra/aws/terraform/modules/compute/variables.tf
+++ b/infra/aws/terraform/modules/compute/variables.tf
@@ -325,3 +325,27 @@ variable "agents_enabled" {
   type        = string
   default     = "false"
 }
+
+variable "enabled_connectors" {
+  description = "List of connectors to deploy"
+  type        = list(string)
+  default     = ["web"]
+}
+
+variable "sandbox_url" {
+  description = "URL of the sandbox service for code execution"
+  type        = string
+  default     = ""
+}
+
+variable "agent_max_iterations" {
+  description = "Maximum iterations for AI agent loops"
+  type        = string
+  default     = "15"
+}
+
+variable "approval_timeout_seconds" {
+  description = "Timeout in seconds for agent approval requests"
+  type        = string
+  default     = "600"
+}

--- a/infra/aws/terraform/terraform.tfvars.example
+++ b/infra/aws/terraform/terraform.tfvars.example
@@ -48,8 +48,6 @@ log_retention_days = 30
 # stale_sync_timeout_minutes      = "10"
 
 # Optional: Google Connector Configuration
-# google_webhook_url                     = ""
-# google_sync_interval_seconds           = ""
 # google_max_age_days                    = "730"
 # webhook_renewal_check_interval_seconds = "3600"
 

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -215,18 +215,6 @@ variable "stale_sync_timeout_minutes" {
 }
 
 # Google Connector Configuration
-variable "google_webhook_url" {
-  description = "Google webhook URL for push notifications"
-  type        = string
-  default     = ""
-}
-
-variable "google_sync_interval_seconds" {
-  description = "Google connector sync interval in seconds"
-  type        = string
-  default     = ""
-}
-
 variable "google_max_age_days" {
   description = "Maximum age in days for Google documents"
   type        = string

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -288,3 +288,27 @@ variable "vpc_cidr" {
   type        = string
   default     = "10.0.0.0/16"
 }
+
+variable "enabled_connectors" {
+  description = "List of connectors to deploy (e.g. [\"google\", \"slack\", \"web\"])"
+  type        = list(string)
+  default     = ["web"]
+}
+
+variable "sandbox_url" {
+  description = "URL of the sandbox service for code execution (leave empty to disable)"
+  type        = string
+  default     = ""
+}
+
+variable "agent_max_iterations" {
+  description = "Maximum iterations for AI agent loops"
+  type        = string
+  default     = "15"
+}
+
+variable "approval_timeout_seconds" {
+  description = "Timeout in seconds for agent approval requests"
+  type        = string
+  default     = "600"
+}

--- a/infra/gcp/terraform/main.tf
+++ b/infra/gcp/terraform/main.tf
@@ -149,8 +149,6 @@ module "compute" {
   stale_sync_timeout_minutes      = var.stale_sync_timeout_minutes
 
   # Google connector configuration
-  google_webhook_url                     = var.google_webhook_url
-  google_sync_interval_seconds           = var.google_sync_interval_seconds
   google_max_age_days                    = var.google_max_age_days
   webhook_renewal_check_interval_seconds = var.webhook_renewal_check_interval_seconds
 

--- a/infra/gcp/terraform/main.tf
+++ b/infra/gcp/terraform/main.tf
@@ -162,6 +162,12 @@ module "compute" {
   session_duration_days      = var.session_duration_days
   ai_answer_enabled          = var.ai_answer_enabled
   agents_enabled             = var.agents_enabled
+  enabled_connectors         = var.enabled_connectors
+  sandbox_url                = var.sandbox_url
+  agent_max_iterations       = var.agent_max_iterations
+  approval_timeout_seconds   = var.approval_timeout_seconds
+  otel_endpoint              = var.otel_endpoint
+  service_version            = var.service_version
 
   content_bucket_name = module.storage.content_bucket_name
   batch_bucket_name   = module.storage.batch_bucket_name

--- a/infra/gcp/terraform/modules/compute/outputs.tf
+++ b/infra/gcp/terraform/modules/compute/outputs.tf
@@ -32,11 +32,9 @@ output "connector_service_uris" {
   description = "Map of connector name to Cloud Run URI"
   value = merge(
     { for k, _ in local.simple_connectors : k => local.service_url["${k}-conn"] },
-    {
-      google    = local.service_url["google-conn"]
-      atlassian = local.service_url["atlassian-conn"]
-      web       = local.service_url["web-conn"]
-    }
+    contains(var.enabled_connectors, "google") ? { google = local.service_url["google-conn"] } : {},
+    contains(var.enabled_connectors, "atlassian") ? { atlassian = local.service_url["atlassian-conn"] } : {},
+    contains(var.enabled_connectors, "web") ? { web = local.service_url["web-conn"] } : {},
   )
 }
 

--- a/infra/gcp/terraform/modules/compute/services.tf
+++ b/infra/gcp/terraform/modules/compute/services.tf
@@ -38,6 +38,7 @@ locals {
   common_env = merge(local.db_env, local.redis_env)
 
   otel_env = {
+    RUST_LOG                    = var.rust_log
     OTEL_EXPORTER_OTLP_ENDPOINT = var.otel_endpoint
     OTEL_DEPLOYMENT_ID          = var.customer_name
     OTEL_DEPLOYMENT_ENVIRONMENT = "production"
@@ -184,7 +185,6 @@ resource "google_cloud_run_v2_service" "searcher" {
           AI_SERVICE_URL             = local.service_url["ai"]
           SEMANTIC_SEARCH_TIMEOUT_MS = var.semantic_search_timeout_ms
           RAG_CONTEXT_WINDOW         = var.rag_context_window
-          RUST_LOG                   = var.rust_log
         })
         content {
           name  = env.key
@@ -256,7 +256,6 @@ resource "google_cloud_run_v2_service" "indexer" {
         for_each = merge(local.common_env, local.storage_env, local.otel_env, {
           PORT           = "3002"
           AI_SERVICE_URL = local.service_url["ai"]
-          RUST_LOG       = var.rust_log
         })
         content {
           name  = env.key
@@ -440,7 +439,6 @@ resource "google_cloud_run_v2_service" "connector_manager" {
           MAX_CONCURRENT_SYNCS_PER_TYPE   = var.max_concurrent_syncs_per_type
           SCHEDULER_POLL_INTERVAL_SECONDS = var.scheduler_poll_interval_seconds
           STALE_SYNC_TIMEOUT_MINUTES      = var.stale_sync_timeout_minutes
-          RUST_LOG                        = var.rust_log
         })
         content {
           name  = env.key
@@ -535,10 +533,7 @@ resource "google_cloud_run_v2_service" "google_connector" {
           PORT                                   = "4001"
           CONNECTOR_HOST_NAME                    = "google-connector"
           CONNECTOR_MANAGER_URL                  = local.service_url["connector-mgr"]
-          RUST_LOG                               = var.rust_log
           AI_SERVICE_URL                         = local.service_url["ai"]
-          GOOGLE_WEBHOOK_URL                     = var.google_webhook_url
-          GOOGLE_SYNC_INTERVAL_SECONDS           = var.google_sync_interval_seconds
           GOOGLE_MAX_AGE_DAYS                    = var.google_max_age_days
           OMNI_DOMAIN                            = var.custom_domain
           WEBHOOK_RENEWAL_CHECK_INTERVAL_SECONDS = var.webhook_renewal_check_interval_seconds
@@ -628,7 +623,6 @@ resource "google_cloud_run_v2_service" "atlassian_connector" {
           PORT                  = "4003"
           CONNECTOR_HOST_NAME   = "atlassian-connector"
           CONNECTOR_MANAGER_URL = local.service_url["connector-mgr"]
-          RUST_LOG              = var.rust_log
         })
         content {
           name  = env.key
@@ -691,7 +685,6 @@ resource "google_cloud_run_v2_service" "web_connector" {
           PORT                  = "4004"
           CONNECTOR_HOST_NAME   = "web-connector"
           CONNECTOR_MANAGER_URL = local.service_url["connector-mgr"]
-          RUST_LOG              = var.rust_log
         })
         content {
           name  = env.key
@@ -754,7 +747,6 @@ resource "google_cloud_run_v2_service" "connectors" {
           PORT                  = tostring(each.value.port)
           CONNECTOR_HOST_NAME   = "${each.key}-connector"
           CONNECTOR_MANAGER_URL = local.service_url["connector-mgr"]
-          RUST_LOG              = var.rust_log
         })
         content {
           name  = env.key

--- a/infra/gcp/terraform/modules/compute/services.tf
+++ b/infra/gcp/terraform/modules/compute/services.tf
@@ -9,6 +9,7 @@ locals {
     "web", "searcher", "indexer", "ai", "connector-mgr",
     "google-conn", "slack-conn", "atlassian-conn", "web-conn",
     "github-conn", "hubspot-conn", "microsoft-conn", "notion-conn", "fireflies-conn",
+    "imap-conn", "linear-conn", "clickup-conn",
   ] : name => "https://omni-${var.customer_name}-${name}-${local.project_number}.${var.region}.run.app" }
 
   db_env = {
@@ -36,15 +37,27 @@ locals {
 
   common_env = merge(local.db_env, local.redis_env)
 
+  otel_env = {
+    OTEL_EXPORTER_OTLP_ENDPOINT = var.otel_endpoint
+    OTEL_DEPLOYMENT_ID          = var.customer_name
+    OTEL_DEPLOYMENT_ENVIRONMENT = "production"
+    SERVICE_VERSION             = var.service_version
+  }
+
   # Connectors with only basic env vars (CONNECTOR_MANAGER_URL, PORT, RUST_LOG)
-  simple_connectors = {
+  all_simple_connectors = {
     slack     = { port = 4002, image = "omni-slack-connector" }
     github    = { port = 4005, image = "omni-github-connector" }
     hubspot   = { port = 4006, image = "omni-hubspot-connector" }
     microsoft = { port = 4007, image = "omni-microsoft-connector" }
     notion    = { port = 4008, image = "omni-notion-connector" }
     fireflies = { port = 4009, image = "omni-fireflies-connector" }
+    imap      = { port = 4010, image = "omni-imap-connector" }
+    linear    = { port = 4011, image = "omni-linear-connector" }
+    clickup   = { port = 4012, image = "omni-clickup-connector" }
   }
+
+  simple_connectors = { for k, v in local.all_simple_connectors : k => v if contains(var.enabled_connectors, k) }
 }
 
 # ============================================================================
@@ -84,22 +97,18 @@ resource "google_cloud_run_v2_service" "web" {
       }
 
       dynamic "env" {
-        for_each = merge(local.common_env, {
-          SEARCHER_URL            = local.service_url["searcher"]
-          INDEXER_URL             = local.service_url["indexer"]
-          AI_SERVICE_URL          = local.service_url["ai"]
-          CONNECTOR_MANAGER_URL   = local.service_url["connector-mgr"]
-          GOOGLE_CONNECTOR_URL    = local.service_url["google-conn"]
-          SLACK_CONNECTOR_URL     = local.service_url["slack-conn"]
-          ATLASSIAN_CONNECTOR_URL = local.service_url["atlassian-conn"]
-          WEB_CONNECTOR_URL       = local.service_url["web-conn"]
-          SESSION_COOKIE_NAME     = var.session_cookie_name
-          SESSION_DURATION_DAYS   = var.session_duration_days
-          OMNI_DOMAIN             = var.custom_domain
-          ORIGIN                  = local.app_url
-          APP_URL                 = local.app_url
-          AI_ANSWER_ENABLED       = var.ai_answer_enabled
-          AGENTS_ENABLED          = var.agents_enabled
+        for_each = merge(local.common_env, local.otel_env, {
+          SEARCHER_URL          = local.service_url["searcher"]
+          INDEXER_URL           = local.service_url["indexer"]
+          AI_SERVICE_URL        = local.service_url["ai"]
+          CONNECTOR_MANAGER_URL = local.service_url["connector-mgr"]
+          SESSION_COOKIE_NAME   = var.session_cookie_name
+          SESSION_DURATION_DAYS = var.session_duration_days
+          OMNI_DOMAIN           = var.custom_domain
+          ORIGIN                = local.app_url
+          APP_URL               = local.app_url
+          AI_ANSWER_ENABLED     = var.ai_answer_enabled
+          AGENTS_ENABLED        = var.agents_enabled
         })
         content {
           name  = env.key
@@ -117,7 +126,7 @@ resource "google_cloud_run_v2_service" "web" {
         }
       }
 
-}
+    }
   }
 
   depends_on = [
@@ -169,7 +178,7 @@ resource "google_cloud_run_v2_service" "searcher" {
       }
 
       dynamic "env" {
-        for_each = merge(local.common_env, local.storage_env, {
+        for_each = merge(local.common_env, local.storage_env, local.otel_env, {
           PORT                       = "3001"
           AI_SERVICE_URL             = local.service_url["ai"]
           SEMANTIC_SEARCH_TIMEOUT_MS = var.semantic_search_timeout_ms
@@ -243,7 +252,7 @@ resource "google_cloud_run_v2_service" "indexer" {
       }
 
       dynamic "env" {
-        for_each = merge(local.common_env, local.storage_env, {
+        for_each = merge(local.common_env, local.storage_env, local.otel_env, {
           PORT           = "3002"
           AI_SERVICE_URL = local.service_url["ai"]
           RUST_LOG       = var.rust_log
@@ -336,20 +345,24 @@ resource "google_cloud_run_v2_service" "ai" {
       }
 
       dynamic "env" {
-        for_each = merge(local.common_env, local.storage_env, {
-          PORT                             = "3003"
-          SEARCHER_URL                     = local.service_url["searcher"]
-          MODEL_PATH                       = "/models"
-          EMBEDDING_MODEL                                 = var.embedding_model
-          AI_WORKERS                                      = var.ai_workers
-          EMBEDDING_MAX_MODEL_LEN                         = var.embedding_max_model_len
-          EMBEDDING_BATCH_S3_BUCKET                       = var.batch_bucket_name
-          EMBEDDING_BATCH_MIN_DOCUMENTS                   = var.embedding_batch_min_documents
-          EMBEDDING_BATCH_MAX_DOCUMENTS                   = var.embedding_batch_max_documents
-          EMBEDDING_BATCH_ACCUMULATION_TIMEOUT_SECONDS    = var.embedding_batch_accumulation_timeout_seconds
-          EMBEDDING_BATCH_ACCUMULATION_POLL_INTERVAL      = var.embedding_batch_accumulation_poll_interval
-          EMBEDDING_BATCH_MONITOR_POLL_INTERVAL           = var.embedding_batch_monitor_poll_interval
-          AGENTS_ENABLED                                  = var.agents_enabled
+        for_each = merge(local.common_env, local.storage_env, local.otel_env, {
+          PORT                                         = "3003"
+          SEARCHER_URL                                 = local.service_url["searcher"]
+          CONNECTOR_MANAGER_URL                        = local.service_url["connector-mgr"]
+          SANDBOX_URL                                  = var.sandbox_url
+          MODEL_PATH                                   = "/models"
+          EMBEDDING_MODEL                              = var.embedding_model
+          AI_WORKERS                                   = var.ai_workers
+          EMBEDDING_MAX_MODEL_LEN                      = var.embedding_max_model_len
+          EMBEDDING_BATCH_S3_BUCKET                    = var.batch_bucket_name
+          EMBEDDING_BATCH_MIN_DOCUMENTS                = var.embedding_batch_min_documents
+          EMBEDDING_BATCH_MAX_DOCUMENTS                = var.embedding_batch_max_documents
+          EMBEDDING_BATCH_ACCUMULATION_TIMEOUT_SECONDS = var.embedding_batch_accumulation_timeout_seconds
+          EMBEDDING_BATCH_ACCUMULATION_POLL_INTERVAL   = var.embedding_batch_accumulation_poll_interval
+          EMBEDDING_BATCH_MONITOR_POLL_INTERVAL        = var.embedding_batch_monitor_poll_interval
+          AGENT_MAX_ITERATIONS                         = var.agent_max_iterations
+          APPROVAL_TIMEOUT_SECONDS                     = var.approval_timeout_seconds
+          AGENTS_ENABLED                               = var.agents_enabled
         })
         content {
           name  = env.key
@@ -420,17 +433,8 @@ resource "google_cloud_run_v2_service" "connector_manager" {
       }
 
       dynamic "env" {
-        for_each = merge(local.common_env, local.storage_env, {
+        for_each = merge(local.common_env, local.storage_env, local.otel_env, {
           PORT                            = "3004"
-          GOOGLE_CONNECTOR_URL            = local.service_url["google-conn"]
-          SLACK_CONNECTOR_URL             = local.service_url["slack-conn"]
-          ATLASSIAN_CONNECTOR_URL         = local.service_url["atlassian-conn"]
-          WEB_CONNECTOR_URL               = local.service_url["web-conn"]
-          GITHUB_CONNECTOR_URL            = local.service_url["github-conn"]
-          HUBSPOT_CONNECTOR_URL           = local.service_url["hubspot-conn"]
-          MICROSOFT_CONNECTOR_URL         = local.service_url["microsoft-conn"]
-          NOTION_CONNECTOR_URL            = local.service_url["notion-conn"]
-          FIREFLIES_CONNECTOR_URL         = local.service_url["fireflies-conn"]
           MAX_CONCURRENT_SYNCS            = var.max_concurrent_syncs
           MAX_CONCURRENT_SYNCS_PER_TYPE   = var.max_concurrent_syncs_per_type
           SCHEDULER_POLL_INTERVAL_SECONDS = var.scheduler_poll_interval_seconds
@@ -492,6 +496,8 @@ resource "google_cloud_run_v2_service_iam_member" "connector_manager_invoker" {
 # ============================================================================
 
 resource "google_cloud_run_v2_service" "google_connector" {
+  count = contains(var.enabled_connectors, "google") ? 1 : 0
+
   name     = "omni-${var.customer_name}-google-conn"
   location = var.region
   ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
@@ -524,14 +530,16 @@ resource "google_cloud_run_v2_service" "google_connector" {
       }
 
       dynamic "env" {
-        for_each = merge(local.redis_env, {
+        for_each = merge(local.redis_env, local.otel_env, {
           PORT                                   = "4001"
+          CONNECTOR_HOST_NAME                    = "google-connector"
           CONNECTOR_MANAGER_URL                  = local.service_url["connector-mgr"]
           RUST_LOG                               = var.rust_log
           AI_SERVICE_URL                         = local.service_url["ai"]
           GOOGLE_WEBHOOK_URL                     = var.google_webhook_url
           GOOGLE_SYNC_INTERVAL_SECONDS           = var.google_sync_interval_seconds
           GOOGLE_MAX_AGE_DAYS                    = var.google_max_age_days
+          OMNI_DOMAIN                            = var.custom_domain
           WEBHOOK_RENEWAL_CHECK_INTERVAL_SECONDS = var.webhook_renewal_check_interval_seconds
         })
         content {
@@ -568,7 +576,9 @@ resource "google_cloud_run_v2_service" "google_connector" {
 }
 
 resource "google_cloud_run_v2_service_iam_member" "google_connector_invoker" {
-  name     = google_cloud_run_v2_service.google_connector.name
+  count = contains(var.enabled_connectors, "google") ? 1 : 0
+
+  name     = google_cloud_run_v2_service.google_connector[0].name
   location = var.region
   role     = "roles/run.invoker"
   member   = "serviceAccount:${var.cloud_run_sa_email}"
@@ -579,6 +589,8 @@ resource "google_cloud_run_v2_service_iam_member" "google_connector_invoker" {
 # ============================================================================
 
 resource "google_cloud_run_v2_service" "atlassian_connector" {
+  count = contains(var.enabled_connectors, "atlassian") ? 1 : 0
+
   name     = "omni-${var.customer_name}-atlassian-conn"
   location = var.region
   ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
@@ -611,8 +623,9 @@ resource "google_cloud_run_v2_service" "atlassian_connector" {
       }
 
       dynamic "env" {
-        for_each = merge(local.redis_env, {
+        for_each = merge(local.redis_env, local.otel_env, {
           PORT                  = "4003"
+          CONNECTOR_HOST_NAME   = "atlassian-connector"
           CONNECTOR_MANAGER_URL = local.service_url["connector-mgr"]
           RUST_LOG              = var.rust_log
         })
@@ -626,7 +639,9 @@ resource "google_cloud_run_v2_service" "atlassian_connector" {
 }
 
 resource "google_cloud_run_v2_service_iam_member" "atlassian_connector_invoker" {
-  name     = google_cloud_run_v2_service.atlassian_connector.name
+  count = contains(var.enabled_connectors, "atlassian") ? 1 : 0
+
+  name     = google_cloud_run_v2_service.atlassian_connector[0].name
   location = var.region
   role     = "roles/run.invoker"
   member   = "serviceAccount:${var.cloud_run_sa_email}"
@@ -637,6 +652,8 @@ resource "google_cloud_run_v2_service_iam_member" "atlassian_connector_invoker" 
 # ============================================================================
 
 resource "google_cloud_run_v2_service" "web_connector" {
+  count = contains(var.enabled_connectors, "web") ? 1 : 0
+
   name     = "omni-${var.customer_name}-web-conn"
   location = var.region
   ingress  = "INGRESS_TRAFFIC_INTERNAL_ONLY"
@@ -669,8 +686,9 @@ resource "google_cloud_run_v2_service" "web_connector" {
       }
 
       dynamic "env" {
-        for_each = merge(local.redis_env, {
+        for_each = merge(local.redis_env, local.otel_env, {
           PORT                  = "4004"
+          CONNECTOR_HOST_NAME   = "web-connector"
           CONNECTOR_MANAGER_URL = local.service_url["connector-mgr"]
           RUST_LOG              = var.rust_log
         })
@@ -684,7 +702,9 @@ resource "google_cloud_run_v2_service" "web_connector" {
 }
 
 resource "google_cloud_run_v2_service_iam_member" "web_connector_invoker" {
-  name     = google_cloud_run_v2_service.web_connector.name
+  count = contains(var.enabled_connectors, "web") ? 1 : 0
+
+  name     = google_cloud_run_v2_service.web_connector[0].name
   location = var.region
   role     = "roles/run.invoker"
   member   = "serviceAccount:${var.cloud_run_sa_email}"
@@ -729,11 +749,12 @@ resource "google_cloud_run_v2_service" "connectors" {
       }
 
       dynamic "env" {
-        for_each = {
+        for_each = merge(local.otel_env, {
           PORT                  = tostring(each.value.port)
+          CONNECTOR_HOST_NAME   = "${each.key}-connector"
           CONNECTOR_MANAGER_URL = local.service_url["connector-mgr"]
           RUST_LOG              = var.rust_log
-        }
+        })
         content {
           name  = env.key
           value = env.value

--- a/infra/gcp/terraform/modules/compute/services.tf
+++ b/infra/gcp/terraform/modules/compute/services.tf
@@ -9,7 +9,7 @@ locals {
     "web", "searcher", "indexer", "ai", "connector-mgr",
     "google-conn", "slack-conn", "atlassian-conn", "web-conn",
     "github-conn", "hubspot-conn", "microsoft-conn", "notion-conn", "fireflies-conn",
-    "imap-conn", "linear-conn", "clickup-conn",
+    "imap-conn", "clickup-conn", "linear-conn", "filesystem-conn",
   ] : name => "https://omni-${var.customer_name}-${name}-${local.project_number}.${var.region}.run.app" }
 
   db_env = {
@@ -46,15 +46,16 @@ locals {
 
   # Connectors with only basic env vars (CONNECTOR_MANAGER_URL, PORT, RUST_LOG)
   all_simple_connectors = {
-    slack     = { port = 4002, image = "omni-slack-connector" }
-    github    = { port = 4005, image = "omni-github-connector" }
-    hubspot   = { port = 4006, image = "omni-hubspot-connector" }
-    microsoft = { port = 4007, image = "omni-microsoft-connector" }
-    notion    = { port = 4008, image = "omni-notion-connector" }
-    fireflies = { port = 4009, image = "omni-fireflies-connector" }
-    imap      = { port = 4010, image = "omni-imap-connector" }
-    linear    = { port = 4011, image = "omni-linear-connector" }
-    clickup   = { port = 4012, image = "omni-clickup-connector" }
+    slack      = { port = 4002, image = "omni-slack-connector" }
+    github     = { port = 4005, image = "omni-github-connector" }
+    hubspot    = { port = 4006, image = "omni-hubspot-connector" }
+    microsoft  = { port = 4007, image = "omni-microsoft-connector" }
+    notion     = { port = 4008, image = "omni-notion-connector" }
+    fireflies  = { port = 4009, image = "omni-fireflies-connector" }
+    imap       = { port = 4010, image = "omni-imap-connector" }
+    clickup    = { port = 4011, image = "omni-clickup-connector" }
+    linear     = { port = 4012, image = "omni-linear-connector" }
+    filesystem = { port = 4013, image = "omni-filesystem-connector" }
   }
 
   simple_connectors = { for k, v in local.all_simple_connectors : k => v if contains(var.enabled_connectors, k) }

--- a/infra/gcp/terraform/modules/compute/variables.tf
+++ b/infra/gcp/terraform/modules/compute/variables.tf
@@ -223,18 +223,6 @@ variable "stale_sync_timeout_minutes" {
 }
 
 # Google Connector Configuration
-variable "google_webhook_url" {
-  description = "Google webhook URL for push notifications"
-  type        = string
-  default     = ""
-}
-
-variable "google_sync_interval_seconds" {
-  description = "Google connector sync interval in seconds"
-  type        = string
-  default     = ""
-}
-
 variable "google_max_age_days" {
   description = "Maximum age in days for Google documents"
   type        = string

--- a/infra/gcp/terraform/modules/compute/variables.tf
+++ b/infra/gcp/terraform/modules/compute/variables.tf
@@ -289,3 +289,39 @@ variable "agents_enabled" {
   type        = string
   default     = "false"
 }
+
+variable "enabled_connectors" {
+  description = "List of connectors to deploy"
+  type        = list(string)
+  default     = ["web"]
+}
+
+variable "sandbox_url" {
+  description = "URL of the sandbox service for code execution"
+  type        = string
+  default     = ""
+}
+
+variable "agent_max_iterations" {
+  description = "Maximum iterations for AI agent loops"
+  type        = string
+  default     = "15"
+}
+
+variable "approval_timeout_seconds" {
+  description = "Timeout in seconds for agent approval requests"
+  type        = string
+  default     = "600"
+}
+
+variable "otel_endpoint" {
+  description = "OpenTelemetry collector endpoint (leave empty to disable)"
+  type        = string
+  default     = ""
+}
+
+variable "service_version" {
+  description = "Service version for OpenTelemetry"
+  type        = string
+  default     = "0.1.0"
+}

--- a/infra/gcp/terraform/terraform.tfvars.example
+++ b/infra/gcp/terraform/terraform.tfvars.example
@@ -35,8 +35,6 @@ custom_domain  = "omni.acme-corp.com"
 # stale_sync_timeout_minutes      = "10"
 
 # Optional: Google Connector Configuration
-# google_webhook_url                     = ""
-# google_sync_interval_seconds           = ""
 # google_max_age_days                    = "730"
 # webhook_renewal_check_interval_seconds = "3600"
 

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -214,18 +214,6 @@ variable "stale_sync_timeout_minutes" {
 }
 
 # Google Connector Configuration
-variable "google_webhook_url" {
-  description = "Google webhook URL for push notifications"
-  type        = string
-  default     = ""
-}
-
-variable "google_sync_interval_seconds" {
-  description = "Google connector sync interval in seconds"
-  type        = string
-  default     = ""
-}
-
 variable "google_max_age_days" {
   description = "Maximum age in days for Google documents"
   type        = string

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -280,3 +280,39 @@ variable "agents_enabled" {
   type        = string
   default     = "false"
 }
+
+variable "enabled_connectors" {
+  description = "List of connectors to deploy (e.g. [\"google\", \"slack\", \"web\"])"
+  type        = list(string)
+  default     = ["web"]
+}
+
+variable "sandbox_url" {
+  description = "URL of the sandbox service for code execution (leave empty to disable)"
+  type        = string
+  default     = ""
+}
+
+variable "agent_max_iterations" {
+  description = "Maximum iterations for AI agent loops"
+  type        = string
+  default     = "15"
+}
+
+variable "approval_timeout_seconds" {
+  description = "Timeout in seconds for agent approval requests"
+  type        = string
+  default     = "600"
+}
+
+variable "otel_endpoint" {
+  description = "OpenTelemetry collector endpoint (leave empty to disable)"
+  type        = string
+  default     = ""
+}
+
+variable "service_version" {
+  description = "Service version for OpenTelemetry"
+  type        = string
+  default     = "0.1.0"
+}


### PR DESCRIPTION
- Add missing connectors (imap, linear, clickup, filesystem) to both AWS and GCP Terraform, add `enabled_connectors` variable to selectively deploy connectors (mirrors Docker Compose `ENABLED_CONNECTORS`)
- Add missing AI service env vars (CONNECTOR_MANAGER_URL, SANDBOX_URL, AGENT_MAX_ITERATIONS, APPROVAL_TIMEOUT_SECONDS), remove stale `*_CONNECTOR_URL` vars from web/connector-manager in favor of connector registration flow with `CONNECTOR_HOST_NAME`
- Add OTEL configuration to GCP (was missing entirely), fix connector port assignments to match .env.example, add filesystem connector to Docker Compose and .env.example, remove stale `embedding_api_key_arn` from AWS IAM