### PR TITLE
Show all search facets always, grey out inactive filters

### DIFF
--- a/services/searcher/src/models.rs
+++ b/services/searcher/src/models.rs
@@ -77,6 +77,8 @@ pub struct SearchResponse {
     pub query: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub facets: Option<Vec<Facet>>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub active_filters: Option<Vec<Facet>>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/services/searcher/src/search.rs
+++ b/services/searcher/src/search.rs
@@ -374,7 +374,7 @@ impl SearchEngine {
         }
         let total_count: i64 = filtered_facets
             .iter()
-            .flat_map(|f| f.values.iter().map(|fv| fv.count))
+            .flat_map(|f| f.values.iter().filter_map(|fv| fv.count))
             .sum();
         let has_more = total_count >= limit;
         let query_time = start_time.elapsed().as_millis() as u64;
@@ -1323,7 +1323,7 @@ fn build_active_filters(request: &SearchRequest) -> Vec<Facet> {
                     .iter()
                     .map(|st| FacetValue {
                         value: source_type_to_string(st),
-                        count: 0,
+                        count: None,
                     })
                     .collect(),
             });
@@ -1335,13 +1335,13 @@ fn build_active_filters(request: &SearchRequest) -> Vec<Facet> {
         if let Some(after) = date_filter.after {
             values.push(FacetValue {
                 value: format!("after:{}", after.date()),
-                count: 0,
+                count: None,
             });
         }
         if let Some(before) = date_filter.before {
             values.push(FacetValue {
                 value: format!("before:{}", before.date()),
-                count: 0,
+                count: None,
             });
         }
         if !values.is_empty() {
@@ -1360,7 +1360,7 @@ fn build_active_filters(request: &SearchRequest) -> Vec<Facet> {
                     .iter()
                     .map(|p| FacetValue {
                         value: p.clone(),
-                        count: 0,
+                        count: None,
                     })
                     .collect(),
             });
@@ -1375,7 +1375,7 @@ fn build_active_filters(request: &SearchRequest) -> Vec<Facet> {
                     .iter()
                     .map(|ct| FacetValue {
                         value: ct.clone(),
-                        count: 0,
+                        count: None,
                     })
                     .collect(),
             });
@@ -1387,7 +1387,7 @@ fn build_active_filters(request: &SearchRequest) -> Vec<Facet> {
             let value = serde_json::to_string(filter).unwrap_or_default();
             filters.push(Facet {
                 name: format!("attribute:{}", key),
-                values: vec![FacetValue { value, count: 0 }],
+                values: vec![FacetValue { value, count: None }],
             });
         }
     }

--- a/services/searcher/src/search.rs
+++ b/services/searcher/src/search.rs
@@ -9,8 +9,9 @@ use redis::{AsyncCommands, Client as RedisClient};
 use shared::db::repositories::{
     DocumentRepository, EmbeddingRepository, GroupRepository, PersonRepository, SourceRepository,
 };
-use shared::models::{ChunkResult, Document};
+use shared::models::{ChunkResult, Document, Facet, FacetValue};
 use shared::utils::safe_str_slice;
