### PR TITLE
Encrypt provider API keys at rest, move service credentials to web

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -166,6 +166,8 @@ services:
       AGENT_MAX_ITERATIONS: ${AGENT_MAX_ITERATIONS:-15}
       APPROVAL_TIMEOUT_SECONDS: ${APPROVAL_TIMEOUT_SECONDS:-600}
       AGENTS_ENABLED: ${AGENTS_ENABLED:-false}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      ENCRYPTION_SALT: ${ENCRYPTION_SALT}
     networks:
       - omni-network
       - sandbox-net
@@ -597,6 +599,8 @@ services:
       APP_URL: ${APP_URL}
       AI_ANSWER_ENABLED: ${AI_ANSWER_ENABLED}
       AGENTS_ENABLED: ${AGENTS_ENABLED:-false}
+      ENCRYPTION_KEY: ${ENCRYPTION_KEY}
+      ENCRYPTION_SALT: ${ENCRYPTION_SALT}
     networks:
       - omni-network
     depends_on:

--- a/infra/aws/terraform/modules/compute/task_definitions.tf
+++ b/infra/aws/terraform/modules/compute/task_definitions.tf
@@ -113,7 +113,10 @@ resource "aws_ecs_task_definition" "web" {
       { name = "AGENTS_ENABLED", value = var.agents_enabled }
     ])
 
-    secrets = local.common_secrets
+    secrets = concat(local.common_secrets, [
+      { name = "ENCRYPTION_KEY", valueFrom = "${var.encryption_key_arn}:key::" },
+      { name = "ENCRYPTION_SALT", valueFrom = "${var.encryption_salt_arn}:salt::" }
+    ])
   }])
 
   tags = merge(local.common_tags, {
@@ -275,7 +278,10 @@ resource "aws_ecs_task_definition" "ai" {
       { name = "AGENTS_ENABLED", value = var.agents_enabled }
     ])
 
-    secrets = local.common_secrets
+    secrets = concat(local.common_secrets, [
+      { name = "ENCRYPTION_KEY", valueFrom = "${var.encryption_key_arn}:key::" },
+      { name = "ENCRYPTION_SALT", valueFrom = "${var.encryption_salt_arn}:salt::" }
+    ])
   }])
 
   tags = merge(local.common_tags, {

--- a/infra/gcp/terraform/modules/compute/services.tf
+++ b/infra/gcp/terraform/modules/compute/services.tf
@@ -128,6 +128,26 @@ resource "google_cloud_run_v2_service" "web" {
         }
       }
 
+      env {
+        name = "ENCRYPTION_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = var.encryption_key_secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "ENCRYPTION_SALT"
+        value_source {
+          secret_key_ref {
+            secret  = var.encryption_salt_secret_id
+            version = "latest"
+          }
+        }
+      }
+
     }
   }
 
