### PR TITLE
Add secondary model selection

### DIFF
--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -207,9 +207,15 @@ async def _run_agent_loop(
         skip_permission_check=is_org_agent,
     )
 
-    # Compaction support
+    # Compaction support — use secondary model for summarization when available
+    secondary_provider = llm_provider
+    if (
+        app_state.secondary_model_id
+        and app_state.secondary_model_id in app_state.models
+    ):
+        secondary_provider = app_state.models[app_state.secondary_model_id]
     compactor = ConversationCompactor(
-        llm_provider=llm_provider,
+        llm_provider=secondary_provider,
         redis_client=app_state.redis_client,
     )
 

--- a/services/ai/db/listener.py
+++ b/services/ai/db/listener.py
@@ -1,0 +1,98 @@
+"""Postgres LISTEN/NOTIFY listener with auto-reconnect."""
+
+import asyncio
+import json
+import logging
+from collections.abc import Awaitable, Callable
+
+import asyncpg
+
+from .connection import construct_database_url
+
+logger = logging.getLogger(__name__)
+
+RECONNECT_DELAY_SECONDS = 2
+
+
+async def start_db_listener(
+    channels: dict[str, Callable[[dict], None]],
+    on_reconnect: Callable[[], Awaitable[None]] | None = None,
+) -> asyncio.Task:
+    """Start a background task that listens for Postgres notifications.
+
+    Args:
+        channels: Mapping of channel name to callback. Callback receives the
+                  parsed JSON payload dict.
+        on_reconnect: Optional async callable invoked after reconnecting to
+                      catch up on any notifications missed during downtime.
+
+    Returns:
+        The background asyncio.Task (cancel it to stop the listener).
+    """
+
+    async def _listener_loop():
+        while True:
+            conn: asyncpg.Connection | None = None
+            try:
+                conn = await asyncpg.connect(construct_database_url())
+
+                def _make_handler(callback: Callable[[dict], None]):
+                    def handler(
+                        conn: asyncpg.Connection,
+                        pid: int,
+                        channel: str,
+                        payload: str,
+                    ):
+                        try:
+                            data = json.loads(payload)
+                            callback(data)
+                        except Exception:
+                            logger.exception(
+                                f"Error handling notification on '{channel}'"
+                            )
+
+                    return handler
+
+                for channel, callback in channels.items():
+                    await conn.add_listener(channel, _make_handler(callback))
+
+                logger.info(
+                    f"DB listener connected, subscribed to: {list(channels.keys())}"
+                )
+
+                # Block until the connection is closed (by Postgres or network)
+                await _wait_for_close(conn)
+
+            except asyncio.CancelledError:
+                logger.info("DB listener task cancelled")
+                if conn and not conn.is_closed():
+                    await conn.close()
+                return
+
+            except Exception:
+                logger.warning(
+                    "DB listener connection lost, "
+                    f"reconnecting in {RECONNECT_DELAY_SECONDS}s...",
+                    exc_info=True,
+                )
+
+            finally:
+                if conn and not conn.is_closed():
+                    await conn.close()
+
+            await asyncio.sleep(RECONNECT_DELAY_SECONDS)
+
+            # Catch up on anything missed while disconnected
+            if on_reconnect:
+                try:
+                    await on_reconnect()
+                except Exception:
+                    logger.exception("Error in on_reconnect callback")
+
+    return asyncio.create_task(_listener_loop())
+
+
+async def _wait_for_close(conn: asyncpg.Connection):
+    """Wait until the connection is terminated."""
+    while not conn.is_closed():
+        await asyncio.sleep(1)

--- a/services/ai/db/model_providers.py
+++ b/services/ai/db/model_providers.py
@@ -88,7 +88,7 @@ class ModelsRepository:
         pool = await self._get_pool()
         query = """
             SELECT m.id, m.model_provider_id, m.model_id, m.display_name,
-                   m.is_default, m.is_deleted, m.created_at, m.updated_at,
+                   m.is_default, m.is_secondary, m.is_deleted, m.created_at, m.updated_at,
                    mp.provider_type, mp.config
             FROM models m
             JOIN model_providers mp ON m.model_provider_id = mp.id
@@ -103,7 +103,7 @@ class ModelsRepository:
         pool = await self._get_pool()
         query = """
             SELECT m.id, m.model_provider_id, m.model_id, m.display_name,