+use shared::SourceType;
 use shared::{
     AIClient, DatabasePool, ObjectStorage, Repository, SearcherConfig, StorageFactory,
     UserRepository,
@@ -237,15 +238,23 @@ impl SearchEngine {
             return Err(anyhow::anyhow!("Search query cannot be empty"));
         }
 
-        let source_ids = repo
-            .fetch_active_source_ids(request.source_types.as_deref())
-            .await?;
+        let all_sources = repo.fetch_active_sources().await?;
+        let all_source_ids: Vec<String> = all_sources.iter().map(|(id, _)| id.clone()).collect();
+        let filtered_source_ids: Vec<String> = if let Some(ref st) = request.source_types {
+            all_sources
+                .iter()
+                .filter(|(_, source_type)| st.contains(source_type))
+                .map(|(id, _)| id.clone())
+                .collect()
+        } else {
+            all_source_ids.clone()
+        };
 
         let search_future = async {
             let start_ts = Instant::now();
             let res = match request.search_mode() {
                 SearchMode::Fulltext => {
-                    self.fulltext_search(&search_repo, &request, &source_ids, &user_groups)
+                    self.fulltext_search(&search_repo, &request, &filtered_source_ids, &user_groups)
                         .await
                 }
                 SearchMode::Semantic => self.semantic_search(&request).await,
@@ -256,17 +265,44 @@ impl SearchEngine {
             res
         };
 
-        let facets_future = async {
+        // Unfiltered facets: query + permissions only, no source_type/date/person/content filters
+        let unfiltered_facets_future = async {
             if request.include_facets() {
                 let start_ts = Instant::now();
-                let content_types = request.content_types.as_deref();
-                let attribute_filters = request.attribute_filters.as_ref();
                 let facets = search_repo
                     .get_facet_counts(
                         &request.query,
-                        &source_ids,
-                        content_types,
-                        attribute_filters,
+                        &all_source_ids,
+                        None,
+                        None,
+                        request.user_email().map(|e| e.as_str()),
+                        &user_groups,
+                        None,
+                        None,
+                    )
+                    .await
+                    .unwrap_or_else(|e| {
+                        info!("Failed to get unfiltered facet counts: {}", e);
+                        vec![]
+                    });
+
+                debug!("Unfiltered facets fetched in {:?}", start_ts.elapsed());
+                facets
+            } else {
+                vec![]
+            }
+        };
+
+        // Filtered facets: used only for total_count (pagination)
+        let filtered_facets_future = async {
+            if request.include_facets() {
+                let start_ts = Instant::now();
+                let facets = search_repo
+                    .get_facet_counts(
+                        &request.query,
+                        &filtered_source_ids,
+                        request.content_types.as_deref(),
+                        request.attribute_filters.as_ref(),
                         request.user_email().map(|e| e.as_str()),
                         &user_groups,
                         request.date_filter.as_ref(),
@@ -274,27 +310,31 @@ impl SearchEngine {
                     )
                     .await
                     .unwrap_or_else(|e| {
-                        info!("Failed to get facet counts: {}", e);
+                        info!("Failed to get filtered facet counts: {}", e);
                         vec![]
                     });
 
-                debug!("Facets fetched in {:?}", start_ts.elapsed());
+                debug!("Filtered facets fetched in {:?}", start_ts.elapsed());
                 facets
             } else {
-                debug!("Facets not requested, returning empty array.");
                 vec![]
             }
         };
 
-        let (search_result, facets) = tokio::join!(search_future, facets_future);
+        let (search_result, facets, filtered_facets) = tokio::join!(
+            search_future,
+            unfiltered_facets_future,
+            filtered_facets_future
+        );
         let mut results = search_result?;
 
         // Apply source boost for implicit source words (e.g. "standup slack")
         if !parsed.boosted_source_types.is_empty() {
-            let boosted_source_ids = repo
-                .fetch_active_source_ids(Some(&parsed.boosted_source_types))
-                .await
-                .unwrap_or_default();
+            let boosted_source_ids: Vec<String> = all_sources
+                .iter()
+                .filter(|(_, st)| parsed.boosted_source_types.contains(st))
+                .map(|(id, _)| id.clone())
+                .collect();
             if !boosted_source_ids.is_empty() {
                 const SOURCE_BOOST_MULTIPLIER: f32 = 1.5;
                 for result in &mut results {
@@ -332,8 +372,7 @@ impl SearchEngine {
         if !parsed.boosted_source_types.is_empty() || !parsed.person_boosts.is_empty() {
             results.sort_by(|a, b| b.score.partial_cmp(&a.score).unwrap_or(Ordering::Equal));
         }
-        // TODO: this will need to change once we introduce more facets beyond just source_type
-        let total_count = facets
+        let total_count: i64 = filtered_facets
             .iter()
             .flat_map(|f| f.values.iter().map(|fv| fv.count))
             .sum();
@@ -341,6 +380,9 @@ impl SearchEngine {
         let query_time = start_time.elapsed().as_millis() as u64;
 
         self.populate_source_types(&mut results).await;
+
+        // Build active_filters from merged request state
+        let active_filters = build_active_filters(&request);
 
         info!(
             "Search completed in {}ms, found {} results",
@@ -361,6 +403,11 @@ impl SearchEngine {
                 None
             } else {
                 Some(facets)
+            },
+            active_filters: if active_filters.is_empty() {
+                None
+            } else {
+                Some(active_filters)
             },
         };
 
@@ -707,6 +754,7 @@ impl SearchEngine {
             has_more: false,
             query: request.query.clone(),
             facets: None,
+            active_filters: None,
         })
     }
 
@@ -1255,4 +1303,94 @@ impl SearchEngine {
 
         prompt
     }
+}
+
+fn source_type_to_string(st: &SourceType) -> String {
+    serde_json::to_value(st)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_default()
+}
+
+fn build_active_filters(request: &SearchRequest) -> Vec<Facet> {
+    let mut filters = Vec::new();
+
+    if let Some(ref source_types) = request.source_types {
+        if !source_types.is_empty() {
+            filters.push(Facet {
+                name: "source_type".to_string(),
+                values: source_types
+                    .iter()
+                    .map(|st| FacetValue {
+                        value: source_type_to_string(st),
+                        count: 0,
+                    })
+                    .collect(),
+            });
+        }
+    }
+
+    if let Some(ref date_filter) = request.date_filter {
+        let mut values = Vec::new();
+        if let Some(after) = date_filter.after {
+            values.push(FacetValue {
+                value: format!("after:{}", after.date()),
+                count: 0,
+            });
+        }
+        if let Some(before) = date_filter.before {
+            values.push(FacetValue {
+                value: format!("before:{}", before.date()),
+                count: 0,
+            });
+        }
+        if !values.is_empty() {
+            filters.push(Facet {
+                name: "date_filter".to_string(),
+                values,
+            });
+        }
+    }
+
+    if let Some(ref person_filters) = request.person_filters {
+        if !person_filters.is_empty() {
+            filters.push(Facet {
+                name: "person_filter".to_string(),
+                values: person_filters
+                    .iter()
+                    .map(|p| FacetValue {
+                        value: p.clone(),
+                        count: 0,
+                    })
+                    .collect(),
+            });
+        }
+    }
+
+    if let Some(ref content_types) = request.content_types {
+        if !content_types.is_empty() {
+            filters.push(Facet {
+                name: "content_type".to_string(),
+                values: content_types
+                    .iter()
+                    .map(|ct| FacetValue {
+                        value: ct.clone(),
+                        count: 0,
+                    })
+                    .collect(),
+            });
+        }
+    }
+
+    if let Some(ref attribute_filters) = request.attribute_filters {
+        for (key, filter) in attribute_filters {
+            let value = serde_json::to_string(filter).unwrap_or_default();
+            filters.push(Facet {
+                name: format!("attribute:{}", key),
+                values: vec![FacetValue { value, count: 0 }],
+            });
+        }
+    }
+
+    filters
 }

--- a/services/searcher/src/search_repository.rs
+++ b/services/searcher/src/search_repository.rs
@@ -534,10 +534,10 @@ impl SearchDocumentRepository {
 fn rows_to_facets(rows: Vec<(String, String, i64)>) -> Vec<Facet> {
     let mut facets_map: HashMap<String, Vec<FacetValue>> = HashMap::new();
     for (facet_name, value, count) in rows {
-        facets_map
-            .entry(facet_name)
-            .or_default()
-            .push(FacetValue { value, count });
+        facets_map.entry(facet_name).or_default().push(FacetValue {
+            value,
+            count: Some(count),
+        });
     }
     facets_map
         .into_iter()

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -158,6 +158,15 @@ impl DocumentRepository {
         Ok(source_ids)
     }
 
+    pub async fn fetch_active_sources(&self) -> Result<Vec<(String, SourceType)>, DatabaseError> {
+        let rows: Vec<(String, SourceType)> =
+            sqlx::query_as(r#"SELECT id, source_type FROM sources WHERE NOT is_deleted"#)
+                .fetch_all(&self.pool)
+                .await?;
+
+        Ok(rows)
+    }
+
     pub async fn fetch_all_permission_users(&self) -> Result<Vec<String>, DatabaseError> {
         let users: Vec<String> = sqlx::query_scalar(
             r#"SELECT DISTINCT lower(elem)

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -479,7 +479,8 @@ pub struct DocumentChunk {
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct FacetValue {
     pub value: String,
-    pub count: i64,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub count: Option<i64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/web/src/lib/types/search.ts
+++ b/web/src/lib/types/search.ts
@@ -95,6 +95,7 @@ export interface SearchResponse {
     has_more: boolean
     query: string
     facets?: Facet[]
+    active_filters?: Facet[]
 }
 
 export interface SearchRequest {

--- a/web/src/lib/types/search.ts
+++ b/web/src/lib/types/search.ts
@@ -80,7 +80,7 @@ export interface SearchResult {
 
 export interface FacetValue {
     value: string
-    count: number
+    count?: number
 }
 
 export interface Facet {

--- a/web/src/lib/utils/icons.ts
+++ b/web/src/lib/utils/icons.ts
@@ -44,13 +44,27 @@ const GOOGLE_SLIDES_MIMETYPES = [
     'application/vnd.ms-powerpoint',
 ]
 
+const SOURCE_TYPE_ICONS: Record<string, string> = {
+    [SourceType.GOOGLE_DRIVE]: googleDriveIcon,
+    [SourceType.GMAIL]: gmailIcon,
+    [SourceType.SLACK]: slackIcon,
+    [SourceType.CONFLUENCE]: confluenceIcon,
+    [SourceType.JIRA]: jiraIcon,
+    [SourceType.FIREFLIES]: firefliesIcon,
+    [SourceType.HUBSPOT]: hubspotIcon,
+    [SourceType.ONE_DRIVE]: oneDriveIcon,
+    [SourceType.OUTLOOK]: outlookIcon,
+    [SourceType.OUTLOOK_CALENDAR]: outlookIcon,
+    [SourceType.SHARE_POINT]: sharePointIcon,
+    [SourceType.MS_TEAMS]: teamsIcon,
+    [SourceType.LINEAR]: linearIcon,
+    [SourceType.GITHUB]: githubIcon,
+    [SourceType.CLICKUP]: clickupIcon,
+    [SourceType.NOTION]: notionIcon,
+}
+
 // Get icon based on source type and content type
 export function getDocumentIconPath(sourceType: string, contentType: string): string | null {
-    // For Gmail, always use Gmail icon
-    if (sourceType === SourceType.GMAIL) {
-        return gmailIcon
-    }
-
     // For Google Drive, check content type to determine specific icon
     if (sourceType === SourceType.GOOGLE_DRIVE) {
         if (contentType === 'document' || GOOGLE_DOCS_MIMETYPES.includes(contentType)) {
@@ -62,69 +76,14 @@ export function getDocumentIconPath(sourceType: string, contentType: string): st
         if (contentType === 'presentation' || GOOGLE_SLIDES_MIMETYPES.includes(contentType)) {
             return googleSlidesIcon
         }
-        // Default to generic Google Drive icon for other file types
         return googleDriveIcon
-    } else if (sourceType === SourceType.CONFLUENCE) {
-        return confluenceIcon
-    } else if (sourceType === SourceType.JIRA) {
-        return jiraIcon
-    } else if (sourceType === SourceType.SLACK) {
-        return slackIcon
-    } else if (sourceType === SourceType.FIREFLIES) {
-        return firefliesIcon
-    } else if (sourceType === SourceType.HUBSPOT) {
-        return hubspotIcon
-    } else if (sourceType === SourceType.NOTION) {
-        return notionIcon
-    } else if (sourceType === SourceType.LINEAR) {
-        return linearIcon
     }
 
-    // For other source types, return null (will use fallback icon)
-    return null
+    return SOURCE_TYPE_ICONS[sourceType] ?? null
 }
 
-// Map source types to icon file paths (legacy function, kept for backward compatibility)
 export function getSourceIconPath(sourceType: string): string | null {
-    switch (sourceType) {
-        case SourceType.GOOGLE_DRIVE:
-            return googleDriveIcon
-        case SourceType.GMAIL:
-            return gmailIcon
-        case SourceType.SLACK:
-            return slackIcon
-        case SourceType.CONFLUENCE:
-            return confluenceIcon
-        case SourceType.JIRA:
-            return jiraIcon
-        case SourceType.FIREFLIES:
-            return firefliesIcon
-        case SourceType.HUBSPOT:
-            return hubspotIcon
-        case SourceType.ONE_DRIVE:
-            return oneDriveIcon
-        case SourceType.OUTLOOK:
-        case SourceType.OUTLOOK_CALENDAR:
-            return outlookIcon
-        case SourceType.SHARE_POINT:
-            return sharePointIcon
-        case SourceType.MS_TEAMS:
-            return teamsIcon
-        case SourceType.LINEAR:
-            return linearIcon
-        case SourceType.GITHUB:
-            return githubIcon
-        case SourceType.LOCAL_FILES:
-            return null // Use fallback FileText icon
-        case SourceType.IMAP:
-            return null // Uses Mail lucide icon
-        case SourceType.CLICKUP:
-            return clickupIcon
-        case SourceType.NOTION:
-            return notionIcon
-        default:
-            return null // Use fallback FileText icon
-    }
+    return SOURCE_TYPE_ICONS[sourceType] ?? null
 }
 
 // Get source type from source ID using sources lookup

--- a/web/src/routes/(app)/search/+page.svelte
+++ b/web/src/routes/(app)/search/+page.svelte
@@ -25,6 +25,18 @@
     // Get selected source types from server data (parsed from URL params)
     let selectedSourceTypes = $derived(new Set(data.selectedSourceTypes || []))
 
+    // Active source types from both URL params and in-query operators (e.g. in:drive)
+    let activeFilterFacets = $derived(data.searchResults?.active_filters || [])
+    let activeSourceTypes = $derived(
+        new Set([
+            ...(data.selectedSourceTypes || []),
+            ...(activeFilterFacets
+                .find((f) => f.name === 'source_type')
+                ?.values.map((v) => v.value) || []),
+        ]),
+    )
+    let hasActiveFilters = $derived(activeFilterFacets.length > 0)
+
     const facetDisplayNames: Record<string, string> = {
         source_type: 'Source Type',
     }
@@ -88,7 +100,7 @@
     }
 
     function getTotalSelectedFilters(): number {
-        return selectedSourceTypes.size
+        return activeSourceTypes.size
     }
 
     let totalPages = $derived(
@@ -320,7 +332,7 @@
                             <div class="flex-1">Filter by Source</div>
                             <Funnel class="h-4 w-4" />
                         </h3>
-                        {#if selectedSourceTypes.size > 0}
+                        {#if activeSourceTypes.size > 0}
                             <Button
                                 variant="ghost"
                                 size="sm"
@@ -333,31 +345,41 @@
                     <div class="flex flex-col space-y-2">
                         {#each sourceFacet.values as facetValue}
                             {@const sourceIcon = getSourceIconPath(facetValue.value)}
-                            {@const isSelected = selectedSourceTypes.has(facetValue.value)}
+                            {@const isActive = activeSourceTypes.has(facetValue.value)}
+                            {@const isDisabled = activeSourceTypes.size > 0 && !isActive}
                             <Button
                                 variant="ghost"
-                                class="flex cursor-pointer justify-between rounded-full {isSelected
-                                    ? 'bg-blue-50 hover:bg-blue-100'
-                                    : 'hover:bg-gray-200'}"
-                                onclick={() => toggleFilter('source_type', facetValue.value)}>
+                                disabled={isDisabled}
+                                class="flex justify-between rounded-full {isActive
+                                    ? 'cursor-pointer bg-blue-50 hover:bg-blue-100'
+                                    : isDisabled
+                                      ? 'cursor-default opacity-50'
+                                      : 'cursor-pointer hover:bg-gray-200'}"
+                                onclick={() =>
+                                    !isDisabled && toggleFilter('source_type', facetValue.value)}>
                                 <div class="flex items-center gap-2">
                                     {#if sourceIcon}
                                         <img
                                             src={sourceIcon}
                                             alt="{facetValue.value} icon"
-                                            class="h-4 w-4" />
+                                            class="h-4 w-4 {isDisabled ? 'grayscale' : ''}" />
                                     {:else}
-                                        <FileText class="h-4 w-4 text-gray-400" />
+                                        <FileText
+                                            class="h-4 w-4 {isDisabled
+                                                ? 'text-gray-300'
+                                                : 'text-gray-400'}" />
                                     {/if}
                                     <span
-                                        class="text-sm font-medium {isSelected
+                                        class="text-sm font-medium {isActive
                                             ? 'text-blue-700'
-                                            : 'text-gray-700'}">
+                                            : isDisabled
+                                              ? 'text-gray-400'
+                                              : 'text-gray-700'}">
                                         {getDisplayValue('source_type', facetValue.value)}
                                     </span>
                                 </div>
                                 <span
-                                    class="rounded-full px-2 py-0.5 text-xs {isSelected
+                                    class="rounded-full px-2 py-0.5 text-xs {isActive
                                         ? 'bg-blue-100 text-blue-700'
                                         : 'bg-gray-100 text-gray-500'}">
                                     {facetValue.count}

--- a/web/src/routes/(app)/search/+page.svelte
+++ b/web/src/routes/(app)/search/+page.svelte
@@ -284,7 +284,7 @@
                         <Search class="mx-auto mb-4 h-12 w-12 text-gray-400" />
                         <h3 class="mb-2 text-lg font-medium text-gray-900">No results found</h3>
                         <p class="mb-4 text-gray-600">
-                            {#if getTotalSelectedFilters() > 0}
+                            {#if selectedSourceTypes.size > 0}
                                 No results found with the current filters. Try clearing filters or
                                 adjusting your search.
                             {:else}
@@ -292,7 +292,7 @@
                                 connected and indexed.
                             {/if}
                         </p>
-                        {#if getTotalSelectedFilters() > 0}
+                        {#if selectedSourceTypes.size > 0}
                             <Button
                                 variant="outline"
                                 onclick={clearFilters}
@@ -332,7 +332,7 @@
                             <div class="flex-1">Filter by Source</div>
                             <Funnel class="h-4 w-4" />
                         </h3>
-                        {#if activeSourceTypes.size > 0}
+                        {#if selectedSourceTypes.size > 0}
                             <Button
                                 variant="ghost"
                                 size="sm"
@@ -389,7 +389,7 @@
                     </div>
                 </div>
 
-                {#if getTotalSelectedFilters() > 0}
+                {#if selectedSourceTypes.size > 0}
                     <div class="mt-4">
                         <Button
                             variant="outline"


### PR DESCRIPTION
- Compute unfiltered facet counts (query + permissions only) so all source types are always visible in the sidebar, even when filters are applied
- Add `active_filters` to search response so the frontend knows which filters are active from both URL params and in-query operators (e.g. `in:drive`, `after:date`)
- Grey out and disable non-active source facets in the sidebar when filters are applied; active filters highlighted in blue