### PR TITLE
Build separate cpu-only and cuda images for docling 

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -73,6 +73,9 @@ LOCAL_EMBEDDINGS_URL=http://embeddings:${LOCAL_EMBEDDINGS_PORT}/v1
 DOCLING_URL=http://docling:${DOCLING_PORT}
 
 # Docling Configuration (AI-based document conversion)
+# DOCLING_DEVICE=cuda              # Set to "cuda" to pull the CUDA-enabled image (default: CPU-only)
+# DOCLING_CPUS=1                   # CPU limit for the docling container
+# DOCLING_MEMORY=2g                # Memory limit for the docling container
 DOCLING_MAX_CONCURRENT_CONVERSIONS=1
 
 # Connector Manager Configuration

--- a/.github/workflows/build-service.yml
+++ b/.github/workflows/build-service.yml
@@ -16,6 +16,15 @@ on:
         required: false
         type: boolean
         default: false
+      build-args:
+        required: false
+        type: string
+        default: ''
+      tag-suffix:
+        description: 'Appended to every image tag (e.g. "-cuda" produces latest-cuda, v0.1.3-cuda)'
+        required: false
+        type: string
+        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -71,7 +80,7 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ env.IMAGE_NAME }}
           flavor: |
-            suffix=-${{ matrix.arch }}
+            suffix=${{ inputs.tag-suffix }}-${{ matrix.arch }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -89,8 +98,9 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha,scope=${{ matrix.arch }}
-          cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+          build-args: ${{ inputs.build-args }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}${{ inputs.tag-suffix }}-${{ matrix.arch }}
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}${{ inputs.tag-suffix }}-${{ matrix.arch }}
 
   create-manifest:
     needs: [build]
@@ -112,6 +122,8 @@ jobs:
         uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_PREFIX }}/${{ env.IMAGE_NAME }}
+          flavor: |
+            suffix=${{ inputs.tag-suffix }}
           tags: |
             type=ref,event=branch
             type=semver,pattern={{version}}
@@ -162,5 +174,6 @@ jobs:
           platforms: linux/amd64
           file: ${{ inputs.dockerfile }}
           push: false
-          cache-from: type=gha,scope=amd64
-          cache-to: type=gha,mode=max,scope=amd64
+          build-args: ${{ inputs.build-args }}
+          cache-from: type=gha,scope=${{ env.IMAGE_NAME }}${{ inputs.tag-suffix }}-amd64
+          cache-to: type=gha,mode=max,scope=${{ env.IMAGE_NAME }}${{ inputs.tag-suffix }}-amd64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -267,6 +267,20 @@ jobs:
       image-name: omni-docling
       docker-context: services/docling
       dockerfile: services/docling/Dockerfile
+      build-args: DEVICE=cpu
+      free-disk-space: true
+    secrets: inherit
+
+  build-docling-cuda:
+    needs: detect-changes
+    if: needs.detect-changes.outputs.is-tag != 'true' && needs.detect-changes.outputs.docling == 'true'
+    uses: ./.github/workflows/build-service.yml
+    with:
+      image-name: omni-docling
+      docker-context: services/docling
+      dockerfile: services/docling/Dockerfile
+      build-args: DEVICE=cuda
+      tag-suffix: -cuda
       free-disk-space: true
     secrets: inherit
 
@@ -440,6 +454,13 @@ jobs:
           - image-name: omni-docling
             docker-context: services/docling
             dockerfile: services/docling/Dockerfile
+            build-args: DEVICE=cpu
+            free-disk-space: true
+          - image-name: omni-docling
+            docker-context: services/docling
+            dockerfile: services/docling/Dockerfile
+            build-args: DEVICE=cuda
+            tag-suffix: -cuda
             free-disk-space: true
           - image-name: omni-migrator
             docker-context: .
@@ -451,6 +472,8 @@ jobs:
       docker-context: ${{ matrix.docker-context }}
       dockerfile: ${{ matrix.dockerfile }}
       free-disk-space: ${{ matrix.free-disk-space }}
+      build-args: ${{ matrix.build-args }}
+      tag-suffix: ${{ matrix.tag-suffix }}
     secrets: inherit
 
   release-connectors:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -199,10 +199,30 @@ services:
     build:
       context: ../services/docling
       dockerfile: Dockerfile
+      args:
+        DEVICE: ${DOCLING_DEVICE:-cpu}
 
   vllm:
     profiles:
       - production