-                   m.is_default, m.is_deleted, m.created_at, m.updated_at,
+                   m.is_default, m.is_secondary, m.is_deleted, m.created_at, m.updated_at,
                    mp.provider_type, mp.config
             FROM models m
             JOIN model_providers mp ON m.model_provider_id = mp.id
@@ -119,7 +119,7 @@ class ModelsRepository:
         pool = await self._get_pool()
         query = """
             SELECT m.id, m.model_provider_id, m.model_id, m.display_name,
-                   m.is_default, m.is_deleted, m.created_at, m.updated_at,
+                   m.is_default, m.is_secondary, m.is_deleted, m.created_at, m.updated_at,
                    mp.provider_type, mp.config
             FROM models m
             JOIN model_providers mp ON m.model_provider_id = mp.id

--- a/services/ai/db/models.py
+++ b/services/ai/db/models.py
@@ -79,6 +79,7 @@ class ModelRecord:
     model_id: str
     display_name: str
     is_default: bool
+    is_secondary: bool
     is_deleted: bool
     provider_type: str
     config: dict
@@ -97,6 +98,7 @@ class ModelRecord:
             model_id=row["model_id"],
             display_name=row["display_name"],
             is_default=row["is_default"],
+            is_secondary=row["is_secondary"],
             is_deleted=row["is_deleted"],
             provider_type=row["provider_type"],
             config=config,

--- a/services/ai/providers/__init__.py
+++ b/services/ai/providers/__init__.py
@@ -72,12 +72,7 @@ def create_llm_provider(provider_type: str, **kwargs) -> LLMProvider:
     elif provider_type.lower() == "bedrock":
         model_id = kwargs.get("model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0")
         region_name = kwargs.get("region_name")
-        secondary_model_id = kwargs.get(
-            "secondary_model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0"
-        )
-        return BedrockProvider(
-            model_id, secondary_model_id=secondary_model_id, region_name=region_name
-        )
+        return BedrockProvider(model_id, region_name=region_name)
 
     elif provider_type.lower() == "openai":
         api_key = kwargs.get("api_key")

--- a/services/ai/providers/bedrock.py
+++ b/services/ai/providers/bedrock.py
@@ -85,11 +85,8 @@ class BedrockProvider(LLMProvider):
 
     MODEL_FAMILIES = ["anthropic", "amazon"]
 
-    def __init__(
-        self, model_id: str, secondary_model_id: str, region_name: str | None = None
-    ):
+    def __init__(self, model_id: str, region_name: str | None = None):
         self.model_id = model_id
-        self.secondary_model_id = secondary_model_id  # Smaller, faster model
         self.model_family = self._determine_model_family(model_id)
         self.region_name = region_name
 
@@ -597,7 +594,7 @@ class BedrockProvider(LLMProvider):
                 ]
 
                 request_params = {
-                    "model": self.secondary_model_id,
+                    "model": self.model_id,
                     "messages": conversation,
                     "max_tokens": max_tokens or 4096,
                     "temperature": temperature or 0.7,

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -85,6 +85,24 @@ def _resolve_llm_provider(state: AppState, chat: Chat) -> LLMProvider:
     return next(iter(models.values()))
 
 
+def _resolve_secondary_provider(state: AppState) -> LLMProvider:
+    """Resolve the secondary (lightweight) model provider.
+    Priority: secondary model -> default model -> first available.
+    Used for title generation, suggested questions, compaction, etc.
+    """
+    models = state.models
+    if not models:
+        raise HTTPException(status_code=503, detail="No models configured")
+
+    if state.secondary_model_id and state.secondary_model_id in models:
+        return models[state.secondary_model_id]
+
+    if state.default_model_id and state.default_model_id in models:
+        return models[state.default_model_id]
+
+    return next(iter(models.values()))
+
+
 def convert_citation_to_param(citation_delta: CitationsDelta) -> TextCitationParam:
     citation = citation_delta.citation
     if citation.type == "char_location":
@@ -336,9 +354,10 @@ async def stream_chat(
         MessageParam(**msg.message) for msg in chat_messages
     ]
 
-    # Check if conversation needs compaction
+    # Check if conversation needs compaction — use secondary model for summarization
+    secondary_provider = _resolve_secondary_provider(request.app.state)
     compactor = ConversationCompactor(
-        llm_provider=llm_provider,
+        llm_provider=secondary_provider,
         redis_client=redis_client,
     )
     if compactor.needs_compaction(messages, all_tools):
@@ -678,7 +697,7 @@ async def generate_chat_title(
         if not chat:
             raise HTTPException(status_code=404, detail="Chat thread not found")
 
-        llm_provider = _resolve_llm_provider(request.app.state, chat)
+        llm_provider = _resolve_secondary_provider(request.app.state)
 
         # Check if title already exists
         if chat.title:

--- a/services/ai/routers/prompts.py
+++ b/services/ai/routers/prompts.py
@@ -23,6 +23,17 @@ def _get_default_llm_provider(request: Request) -> LLMProvider | None:
     return next(iter(models.values()), None)
 
 
+def _get_secondary_llm_provider(request: Request) -> LLMProvider | None:
+    """Return the secondary (lightweight) LLM provider, falling back to default."""
+    models = getattr(request.app.state, "models", None)
+    if not models:
+        return None
+    secondary_id = getattr(request.app.state, "secondary_model_id", None)
+    if secondary_id and secondary_id in models:
+        return models[secondary_id]
+    return _get_default_llm_provider(request)
+
+
 @router.post("/prompt")
 async def generate_response(request: Request, body: PromptRequest):
     """Generate a response from the configured LLM provider with streaming support."""
@@ -65,8 +76,8 @@ async def generate_response(request: Request, body: PromptRequest):
 async def _generate_non_streaming_response(
     request: Request, body: PromptRequest
 ) -> PromptResponse:
-    """Generate non-streaming response for backward compatibility."""
-    llm_provider = _get_default_llm_provider(request)
+    """Generate non-streaming response using the secondary (lightweight) model."""
+    llm_provider = _get_secondary_llm_provider(request)
     if not llm_provider:
         raise HTTPException(status_code=500, detail="LLM provider not initialized")
 

--- a/services/ai/services/providers.py
+++ b/services/ai/services/providers.py
@@ -14,6 +14,7 @@ from db_config import (
     invalidate_embedding_config_cache,
 )
 from db import ModelsRepository, ModelRecord, EmbeddingProvidersRepository
+from db.listener import start_db_listener
 from providers import create_llm_provider, LLMProvider
 from embeddings import create_embedding_provider
 from tools import SearcherTool
@@ -209,43 +210,77 @@ async def reload_embedding_provider(app_state: AppState) -> None:
     await _init_embedding_provider(app_state)
 
 
-PROVIDER_WATCH_INTERVAL_SECONDS = 30
+def _handle_model_provider_notification(app_state: AppState, payload: dict) -> None:
+    """Handle model_provider_changed notification — update default/secondary pointers."""
+    model_id = payload.get("id", "").strip()
+    if not model_id or model_id not in app_state.models:
+        return
+
+    if payload.get("is_default"):
+        app_state.default_model_id = model_id
+        logger.info(f"Default model updated to {model_id} via NOTIFY")
+    elif app_state.default_model_id == model_id:
+        app_state.default_model_id = None
+        logger.info(f"Default model cleared (was {model_id}) via NOTIFY")
+
+    if payload.get("is_secondary"):
+        app_state.secondary_model_id = model_id
+        logger.info(f"Secondary model updated to {model_id} via NOTIFY")
+    elif app_state.secondary_model_id == model_id:
+        app_state.secondary_model_id = None
+        logger.info(f"Secondary model cleared (was {model_id}) via NOTIFY")
 
 
-async def _watch_embedding_provider(app_state: AppState) -> None:
-    """Poll DB for embedding provider changes and reload when detected."""
-    repo = EmbeddingProvidersRepository()
-    while True:
-        await asyncio.sleep(PROVIDER_WATCH_INTERVAL_SECONDS)
-        try:
-            fingerprint = await repo.get_current_fingerprint()
-            current_id = fingerprint[0] if fingerprint else None
-            current_updated_at = fingerprint[1] if fingerprint else None
+def _handle_embedding_provider_notification(app_state: AppState, payload: dict) -> None:
+    """Handle embedding_provider_changed notification — reload embedding provider."""
+    logger.info(
+        f"Embedding provider change detected via NOTIFY (id={payload.get('id')}), reloading"
+    )
+    asyncio.create_task(reload_embedding_provider(app_state))
 
-            if (
-                current_id != app_state.embedding_provider_id
-                or current_updated_at != app_state.embedding_provider_updated_at
-            ):
-                if fingerprint is None:
-                    logger.info("Embedding provider removed, clearing provider")
-                else:
-                    logger.info(
-                        f"Embedding provider change detected (id={current_id}), reloading"
-                    )
-                await reload_embedding_provider(app_state)
-        except Exception:
-            logger.exception("Error checking for embedding provider changes")
+
+async def _refresh_model_flags(app_state: AppState) -> None:
+    """Re-read default/secondary model flags from DB (catch-up after reconnect)."""
+    repo = ModelsRepository()
+    records = await repo.list_active()
+    default_id: str | None = None
+    secondary_id: str | None = None
+    for record in records:
+        if record.is_default:
+            default_id = record.id
+        if record.is_secondary:
+            secondary_id = record.id
+    app_state.default_model_id = default_id
+    app_state.secondary_model_id = secondary_id
+    logger.info(
+        f"Refreshed model flags: default={default_id}, secondary={secondary_id}"
+    )
 
 
 async def initialize_providers(app_state: AppState) -> None:
     """Initialize all providers (embedding, LLM, tools, storage)."""
     await _init_embedding_provider(app_state)
 
-    asyncio.create_task(_watch_embedding_provider(app_state))
-    logger.info("Started embedding provider watcher")
-
     # Initialize models from database
     await load_models(app_state)
+
+    # Start DB listener for real-time config change notifications
+    async def _on_reconnect():
+        await _refresh_model_flags(app_state)
+        await reload_embedding_provider(app_state)
+
+    app_state.listener_task = await start_db_listener(
+        channels={
+            "model_provider_changed": lambda payload: _handle_model_provider_notification(
+                app_state, payload
+            ),
+            "embedding_provider_changed": lambda payload: _handle_embedding_provider_notification(
+                app_state, payload
+            ),
+        },
+        on_reconnect=_on_reconnect,
+    )
+    logger.info("Started DB change listener")
 
     # Initialize Redis client for caching
     app_state.redis_client = aioredis.from_url(REDIS_URL, decode_responses=True)
@@ -270,6 +305,9 @@ async def start_batch_processor(app_state: AppState) -> None:
 
 async def shutdown_providers(app_state: "AppState"):
     """Cleanup providers on shutdown."""
+    if app_state.listener_task:
+        app_state.listener_task.cancel()
+        logger.info("Cancelled DB listener task")
     if app_state.redis_client:
         await app_state.redis_client.close()
         logger.info("Closed Redis client")

--- a/services/ai/services/providers.py
+++ b/services/ai/services/providers.py
@@ -46,7 +46,6 @@ def _create_provider_from_model_record(record: ModelRecord) -> LLMProvider:
         return create_llm_provider(
             "bedrock",
             model_id=model_id,
-            secondary_model_id=model_id,
             region_name=region_name,
         )
 
@@ -90,6 +89,7 @@ async def load_models(app_state: AppState) -> None:
 
     models: dict[str, LLMProvider] = {}
     default_id: str | None = None
+    secondary_id: str | None = None
 
     for record in records:
         try:
@@ -100,6 +100,8 @@ async def load_models(app_state: AppState) -> None:
             )
             if record.is_default:
                 default_id = record.id
+            if record.is_secondary:
+                secondary_id = record.id
         except Exception as e:
             logger.error(
                 f"Failed to initialize model '{record.display_name}' (id={record.id}): {e}"
@@ -107,13 +109,16 @@ async def load_models(app_state: AppState) -> None:
 
     app_state.models = models
     app_state.default_model_id = default_id
+    app_state.secondary_model_id = secondary_id
 
     if not models:
         logger.warning(
             "No models configured — chat will be unavailable until models are added"
         )
     else:
-        logger.info(f"Loaded {len(models)} model(s), default={default_id}")
+        logger.info(
+            f"Loaded {len(models)} model(s), default={default_id}, secondary={secondary_id}"
+        )
 
 
 async def _init_embedding_provider(app_state: AppState) -> None:

--- a/services/ai/state.py
+++ b/services/ai/state.py
@@ -25,6 +25,7 @@ class AppState:
     embedding_provider_updated_at: datetime | None = None
     models: dict[str, LLMProvider] = field(default_factory=dict)
     default_model_id: str | None = None
+    secondary_model_id: str | None = None
     searcher_tool: SearcherTool | None = None
     content_storage: ContentStorage | None = None
     redis_client: aioredis.Redis | None = None

--- a/services/ai/state.py
+++ b/services/ai/state.py
@@ -1,5 +1,6 @@
 """Typed application state for FastAPI app.state"""
 
+import asyncio
 from dataclasses import dataclass, field
 from datetime import datetime
 
@@ -29,4 +30,5 @@ class AppState:
     searcher_tool: SearcherTool | None = None
     content_storage: ContentStorage | None = None
     redis_client: aioredis.Redis | None = None
+    listener_task: asyncio.Task | None = None
     agent_run_queues: dict = field(default_factory=dict)  # {run_id: asyncio.Queue}

--- a/services/migrations/071_add_secondary_model_flag.sql
+++ b/services/migrations/071_add_secondary_model_flag.sql
@@ -1,2 +1,39 @@
 ALTER TABLE models ADD COLUMN is_secondary BOOLEAN NOT NULL DEFAULT FALSE;
 CREATE UNIQUE INDEX idx_models_single_secondary ON models (is_secondary) WHERE is_secondary = TRUE;
+
+-- Notify AI service when default/secondary model flags change
+CREATE OR REPLACE FUNCTION notify_model_provider_change() RETURNS trigger AS $$
+BEGIN
+    IF OLD.is_default IS DISTINCT FROM NEW.is_default
+       OR OLD.is_secondary IS DISTINCT FROM NEW.is_secondary THEN
+        PERFORM pg_notify('model_provider_changed', json_build_object(
+            'id', NEW.id,
+            'is_default', NEW.is_default,
+            'is_secondary', NEW.is_secondary
+        )::text);
+    END IF;
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER model_provider_notify
+    AFTER UPDATE ON models
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_model_provider_change();
+
+-- Notify AI service when embedding provider config changes
+CREATE OR REPLACE FUNCTION notify_embedding_provider_change() RETURNS trigger AS $$
+BEGIN
+    PERFORM pg_notify('embedding_provider_changed', json_build_object(
+        'id', NEW.id,
+        'is_current', NEW.is_current,
+        'is_deleted', NEW.is_deleted
+    )::text);
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER embedding_provider_notify
+    AFTER INSERT OR UPDATE ON embedding_providers
+    FOR EACH ROW
+    EXECUTE FUNCTION notify_embedding_provider_change();

--- a/services/migrations/071_add_secondary_model_flag.sql
+++ b/services/migrations/071_add_secondary_model_flag.sql
@@ -1,0 +1,2 @@
+ALTER TABLE models ADD COLUMN is_secondary BOOLEAN NOT NULL DEFAULT FALSE;
+CREATE UNIQUE INDEX idx_models_single_secondary ON models (is_secondary) WHERE is_secondary = TRUE;

--- a/web/src/lib/server/db/model-providers.ts
+++ b/web/src/lib/server/db/model-providers.ts
@@ -39,6 +39,7 @@ export interface CreateModelInput {
     modelId: string
     displayName: string
     isDefault?: boolean
+    isSecondary?: boolean
 }
 
 export const PREDEFINED_MODELS: Record<
@@ -186,6 +187,13 @@ export async function createModel(input: CreateModelInput): Promise<Model> {
             .where(eq(models.isDefault, true))
     }
 
+    if (input.isSecondary) {
+        await db
+            .update(models)
+            .set({ isSecondary: false, updatedAt: new Date() })
+            .where(eq(models.isSecondary, true))
+    }
+
     const [model] = await db
         .insert(models)
         .values({
@@ -194,6 +202,7 @@ export async function createModel(input: CreateModelInput): Promise<Model> {
             modelId: input.modelId,
             displayName: input.displayName,
             isDefault: input.isDefault ?? false,
+            isSecondary: input.isSecondary ?? false,
         })
         .returning()
 
@@ -203,7 +212,7 @@ export async function createModel(input: CreateModelInput): Promise<Model> {
 export async function deleteModel(id: string): Promise<boolean> {
     const [updated] = await db
         .update(models)
-        .set({ isDeleted: true, isDefault: false, updatedAt: new Date() })
+        .set({ isDeleted: true, isDefault: false, isSecondary: false, updatedAt: new Date() })
         .where(eq(models.id, id))
         .returning()
 
@@ -219,6 +228,21 @@ export async function setDefaultModel(id: string): Promise<boolean> {
     const [updated] = await db
         .update(models)
         .set({ isDefault: true, updatedAt: new Date() })
+        .where(and(eq(models.id, id), eq(models.isDeleted, false)))
+        .returning()
+
+    return !!updated
+}
+
+export async function setSecondaryModel(id: string): Promise<boolean> {
+    await db
+        .update(models)
+        .set({ isSecondary: false, updatedAt: new Date() })
+        .where(eq(models.isSecondary, true))
+
+    const [updated] = await db
+        .update(models)
+        .set({ isSecondary: true, updatedAt: new Date() })
         .where(and(eq(models.id, id), eq(models.isDeleted, false)))
         .returning()
 

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -149,6 +149,7 @@ export const models = pgTable('models', {
     modelId: text('model_id').notNull(),
     displayName: text('display_name').notNull(),
     isDefault: boolean('is_default').notNull().default(false),
+    isSecondary: boolean('is_secondary').notNull().default(false),
     isDeleted: boolean('is_deleted').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),

--- a/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
@@ -11,6 +11,7 @@ import {
     createModel,
     deleteModel,
     setDefaultModel,
+    setSecondaryModel,
     createPredefinedModels,
     MODEL_PROVIDER_TYPES,
     type ModelProviderConfig,
@@ -50,6 +51,7 @@ export const load: PageServerLoad = async ({ locals }) => {
                     modelId: m.modelId,
                     displayName: m.displayName,
                     isDefault: m.isDefault,
+                    isSecondary: m.isSecondary,
                 })),
             }
         }),
@@ -146,6 +148,7 @@ export const actions: Actions = {
         const modelId = (formData.get('modelId') as string)?.trim()
         const displayName = (formData.get('displayName') as string)?.trim()
         const isDefault = formData.get('isDefault') === 'true'
+        const isSecondary = formData.get('isSecondary') === 'true'
 
         if (!providerId) return fail(400, { error: 'Provider ID is required' })
         if (!modelId) return fail(400, { error: 'Model ID is required' })
@@ -157,6 +160,7 @@ export const actions: Actions = {
                 modelId,
                 displayName,
                 isDefault,
+                isSecondary,
             })
             await reloadAIProviders()
             return { success: true, message: 'Model added' }
@@ -197,6 +201,23 @@ export const actions: Actions = {
         } catch (err) {
             console.error('Failed to set default model:', err)
             return fail(500, { error: 'Failed to set default model' })
+        }
+    },
+
+    setSecondaryModel: async ({ request, locals }) => {
+        requireAdmin(locals)
+
+        const formData = await request.formData()
+        const id = formData.get('id') as string
+        if (!id) return fail(400, { error: 'Model ID is required' })
+
+        try {
+            await setSecondaryModel(id)
+            await reloadAIProviders()
+            return { success: true, message: 'Secondary model updated' }
+        } catch (err) {
+            console.error('Failed to set secondary model:', err)
+            return fail(500, { error: 'Failed to set secondary model' })
         }
     },
 }

--- a/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
@@ -196,7 +196,6 @@ export const actions: Actions = {
 
         try {
             await setDefaultModel(id)
-            await reloadAIProviders()
             return { success: true, message: 'Default model updated' }
         } catch (err) {
             console.error('Failed to set default model:', err)
@@ -213,7 +212,6 @@ export const actions: Actions = {
 
         try {
             await setSecondaryModel(id)
-            await reloadAIProviders()
             return { success: true, message: 'Secondary model updated' }
         } catch (err) {
             console.error('Failed to set secondary model:', err)

--- a/web/src/routes/(admin)/admin/settings/llm/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.svelte
@@ -7,7 +7,17 @@
     import * as Alert from '$lib/components/ui/alert'
     import * as AlertDialog from '$lib/components/ui/alert-dialog'
     import * as Dialog from '$lib/components/ui/dialog'
-    import { CheckCircle2, Loader2, Info, Pencil, Trash2, Star, Server, Plus } from '@lucide/svelte'
+    import {
+        CheckCircle2,
+        Loader2,
+        Info,
+        Pencil,
+        Trash2,
+        Star,
+        Zap,
+        Server,
+        Plus,
+    } from '@lucide/svelte'
     import { cn } from '$lib/utils'
     import { toast } from 'svelte-sonner'
     import type { PageData } from './$types'
@@ -44,6 +54,7 @@
         modelId: string
         displayName: string
         isDefault: boolean
+        isSecondary: boolean
     }
 
     const emptyProviderForm: ProviderFormState = {
@@ -60,6 +71,7 @@
         modelId: '',
         displayName: '',
         isDefault: false,
+        isSecondary: false,
     }
 
     let dialogOpen = $state(false)
@@ -266,11 +278,38 @@
                                                         </button>
                                                     </form>
                                                 {/if}
+                                                {#if model.isSecondary}
+                                                    <Zap
+                                                        class="h-3.5 w-3.5 fill-blue-400 text-blue-400" />
+                                                {:else}
+                                                    <form
+                                                        method="POST"
+                                                        action="?/setSecondaryModel"
+                                                        use:enhance={enhanceWithToast}>
+                                                        <input
+                                                            type="hidden"
+                                                            name="id"
+                                                            value={model.id} />
+                                                        <button
+                                                            type="submit"
+                                                            class="cursor-pointer"
+                                                            title="Set as secondary (lightweight) model">
+                                                            <Zap
+                                                                class="text-muted-foreground h-3.5 w-3.5 hover:text-blue-400" />
+                                                        </button>
+                                                    </form>
+                                                {/if}
                                                 <span>{model.displayName}</span>
                                                 {#if model.isDefault}
                                                     <span
                                                         class="bg-primary/10 text-primary rounded-full px-1.5 py-0.5 text-xs">
                                                         Default
+                                                    </span>
+                                                {/if}
+                                                {#if model.isSecondary}
+                                                    <span
+                                                        class="rounded-full bg-blue-500/10 px-1.5 py-0.5 text-xs text-blue-600">
+                                                        Secondary
                                                     </span>
                                                 {/if}
                                             </div>
@@ -604,6 +643,23 @@
                                 (modelFormState.isDefault = (e.target as HTMLInputElement).checked)}
                             class="h-4 w-4" />
                         <Label for="isDefaultModel" class="font-normal">Set as default model</Label>
+                    </div>
+
+                    <div class="flex items-center gap-2">
+                        <input
+                            type="checkbox"
+                            id="isSecondaryModel"
+                            name="isSecondary"
+                            value="true"
+                            checked={modelFormState.isSecondary}
+                            onchange={(e) =>
+                                (modelFormState.isSecondary = (
+                                    e.target as HTMLInputElement
+                                ).checked)}
+                            class="h-4 w-4" />
+                        <Label for="isSecondaryModel" class="font-normal">
+                            Set as secondary (lightweight) model
+                        </Label>
                     </div>
 
                     <Dialog.Footer>


### PR DESCRIPTION
- Add secondary (lightweight) model selection to LLM settings UI — admins can designate a model for title generation, suggested questions, and conversation compaction
- Thread secondary model through the AI service: new `is_secondary` DB column, app-level resolution with fallback to default, Bedrock provider cleanup