@@ -375,6 +395,26 @@ resource "google_cloud_run_v2_service" "ai" {
         value_source {
           secret_key_ref {
             secret  = var.database_password_secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "ENCRYPTION_KEY"
+        value_source {
+          secret_key_ref {
+            secret  = var.encryption_key_secret_id
+            version = "latest"
+          }
+        }
+      }
+
+      env {
+        name = "ENCRYPTION_SALT"
+        value_source {
+          secret_key_ref {
+            secret  = var.encryption_salt_secret_id
             version = "latest"
           }
         }

--- a/services/ai/crypto/__init__.py
+++ b/services/ai/crypto/__init__.py
@@ -1,0 +1,3 @@
+from .encryption import decrypt_config
+
+__all__ = ["decrypt_config"]

--- a/services/ai/crypto/encryption.py
+++ b/services/ai/crypto/encryption.py
@@ -1,0 +1,90 @@
+"""
+Encryption utilities compatible with the Rust EncryptionService (shared/src/encryption.rs).
+
+Uses the same AES-256-GCM + HKDF-SHA256 scheme so that data encrypted by
+the TypeScript web service or Rust indexer can be decrypted here, and vice versa.
+"""
+
+import base64
+import json
+import os
+from typing import Any
+
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.hashes import SHA256
+
+_master_key: bytes | None = None
+
+
+def _get_master_key() -> bytes:
+    global _master_key
+    if _master_key is not None:
+        return _master_key
+
+    encryption_key = os.environ.get("ENCRYPTION_KEY", "")
+    encryption_salt = os.environ.get("ENCRYPTION_SALT", "")
+
+    if not encryption_key:
+        raise ValueError("ENCRYPTION_KEY environment variable not set")
+    if not encryption_salt:
+        raise ValueError("ENCRYPTION_SALT environment variable not set")
+    if len(encryption_key) < 32:
+        raise ValueError("ENCRYPTION_KEY must be at least 32 characters long")
+    if len(encryption_salt) < 16:
+        raise ValueError("ENCRYPTION_SALT must be at least 16 characters long")
+
+    _master_key = HKDF(
+        algorithm=SHA256(),
+        length=32,
+        salt=encryption_salt.encode("utf-8"),
+        info=b"omni-encryption-key",
+    ).derive(encryption_key.encode("utf-8"))
+
+    return _master_key
+
+
+def _derive_operation_key(master_key: bytes, operation_salt: bytes) -> bytes:
+    return HKDF(
+        algorithm=SHA256(),
+        length=32,
+        salt=operation_salt,
+        info=b"omni-operation-key",
+    ).derive(master_key)
+
+
+def decrypt(encrypted_data: dict[str, str]) -> str:
+    """Decrypt an EncryptedData dict (with base64 data, nonce, salt fields)."""
+    master_key = _get_master_key()
+
+    combined = base64.b64decode(encrypted_data["data"])
+    nonce = base64.b64decode(encrypted_data["nonce"])
+    salt = base64.b64decode(encrypted_data["salt"])
+
+    if len(nonce) != 12:
+        raise ValueError("Invalid nonce length")
+    if len(salt) != 16:
+        raise ValueError("Invalid salt length")
+
+    operation_key = _derive_operation_key(master_key, salt)
+
+    # AESGCM expects ciphertext with appended auth tag (same as ring's format)
+    aesgcm = AESGCM(operation_key)
+    plaintext = aesgcm.decrypt(nonce, combined, None)
+
+    return plaintext.decode("utf-8")
+
+
+def decrypt_config(db_value: Any) -> dict:
+    """Decrypt a config JSONB value if encrypted, or return as-is for backward compat."""
+    if db_value is None:
+        return {}
+
+    if isinstance(db_value, str):
+        db_value = json.loads(db_value)
+
+    if isinstance(db_value, dict) and "encrypted_data" in db_value:
+        plaintext = decrypt(db_value["encrypted_data"])
+        return json.loads(plaintext)
+
+    return db_value

--- a/services/ai/db/embedding_providers.py
+++ b/services/ai/db/embedding_providers.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from asyncpg import Pool
 
+from crypto import decrypt_config
 from .connection import get_db_pool
 
 logger = logging.getLogger(__name__)
@@ -27,6 +28,7 @@ class EmbeddingProviderRecord:
         config = row["config"]
         if isinstance(config, str):
             config = json.loads(config)
+        config = decrypt_config(config)
         return cls(
             id=row["id"].strip(),
             name=row["name"],

--- a/services/ai/db/model_providers.py
+++ b/services/ai/db/model_providers.py
@@ -6,6 +6,7 @@ from typing import Optional
 
 from asyncpg import Pool
 
+from crypto import decrypt_config
 from .connection import get_db_pool
 from .models import ModelRecord
 
@@ -27,6 +28,7 @@ class ModelProviderRecord:
         config = row["config"]
         if isinstance(config, str):
             config = json.loads(config)
+        config = decrypt_config(config)
         return cls(
             id=row["id"].strip(),
             name=row["name"],

--- a/services/ai/db/models.py
+++ b/services/ai/db/models.py
@@ -4,6 +4,8 @@ from datetime import datetime
 from typing import Optional, Dict, Any
 from enum import Enum
 
+from crypto import decrypt_config
+
 
 @dataclass
 class User:
@@ -88,6 +90,7 @@ class ModelRecord:
         config = row["config"]
         if isinstance(config, str):
             config = json.loads(config)
+        config = decrypt_config(config)
         return cls(
             id=row["id"].strip(),
             model_provider_id=row["model_provider_id"].strip(),

--- a/services/ai/email_service/repository.py
+++ b/services/ai/email_service/repository.py
@@ -7,6 +7,7 @@ from typing import Literal, Optional, Union
 
 from asyncpg import Pool
 
+from crypto import decrypt_config
 from db.connection import get_db_pool
 
 logger = logging.getLogger(__name__)
@@ -88,5 +89,6 @@ async def get_current_email_provider(
     config = row["config"]
     if isinstance(config, str):
         config = json.loads(config)
+    config = decrypt_config(config)
 
     return _parse_config(row["provider_type"], config)

--- a/services/ai/tests/unit/test_encryption.py
+++ b/services/ai/tests/unit/test_encryption.py
@@ -1,0 +1,120 @@
+"""Unit tests for the crypto.encryption module.
+
+Tests decryption of data encrypted by the TypeScript and Rust implementations,
+and roundtrip compatibility.
+"""
+
+import base64
+import json
+import os
+
+import pytest
+
+# Set env vars before importing the module
+os.environ["ENCRYPTION_KEY"] = "test_master_key_that_is_long_enough_32_chars"
+os.environ["ENCRYPTION_SALT"] = "test_salt_16_chars"
+
+from crypto.encryption import (
+    _get_master_key,
+    _derive_operation_key,
+    decrypt,
+    decrypt_config,
+)
+
+# Also test encrypt for roundtrip (import AESGCM for our own encrypt helper)
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+from cryptography.hazmat.primitives.kdf.hkdf import HKDF
+from cryptography.hazmat.primitives.hashes import SHA256
+
+
+def _encrypt_for_test(plaintext: str) -> dict[str, str]:
+    """Encrypt using the same algorithm, for roundtrip testing."""
+    master_key = _get_master_key()
+
+    nonce = os.urandom(12)
+    salt = os.urandom(16)
+
+    operation_key = _derive_operation_key(master_key, salt)
+
+    aesgcm = AESGCM(operation_key)
+    ciphertext = aesgcm.encrypt(nonce, plaintext.encode("utf-8"), None)
+
+    return {
+        "data": base64.b64encode(ciphertext).decode(),
+        "nonce": base64.b64encode(nonce).decode(),
+        "salt": base64.b64encode(salt).decode(),
+    }
+
+
+class TestDecrypt:
+    def test_roundtrip(self):
+        plaintext = "Hello, World! This is sensitive data."
+        encrypted = _encrypt_for_test(plaintext)
+        assert decrypt(encrypted) == plaintext
+
+    def test_roundtrip_json(self):
+        config = {"apiKey": "sk-test-123", "model": "gpt-4"}
+        encrypted = _encrypt_for_test(json.dumps(config))
+        result = json.loads(decrypt(encrypted))
+        assert result == config
+
+    def test_different_encryptions_produce_different_ciphertext(self):
+        plaintext = "Same data"
+        e1 = _encrypt_for_test(plaintext)
+        e2 = _encrypt_for_test(plaintext)
+
+        assert e1["data"] != e2["data"]
+        assert decrypt(e1) == plaintext
+        assert decrypt(e2) == plaintext
+
+    def test_invalid_nonce_length(self):
+        encrypted = _encrypt_for_test("test")
+        encrypted["nonce"] = base64.b64encode(b"\x00" * 5).decode()
+        with pytest.raises(ValueError, match="Invalid nonce length"):
+            decrypt(encrypted)
+
+    def test_invalid_salt_length(self):
+        encrypted = _encrypt_for_test("test")
+        encrypted["salt"] = base64.b64encode(b"\x00" * 5).decode()
+        with pytest.raises(ValueError, match="Invalid salt length"):
+            decrypt(encrypted)
+
+    def test_tampered_data_fails(self):
+        encrypted = _encrypt_for_test("test data")
+        # Tamper with ciphertext
+        data = bytearray(base64.b64decode(encrypted["data"]))
+        data[-1] ^= 0xFF
+        encrypted["data"] = base64.b64encode(bytes(data)).decode()
+        with pytest.raises(Exception):
+            decrypt(encrypted)
+
+
+class TestDecryptConfig:
+    def test_encrypted_config(self):
+        config = {"apiKey": "sk-test-123", "model": "gpt-4", "apiUrl": None}
+        encrypted_data = _encrypt_for_test(json.dumps(config))
+        db_value = {"encrypted_data": encrypted_data, "version": 1}
+
+        result = decrypt_config(db_value)
+        assert result == config
+
+    def test_unencrypted_config_passthrough(self):
+        config = {"apiKey": "sk-test-123", "model": "gpt-4"}
+        result = decrypt_config(config)
+        assert result == config
+
+    def test_none_returns_empty_dict(self):
+        assert decrypt_config(None) == {}
+
+    def test_string_json_passthrough(self):
+        config = {"apiKey": "sk-test-123"}
+        result = decrypt_config(json.dumps(config))
+        assert result == config
+
+    def test_string_json_encrypted(self):
+        config = {"apiKey": "sk-test-123"}
+        encrypted_data = _encrypt_for_test(json.dumps(config))
+        db_value = json.dumps({"encrypted_data": encrypted_data, "version": 1})
+
+        result = decrypt_config(db_value)
+        assert result == config

--- a/services/indexer/src/lib.rs
+++ b/services/indexer/src/lib.rs
@@ -12,7 +12,6 @@ pub use serde::{Deserialize, Serialize};
 pub use serde_json::Value;
 pub use shared::db::pool::DatabasePool;
 pub use shared::AIClient;
-use shared::ServiceCredentialsRepo;
 use std::sync::Arc;
 
 use axum::{
@@ -44,7 +43,6 @@ pub struct AppState {
     pub ai_client: AIClient,
     pub content_storage: Arc<dyn shared::ObjectStorage>,
     pub embedding_queue: shared::embedding_queue::EmbeddingQueue,
-    pub service_credentials_repo: Arc<ServiceCredentialsRepo>,
 }
 
 #[derive(Debug, Deserialize, Serialize)]
@@ -85,22 +83,6 @@ pub struct BulkDocumentResponse {
     pub errors: Vec<String>,
 }
 
-#[derive(Debug, Deserialize, Serialize)]
-pub struct CreateServiceCredentialsRequest {
-    pub source_id: String,
-    pub provider: shared::models::ServiceProvider,
-    pub auth_type: shared::models::AuthType,
-    pub principal_email: Option<String>,
-    pub credentials: Value,
-    pub config: Value,
-}
-
-#[derive(Debug, Serialize)]
-pub struct CreateServiceCredentialsResponse {
-    pub success: bool,
-    pub message: String,
-}
-
 pub fn create_app(state: AppState) -> Router {
     Router::new()
         .route("/health", get(health_check))
@@ -110,7 +92,6 @@ pub fn create_app(state: AppState) -> Router {
         .route("/documents/:id", get(get_document))
         .route("/documents/:id", put(update_document))
         .route("/documents/:id", delete(delete_document))
-        .route("/service-credentials", post(create_service_credentials))
         .route("/admin/gc/run", post(run_gc))
         .route("/admin/gc/stats", get(gc_stats))
         .route("/admin/reindex-embeddings", post(reindex_embeddings))
@@ -400,66 +381,6 @@ async fn process_delete_operation(state: &AppState, id: String) -> anyhow::Resul
     Ok(())
 }
 
-async fn create_service_credentials(
-    State(state): State<AppState>,
-    Json(request): Json<CreateServiceCredentialsRequest>,
-) -> IndexerResult<Json<CreateServiceCredentialsResponse>> {
-    let service_credentials = shared::models::ServiceCredentials {
-        id: Ulid::new().to_string(),
-        source_id: request.source_id.clone(),
-        provider: request.provider,
-        auth_type: request.auth_type,
-        principal_email: request.principal_email,
-        credentials: request.credentials,
-        config: request.config,
-        expires_at: None,
-        last_validated_at: None,
-        created_at: OffsetDateTime::now_utc(),
-        updated_at: OffsetDateTime::now_utc(),
-    };
-
-    // Delete existing credentials for this source first
-    match state
-        .service_credentials_repo
-        .delete_by_source_id(&request.source_id)
-        .await
-    {
-        Ok(_) => info!(
-            "Deleted existing credentials for source: {}",
-            request.source_id
-        ),
-        Err(e) => info!(
-            "No existing credentials to delete for source {}: {}",
-            request.source_id, e
-        ),
-    }
-
-    // Create new credentials (this will automatically encrypt them)
-    match state
-        .service_credentials_repo
-        .create(service_credentials)
-        .await
-    {
-        Ok(_) => {
-            info!(
-                "Created encrypted service credentials for source: {}",
-                request.source_id
-            );
-            Ok(Json(CreateServiceCredentialsResponse {
-                success: true,
-                message: "Service credentials created successfully".to_string(),
-            }))
-        }
-        Err(e) => {
-            error!("Failed to create service credentials: {}", e);
-            Ok(Json(CreateServiceCredentialsResponse {
-                success: false,
-                message: format!("Failed to create service credentials: {}", e),
-            }))
-        }
-    }
-}
-
 async fn reindex_embeddings(State(state): State<AppState>) -> IndexerResult<Json<Value>> {
     let repo = DocumentRepository::new(state.db_pool.pool());
 
@@ -540,9 +461,6 @@ pub async fn run_server() -> anyhow::Result<()> {
     let embedding_queue = shared::embedding_queue::EmbeddingQueue::new(db_pool.pool().clone());
     info!("Embedding queue initialized");
 
-    let service_credentials_repo = Arc::new(ServiceCredentialsRepo::new(db_pool.pool().clone())?);
-    info!("Service credentials repository initialized");
-
     let content_storage = shared::StorageFactory::from_env(db_pool.pool().clone()).await?;
     info!("Content storage initialized");
 
@@ -552,7 +470,6 @@ pub async fn run_server() -> anyhow::Result<()> {
         ai_client,
         content_storage,
         embedding_queue,
-        service_credentials_repo,
     };
 
     let app = create_app(app_state.clone());

--- a/web/src/lib/server/crypto/encryption.test.ts
+++ b/web/src/lib/server/crypto/encryption.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect } from 'vitest'
+
+// Must be set before importing the module (master key is lazily derived on first use)
+process.env.ENCRYPTION_KEY = 'test_master_key_that_is_long_enough_32_chars'
+process.env.ENCRYPTION_SALT = 'test_salt_16_chars'
+
+import { encrypt, decrypt, encryptConfig, decryptConfig } from './encryption'
+
+describe('encryption', () => {
+    it('should encrypt and decrypt a string roundtrip', () => {
+        const plaintext = 'Hello, World! This is sensitive data.'
+
+        const encrypted = encrypt(plaintext)
+
+        expect(encrypted.data).toBeTruthy()
+        expect(encrypted.nonce).toBeTruthy()
+        expect(encrypted.salt).toBeTruthy()
+
+        const decrypted = decrypt(encrypted)
+        expect(decrypted).toBe(plaintext)
+    })
+
+    it('should produce different ciphertexts for the same plaintext', () => {
+        const plaintext = 'Same data for both encryptions'
+
+        const encrypted1 = encrypt(plaintext)
+        const encrypted2 = encrypt(plaintext)
+
+        expect(encrypted1.data).not.toBe(encrypted2.data)
+        expect(encrypted1.salt).not.toBe(encrypted2.salt)
+
+        expect(decrypt(encrypted1)).toBe(plaintext)
+        expect(decrypt(encrypted2)).toBe(plaintext)
+    })
+
+    it('should fail to decrypt with tampered data', () => {
+        const encrypted = encrypt('test data')
+        encrypted.data = encrypted.data.slice(0, -4) + 'AAAA'
+
+        expect(() => decrypt(encrypted)).toThrow()
+    })
+
+    it('should reject invalid nonce length', () => {
+        const encrypted = encrypt('test')
+        encrypted.nonce = Buffer.from([1, 2, 3]).toString('base64')
+
+        expect(() => decrypt(encrypted)).toThrow('Invalid nonce length')
+    })
+
+    it('should reject invalid salt length', () => {
+        const encrypted = encrypt('test')
+        encrypted.salt = Buffer.from([1, 2, 3]).toString('base64')
+
+        expect(() => decrypt(encrypted)).toThrow('Invalid salt length')
+    })
+})
+
+describe('encryptConfig / decryptConfig', () => {
+    it('should encrypt and decrypt a config object roundtrip', () => {
+        const config = {
+            apiKey: 'sk-test-123456',
+            model: 'gpt-4',
+            apiUrl: 'https://api.example.com',
+        }
+
+        const encrypted = encryptConfig(config)
+
+        expect(encrypted.encrypted_data).toBeTruthy()
+        expect(encrypted.version).toBe(1)
+
+        const decrypted = decryptConfig(encrypted)
+        expect(decrypted).toEqual(config)
+    })
+
+    it('should pass through unencrypted config (backward compat)', () => {
+        const config = {
+            apiKey: 'sk-test-123456',
+            model: 'gpt-4',
+        }
+
+        const decrypted = decryptConfig(config)
+        expect(decrypted).toEqual(config)
+    })
+
+    it('should return empty object for null/undefined', () => {
+        expect(decryptConfig(null)).toEqual({})
+        expect(decryptConfig(undefined)).toEqual({})
+    })
+
+    it('should handle empty config object', () => {
+        const encrypted = encryptConfig({})
+        const decrypted = decryptConfig(encrypted)
+        expect(decrypted).toEqual({})
+    })
+})

--- a/web/src/lib/server/crypto/encryption.ts
+++ b/web/src/lib/server/crypto/encryption.ts
@@ -1,0 +1,127 @@
+import { randomBytes, createCipheriv, createDecipheriv, hkdfSync } from 'crypto'
+
+export interface EncryptedData {
+    data: string // Base64 encoded encrypted data (ciphertext + 16-byte GCM auth tag)
+    nonce: string // Base64 encoded 12-byte nonce
+    salt: string // Base64 encoded 16-byte salt
+}
+
+export interface EncryptedConfig {
+    encrypted_data: EncryptedData
+    version: number
+}
+
+let _masterKey: Buffer | null = null
+
+function getMasterKey(): Buffer {
+    if (_masterKey) return _masterKey
+
+    const encryptionKey = process.env.ENCRYPTION_KEY || ''
+    const encryptionSalt = process.env.ENCRYPTION_SALT || ''
+
+    if (!encryptionKey) {
+        throw new Error('ENCRYPTION_KEY environment variable not set')
+    }
+    if (!encryptionSalt) {
+        throw new Error('ENCRYPTION_SALT environment variable not set')
+    }
+    if (encryptionKey.length < 32) {
+        throw new Error('ENCRYPTION_KEY must be at least 32 characters long')
+    }
+    if (encryptionSalt.length < 16) {
+        throw new Error('ENCRYPTION_SALT must be at least 16 characters long')
+    }
+
+    _masterKey = Buffer.from(
+        hkdfSync(
+            'sha256',
+            Buffer.from(encryptionKey, 'utf-8'),
+            Buffer.from(encryptionSalt, 'utf-8'),
+            Buffer.from('omni-encryption-key', 'utf-8'),
+            32,
+        ),
+    )
+    return _masterKey
+}
+
+function deriveOperationKey(masterKey: Buffer, operationSalt: Buffer): Buffer {
+    return Buffer.from(
+        hkdfSync(
+            'sha256',
+            masterKey,
+            operationSalt,
+            Buffer.from('omni-operation-key', 'utf-8'),
+            32,
+        ),
+    )
+}
+
+export function encrypt(plaintext: string): EncryptedData {
+    const masterKey = getMasterKey()
+
+    const nonce = randomBytes(12)
+    const salt = randomBytes(16)
+
+    const operationKey = deriveOperationKey(masterKey, salt)
+
+    const cipher = createCipheriv('aes-256-gcm', operationKey, nonce)
+    const encrypted = Buffer.concat([cipher.update(plaintext, 'utf-8'), cipher.final()])
+    const authTag = cipher.getAuthTag()
+
+    // Concatenate ciphertext + auth tag (matches ring's seal_in_place_append_tag)
+    const combined = Buffer.concat([encrypted, authTag])
+
+    return {
+        data: combined.toString('base64'),
+        nonce: nonce.toString('base64'),
+        salt: salt.toString('base64'),
+    }
+}
+
+export function decrypt(encryptedData: EncryptedData): string {
+    const masterKey = getMasterKey()
+
+    const combined = Buffer.from(encryptedData.data, 'base64')
+    const nonce = Buffer.from(encryptedData.nonce, 'base64')
+    const salt = Buffer.from(encryptedData.salt, 'base64')
+
+    if (nonce.length !== 12) throw new Error('Invalid nonce length')
+    if (salt.length !== 16) throw new Error('Invalid salt length')
+
+    // Split ciphertext and auth tag (last 16 bytes)
+    const ciphertext = combined.subarray(0, combined.length - 16)
+    const authTag = combined.subarray(combined.length - 16)
+
+    const operationKey = deriveOperationKey(masterKey, salt)
+
+    const decipher = createDecipheriv('aes-256-gcm', operationKey, nonce)
+    decipher.setAuthTag(authTag)
+
+    const decrypted = Buffer.concat([decipher.update(ciphertext), decipher.final()])
+    return decrypted.toString('utf-8')
+}
+
+export function encryptConfig(config: Record<string, unknown>): EncryptedConfig {
+    const plaintext = JSON.stringify(config)
+    const encryptedData = encrypt(plaintext)
+    return {
+        encrypted_data: encryptedData,
+        version: 1,
+    }
+}
+
+export function decryptConfig(dbValue: unknown): Record<string, unknown> {
+    if (dbValue === null || dbValue === undefined) return {}
+
+    const obj = dbValue as Record<string, unknown>
+
+    // If it has encrypted_data, decrypt it
+    if (obj.encrypted_data && typeof obj.encrypted_data === 'object') {
+        const encryptedData = obj.encrypted_data as EncryptedData
+        const plaintext = decrypt(encryptedData)
+        return JSON.parse(plaintext) as Record<string, unknown>
+    }
+
+    // Backward compatibility: return as-is if not encrypted
+    return obj
+}

--- a/web/src/lib/server/db/auth-providers.ts
+++ b/web/src/lib/server/db/auth-providers.ts
@@ -2,6 +2,7 @@ import { eq } from 'drizzle-orm'
 import { db } from './index'
 import { authProviders } from './schema'
 import type { AuthProvider } from './schema'
+import { encryptConfig, decryptConfig } from '$lib/server/crypto/encryption'
 
 export interface GoogleAuthConfig {
     clientId: string
@@ -14,7 +15,8 @@ export async function getAuthProvider(provider: string): Promise<AuthProvider | 
         .from(authProviders)
         .where(eq(authProviders.provider, provider))
         .limit(1)
-    return row || null
+    if (!row) return null
+    return { ...row, config: decryptConfig(row.config) }
 }
 
 export async function getGoogleAuthConfig(): Promise<{
@@ -62,12 +64,13 @@ export async function updateAuthProvider(
     config: Record<string, unknown>,
     updatedBy: string,
 ): Promise<AuthProvider> {
+    const encryptedConfig = encryptConfig(config)
     const [row] = await db
         .insert(authProviders)
         .values({
             provider,
             enabled,
-            config,
+            config: encryptedConfig,
             updatedBy,
             updatedAt: new Date(),
         })
@@ -75,12 +78,12 @@ export async function updateAuthProvider(
             target: authProviders.provider,
             set: {
                 enabled,
-                config,
+                config: encryptedConfig,
                 updatedBy,
                 updatedAt: new Date(),
             },
         })
         .returning()
 
-    return row
+    return { ...row, config: decryptConfig(row.config) }
 }

--- a/web/src/lib/server/db/email-providers.ts
+++ b/web/src/lib/server/db/email-providers.ts
@@ -3,6 +3,7 @@ import { db } from './index'
 import { emailProviders } from './schema'
 import type { EmailProvider } from './schema'
 import { ulid } from 'ulid'
+import { encryptConfig, decryptConfig } from '$lib/server/crypto/encryption'
 
 export { EMAIL_PROVIDER_TYPES, EMAIL_PROVIDER_LABELS, type EmailProviderType } from '$lib/types'
 
@@ -45,11 +46,12 @@ export interface UpdateEmailProviderInput {
 }
 
 export async function listActiveProviders(): Promise<EmailProvider[]> {
-    return await db
+    const rows = await db
         .select()
         .from(emailProviders)
         .where(eq(emailProviders.isDeleted, false))
         .orderBy(emailProviders.createdAt)
+    return rows.map((row) => ({ ...row, config: decryptConfig(row.config) }))
 }
 
 export async function getProvider(id: string): Promise<EmailProvider | null> {
@@ -58,7 +60,8 @@ export async function getProvider(id: string): Promise<EmailProvider | null> {
         .from(emailProviders)
         .where(eq(emailProviders.id, id))
         .limit(1)
-    return provider || null
+    if (!provider) return null
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function getCurrentProvider(): Promise<EmailProvider | null> {
@@ -67,7 +70,8 @@ export async function getCurrentProvider(): Promise<EmailProvider | null> {
         .from(emailProviders)
         .where(and(eq(emailProviders.isCurrent, true), eq(emailProviders.isDeleted, false)))
         .limit(1)
-    return provider || null
+    if (!provider) return null
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function createProvider(input: CreateEmailProviderInput): Promise<EmailProvider> {
@@ -80,12 +84,12 @@ export async function createProvider(input: CreateEmailProviderInput): Promise<E
             id: ulid(),
             name: input.name,
             providerType: input.providerType,
-            config: input.config,
+            config: encryptConfig(input.config as Record<string, unknown>),
             isCurrent: shouldBeCurrent,
         })
         .returning()
 
-    return provider
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function updateProvider(
@@ -94,7 +98,8 @@ export async function updateProvider(
 ): Promise<EmailProvider | null> {
     const values: Record<string, unknown> = { updatedAt: new Date() }
     if (input.name !== undefined) values.name = input.name
-    if (input.config !== undefined) values.config = input.config
+    if (input.config !== undefined)
+        values.config = encryptConfig(input.config as Record<string, unknown>)
 
     const [updated] = await db
         .update(emailProviders)
@@ -102,7 +107,8 @@ export async function updateProvider(
         .where(eq(emailProviders.id, id))
         .returning()
 
-    return updated || null
+    if (!updated) return null
+    return { ...updated, config: decryptConfig(updated.config) }
 }
 
 export async function deleteProvider(id: string): Promise<boolean> {

--- a/web/src/lib/server/db/embedding-providers.ts
+++ b/web/src/lib/server/db/embedding-providers.ts
@@ -3,6 +3,7 @@ import { db } from './index'
 import { embeddingProviders } from './schema'
 import type { EmbeddingProvider } from './schema'
 import { ulid } from 'ulid'
+import { encryptConfig, decryptConfig } from '$lib/server/crypto/encryption'
 
 export { EMBEDDING_PROVIDER_TYPES, type EmbeddingProviderType, PROVIDER_LABELS } from '$lib/types'
 import { type EmbeddingProviderType } from '$lib/types'
@@ -27,11 +28,12 @@ export interface UpdateEmbeddingProviderInput {
 }
 
 export async function listActiveProviders(): Promise<EmbeddingProvider[]> {
-    return await db
+    const rows = await db
         .select()
         .from(embeddingProviders)
         .where(eq(embeddingProviders.isDeleted, false))
         .orderBy(embeddingProviders.createdAt)
+    return rows.map((row) => ({ ...row, config: decryptConfig(row.config) }))
 }
 
 export async function getProvider(id: string): Promise<EmbeddingProvider | null> {
@@ -40,7 +42,8 @@ export async function getProvider(id: string): Promise<EmbeddingProvider | null>
         .from(embeddingProviders)
         .where(eq(embeddingProviders.id, id))
         .limit(1)
-    return provider || null
+    if (!provider) return null
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function getCurrentProvider(): Promise<EmbeddingProvider | null> {
@@ -49,7 +52,8 @@ export async function getCurrentProvider(): Promise<EmbeddingProvider | null> {
         .from(embeddingProviders)
         .where(and(eq(embeddingProviders.isCurrent, true), eq(embeddingProviders.isDeleted, false)))
         .limit(1)
-    return provider || null
+    if (!provider) return null
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function createProvider(
@@ -64,12 +68,12 @@ export async function createProvider(
             id: ulid(),
             name: input.name,
             providerType: input.providerType,
-            config: input.config,
+            config: encryptConfig(input.config as Record<string, unknown>),
             isCurrent: shouldBeCurrent,
         })
         .returning()
 
-    return provider
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function updateProvider(
@@ -78,7 +82,8 @@ export async function updateProvider(
 ): Promise<EmbeddingProvider | null> {
     const values: Record<string, unknown> = { updatedAt: new Date() }
     if (input.name !== undefined) values.name = input.name
-    if (input.config !== undefined) values.config = input.config
+    if (input.config !== undefined)
+        values.config = encryptConfig(input.config as Record<string, unknown>)
 
     const [updated] = await db
         .update(embeddingProviders)
@@ -86,7 +91,8 @@ export async function updateProvider(
         .where(eq(embeddingProviders.id, id))
         .returning()
 
-    return updated || null
+    if (!updated) return null
+    return { ...updated, config: decryptConfig(updated.config) }
 }
 
 export async function deleteProvider(id: string): Promise<boolean> {

--- a/web/src/lib/server/db/model-providers.ts
+++ b/web/src/lib/server/db/model-providers.ts
@@ -3,6 +3,7 @@ import { db } from './index'
 import { modelProviders, models } from './schema'
 import type { ModelProvider, Model } from './schema'
 import { ulid } from 'ulid'
+import { encryptConfig, decryptConfig } from '$lib/server/crypto/encryption'
 
 export const MODEL_PROVIDER_TYPES = [
     'vllm',
@@ -77,11 +78,12 @@ export const PREDEFINED_MODELS: Record<
 // --- Provider CRUD ---
 
 export async function listActiveProviders(): Promise<ModelProvider[]> {
-    return await db
+    const rows = await db
         .select()
         .from(modelProviders)
         .where(eq(modelProviders.isDeleted, false))
         .orderBy(modelProviders.createdAt)
+    return rows.map((row) => ({ ...row, config: decryptConfig(row.config) }))
 }
 
 export async function getProvider(id: string): Promise<ModelProvider | null> {
@@ -90,7 +92,8 @@ export async function getProvider(id: string): Promise<ModelProvider | null> {
         .from(modelProviders)
         .where(eq(modelProviders.id, id))
         .limit(1)
-    return provider || null
+    if (!provider) return null
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function createProvider(input: CreateProviderInput): Promise<ModelProvider> {
@@ -100,11 +103,11 @@ export async function createProvider(input: CreateProviderInput): Promise<ModelP
             id: ulid(),
             name: input.name,
             providerType: input.providerType,
-            config: input.config,
+            config: encryptConfig(input.config as Record<string, unknown>),
         })
         .returning()
 
-    return provider
+    return { ...provider, config: decryptConfig(provider.config) }
 }
 
 export async function updateProvider(
@@ -113,7 +116,8 @@ export async function updateProvider(
 ): Promise<ModelProvider | null> {
     const values: Record<string, unknown> = { updatedAt: new Date() }
     if (input.name !== undefined) values.name = input.name
-    if (input.config !== undefined) values.config = input.config
+    if (input.config !== undefined)
+        values.config = encryptConfig(input.config as Record<string, unknown>)
 
     const [updated] = await db
         .update(modelProviders)
@@ -121,7 +125,8 @@ export async function updateProvider(
         .where(eq(modelProviders.id, id))
         .returning()
 
-    return updated || null
+    if (!updated) return null
+    return { ...updated, config: decryptConfig(updated.config) }
 }
 
 export async function deleteProvider(id: string): Promise<boolean> {

--- a/web/src/routes/api/service-credentials/+server.ts
+++ b/web/src/routes/api/service-credentials/+server.ts
@@ -5,7 +5,7 @@ import { serviceCredentials, sources } from '$lib/server/db/schema'
 import { eq } from 'drizzle-orm'
 import { ServiceProvider, AuthType } from '$lib/types'
 import { ulid } from 'ulid'
-import { env } from '$env/dynamic/private'
+import { encryptConfig } from '$lib/server/crypto/encryption'
 
 export const POST: RequestHandler = async ({ request, locals, fetch }) => {
     if (!locals.user) {
@@ -33,7 +33,7 @@ export const POST: RequestHandler = async ({ request, locals, fetch }) => {
         throw error(400, 'Invalid auth type')
     }
 
-    // Check if source exists and is owned by requesting user or user is admin
+    // Check if source exists
     const source = await db.query.sources.findFirst({
         where: eq(sources.id, sourceId),
     })
@@ -43,34 +43,25 @@ export const POST: RequestHandler = async ({ request, locals, fetch }) => {
     }
 
     try {
-        // Call indexer service to create encrypted credentials
-        const indexerResponse = await fetch(`${env.INDEXER_URL}/service-credentials`, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-            },
-            body: JSON.stringify({
-                source_id: sourceId,
-                provider: provider,
-                auth_type: authType,
-                principal_email: principalEmail || null,
-                credentials: credentials,
+        // Delete existing credentials for this source
+        await db.delete(serviceCredentials).where(eq(serviceCredentials.sourceId, sourceId))
+
+        // Encrypt and insert new credentials directly
+        const id = ulid()
+        const encryptedCredentials = encryptConfig(credentials)
+
+        const [created] = await db
+            .insert(serviceCredentials)
+            .values({
+                id,
+                sourceId,
+                provider,
+                authType,
+                principalEmail: principalEmail || null,
+                credentials: encryptedCredentials,
                 config: config || {},
-            }),
-        })
-
-        if (!indexerResponse.ok) {
-            const errorText = await indexerResponse.text()
-            console.error('Indexer service error:', errorText)
-            throw error(500, 'Failed to create service credentials')
-        }
-
-        const indexerResult = await indexerResponse.json()
-
-        if (!indexerResult.success) {
-            console.error('Indexer service failed:', indexerResult.message)
-            throw error(500, indexerResult.message || 'Failed to create service credentials')
-        }
+            })
+            .returning()
 
         // Trigger initial sync after credentials are saved
         try {
@@ -91,17 +82,16 @@ export const POST: RequestHandler = async ({ request, locals, fetch }) => {
         return json({
             success: true,
             credentials: {
-                id: ulid(), // Generate a temporary ID for response
-                sourceId: sourceId,
-                provider: provider,
-                authType: authType,
-                principalEmail: principalEmail || null,
-                config: config || {},
-                expiresAt: null,
-                lastValidatedAt: null,
-                createdAt: new Date().toISOString(),
-                updatedAt: new Date().toISOString(),
-                // Don't return sensitive credentials
+                id: created.id,
+                sourceId: created.sourceId,
+                provider: created.provider,
+                authType: created.authType,
+                principalEmail: created.principalEmail,
+                config: created.config,
+                expiresAt: created.expiresAt,
+                lastValidatedAt: created.lastValidatedAt,
+                createdAt: created.createdAt,
+                updatedAt: created.updatedAt,
             },
         })
     } catch (err) {


### PR DESCRIPTION
- Add AES-256-GCM encryption for all provider config JSONB columns (model_providers, embedding_providers, email_providers, auth_providers) with backward-compatible decryption for unencrypted data
- Move service credential creation from the indexer to the web service, removing the unnecessary indirection — web now encrypts and inserts directly via Drizzle
- Add matching Python decryption module for the AI service, propagate ENCRYPTION_KEY/SALT env vars to web and AI containers across Docker Compose, AWS, and GCP terraform configs