+
+  llama-server:
+    image: local/llama.cpp:server-cuda
+    container_name: omni-llama-server
+    ports:
+      - "8080:8080"
+    volumes:
+      - /home/praveen/workspace/gguf-models:/models
+    deploy:
+      resources:
+        reservations:
+          devices:
+            - driver: nvidia
+              count: all
+              capabilities: [gpu]
+    networks:
+      - omni-network
+    command: -m /models/gemma-4-26B-A4B-it-Q4_K_M.gguf --port 8080 --host 0.0.0.0 -n 42000 --parallel 1 
   
   embeddings:
     ports:

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -206,24 +206,6 @@ services:
     profiles:
       - production
 
-  llama-server:
-    image: local/llama.cpp:server-cuda
-    container_name: omni-llama-server
-    ports:
-      - "8080:8080"
-    volumes:
-      - /home/praveen/workspace/gguf-models:/models
-    deploy:
-      resources:
-        reservations:
-          devices:
-            - driver: nvidia
-              count: all
-              capabilities: [gpu]
-    networks:
-      - omni-network
-    command: -m /models/gemma-4-26B-A4B-it-Q4_K_M.gguf --port 8080 --host 0.0.0.0 -n 42000 --parallel 1 
-  
   embeddings:
     ports:
       - "${LOCAL_EMBEDDINGS_PORT}:${LOCAL_EMBEDDINGS_PORT}"

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -311,8 +311,10 @@ services:
   # Docling Service - AI-based document to Markdown conversion
   # Provides superior PDF extraction, OCR, and structure-aware output
   # Always deployed; enable via the admin UI at /admin/settings/document-conversion
+  # Default image is CPU-only (~1.5 GB). For GPU, set DOCLING_DEVICE=cuda in .env
+  # to use the -cuda tagged image.
   docling:
-    image: ghcr.io/getomnico/omni/omni-docling:${OMNI_VERSION:-latest}
+    image: ghcr.io/getomnico/omni/omni-docling:${OMNI_VERSION:-latest}${DOCLING_DEVICE:+-${DOCLING_DEVICE}}
     container_name: omni-docling
     expose:
       - "${DOCLING_PORT:-8003}"
@@ -323,6 +325,11 @@ services:
     volumes:
       - docling_models:/root/.cache
     restart: unless-stopped
+    deploy:
+      resources:
+        limits:
+          cpus: "${DOCLING_CPUS:-2}"
+          memory: "${DOCLING_MEMORY:-4g}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${DOCLING_PORT:-8003}/health"]
       interval: 30s

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -316,9 +316,8 @@ services:
   docling:
     image: ghcr.io/getomnico/omni/omni-docling:${OMNI_VERSION:-latest}${DOCLING_DEVICE:+-${DOCLING_DEVICE}}
     container_name: omni-docling
-    expose:
-      - "${DOCLING_PORT:-8003}"
     environment:
+      PORT: ${DOCLING_PORT:-8003}
       MAX_CONCURRENT_CONVERSIONS: ${DOCLING_MAX_CONCURRENT_CONVERSIONS:-1}
     networks:
       - omni-network

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -328,8 +328,8 @@ services:
     deploy:
       resources:
         limits:
-          cpus: "${DOCLING_CPUS:-2}"
-          memory: "${DOCLING_MEMORY:-4g}"
+          cpus: "${DOCLING_CPUS:-1}"
+          memory: "${DOCLING_MEMORY:-2g}"
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:${DOCLING_PORT:-8003}/health"]
       interval: 30s

--- a/services/docling/Dockerfile
+++ b/services/docling/Dockerfile
@@ -1,5 +1,6 @@
-FROM python:3.12-slim
+ARG DEVICE=cpu
 
+FROM python:3.12-slim AS base
 
 # libgomp1: required by PyTorch CPU; libglib2.0-0: required by OpenCV headless
 # g++: required by torch inductor for JIT C++ compilation
@@ -15,11 +16,23 @@ WORKDIR /app
 
 COPY requirements.txt .
 
+# --- CPU variant: pre-install CPU-only PyTorch (~200 MB vs ~4.7 GB with CUDA) ---
+FROM base AS deps-cpu
+RUN pip install --no-cache-dir torch torchvision --index-url https://download.pytorch.org/whl/cpu \
+ && pip install --no-cache-dir -r requirements.txt \
+ && pip uninstall -y opencv-python \
+ && pip install --no-cache-dir --force-reinstall opencv-python-headless
+
+# --- CUDA variant: install normally (includes CUDA runtime libs) ---
+FROM base AS deps-cuda
 # rapidocr (a docling dependency) pulls in opencv-python (non-headless).
 # Replace it with the headless variant to avoid a missing libGL.so.1 error.
 RUN pip install --no-cache-dir -r requirements.txt \
  && pip uninstall -y opencv-python \
  && pip install --no-cache-dir --force-reinstall opencv-python-headless
