### PR TITLE
Fix Gmail thread sync: URLs, permissions, content extraction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4258,12 +4258,12 @@ dependencies = [
  "dotenvy",
  "futures",
  "governor",
+ "html2text",
  "jsonwebtoken",
  "nonzero_ext",
  "omni-connector-manager",
  "rand 0.8.5",
  "redis",
- "regex",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -4276,6 +4276,7 @@ dependencies = [
  "tower-http 0.6.8",
  "tracing",
  "tracing-subscriber",
+ "urlencoding",
  "uuid",
 ]
 

--- a/connectors/google/Cargo.toml
+++ b/connectors/google/Cargo.toml
@@ -36,7 +36,8 @@ futures = { workspace = true }
 governor = { workspace = true }
 nonzero_ext = { workspace = true }
 rand = { workspace = true }
-regex = "1.10"
+html2text = "0.16"
+urlencoding = "2.1"
 # HTTP server dependencies
 dashmap = { workspace = true }
 tower = { workspace = true }

--- a/connectors/google/src/gmail.rs
+++ b/connectors/google/src/gmail.rs
@@ -645,33 +645,100 @@ impl GmailClient {
 
     pub fn extract_message_content(&self, message: &GmailMessage) -> Result<String> {
         if let Some(ref payload) = message.payload {
-            self.extract_text_from_payload(payload)
+            let mut plain_parts: Vec<String> = Vec::new();
+            let mut html_parts: Vec<String> = Vec::new();
+            Self::collect_text_parts(payload, &mut plain_parts, &mut html_parts);
+
+            let body = if !plain_parts.is_empty() {
+                plain_parts.join("\n\n")
+            } else if !html_parts.is_empty() {
+                let combined = html_parts.join("\n\n");
+                html_to_text(&combined)
+            } else {
+                String::new()
+            };
+
+            Ok(body)
         } else {
             Ok(String::new())
         }
     }
 
-    fn extract_text_from_payload(&self, payload: &MessagePart) -> Result<String> {
-        let mut content = String::new();
+    /// Extract message content including text from supported attachments.
+    pub async fn extract_message_content_with_attachments(
+        &self,
+        message: &GmailMessage,
+        auth: &GoogleAuth,
+        user_email: &str,
+    ) -> Result<String> {
+        let mut body = self.extract_message_content(message)?;
 
-        // If this part has a body with data, extract it
-        if let Some(ref body) = payload.body {
-            if let Some(ref data) = body.data {
-                if let Some(mime_type) = &payload.mime_type {
-                    if mime_type.starts_with("text/") {
-                        match URL_SAFE_NO_PAD.decode(data) {
-                            Ok(decoded) => {
-                                if let Ok(text) = String::from_utf8(decoded) {
-                                    if mime_type == "text/html" {
-                                        // Simple HTML to text conversion
-                                        content.push_str(&self.html_to_text(&text));
-                                    } else {
-                                        content.push_str(&text);
-                                    }
-                                }
+        if let Some(ref payload) = message.payload {
+            let mut attachment_parts: Vec<AttachmentInfo> = Vec::new();
+            Self::collect_attachment_parts(payload, &mut attachment_parts);
+
+            for att in attachment_parts {
+                match self
+                    .download_attachment(auth, user_email, &message.id, &att.attachment_id)
+                    .await
+                {
+                    Ok(data) => {
+                        match shared::content_extractor::extract_content(
+                            &data,
+                            &att.mime_type,
+                            Some(&att.filename),
+                        ) {
+                            Ok(text) if !text.trim().is_empty() => {
+                                body.push_str(&format!(
+                                    "\n\n[Attachment: {}]\n{}",
+                                    att.filename, text
+                                ));
+                            }
+                            Ok(_) => {
+                                body.push_str(&format!("\n\n[Attachment: {}]", att.filename));
                             }
                             Err(e) => {
-                                debug!("Failed to decode message part: {}", e);
+                                debug!(
+                                    "Failed to extract content from attachment {}: {}",
+                                    att.filename, e
+                                );
+                                body.push_str(&format!("\n\n[Attachment: {}]", att.filename));
+                            }
+                        }
+                    }
+                    Err(e) => {
+                        debug!(
+                            "Failed to download attachment {} ({}): {}",
+                            att.filename, att.attachment_id, e
+                        );
+                        body.push_str(&format!("\n\n[Attachment: {}]", att.filename));
+                    }
+                }
+            }
+        }
+
+        Ok(body)
+    }
+
+    /// Recursively collect text/plain and text/html parts separately,
+    /// skipping parts that are file attachments.
+    fn collect_text_parts(part: &MessagePart, plain: &mut Vec<String>, html: &mut Vec<String>) {
+        // Skip file attachments
+        if is_file_attachment(part) {
+            return;
+        }
+
+        if let Some(ref body) = part.body {
+            if let Some(ref data) = body.data {
+                if let Some(ref mime_type) = part.mime_type {
+                    if let Ok(decoded) = URL_SAFE_NO_PAD.decode(data) {
+                        if let Ok(text) = String::from_utf8(decoded) {
+                            if !text.trim().is_empty() {
+                                if mime_type == "text/plain" {
+                                    plain.push(text);
+                                } else if mime_type == "text/html" {
+                                    html.push(text);
+                                }
                             }
                         }
                     }
@@ -679,33 +746,113 @@ impl GmailClient {
             }
         }
 
-        // Recursively process parts
-        if let Some(ref parts) = payload.parts {
-            for part in parts {
-                if let Ok(part_content) = self.extract_text_from_payload(part) {
-                    if !part_content.is_empty() {
-                        content.push_str(&part_content);
-                        content.push('\n');
+        if let Some(ref parts) = part.parts {
+            for sub in parts {
+                Self::collect_text_parts(sub, plain, html);
+            }
+        }
+    }
+
+    /// Recursively collect attachment parts that have a supported MIME type.
+    fn collect_attachment_parts(part: &MessagePart, attachments: &mut Vec<AttachmentInfo>) {
+        if is_file_attachment(part) {
+            if let Some(ref body) = part.body {
+                if let Some(ref attachment_id) = body.attachment_id {
+                    let mime_type = part
+                        .mime_type
+                        .as_deref()
+                        .unwrap_or("application/octet-stream");
+                    let filename = part.filename.as_deref().unwrap_or("attachment");
+
+                    // Infer MIME type from extension if declared as octet-stream
+                    let effective_mime = if mime_type == "application/octet-stream" {
+                        mime_type_from_extension(filename).unwrap_or(mime_type)
+                    } else {
+                        mime_type
+                    };
+
+                    if is_supported_attachment_type(effective_mime) {
+                        // Skip very large attachments (>10MB)
+                        let too_large = body.size.map_or(false, |s| s > 10 * 1024 * 1024);
+                        if !too_large {
+                            attachments.push(AttachmentInfo {
+                                attachment_id: attachment_id.clone(),
+                                filename: filename.to_string(),
+                                mime_type: effective_mime.to_string(),
+                            });
+                        }
                     }
                 }
             }
         }
 
-        Ok(content)
+        if let Some(ref parts) = part.parts {
+            for sub in parts {
+                Self::collect_attachment_parts(sub, attachments);
+            }
+        }
     }
 
-    fn html_to_text(&self, html: &str) -> String {
-        // Simple HTML tag removal - in production, consider using a proper HTML parser
-        let re = regex::Regex::new(r"<[^>]*>").unwrap();
-        let text = re.replace_all(html, " ");
+    pub async fn download_attachment(
+        &self,
+        auth: &GoogleAuth,
+        user_email: &str,
+        message_id: &str,
+        attachment_id: &str,
+    ) -> Result<Vec<u8>> {
+        let message_id = message_id.to_string();
+        let attachment_id = attachment_id.to_string();
 
-        // Decode common HTML entities
-        text.replace("&nbsp;", " ")
-            .replace("&amp;", "&")
-            .replace("&lt;", "<")
-            .replace("&gt;", ">")
-            .replace("&quot;", "\"")
-            .replace("&#39;", "'")
+        let rate_limiter = self.get_or_create_user_rate_limiter(user_email)?;
+        execute_with_auth_retry(auth, user_email, rate_limiter.clone(), |token| {
+            let message_id = message_id.clone();
+            let attachment_id = attachment_id.clone();
+            async move {
+                let url = format!(
+                    "{}/users/{}/messages/{}/attachments/{}",
+                    GMAIL_API_BASE, user_email, message_id, attachment_id
+                );
+
+                let response = self
+                    .client
+                    .get(&url)
+                    .bearer_auth(&token)
+                    .send()
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to download attachment {} for message {}",
+                            attachment_id, message_id
+                        )
+                    })?;
+
+                let status = response.status();
+                if is_auth_error(status) {
+                    return Ok(ApiResult::AuthError);
+                } else if !status.is_success() {
+                    let error_text = response.text().await?;
+                    return Ok(ApiResult::OtherError(anyhow!(
+                        "Gmail API attachment download error: HTTP {} - {}",
+                        status,
+                        error_text
+                    )));
+                }
+
+                let body: AttachmentResponse = response.json().await.with_context(|| {
+                    format!(
+                        "Failed to parse attachment response for {} in message {}",
+                        attachment_id, message_id
+                    )
+                })?;
+
+                let decoded = URL_SAFE_NO_PAD
+                    .decode(&body.data)
+                    .with_context(|| "Failed to decode attachment data")?;
+
+                Ok(ApiResult::Success(decoded))
+            }
+        })
+        .await
     }
 
     pub fn get_header_value(&self, message: &GmailMessage, header_name: &str) -> Option<String> {
@@ -876,4 +1023,62 @@ pub struct GmailThreadResponse {
     #[serde(rename = "historyId")]
     pub history_id: Option<String>,
     pub messages: Vec<GmailMessage>,
+}
+
+#[derive(Debug, Deserialize)]
+struct AttachmentResponse {
+    data: String,
+}
+
+#[derive(Debug)]
+pub struct AttachmentInfo {
+    pub attachment_id: String,
+    pub filename: String,
+    pub mime_type: String,
+}
+
+const SUPPORTED_ATTACHMENT_TYPES: &[&str] = &[
+    "application/pdf",
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+    "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+    "application/vnd.ms-excel",
+    "text/plain",
+    "text/html",
+    "text/csv",
+    "text/markdown",
+];
+
+fn is_supported_attachment_type(mime_type: &str) -> bool {
+    SUPPORTED_ATTACHMENT_TYPES.iter().any(|&t| t == mime_type)
+}
+
+fn is_file_attachment(part: &MessagePart) -> bool {
+    part.filename.as_ref().is_some_and(|f| !f.is_empty())
+        || part
+            .body
+            .as_ref()
+            .is_some_and(|b| b.attachment_id.is_some())
+}
+
+const HTML_TEXT_WIDTH: usize = 100;
+
+fn html_to_text(html: &str) -> String {
+    html2text::from_read(html.as_bytes(), HTML_TEXT_WIDTH).unwrap_or_default()
+}
+
+fn mime_type_from_extension(filename: &str) -> Option<&'static str> {
+    let ext = filename.rsplit('.').next()?.to_ascii_lowercase();
+    match ext.as_str() {
+        "pdf" => Some("application/pdf"),
+        "docx" => Some("application/vnd.openxmlformats-officedocument.wordprocessingml.document"),
+        "xlsx" => Some("application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"),
+        "pptx" => Some("application/vnd.openxmlformats-officedocument.presentationml.presentation"),
+        "xls" => Some("application/vnd.ms-excel"),
+        "txt" => Some("text/plain"),
+        "html" | "htm" => Some("text/html"),
+        "csv" => Some("text/csv"),
+        "md" | "markdown" => Some("text/markdown"),
+        _ => None,
+    }
 }

--- a/connectors/google/src/gmail.rs
+++ b/connectors/google/src/gmail.rs
@@ -664,60 +664,56 @@ impl GmailClient {
         }
     }
 
-    /// Extract message content including text from supported attachments.
-    pub async fn extract_message_content_with_attachments(
+    /// Download and extract text from all supported attachments in a message.
+    /// Returns structured attachment data for separate document indexing.
+    pub async fn extract_attachments(
         &self,
         message: &GmailMessage,
         auth: &GoogleAuth,
         user_email: &str,
-    ) -> Result<String> {
-        let mut body = self.extract_message_content(message)?;
+    ) -> Vec<ExtractedAttachment> {
+        let mut results = Vec::new();
 
-        if let Some(ref payload) = message.payload {
-            let mut attachment_parts: Vec<AttachmentInfo> = Vec::new();
-            Self::collect_attachment_parts(payload, &mut attachment_parts);
+        let Some(ref payload) = message.payload else {
+            return results;
+        };
 
-            for att in attachment_parts {
-                match self
-                    .download_attachment(auth, user_email, &message.id, &att.attachment_id)
-                    .await
-                {
-                    Ok(data) => {
-                        match shared::content_extractor::extract_content(
-                            &data,
-                            &att.mime_type,
-                            Some(&att.filename),
-                        ) {
-                            Ok(text) if !text.trim().is_empty() => {
-                                body.push_str(&format!(
-                                    "\n\n[Attachment: {}]\n{}",
-                                    att.filename, text
-                                ));
-                            }
-                            Ok(_) => {
-                                body.push_str(&format!("\n\n[Attachment: {}]", att.filename));
-                            }
-                            Err(e) => {
-                                debug!(
-                                    "Failed to extract content from attachment {}: {}",
-                                    att.filename, e
-                                );
-                                body.push_str(&format!("\n\n[Attachment: {}]", att.filename));
-                            }
-                        }
-                    }
-                    Err(e) => {
-                        debug!(
-                            "Failed to download attachment {} ({}): {}",
-                            att.filename, att.attachment_id, e
-                        );
-                        body.push_str(&format!("\n\n[Attachment: {}]", att.filename));
-                    }
+        let mut attachment_parts: Vec<AttachmentInfo> = Vec::new();
+        Self::collect_attachment_parts(payload, &mut attachment_parts);
+
+        for att in attachment_parts {
+            match self
+                .download_attachment(auth, user_email, &message.id, &att.attachment_id)
+                .await
+            {
+                Ok(data) => {
+                    let size = data.len() as u64;
+                    let extracted_text = shared::content_extractor::extract_content(
+                        &data,
+                        &att.mime_type,
+                        Some(&att.filename),
+                    )
+                    .unwrap_or_default();
+
+                    results.push(ExtractedAttachment {
+                        message_id: message.id.clone(),
+                        attachment_id: att.attachment_id,
+                        filename: att.filename,
+                        mime_type: att.mime_type,
+                        size,
+                        extracted_text,
+                    });
+                }
+                Err(e) => {
+                    debug!(
+                        "Failed to download attachment {} ({}): {}",
+                        att.filename, att.attachment_id, e
+                    );
                 }
             }
         }
 
-        Ok(body)
+        results
     }
 
     /// Recursively collect text/plain and text/html parts separately,
@@ -1035,6 +1031,16 @@ pub struct AttachmentInfo {
     pub attachment_id: String,
     pub filename: String,
     pub mime_type: String,
+}
+
+#[derive(Debug, Clone)]
+pub struct ExtractedAttachment {
+    pub message_id: String,
+    pub attachment_id: String,
+    pub filename: String,
+    pub mime_type: String,
+    pub size: u64,
+    pub extracted_text: String,
 }
 
 const SUPPORTED_ATTACHMENT_TYPES: &[&str] = &[

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -383,6 +383,7 @@ pub struct GmailThread {
     pub subject: String,
     pub latest_date: String,
     pub total_messages: usize,
+    pub message_id: Option<String>,
 }
 
 impl GmailThread {
@@ -394,10 +395,18 @@ impl GmailThread {
             subject: String::new(),
             latest_date: String::new(),
             total_messages: 0,
+            message_id: None,
         }
     }
 
     pub fn add_message(&mut self, message: GmailMessage) {
+        // Extract Message-ID from first message for permalink URL
+        if self.message_id.is_none() {
+            if let Some(mid) = self.extract_header_value(&message, "Message-ID") {
+                self.message_id = Some(mid);
+            }
+        }
+
         // Update subject from first message if not set
         if self.subject.is_empty() {
             if let Some(subject) = self.extract_header_value(&message, "Subject") {
@@ -430,28 +439,13 @@ impl GmailThread {
     }
 
     fn extract_participants(&mut self, message: &GmailMessage) {
-        let headers_to_check = ["From", "To", "Cc", "Bcc"];
+        // Gmail API does not expose Bcc headers to other recipients
+        let headers_to_check = ["From", "To", "Cc"];
 
         for header_name in &headers_to_check {
             if let Some(header_value) = self.extract_header_value(message, header_name) {
-                // Parse email addresses from header value
-                // Simple parsing - in production might want more sophisticated email parsing
-                for email in header_value.split(',') {
-                    let email = email.trim();
-                    // Extract email from "Name <email@domain.com>" format
-                    if let Some(start) = email.find('<') {
-                        if let Some(end) = email.find('>') {
-                            if start < end {
-                                let extracted_email = email[start + 1..end].trim().to_lowercase();
-                                if !extracted_email.is_empty() {
-                                    self.participants.insert(extracted_email);
-                                }
-                            }
-                        }
-                    } else if email.contains('@') {
-                        // Direct email format
-                        self.participants.insert(email.to_lowercase());
-                    }
+                for email in parse_email_addresses(&header_value) {
+                    self.participants.insert(email);
                 }
             }
         }
@@ -468,23 +462,24 @@ impl GmailThread {
             .map(|h| h.value.clone())
     }
 
-    pub fn aggregate_content(
+    pub async fn aggregate_content(
         &self,
         gmail_client: &crate::gmail::GmailClient,
+        auth: &crate::auth::GoogleAuth,
+        user_email: &str,
     ) -> Result<String, anyhow::Error> {
         let mut content_parts = Vec::new();
 
         // Add subject as the first part
         if !self.subject.is_empty() {
             content_parts.push(format!("Subject: {}", self.subject));
-            content_parts.push(String::new()); // Empty line
+            content_parts.push(String::new());
         }
 
         // Add each message content
         for (i, message) in self.messages.iter().enumerate() {
             content_parts.push(format!("=== Message {} ===", i + 1));
 
-            // Add basic message info
             if let Some(from) = self.extract_header_value(message, "From") {
                 content_parts.push(format!("From: {}", from));
             }
@@ -492,10 +487,12 @@ impl GmailThread {
                 content_parts.push(format!("Date: {}", date));
             }
 
-            content_parts.push(String::new()); // Empty line
+            content_parts.push(String::new());
 
-            // Add message content
-            match gmail_client.extract_message_content(message) {
+            match gmail_client
+                .extract_message_content_with_attachments(message, auth, user_email)
+                .await
+            {
                 Ok(message_content) => {
                     if !message_content.trim().is_empty() {
                         content_parts.push(message_content.trim().to_string());
@@ -506,7 +503,7 @@ impl GmailThread {
                 }
             }
 
-            content_parts.push(String::new()); // Empty line between messages
+            content_parts.push(String::new());
         }
 
         Ok(content_parts.join("\n"))
@@ -553,7 +550,7 @@ impl GmailThread {
         sync_run_id: &str,
         source_id: &str,
         content_id: &str,
-        _gmail_client: &crate::gmail::GmailClient,
+        known_groups: &HashSet<String>,
     ) -> Result<ConnectorEvent, anyhow::Error> {
         let mut extra = HashMap::new();
         extra.insert("thread_id".to_string(), json!(self.thread_id));
@@ -572,6 +569,27 @@ impl GmailThread {
             None
         };
 
+        // Build URL using rfc822msgid search for reliable Gmail permalinks.
+        // Gmail web UI uses internal IDs that differ from API thread IDs,
+        // so a search-based URL is the most reliable way to link to a thread.
+        let url = self
+            .message_id
+            .as_ref()
+            .map(|mid| {
+                let clean_id = mid.trim_start_matches('<').trim_end_matches('>');
+                let encoded = urlencoding::encode(clean_id);
+                format!(
+                    "https://mail.google.com/mail/#search/rfc822msgid%3A{}",
+                    encoded
+                )
+            })
+            .or_else(|| {
+                Some(format!(
+                    "https://mail.google.com/mail/#all/{}",
+                    self.thread_id
+                ))
+            });
+
         let metadata = DocumentMetadata {
             title: Some(if self.subject.is_empty() {
                 format!("Gmail Thread {}", self.thread_id)
@@ -584,18 +602,26 @@ impl GmailThread {
             content_type: Some("email_thread".to_string()),
             mime_type: Some("application/x-gmail-thread".to_string()),
             size: None,
-            url: Some(format!(
-                "https://mail.google.com/mail/u/0/#inbox/{}",
-                self.thread_id
-            )),
+            url,
             path: Some(format!("/Gmail/{}", self.subject)),
             extra: Some(extra),
         };
 
+        // Split participants into users and groups based on known org groups
+        let mut users = Vec::new();
+        let mut groups = Vec::new();
+        for participant in &self.participants {
+            if known_groups.contains(participant) {
+                groups.push(participant.clone());
+            } else {
+                users.push(participant.clone());
+            }
+        }
+
         let permissions = DocumentPermissions {
             public: false,
-            users: self.participants.iter().cloned().collect(),
-            groups: vec![],
+            users,
+            groups,
         };
 
         let attributes = self.to_attributes().into_attributes();
@@ -610,6 +636,59 @@ impl GmailThread {
             attributes: Some(attributes),
         })
     }
+}
+
+/// Parse email addresses from a header value, handling quoted display names
+/// that may contain commas (e.g., `"Smith, John" <john@example.com>`).
+fn parse_email_addresses(header_value: &str) -> Vec<String> {
+    let mut results = Vec::new();
+    let mut current = String::new();
+    let mut in_quotes = false;
+
+    for ch in header_value.chars() {
+        match ch {
+            '"' => {
+                in_quotes = !in_quotes;
+                current.push(ch);
+            }
+            ',' if !in_quotes => {
+                if let Some(email) = extract_email(&current) {
+                    results.push(email);
+                }
+                current.clear();
+            }
+            _ => current.push(ch),
+        }
+    }
+
+    // Process the last segment
+    if let Some(email) = extract_email(&current) {
+        results.push(email);
+    }
+
+    results
+}
+
+/// Extract a lowercased email address from a string that may be in
+/// `"Display Name" <email@domain.com>` or bare `email@domain.com` format.
+fn extract_email(s: &str) -> Option<String> {
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    if let Some(start) = s.find('<') {
+        if let Some(end) = s.find('>') {
+            if start < end {
+                let email = s[start + 1..end].trim().to_lowercase();
+                if !email.is_empty() && email.contains('@') {
+                    return Some(email);
+                }
+            }
+        }
+    } else if s.contains('@') {
+        return Some(s.to_lowercase());
+    }
+    None
 }
 
 #[cfg(test)]
@@ -911,6 +990,39 @@ mod tests {
             }
             _ => panic!("Expected DocumentCreated event"),
         }
+    }
+
+    #[test]
+    fn test_parse_email_addresses_simple() {
+        let result = parse_email_addresses("alice@example.com, bob@example.com");
+        assert_eq!(result, vec!["alice@example.com", "bob@example.com"]);
+    }
+
+    #[test]
+    fn test_parse_email_addresses_with_display_names() {
+        let result = parse_email_addresses("Alice <alice@example.com>, Bob <bob@example.com>");
+        assert_eq!(result, vec!["alice@example.com", "bob@example.com"]);
+    }
+
+    #[test]
+    fn test_parse_email_addresses_quoted_commas() {
+        let result = parse_email_addresses(
+            r#""Smith, John" <john@example.com>, "Doe, Jane" <jane@example.com>"#,
+        );
+        assert_eq!(result, vec!["john@example.com", "jane@example.com"]);
+    }
+
+    #[test]
+    fn test_parse_email_addresses_mixed() {
+        let result =
+            parse_email_addresses(r#"plain@example.com, "Quoted, Name" <quoted@example.com>"#);
+        assert_eq!(result, vec!["plain@example.com", "quoted@example.com"]);
+    }
+
+    #[test]
+    fn test_gmail_thread_new_has_no_message_id() {
+        let thread = GmailThread::new("t1".to_string());
+        assert!(thread.message_id.is_none());
     }
 }
 

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -79,7 +79,7 @@ impl From<GoogleDriveFile> for FolderMetadata {
     }
 }
 
-fn mime_type_to_content_type(mime_type: &str) -> Option<String> {
+pub fn mime_type_to_content_type(mime_type: &str) -> Option<String> {
     match mime_type {
         "application/vnd.google-apps.document" => Some("document".to_string()),
         "application/vnd.google-apps.spreadsheet" => Some("spreadsheet".to_string()),
@@ -462,11 +462,9 @@ impl GmailThread {
             .map(|h| h.value.clone())
     }
 
-    pub async fn aggregate_content(
+    pub fn aggregate_content(
         &self,
         gmail_client: &crate::gmail::GmailClient,
-        auth: &crate::auth::GoogleAuth,
-        user_email: &str,
     ) -> Result<String, anyhow::Error> {
         let mut content_parts = Vec::new();
 
@@ -476,7 +474,7 @@ impl GmailThread {
             content_parts.push(String::new());
         }
 
-        // Add each message content
+        // Add each message's text content (attachments are indexed as separate documents)
         for (i, message) in self.messages.iter().enumerate() {
             content_parts.push(format!("=== Message {} ===", i + 1));
 
@@ -489,10 +487,7 @@ impl GmailThread {
 
             content_parts.push(String::new());
 
-            match gmail_client
-                .extract_message_content_with_attachments(message, auth, user_email)
-                .await
-            {
+            match gmail_client.extract_message_content(message) {
                 Ok(message_content) => {
                     if !message_content.trim().is_empty() {
                         content_parts.push(message_content.trim().to_string());

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -15,11 +15,13 @@ use crate::cache::LruFolderCache;
 use crate::drive::{DriveClient, FileContent};
 use crate::gmail::{GmailClient, MessageFormat};
 use crate::models::{
-    GmailThread, GoogleConnectorState, SyncRequest, UserFile, WebhookChannel,
-    WebhookChannelResponse, WebhookNotification,
+    mime_type_to_content_type, GmailThread, GoogleConnectorState, SyncRequest, UserFile,
+    WebhookChannel, WebhookChannelResponse, WebhookNotification,
 };
+use serde_json::json;
 use shared::models::{
-    AuthType, ConnectorEvent, ServiceCredentials, ServiceProvider, Source, SourceType, SyncType,
+    AuthType, ConnectorEvent, DocumentMetadata, DocumentPermissions, ServiceCredentials,
+    ServiceProvider, Source, SourceType, SyncType,
 };
 use shared::RateLimiter;
 use shared::SdkClient;
@@ -2171,10 +2173,8 @@ impl SyncManager {
                         debug!("Gmail thread {} has no messages, skipping", thread_id);
                     }
                 } else {
-                    match gmail_thread
-                        .aggregate_content(&self.gmail_client, &service_auth, user_email)
-                        .await
-                    {
+                    // Index thread conversation content (no attachment text)
+                    match gmail_thread.aggregate_content(&self.gmail_client) {
                         Ok(content) => {
                             if !content.trim().is_empty() {
                                 match self.sdk_client.store_content(sync_run_id, &content).await {
@@ -2235,6 +2235,113 @@ impl SyncManager {
                                 "Failed to aggregate content for Gmail thread {}: {}",
                                 thread_id, e
                             );
+                        }
+                    }
+
+                    // Index attachments as separate documents
+                    let thread_url = gmail_thread.message_id.as_ref().map(|mid| {
+                        let clean_id = mid.trim_start_matches('<').trim_end_matches('>');
+                        let encoded = urlencoding::encode(clean_id);
+                        format!(
+                            "https://mail.google.com/mail/#search/rfc822msgid%3A{}",
+                            encoded
+                        )
+                    });
+
+                    // Build permissions once for all attachments in this thread
+                    let mut att_users = Vec::new();
+                    let mut att_groups = Vec::new();
+                    for participant in &gmail_thread.participants {
+                        if known_groups.contains(participant) {
+                            att_groups.push(participant.clone());
+                        } else {
+                            att_users.push(participant.clone());
+                        }
+                    }
+                    let att_permissions = DocumentPermissions {
+                        public: false,
+                        users: att_users,
+                        groups: att_groups,
+                    };
+
+                    for message in &gmail_thread.messages {
+                        let attachments = self
+                            .gmail_client
+                            .extract_attachments(message, &service_auth, user_email)
+                            .await;
+
+                        for att in attachments {
+                            if att.extracted_text.trim().is_empty() {
+                                continue;
+                            }
+
+                            let att_content_id = match self
+                                .sdk_client
+                                .store_content(sync_run_id, &att.extracted_text)
+                                .await
+                            {
+                                Ok(id) => id,
+                                Err(e) => {
+                                    error!(
+                                        "Failed to store attachment content for {}: {}",
+                                        att.filename, e
+                                    );
+                                    continue;
+                                }
+                            };
+
+                            let att_doc_id = format!(
+                                "{}:att:{}:{}",
+                                thread_id, att.message_id, att.attachment_id
+                            );
+
+                            let mut att_extra = HashMap::new();
+                            att_extra.insert("parent_thread_id".to_string(), json!(thread_id));
+
+                            let att_metadata = DocumentMetadata {
+                                title: Some(att.filename.clone()),
+                                author: None,
+                                created_at: None,
+                                updated_at: None,
+                                content_type: mime_type_to_content_type(&att.mime_type),
+                                mime_type: Some(att.mime_type.clone()),
+                                size: Some(att.size.to_string()),
+                                url: thread_url.clone(),
+                                path: Some(format!(
+                                    "/Gmail/{}/{}",
+                                    gmail_thread.subject, att.filename
+                                )),
+                                extra: Some(att_extra),
+                            };
+
+                            let att_event = ConnectorEvent::DocumentCreated {
+                                sync_run_id: sync_run_id.to_string(),
+                                source_id: source_id.to_string(),
+                                document_id: att_doc_id.clone(),
+                                content_id: att_content_id,
+                                metadata: att_metadata,
+                                permissions: att_permissions.clone(),
+                                attributes: Some(HashMap::new()),
+                            };
+
+                            match self
+                                .sdk_client
+                                .emit_event(sync_run_id, source_id, att_event)
+                                .await
+                            {
+                                Ok(_) => {
+                                    debug!(
+                                        "Queued attachment {} for thread {}",
+                                        att.filename, thread_id
+                                    );
+                                }
+                                Err(e) => {
+                                    error!(
+                                        "Failed to queue attachment {} for thread {}: {}",
+                                        att.filename, thread_id, e
+                                    );
+                                }
+                            }
                         }
                     }
                 }

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -268,7 +268,7 @@ impl SyncManager {
         };
 
         // Sync group memberships (org-wide, shared between Drive and Gmail)
-        self.maybe_sync_groups(&source, &sync_run_id).await;
+        let known_groups = self.maybe_sync_groups(&source, &sync_run_id).await;
 
         // Run the sync
         let result = match source.source_type {
@@ -277,7 +277,7 @@ impl SyncManager {
                     .await
             }
             SourceType::Gmail => {
-                self.sync_gmail_source_internal(&source, &sync_run_id, sync_type)
+                self.sync_gmail_source_internal(&source, &sync_run_id, sync_type, known_groups)
                     .await
             }
             _ => Err(anyhow!("Unsupported source type: {:?}", source.source_type)),
@@ -1068,6 +1068,7 @@ impl SyncManager {
         source: &Source,
         sync_run_id: &str,
         sync_type: SyncType,
+        known_groups: HashSet<String>,
     ) -> Result<(usize, usize, usize)> {
         let service_creds = self.get_service_credentials(&source.id).await?;
         let service_auth = Arc::new(self.create_auth(&service_creds, source.source_type).await?);
@@ -1126,6 +1127,7 @@ impl SyncManager {
         let mut new_history_ids: HashMap<String, String> = HashMap::new();
 
         let processed_threads = Arc::new(std::sync::Mutex::new(HashSet::<String>::new()));
+        let known_groups = Arc::new(known_groups);
 
         info!(
             "Starting sequential user processing for {} users (Gmail, incremental={})",
@@ -1178,6 +1180,7 @@ impl SyncManager {
                                 sync_run_id,
                                 start_id,
                                 processed_threads.clone(),
+                                known_groups.clone(),
                             )
                             .await
                         {
@@ -1196,6 +1199,7 @@ impl SyncManager {
                                         sync_run_id,
                                         processed_threads.clone(),
                                         Some(&gmail_cutoff_date),
+                                        known_groups.clone(),
                                     )
                                     .await
                                 } else {
@@ -1211,6 +1215,7 @@ impl SyncManager {
                             sync_run_id,
                             processed_threads.clone(),
                             Some(&gmail_cutoff_date),
+                            known_groups.clone(),
                         )
                         .await
                     };
@@ -1825,6 +1830,7 @@ impl SyncManager {
         sync_run_id: &str,
         processed_threads: Arc<std::sync::Mutex<HashSet<String>>>,
         created_after: Option<&str>,
+        known_groups: Arc<HashSet<String>>,
     ) -> Result<(usize, usize)> {
         info!("Processing Gmail for user: {}", user_email);
 
@@ -1906,6 +1912,7 @@ impl SyncManager {
             source_id,
             sync_run_id,
             processed_threads,
+            known_groups,
         )
         .await
     }
@@ -1918,6 +1925,7 @@ impl SyncManager {
         sync_run_id: &str,
         start_history_id: &str,
         processed_threads: Arc<std::sync::Mutex<HashSet<String>>>,
+        known_groups: Arc<HashSet<String>>,
     ) -> Result<(usize, usize)> {
         info!(
             "Processing incremental Gmail sync for user {} from historyId {}",
@@ -2001,6 +2009,7 @@ impl SyncManager {
             source_id,
             sync_run_id,
             processed_threads,
+            known_groups,
         )
         .await
     }
@@ -2013,6 +2022,7 @@ impl SyncManager {
         source_id: &str,
         sync_run_id: &str,
         processed_threads: Arc<std::sync::Mutex<HashSet<String>>>,
+        known_groups: Arc<HashSet<String>>,
     ) -> Result<(usize, usize)> {
         let mut total_processed = 0;
         let mut total_updated = 0;
@@ -2133,8 +2143,38 @@ impl SyncManager {
                     }
                 }
 
-                if gmail_thread.total_messages > 0 {
-                    match gmail_thread.aggregate_content(&self.gmail_client) {
+                if gmail_thread.total_messages == 0 {
+                    // Thread has no messages — emit deletion if previously synced
+                    if sync_state
+                        .get_thread_sync_state(source_id, thread_id)
+                        .await
+                        .ok()
+                        .flatten()
+                        .is_some()
+                    {
+                        let event = ConnectorEvent::DocumentDeleted {
+                            sync_run_id: sync_run_id.to_string(),
+                            source_id: source_id.to_string(),
+                            document_id: thread_id.clone(),
+                        };
+                        if let Err(e) = self
+                            .sdk_client
+                            .emit_event(sync_run_id, source_id, event)
+                            .await
+                        {
+                            error!(
+                                "Failed to emit deletion for empty thread {}: {}",
+                                thread_id, e
+                            );
+                        }
+                    } else {
+                        debug!("Gmail thread {} has no messages, skipping", thread_id);
+                    }
+                } else {
+                    match gmail_thread
+                        .aggregate_content(&self.gmail_client, &service_auth, user_email)
+                        .await
+                    {
                         Ok(content) => {
                             if !content.trim().is_empty() {
                                 match self.sdk_client.store_content(sync_run_id, &content).await {
@@ -2143,7 +2183,7 @@ impl SyncManager {
                                             sync_run_id,
                                             source_id,
                                             &content_id,
-                                            &self.gmail_client,
+                                            &known_groups,
                                         ) {
                                             Ok(event) => {
                                                 match self
@@ -2197,8 +2237,6 @@ impl SyncManager {
                             );
                         }
                     }
-                } else {
-                    debug!("Gmail thread {} has no messages, skipping", thread_id);
                 }
 
                 drop(gmail_thread);
@@ -2217,12 +2255,12 @@ impl SyncManager {
 
     /// Sync group memberships if this is a service-account (domain-wide) source.
     /// OAuth single-user sources don't have Admin API access, so we skip them.
-    async fn maybe_sync_groups(&self, source: &Source, sync_run_id: &str) {
+    async fn maybe_sync_groups(&self, source: &Source, sync_run_id: &str) -> HashSet<String> {
         let service_creds = match self.get_service_credentials(&source.id).await {
             Ok(creds) => creds,
             Err(e) => {
                 warn!("Failed to get service credentials for group sync: {}", e);
-                return;
+                return HashSet::new();
             }
         };
 
@@ -2230,21 +2268,21 @@ impl SyncManager {
             Ok(auth) => auth,
             Err(e) => {
                 warn!("Failed to create auth for group sync: {}", e);
-                return;
+                return HashSet::new();
             }
         };
 
         // Only service-account (domain-wide) setups have Admin API access
         if service_auth.is_oauth() {
             debug!("Skipping group sync for OAuth source {}", source.id);
-            return;
+            return HashSet::new();
         }
 
         let domain = match self.get_domain_from_credentials(&service_creds) {
             Ok(d) => d,
             Err(e) => {
                 warn!("Failed to get domain for group sync: {}", e);
-                return;
+                return HashSet::new();
             }
         };
 
@@ -2252,7 +2290,7 @@ impl SyncManager {
             Ok(email) => email,
             Err(e) => {
                 warn!("Failed to get user email for group sync: {}", e);
-                return;
+                return HashSet::new();
             }
         };
 
@@ -2260,18 +2298,22 @@ impl SyncManager {
             Ok(token) => token,
             Err(e) => {
                 warn!("Failed to get access token for group sync: {}", e);
-                return;
+                return HashSet::new();
             }
         };
 
-        if let Err(e) = self
+        match self
             .sync_groups(&source.id, sync_run_id, &domain, &access_token)
             .await
         {
-            warn!(
-                "Failed to sync group memberships: {}. Continuing with document sync.",
-                e
-            );
+            Ok(group_emails) => group_emails,
+            Err(e) => {
+                warn!(
+                    "Failed to sync group memberships: {}. Continuing with document sync.",
+                    e
+                );
+                HashSet::new()
+            }
         }
     }
 
@@ -2281,7 +2323,7 @@ impl SyncManager {
         sync_run_id: &str,
         domain: &str,
         access_token: &str,
-    ) -> Result<()> {
+    ) -> Result<HashSet<String>> {
         info!("Syncing group memberships for domain: {}", domain);
 
         let groups = self
@@ -2290,8 +2332,11 @@ impl SyncManager {
             .await?;
         info!("Found {} groups in domain {}", groups.len(), domain);
 
+        let mut group_emails: HashSet<String> = HashSet::new();
         let mut total_members = 0;
         for group in &groups {
+            group_emails.insert(group.email.to_lowercase());
+
             let members = self
                 .admin_client
                 .list_all_group_members(access_token, &group.email)
@@ -2334,6 +2379,6 @@ impl SyncManager {
             groups.len(),
             total_members
         );
-        Ok(())
+        Ok(group_emails)
     }
 }


### PR DESCRIPTION
- Fix Gmail thread URLs to use rfc822msgid search links instead of broken hex thread IDs, and remove hardcoded /u/0/#inbox/ path
- Split thread participants into users vs groups in permissions using known org groups from Admin API, fix email parsing for quoted display names, remove dead Bcc extraction
- Refactor content extraction to handle multipart/alternative correctly (prefer plain text, fall back to html2text), download and index text from supported attachments (PDF, DOCX, XLSX, etc.), and emit DocumentDeleted events for empty threads