### PR TITLE
Enrich system prompt with date/time, user info, and operator values

### DIFF
--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -40,6 +40,7 @@ from tools import (
 from tools.connector_handler import ConnectorAction
 from tools.email_handler import EmailToolHandler
 from tools.sandbox_handler import SandboxToolHandler
+from tools.search_handler import fetch_operator_values
 
 from .models import Agent, AgentRun
 from .repository import AgentRunRepository
@@ -122,10 +123,22 @@ async def _build_agent_registry(
     if CONNECTOR_MANAGER_URL and connector_actions:
         search_operators = connector_handler.search_operators
 
+    active_sources = [s for s in (sources or []) if s.is_active and not s.is_deleted]
+    connected_source_types = list({s.source_type for s in active_sources})
+    operator_values: dict[str, list[str]] = {}
+    if search_operators:
+        operator_values = await fetch_operator_values(
+            app_state.searcher_tool.client,
+            search_operators,
+            redis_client=app_state.redis_client,
+        )
+
     registry.register(
         SearchToolHandler(
             searcher_tool=app_state.searcher_tool,
             search_operators=search_operators,
+            connected_source_types=connected_source_types,
+            operator_values=operator_values,
         )
     )
 
@@ -180,25 +193,33 @@ async def _run_agent_loop(
     registry, connector_actions = await _build_agent_registry(app_state, agent, sources)
     all_tools = registry.get_all_tools()
 
+    # Org agents search all data (no user-scoping); personal agents are scoped to owner
+    # Using run ID as chat_id — tool handlers use this to scope sandbox workspaces and cache keys
+    is_org_agent = agent.agent_type == "org"
+    agent_user_email: str | None = None
+    agent_user_name: str | None = None
+    if not is_org_agent and agent.user_id:
+        users_repo = UsersRepository()
+        agent_user = await users_repo.find_by_id(agent.user_id)
+        if agent_user:
+            agent_user_email = agent_user.email
+            agent_user_name = agent_user.full_name
+
     # Build system prompt
     active_sources = [s for s in (sources or []) if s.is_active and not s.is_deleted]
-    system_prompt = build_agent_system_prompt(agent, active_sources, connector_actions)
+    system_prompt = build_agent_system_prompt(
+        agent,
+        active_sources,
+        connector_actions,
+        user_name=agent_user_name if not is_org_agent else None,
+        user_email=agent_user_email if not is_org_agent else None,
+    )
 
     # Initialize conversation with a single trigger message
     conversation_messages: list[MessageParam] = [
         MessageParam(role="user", content="Execute your scheduled task now.")
     ]
     execution_log: list[MessageParam] = list(conversation_messages)
-
-    # Org agents search all data (no user-scoping); personal agents are scoped to owner
-    # Using run ID as chat_id — tool handlers use this to scope sandbox workspaces and cache keys
-    is_org_agent = agent.agent_type == "org"
-    agent_user_email: str | None = None
-    if not is_org_agent and agent.user_id:
-        users_repo = UsersRepository()
-        agent_user = await users_repo.find_by_id(agent.user_id)
-        if agent_user:
-            agent_user_email = agent_user.email
 
     context = ToolContext(
         chat_id=run.id,

--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -1,3 +1,6 @@
+from datetime import datetime, timezone
+
+
 SOURCE_DISPLAY_NAMES = {
     "google_drive": "Google Drive",
     "gmail": "Gmail",
@@ -18,7 +21,8 @@ SOURCE_DISPLAY_NAMES = {
 
 SYSTEM_PROMPT_TEMPLATE = """You are Omni AI, a workplace agent that helps employees find information and complete tasks across their connected apps.
 
-Connected apps: {connected_apps}
+Current date and time: {current_datetime} (UTC)
+{user_line}Connected apps: {connected_apps}
 {actions_section}
 # Searching
 - Use inline query operators for efficient filtering: in:slack, type:pdf, status:done, by:sarah, before:2024-06, after:2024-01.
@@ -69,7 +73,8 @@ Execute this task now using the tools available to you.
 Do not ask questions — use your best judgment.
 When done, provide a brief summary of what you did and the outcomes.
 
-Connected apps: {connected_apps}
+Current date and time: {current_datetime} (UTC)
+{user_line}Connected apps: {connected_apps}
 {actions_section}
 # Searching
 - Use inline query operators for efficient filtering: in:slack, type:pdf, status:done, by:sarah, before:2024-06, after:2024-01.
@@ -85,10 +90,36 @@ Connected apps: {connected_apps}
 - Focus on completing the task efficiently."""
 
 
+def _format_datetime(dt: datetime | None = None) -> str:
+    if dt is None:
+        dt = datetime.now(timezone.utc)
+    return dt.strftime("%A, %B %d, %Y %H:%M UTC")
+
+
+def _format_user_line(
+    user_name: str | None,
+    user_email: str | None,
+    prefix: str = "User",
+) -> str:
+    if user_name and user_email:
+        identity = f"{user_name} ({user_email})"
+    elif user_email:
+        identity = user_email
+    elif user_name:
+        identity = user_name
+    else:
+        return ""
+    # Escape braces so .format() doesn't choke on user-supplied strings
+    identity = identity.replace("{", "{{").replace("}", "}}")
+    return f"{prefix}: {identity}\n"
+
+
 def build_agent_system_prompt(
     agent,
     sources: list,
     connector_actions: list | None = None,
+    user_name: str | None = None,
+    user_email: str | None = None,
 ) -> str:
     """Build system prompt for a background agent."""
     seen = set()
@@ -119,8 +150,12 @@ def build_agent_system_prompt(
 
         actions_section = "\n".join(actions_lines)
 
+    user_line = _format_user_line(user_name, user_email, prefix="Running on behalf of")
+
     return AGENT_SYSTEM_PROMPT_TEMPLATE.format(
         instructions=agent.instructions,
+        current_datetime=_format_datetime(),
+        user_line=user_line,
         connected_apps=connected_apps,
         actions_section=actions_section,
     )
@@ -129,12 +164,16 @@ def build_agent_system_prompt(
 def build_chat_system_prompt(
     sources: list,
     connector_actions: list | None = None,
+    user_name: str | None = None,
+    user_email: str | None = None,
 ) -> str:
     """Build system prompt from active sources and connector actions.
 
     Args:
         sources: list of Source dataclass instances (from db.models)
         connector_actions: list of ConnectorAction dataclass instances (from tools.connector_handler)
+        user_name: display name of the current user
+        user_email: email of the current user
     """
     seen = set()
     display_names = []
@@ -169,7 +208,11 @@ def build_chat_system_prompt(
 
         actions_section = "\n".join(actions_lines)
 
+    user_line = _format_user_line(user_name, user_email)
+
     return SYSTEM_PROMPT_TEMPLATE.format(
+        current_datetime=_format_datetime(),
+        user_line=user_line,
         connected_apps=connected_apps,
         actions_section=actions_section,
     )

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -22,7 +22,7 @@ from tools import (
     DocumentToolHandler,
     PeopleSearchHandler,
 )
-from tools.connector_handler import ConnectorAction
+from tools.connector_handler import ConnectorAction, SearchOperator
 from tools.sandbox_handler import SandboxToolHandler
 from tools.search_handler import fetch_operator_values
 from config import (
@@ -160,7 +160,7 @@ class RegistryResult:
     registry: ToolRegistry
     connector_actions: list[ConnectorAction] | None
     sources: list[Source] | None
-    search_operators: list[dict] | None
+    search_operators: list[SearchOperator] | None
 
 
 async def _fetch_sources_from_connector_manager() -> list[Source] | None:
@@ -185,7 +185,7 @@ async def _build_registry(request: Request, chat: Chat) -> RegistryResult:
     sources = await _fetch_sources_from_connector_manager()
 
     connector_actions: list[ConnectorAction] | None = None
-    search_operators: list[dict] | None = None
+    search_operators: list[SearchOperator] | None = None
 
     # Register connector tools if connector-manager is configured
     if CONNECTOR_MANAGER_URL:

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -24,6 +24,7 @@ from tools import (
 )
 from tools.connector_handler import ConnectorAction
 from tools.sandbox_handler import SandboxToolHandler
+from tools.search_handler import fetch_operator_values
 from config import (
     DEFAULT_MAX_TOKENS,
     DEFAULT_TEMPERATURE,
@@ -206,11 +207,24 @@ async def _build_registry(request: Request, chat: Chat) -> RegistryResult:
         if connector_handler.search_operators:
             search_operators = connector_handler.search_operators
 
+    # Fetch dynamic operator values for enriched search tool description
+    active_sources = [s for s in (sources or []) if s.is_active and not s.is_deleted]
+    connected_source_types = list({s.source_type for s in active_sources})
+    operator_values: dict[str, list[str]] = {}
+    if search_operators:
+        operator_values = await fetch_operator_values(
+            request.app.state.searcher_tool.client,
+            search_operators,
+            redis_client=getattr(request.app.state, "redis_client", None),
+        )
+
     # Register search tools (with dynamic operators from connector manifests)
     registry.register(
         SearchToolHandler(
             searcher_tool=request.app.state.searcher_tool,
             search_operators=search_operators,
+            connected_source_types=connected_source_types,
+            operator_values=operator_values,
         )
     )
 
@@ -309,13 +323,15 @@ async def stream_chat(
 
     llm_provider = _resolve_llm_provider(request.app.state, chat)
 
-    # Resolve user email for permission checks
+    # Resolve user info for permission checks and system prompt
     user_email: str | None = None
+    user_name: str | None = None
     if chat.user_id:
         users_repo = UsersRepository()
         user = await users_repo.find_by_id(chat.user_id)
         if user:
             user_email = user.email
+            user_name = user.full_name
 
     messages_repo = MessagesRepository()
     chat_messages = await messages_repo.get_active_path(chat_id)
@@ -369,7 +385,10 @@ async def stream_chat(
         s for s in (build_result.sources or []) if s.is_active and not s.is_deleted
     ]
     system_prompt = build_chat_system_prompt(
-        active_sources, build_result.connector_actions
+        active_sources,
+        build_result.connector_actions,
+        user_name=user_name,
+        user_email=user_email,
     )
 
     # Stream AI response with tool calling

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 import logging
 from dataclasses import asdict, dataclass
+from typing import Literal
 
 import httpx
 import redis.asyncio as aioredis
@@ -16,6 +17,17 @@ from tools.registry import ToolContext, ToolResult
 logger = logging.getLogger(__name__)
 
 ACTIONS_CACHE_TTL = 60  # seconds
+
+
+@dataclass
+class SearchOperator:
+    """A search operator declared by a connector."""
+
+    operator: str
+    attribute_key: str
+    value_type: Literal["text", "person", "datetime"]
+    source_type: str
+    display_name: str
 
 
 @dataclass
@@ -53,7 +65,7 @@ class ConnectorToolHandler:
         self._documents_repo = documents_repo
         self._actions: dict[str, ConnectorAction] = {}
         self._tools: list[dict] = []
-        self._search_operators: list[dict] = []
+        self._search_operators: list[SearchOperator] = []
         self._initialized = False
 
     async def _ensure_initialized(self) -> None:
@@ -130,7 +142,7 @@ class ConnectorToolHandler:
                 source_by_type.setdefault(st, []).append(source)
 
         # Extract search operators from connector manifests
-        search_operators: list[dict] = []
+        search_operators: list[SearchOperator] = []
         for connector in connectors:
             source_type = connector.get("source_type", "")
             manifest = connector.get("manifest")
@@ -139,14 +151,18 @@ class ConnectorToolHandler:
 
             display_name = manifest.get("display_name", source_type)
             for op in manifest.get("search_operators", []):
+                operator = op.get("operator")
+                attribute_key = op.get("attribute_key")
+                if not operator or not attribute_key:
+                    continue
                 search_operators.append(
-                    {
-                        "operator": op.get("operator", ""),
-                        "attribute_key": op.get("attribute_key", ""),
-                        "value_type": op.get("value_type", "text"),
-                        "source_type": source_type,
-                        "display_name": display_name,
-                    }
+                    SearchOperator(
+                        operator=operator,
+                        attribute_key=attribute_key,
+                        value_type=op.get("value_type", "text"),
+                        source_type=source_type,
+                        display_name=display_name,
+                    )
                 )
 
         self._search_operators = search_operators
@@ -231,7 +247,7 @@ class ConnectorToolHandler:
             )
 
     @property
-    def search_operators(self) -> list[dict]:
+    def search_operators(self) -> list[SearchOperator]:
         return self._search_operators
 
     def get_tools(self) -> list[dict]:

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -22,6 +22,7 @@ from tools.searcher_client import (
     SearchResponse,
     SearchResult,
 )
+from tools.connector_handler import SearchOperator
 from tools.registry import ToolContext, ToolResult
 
 logger = logging.getLogger(__name__)
@@ -30,24 +31,6 @@ _TOOL_NAMES = {"search_documents"}
 
 # Operators already documented as universal — exclude from connector-specific lists
 _UNIVERSAL_OPERATORS = {"by", "in", "from", "type", "before", "after"}
-
-# Maps source_type (as stored in db) to the aliases accepted by the in: operator
-SOURCE_TYPE_IN_ALIASES: dict[str, list[str]] = {
-    "google_drive": ["drive", "gdrive"],
-    "gmail": ["gmail", "email"],
-    "slack": ["slack"],
-    "confluence": ["confluence", "wiki"],
-    "jira": ["jira"],
-    "github": ["github", "gh"],
-    "notion": ["notion"],
-    "one_drive": ["onedrive"],
-    "share_point": ["sharepoint"],
-    "outlook": ["outlook"],
-    "hubspot": ["hubspot"],
-    "fireflies": ["fireflies"],
-    "clickup": ["clickup"],
-    "web": ["web"],
-}
 
 TYPE_VALID_VALUES = [
     "sheet",
@@ -72,7 +55,7 @@ _operator_values_mem_ts: float = 0
 
 async def fetch_operator_values(
     searcher_client: SearcherClient,
-    search_operators: list[dict],
+    search_operators: list[SearchOperator],
     redis_client: aioredis.Redis | None = None,
 ) -> dict[str, list[str]]:
     """Fetch and cache distinct values for dynamic search operators.
@@ -99,9 +82,9 @@ async def fetch_operator_values(
             logger.warning(f"Failed to read operator values cache: {e}")
 
     attribute_keys = [
-        op["attribute_key"]
+        op.attribute_key
         for op in search_operators
-        if op["operator"] not in _UNIVERSAL_OPERATORS and op.get("attribute_key")
+        if op.operator not in _UNIVERSAL_OPERATORS and op.attribute_key
     ]
     if not attribute_keys:
         return {}
@@ -129,21 +112,14 @@ async def fetch_operator_values(
 
 
 def _build_query_description(
-    search_operators: list[dict],
+    search_operators: list[SearchOperator],
     connected_source_types: list[str] | None = None,
     operator_values: dict[str, list[str]] | None = None,
 ) -> str:
     """Build a rich description for the query parameter with operator syntax."""
-    # Build in: values filtered to connected sources
+    # Build in: values from connected source types (the searcher accepts source_type values directly)
     if connected_source_types:
-        in_aliases = []
-        for st in connected_source_types:
-            aliases = SOURCE_TYPE_IN_ALIASES.get(st)
-            if aliases:
-                in_aliases.append(aliases[0])  # primary alias
-        in_values_str = (
-            f". Values: {', '.join(sorted(in_aliases))}" if in_aliases else ""
-        )
+        in_values_str = f". Values: {', '.join(sorted(connected_source_types))}"
     else:
         in_values_str = ""
 
@@ -163,18 +139,13 @@ def _build_query_description(
 
     # Group connector-specific operators by source_type
     ops_by_source: dict[str, list[str]] = {}
-    # Build a lookup from attribute_key to operator name for value mapping
-    attr_key_to_operator: dict[str, str] = {}
     for op in search_operators:
-        if op["operator"] in _UNIVERSAL_OPERATORS:
+        if op.operator in _UNIVERSAL_OPERATORS:
             continue
-        display_name = op.get("display_name", op.get("source_type", ""))
-        attr_key = op.get("attribute_key", "")
-        operator_name = op["operator"]
-        attr_key_to_operator[attr_key] = operator_name
+        display_name = op.display_name or op.source_type
 
         # Build operator text with values if available
-        values = (operator_values or {}).get(attr_key, []) if attr_key else []
+        values = (operator_values or {}).get(op.attribute_key, [])
         if values:
             displayed = values[:_MAX_DISPLAYED_VALUES]
             suffix = ", ..." if len(values) > _MAX_DISPLAYED_VALUES else ""
@@ -182,7 +153,7 @@ def _build_query_description(
         else:
             values_str = ""
         ops_by_source.setdefault(display_name, []).append(
-            f"{operator_name}:<value>{values_str}"
+            f"{op.operator}:<value>{values_str}"
         )
 
     if ops_by_source:
@@ -206,7 +177,7 @@ def _build_query_description(
 
 
 def _build_search_tools(
-    search_operators: list[dict] | None = None,
+    search_operators: list[SearchOperator] | None = None,
     connected_source_types: list[str] | None = None,
     operator_values: dict[str, list[str]] | None = None,
 ) -> list[dict]:
@@ -249,7 +220,7 @@ class SearchToolHandler:
     def __init__(
         self,
         searcher_tool: SearcherTool,
-        search_operators: list[dict] | None = None,
+        search_operators: list[SearchOperator] | None = None,
         connected_source_types: list[str] | None = None,
         operator_values: dict[str, list[str]] | None = None,
     ) -> None:

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 
 import redis.asyncio as aioredis
 from pydantic import ValidationError
@@ -64,18 +65,36 @@ _MAX_DISPLAYED_VALUES = 20
 _OPERATOR_VALUES_CACHE_KEY = "search:operator_values"
 _OPERATOR_VALUES_CACHE_TTL = 300  # 5 minutes
 
+# In-memory cache so the hot path (every LLM call) is a timestamp check, not a Redis round-trip.
+_operator_values_mem: dict[str, list[str]] = {}
+_operator_values_mem_ts: float = 0
+
 
 async def fetch_operator_values(
     searcher_client: SearcherClient,
     search_operators: list[dict],
     redis_client: aioredis.Redis | None = None,
 ) -> dict[str, list[str]]:
-    """Fetch and cache distinct values for dynamic search operators."""
+    """Fetch and cache distinct values for dynamic search operators.
+
+    Cache hierarchy: in-memory (instant) → Redis (network) → searcher API (DB query).
+    """
+    global _operator_values_mem, _operator_values_mem_ts
+
+    now = time.monotonic()
+    if (
+        _operator_values_mem
+        and (now - _operator_values_mem_ts) < _OPERATOR_VALUES_CACHE_TTL
+    ):
+        return _operator_values_mem
+
     if redis_client:
         try:
             cached = await redis_client.get(_OPERATOR_VALUES_CACHE_KEY)
             if cached:
-                return json.loads(cached)
+                _operator_values_mem = json.loads(cached)
+                _operator_values_mem_ts = now
+                return _operator_values_mem
         except Exception as e:
             logger.warning(f"Failed to read operator values cache: {e}")
 
@@ -92,6 +111,9 @@ async def fetch_operator_values(
     except Exception as e:
         logger.warning(f"Failed to fetch operator values from searcher: {e}")
         return {}
+
+    _operator_values_mem = values
+    _operator_values_mem_ts = now
 
     if redis_client and values:
         try:

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import json
 import logging
 
+import redis.asyncio as aioredis
 from pydantic import ValidationError
 from anthropic.types import (
     TextBlockParam,
@@ -13,7 +15,12 @@ from anthropic.types import (
 
 from models.chat import SearchToolParams
 from tools.searcher_tool import SearcherTool
-from tools.searcher_client import SearchRequest, SearchResponse, SearchResult
+from tools.searcher_client import (
+    SearcherClient,
+    SearchRequest,
+    SearchResponse,
+    SearchResult,
+)
 from tools.registry import ToolContext, ToolResult
 
 logger = logging.getLogger(__name__)
@@ -23,30 +30,138 @@ _TOOL_NAMES = {"search_documents"}
 # Operators already documented as universal — exclude from connector-specific lists
 _UNIVERSAL_OPERATORS = {"by", "in", "from", "type", "before", "after"}
 
+# Maps source_type (as stored in db) to the aliases accepted by the in: operator
+SOURCE_TYPE_IN_ALIASES: dict[str, list[str]] = {
+    "google_drive": ["drive", "gdrive"],
+    "gmail": ["gmail", "email"],
+    "slack": ["slack"],
+    "confluence": ["confluence", "wiki"],
+    "jira": ["jira"],
+    "github": ["github", "gh"],
+    "notion": ["notion"],
+    "one_drive": ["onedrive"],
+    "share_point": ["sharepoint"],
+    "outlook": ["outlook"],
+    "hubspot": ["hubspot"],
+    "fireflies": ["fireflies"],
+    "clickup": ["clickup"],
+    "web": ["web"],
+}
+
+TYPE_VALID_VALUES = [
+    "sheet",
+    "doc",
+    "slide",
+    "pdf",
+    "issue",
+    "pr",
+    "page",
+    "email",
+    "meeting",
+]
+
+_MAX_DISPLAYED_VALUES = 20
+_OPERATOR_VALUES_CACHE_KEY = "search:operator_values"
+_OPERATOR_VALUES_CACHE_TTL = 300  # 5 minutes
+
+
+async def fetch_operator_values(
+    searcher_client: SearcherClient,
+    search_operators: list[dict],
+    redis_client: aioredis.Redis | None = None,
+) -> dict[str, list[str]]:
+    """Fetch and cache distinct values for dynamic search operators."""
+    if redis_client:
+        try:
+            cached = await redis_client.get(_OPERATOR_VALUES_CACHE_KEY)
+            if cached:
+                return json.loads(cached)
+        except Exception as e:
+            logger.warning(f"Failed to read operator values cache: {e}")
+
+    attribute_keys = [
+        op["attribute_key"]
+        for op in search_operators
+        if op["operator"] not in _UNIVERSAL_OPERATORS and op.get("attribute_key")
+    ]
+    if not attribute_keys:
+        return {}
+
+    try:
+        values = await searcher_client.get_attribute_values(attribute_keys)
+    except Exception as e:
+        logger.warning(f"Failed to fetch operator values from searcher: {e}")
+        return {}
+
+    if redis_client and values:
+        try:
+            await redis_client.set(
+                _OPERATOR_VALUES_CACHE_KEY,
+                json.dumps(values),
+                ex=_OPERATOR_VALUES_CACHE_TTL,
+            )
+        except Exception as e:
+            logger.warning(f"Failed to cache operator values: {e}")
+
+    return values
+
 
 def _build_query_description(
     search_operators: list[dict],
+    connected_source_types: list[str] | None = None,
+    operator_values: dict[str, list[str]] | None = None,
 ) -> str:
     """Build a rich description for the query parameter with operator syntax."""
+    # Build in: values filtered to connected sources
+    if connected_source_types:
+        in_aliases = []
+        for st in connected_source_types:
+            aliases = SOURCE_TYPE_IN_ALIASES.get(st)
+            if aliases:
+                in_aliases.append(aliases[0])  # primary alias
+        in_values_str = (
+            f". Values: {', '.join(sorted(in_aliases))}" if in_aliases else ""
+        )
+    else:
+        in_values_str = ""
+
+    type_values_str = ", ".join(TYPE_VALID_VALUES)
+
     lines = [
         "The search query. Supports inline operators for filtering:",
         "",
         "Universal operators:",
-        "- in:<source> — filter by app (e.g., in:slack, in:drive, in:jira)",
+        f"- in:<source> — filter by app{in_values_str}",
         "- by:<person> — filter by author/creator",
         "- from:<person> — filter by sender (emails, messages)",
-        "- type:<type> — content type (sheet, doc, pdf, email, issue, pr, meeting, slide, page)",
+        f"- type:<type> — content type. Values: {type_values_str}",
         "- before:<date> / after:<date> — date range (YYYY-MM-DD, YYYY-MM, or YYYY)",
         "Date keywords (no operator needed): last week, last month, this week, yesterday, today",
     ]
 
     # Group connector-specific operators by source_type
     ops_by_source: dict[str, list[str]] = {}
+    # Build a lookup from attribute_key to operator name for value mapping
+    attr_key_to_operator: dict[str, str] = {}
     for op in search_operators:
         if op["operator"] in _UNIVERSAL_OPERATORS:
             continue
         display_name = op.get("display_name", op.get("source_type", ""))
-        ops_by_source.setdefault(display_name, []).append(f"{op['operator']}:<value>")
+        attr_key = op.get("attribute_key", "")
+        operator_name = op["operator"]
+        attr_key_to_operator[attr_key] = operator_name
+
+        # Build operator text with values if available
+        values = (operator_values or {}).get(attr_key, []) if attr_key else []
+        if values:
+            displayed = values[:_MAX_DISPLAYED_VALUES]
+            suffix = ", ..." if len(values) > _MAX_DISPLAYED_VALUES else ""
+            values_str = f" ({', '.join(displayed)}{suffix})"
+        else:
+            values_str = ""
+        ops_by_source.setdefault(display_name, []).append(
+            f"{operator_name}:<value>{values_str}"
+        )
 
     if ops_by_source:
         lines.append("")
@@ -59,15 +174,26 @@ def _build_query_description(
     lines.append(
         'Examples: "status:done in:jira sprint tasks", "type:pdf after:2024-01 invoice", "budget last week"'
     )
+    lines.append("")
+    lines.append(
+        "Important: Boolean operators (AND, OR, NOT) are NOT supported. "
+        "Use multiple inline operators in the same query instead."
+    )
 
     return "\n".join(lines)
 
 
 def _build_search_tools(
     search_operators: list[dict] | None = None,
+    connected_source_types: list[str] | None = None,
+    operator_values: dict[str, list[str]] | None = None,
 ) -> list[dict]:
     """Build the search tool definition with dynamic operators."""
-    query_desc = _build_query_description(search_operators or [])
+    query_desc = _build_query_description(
+        search_operators or [],
+        connected_source_types=connected_source_types,
+        operator_values=operator_values,
+    )
 
     return [
         {
@@ -102,9 +228,15 @@ class SearchToolHandler:
         self,
         searcher_tool: SearcherTool,
         search_operators: list[dict] | None = None,
+        connected_source_types: list[str] | None = None,
+        operator_values: dict[str, list[str]] | None = None,
     ) -> None:
         self._searcher = searcher_tool
-        self._tools = _build_search_tools(search_operators)
+        self._tools = _build_search_tools(
+            search_operators,
+            connected_source_types=connected_source_types,
+            operator_values=operator_values,
+        )
 
     def get_tools(self) -> list[dict]:
         return self._tools

--- a/services/ai/tools/searcher_client.py
+++ b/services/ai/tools/searcher_client.py
@@ -175,6 +175,27 @@ class SearcherClient:
             logger.error(f"People search failed: {e}")
             raise
 
+    async def get_attribute_values(
+        self, keys: list[str], limit: int = 25
+    ) -> dict[str, list[str]]:
+        """Fetch distinct values for the given attribute keys from the index."""
+        try:
+            response = await self.client.get(
+                f"{self.searcher_url}/attributes/values",
+                params={"keys": ",".join(keys), "limit": limit},
+            )
+            if response.status_code == 200:
+                data = response.json()
+                return data.get("attributes", {})
+            else:
+                logger.error(
+                    f"Attribute values fetch error: {response.status_code} - {response.text}"
+                )
+                return {}
+        except Exception as e:
+            logger.error(f"Failed to fetch attribute values: {e}")
+            return {}
+
     async def close(self):
         """Close the HTTP client"""
         await self.client.aclose()

--- a/services/searcher/src/handlers.rs
+++ b/services/searcher/src/handlers.rs
@@ -1,6 +1,7 @@
 use crate::models::{
-    PeopleSearchResponse, PersonResult, RecentSearchesRequest, SearchRequest,
-    SuggestedQuestionsRequest, SuggestedQuestionsResponse, TypeaheadQuery, TypeaheadResponse,
+    AttributeValuesResponse, PeopleSearchResponse, PersonResult, RecentSearchesRequest,
+    SearchRequest, SuggestedQuestionsRequest, SuggestedQuestionsResponse, TypeaheadQuery,
+    TypeaheadResponse,
 };
 use crate::search::SearchEngine;
 use crate::search_repository::SearchDocumentRepository;
@@ -355,7 +356,7 @@ pub struct AttributeValuesQuery {
 pub async fn attribute_values(
     State(state): State<AppState>,
     Query(query): Query<AttributeValuesQuery>,
-) -> SearcherResult<Json<Value>> {
+) -> SearcherResult<Json<AttributeValuesResponse>> {
     let keys: Vec<String> = query
         .keys
         .split(',')
@@ -371,10 +372,10 @@ pub async fn attribute_values(
 
     let limit = query.limit.unwrap_or(25).min(100);
     let repo = SearchDocumentRepository::new(state.db_pool.pool());
-    let values = repo
+    let attributes = repo
         .get_distinct_attribute_values(&keys, limit)
         .await
         .map_err(|e| SearcherError::Internal(anyhow!("Failed to fetch attribute values: {}", e)))?;
 
-    Ok(Json(json!({ "attributes": values })))
+    Ok(Json(AttributeValuesResponse { attributes }))
 }

--- a/services/searcher/src/handlers.rs
+++ b/services/searcher/src/handlers.rs
@@ -3,6 +3,7 @@ use crate::models::{
     SuggestedQuestionsRequest, SuggestedQuestionsResponse, TypeaheadQuery, TypeaheadResponse,
 };
 use crate::search::SearchEngine;
+use crate::search_repository::SearchDocumentRepository;
 use crate::suggested_questions::{self, SuggestedQuestionsGenerator};
 use crate::{AppState, Result as SearcherResult, SearcherError};
 use anyhow::anyhow;
@@ -343,4 +344,37 @@ pub async fn people_search(
         .collect();
 
     Ok(Json(PeopleSearchResponse { people }))
+}
+
+#[derive(Debug, serde::Deserialize)]
+pub struct AttributeValuesQuery {
+    pub keys: String,
+    pub limit: Option<i64>,
+}
+
+pub async fn attribute_values(
+    State(state): State<AppState>,
+    Query(query): Query<AttributeValuesQuery>,
+) -> SearcherResult<Json<Value>> {
+    let keys: Vec<String> = query
+        .keys
+        .split(',')
+        .map(|k| k.trim().to_string())
+        .filter(|k| !k.is_empty())
+        .collect();
+
+    if keys.is_empty() {
+        return Err(SearcherError::BadRequest(
+            "keys parameter is required".to_string(),
+        ));
+    }
+
+    let limit = query.limit.unwrap_or(25).min(100);
+    let repo = SearchDocumentRepository::new(state.db_pool.pool());
+    let values = repo
+        .get_distinct_attribute_values(&keys, limit)
+        .await
+        .map_err(|e| SearcherError::Internal(anyhow!("Failed to fetch attribute values: {}", e)))?;
+
+    Ok(Json(json!({ "attributes": values })))
 }

--- a/services/searcher/src/lib.rs
+++ b/services/searcher/src/lib.rs
@@ -98,6 +98,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/typeahead", get(handlers::typeahead))
         .route("/people/search", get(handlers::people_search))
         .route("/suggested-questions", post(handlers::suggested_questions))
+        .route("/attributes/values", get(handlers::attribute_values))
         .layer(
             ServiceBuilder::new()
                 .layer(middleware::from_fn(telemetry::middleware::trace_layer))

--- a/services/searcher/src/models.rs
+++ b/services/searcher/src/models.rs
@@ -165,6 +165,11 @@ pub struct PeopleSearchResponse {
     pub people: Vec<PersonResult>,
 }
 
+#[derive(Debug, Serialize)]
+pub struct AttributeValuesResponse {
+    pub attributes: std::collections::HashMap<String, Vec<String>>,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/services/searcher/src/models.rs
+++ b/services/searcher/src/models.rs
@@ -167,7 +167,7 @@ pub struct PeopleSearchResponse {
 
 #[derive(Debug, Serialize)]
 pub struct AttributeValuesResponse {
-    pub attributes: std::collections::HashMap<String, Vec<String>>,
+    pub attributes: HashMap<String, Vec<String>>,
 }
 
 #[cfg(test)]

--- a/services/searcher/src/search_repository.rs
+++ b/services/searcher/src/search_repository.rs
@@ -529,6 +529,37 @@ impl SearchDocumentRepository {
         let facet_rows = query_builder.fetch_all(&self.pool).await?;
         Ok(rows_to_facets(facet_rows))
     }
+
+    pub async fn get_distinct_attribute_values(
+        &self,
+        keys: &[String],
+        limit: i64,
+    ) -> Result<HashMap<String, Vec<String>>, DatabaseError> {
+        let mut result: HashMap<String, Vec<String>> = HashMap::new();
+
+        for key in keys {
+            let rows: Vec<(String,)> = sqlx::query_as(
+                r#"
+                SELECT DISTINCT attributes->>$1 AS val
+                FROM documents
+                WHERE attributes ? $1 AND attributes->>$1 IS NOT NULL
+                ORDER BY val
+                LIMIT $2
+                "#,
+            )
+            .bind(key)
+            .bind(limit)
+            .fetch_all(&self.pool)
+            .await?;
+
+            let values: Vec<String> = rows.into_iter().map(|(v,)| v).collect();
+            if !values.is_empty() {
+                result.insert(key.clone(), values);
+            }
+        }
+
+        Ok(result)
+    }
 }
 
 fn rows_to_facets(rows: Vec<(String, String, i64)>) -> Vec<Facet> {

--- a/services/searcher/src/search_repository.rs
+++ b/services/searcher/src/search_repository.rs
@@ -535,29 +535,36 @@ impl SearchDocumentRepository {
         keys: &[String],
         limit: i64,
     ) -> Result<HashMap<String, Vec<String>>, DatabaseError> {
-        let mut result: HashMap<String, Vec<String>> = HashMap::new();
-
-        for key in keys {
-            let rows: Vec<(String,)> = sqlx::query_as(
-                r#"
-                SELECT DISTINCT attributes->>$1 AS val
-                FROM documents
-                WHERE attributes ? $1 AND attributes->>$1 IS NOT NULL
-                ORDER BY val
-                LIMIT $2
-                "#,
-            )
-            .bind(key)
-            .bind(limit)
-            .fetch_all(&self.pool)
-            .await?;
-
-            let values: Vec<String> = rows.into_iter().map(|(v,)| v).collect();
-            if !values.is_empty() {
-                result.insert(key.clone(), values);
-            }
+        if keys.is_empty() {
+            return Ok(HashMap::new());
         }
 
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            r#"
+            SELECT key, val FROM (
+                SELECT
+                    key,
+                    val,
+                    ROW_NUMBER() OVER (PARTITION BY key ORDER BY val) AS rn
+                FROM (
+                    SELECT DISTINCT k AS key, attributes->>k AS val
+                    FROM documents, UNNEST($1::text[]) AS k
+                    WHERE attributes ? k AND attributes->>k IS NOT NULL
+                ) distinct_vals
+            ) ranked
+            WHERE rn <= $2
+            ORDER BY key, val
+            "#,
+        )
+        .bind(keys)
+        .bind(limit)
+        .fetch_all(&self.pool)
+        .await?;
+
+        let mut result: HashMap<String, Vec<String>> = HashMap::new();
+        for (key, val) in rows {
+            result.entry(key).or_default().push(val);
+        }
         Ok(result)
     }
 }


### PR DESCRIPTION
- Inject current UTC date/time and user identity (name + email) into chat and agent system prompts so the LLM can resolve relative dates and personalize responses
- Enrich search tool description with valid operator values: static values for `in:` (filtered to connected sources) and `type:`, dynamic values for connector-specific operators (status, channel, project, etc.) fetched from a new `/attributes/values` searcher endpoint and cached in Redis
- Add explicit warning that boolean operators (AND, OR, NOT) are not supported in search queries