+
+# --- Final stage: pick the variant based on DEVICE arg ---
+FROM deps-${DEVICE}
 
 COPY app.py .
 

--- a/services/docling/Dockerfile
+++ b/services/docling/Dockerfile
@@ -36,5 +36,5 @@ FROM deps-${DEVICE}
 
 COPY app.py .
 
-EXPOSE 8003
-CMD ["uvicorn", "app:app", "--host", "0.0.0.0", "--port", "8003"]
+EXPOSE ${PORT}
+CMD uvicorn app:app --host 0.0.0.0 --port ${PORT}

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -16,7 +16,11 @@ import uvicorn
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
 from docling.datamodel.base_models import ConversionStatus, InputFormat
 from docling.datamodel.document import DocumentStream
-from docling.datamodel.pipeline_options import PdfPipelineOptions, RapidOcrOptions, TableFormerMode
+from docling.datamodel.pipeline_options import (
+    PdfPipelineOptions,
+    RapidOcrOptions,
+    TableFormerMode,
+)
 from docling.document_converter import DocumentConverter, PdfFormatOption
 from fastapi import FastAPI, File, HTTPException, UploadFile
 from fastapi.responses import JSONResponse
@@ -31,6 +35,7 @@ _ready: bool = False
 
 class _SuppressFilter(logging.Filter):
     """Drop noisy RapidOCR messages that fire on blank/whitespace page regions."""
+
     _SUPPRESSED = {
         "The text detection result is empty",
         "RapidOCR returned empty result!",
@@ -65,14 +70,26 @@ def _build_converter() -> DocumentConverter:
     pipeline_options.table_structure_options.mode = TableFormerMode.ACCURATE
     pipeline_options.do_ocr = True
     pipeline_options.ocr_options = RapidOcrOptions(backend="torch")
-    pipeline_options.images_scale = 1.5  # higher resolution improves OCR/layout accuracy
+    pipeline_options.images_scale = (
+        1.5  # higher resolution improves OCR/layout accuracy
+    )
     pipeline_options.generate_picture_images = True
     pipeline_options.generate_table_images = True
-    pipeline_options.do_code_enrichment = False    # VLM per code block; adds latency on code-heavy docs
-    pipeline_options.do_formula_enrichment = False  # VLM per formula; adds latency on math-heavy docs
-    pipeline_options.do_picture_classification = True  # lightweight ViT; minimal overhead
-    pipeline_options.do_picture_description = False     # SmolVLM per image; significant latency per figure
-    pipeline_options.do_chart_extraction = False        # Granite Vision 2B per chart; high RAM + latency
+    pipeline_options.do_code_enrichment = (
+        False  # VLM per code block; adds latency on code-heavy docs
+    )
+    pipeline_options.do_formula_enrichment = (
+        False  # VLM per formula; adds latency on math-heavy docs
+    )
+    pipeline_options.do_picture_classification = (
+        True  # lightweight ViT; minimal overhead
+    )
+    pipeline_options.do_picture_description = (
+        False  # SmolVLM per image; significant latency per figure
+    )
+    pipeline_options.do_chart_extraction = (
+        False  # Granite Vision 2B per chart; high RAM + latency
+    )
     converter = DocumentConverter(
         format_options={
             InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
@@ -85,13 +102,14 @@ def _build_converter() -> DocumentConverter:
 def _download_models() -> None:
     """Pre-download all Docling models so the first conversion doesn't stall."""
     from docling.utils.model_downloader import download_models
+
     download_models(
         progress=True,
         with_layout=True,
         with_tableformer=True,
-        with_code_formula=False,        # ~500 MB; needed for do_code/formula_enrichment
+        with_code_formula=False,  # ~500 MB; needed for do_code/formula_enrichment
         with_picture_classifier=True,  # ~90 MB; needed for do_picture_classification
-        with_smolvlm=False,             # ~500 MB; needed for do_picture_description
+        with_smolvlm=False,  # ~500 MB; needed for do_picture_description
         with_granitedocling=False,
         with_granitedocling_mlx=False,
         with_smoldocling=False,
@@ -153,7 +171,9 @@ async def _init_converter() -> None:
         _ready = True
         logger.info("Ready — %d converter(s) available.", _MAX_CONCURRENT)
     except Exception:
-        logger.exception("Failed to initialise converter(s). Service will remain unavailable.")
+        logger.exception(
+            "Failed to initialise converter(s). Service will remain unavailable."
+        )
 
 
 async def _cleanup_loop() -> None:
@@ -173,7 +193,9 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
     converter = await _converter_pool.get()
     try:
         job.status = JobStatus.RUNNING
-        logger.info("Job %s: conversion started (%s, %d bytes).", job.id, filename, len(data))
+        logger.info(
+            "Job %s: conversion started (%s, %d bytes).", job.id, filename, len(data)
+        )
         t0 = time.monotonic()
         stream = DocumentStream(name=filename, stream=io.BytesIO(data))
         try:
@@ -183,11 +205,20 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
         except Exception as exc:
             elapsed = time.monotonic() - t0
             job.status = JobStatus.FAILED
-            if "not supported" in str(exc).lower() or "cannot convert" in str(exc).lower():
+            if (
+                "not supported" in str(exc).lower()
+                or "cannot convert" in str(exc).lower()
+            ):
                 job.detail = f"Unsupported format: {exc}"
             else:
                 job.detail = f"Conversion error: {exc}"
-            logger.error("Job %s: failed after %.1fs — %s", job.id, elapsed, job.detail, exc_info=True)
+            logger.error(
+                "Job %s: failed after %.1fs — %s",
+                job.id,
+                elapsed,
+                job.detail,
+                exc_info=True,
+            )
             return
     finally:
         _converter_pool.put_nowait(converter)
@@ -195,18 +226,29 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
     elapsed = time.monotonic() - t0
     # Converter returned to pool; do cheap post-processing outside the slot.
     try:
-        if result.status not in (ConversionStatus.SUCCESS, ConversionStatus.PARTIAL_SUCCESS):
+        if result.status not in (
+            ConversionStatus.SUCCESS,
+            ConversionStatus.PARTIAL_SUCCESS,
+        ):
             job.status = JobStatus.FAILED
             job.detail = "Conversion failed."
             logger.error("Job %s: failed after %.1fs — %s", job.id, elapsed, job.detail)
             return
         job.markdown = result.document.export_to_markdown()
         job.status = JobStatus.COMPLETED
-        logger.info("Job %s: completed in %.1fs (%d chars).", job.id, elapsed, len(job.markdown))
+        logger.info(
+            "Job %s: completed in %.1fs (%d chars).", job.id, elapsed, len(job.markdown)
+        )
     except Exception as exc:
         job.status = JobStatus.FAILED
         job.detail = f"Post-processing error: {exc}"
-        logger.error("Job %s: failed after %.1fs — %s", job.id, elapsed, job.detail, exc_info=True)
+        logger.error(
+            "Job %s: failed after %.1fs — %s",
+            job.id,
+            elapsed,
+            job.detail,
+            exc_info=True,
+        )
 
 
 app = FastAPI(title="docling", version="1.0.0", lifespan=lifespan)
@@ -223,9 +265,14 @@ def health():
 async def submit_conversion(file: UploadFile = File(...)):
     """Submit a document for conversion. Returns a job ID immediately (HTTP 202)."""
     if not _ready:
-        raise HTTPException(status_code=503, detail="Service is starting up; models are being loaded. Try again shortly.")
+        raise HTTPException(
+            status_code=503,
+            detail="Service is starting up; models are being loaded. Try again shortly.",
+        )
     if not file.filename:
-        raise HTTPException(status_code=400, detail="A filename with extension is required.")
+        raise HTTPException(
+            status_code=400, detail="A filename with extension is required."
+        )
 
     data = await file.read()
     job_id = str(uuid.uuid4())
@@ -255,4 +302,8 @@ async def get_job(job_id: str):
 
 
 if __name__ == "__main__":
-    uvicorn.run("app:app", host="0.0.0.0", port=8003, log_level="info")
+    port_str = os.getenv("PORT")
+    if not port_str:
+        logger.error("PORT environment variable is required but not set")
+        raise SystemExit(1)
+    uvicorn.run("app:app", host="0.0.0.0", port=int(port_str), log_level="info")


### PR DESCRIPTION
The docling workflow builds an image with gpu support by default, making it a very large image (~3 GB). Since we're including docling in our stack by default, it adds significant overhead for every install, especially because it is not enabled by default.

A better solution is to build two separate images: one meant for CPU-only usage, and one with cuda support. And our stack will use the CPU version by default, reducing the overhead significantly.