### PR TITLE
Use pdb.parse() Tantivy query strings for BM25 search

### DIFF
--- a/docker/docker-compose.benchmark.yml
+++ b/docker/docker-compose.benchmark.yml
@@ -28,6 +28,11 @@ services:
       POSTGRES_DB: omni_benchmark
       POSTGRES_USER: omni_bench
       POSTGRES_PASSWORD: omni_bench_password
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U omni_bench -d omni_benchmark"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   redis:
     container_name: omni-redis-benchmark

--- a/docker/docker-compose.benchmark.yml
+++ b/docker/docker-compose.benchmark.yml
@@ -97,6 +97,10 @@ services:
     profiles: [full]
   caddy:
     profiles: [full]
+  docling:
+    profiles: [full]
+  sandbox:
+    profiles: [full]
 
 volumes:
   postgres_benchmark_data:

--- a/services/searcher/src/search_repository.rs
+++ b/services/searcher/src/search_repository.rs
@@ -483,13 +483,17 @@ fn build_tantivy_query(terms: &[String], original_query: &str) -> String {
         let escaped = escape_tantivy_term(term);
         clauses.push(format!("title:{escaped}^2"));
         clauses.push(format!("title_secondary:{escaped}^2"));
+        clauses.push(format!("title_en:{escaped}^2"));
         clauses.push(format!("content:{escaped}"));
+        clauses.push(format!("content_en:{escaped}"));
     }
 
     // Phrase matching on the original query with slop and boost
     let escaped_phrase = original_query.replace('\\', "\\\\").replace('"', "\\\"");
     clauses.push(format!("title:\"{escaped_phrase}\"~2^10"));
+    clauses.push(format!("title_en:\"{escaped_phrase}\"~2^10"));
     clauses.push(format!("content:\"{escaped_phrase}\"~2^5"));
+    clauses.push(format!("content_en:\"{escaped_phrase}\"~2^5"));
 
     clauses.join(" ")
 }

--- a/services/searcher/src/search_repository.rs
+++ b/services/searcher/src/search_repository.rs
@@ -8,6 +8,14 @@ use sqlx::{FromRow, PgPool};
 use std::collections::{HashMap, HashSet};
 use tracing::debug;
 
+/// Extra candidates fetched beyond offset+limit so that recency re-ranking
+/// doesn't miss relevant results.
+const CANDIDATE_PADDING: i64 = 200;
+
+/// Maximum candidates considered for facet counts. TopN pushes this limit into
+/// the Tantivy index scan, avoiding full result-set materialisation.
+const FACET_CANDIDATE_LIMIT: i64 = 10_000;
+
 #[derive(FromRow)]
 pub struct SearchHit {
     #[sqlx(flatten)]
@@ -64,12 +72,11 @@ impl SearchDocumentRepository {
         // Tokenize query via ParadeDB: splits on non-alphanumeric, ASCII-folds.
         // No stemming or stopwords — dropping stopwords would remove valid words
         // in non-English languages (e.g. German "die", "in", "was").
-        let raw_terms: Vec<String> = sqlx::query_scalar(
-            "SELECT unnest($1::pdb.simple('ascii_folding=true')::text[])"
-        )
-        .bind(query)
-        .fetch_all(&self.pool)
-        .await?;
+        let raw_terms: Vec<String> =
+            sqlx::query_scalar("SELECT unnest($1::pdb.simple('ascii_folding=true')::text[])")
+                .bind(query)
+                .fetch_all(&self.pool)
+                .await?;
 
         let mut seen = HashSet::new();
         // Cap at 12 terms. Without stopword removal longer queries produce more
@@ -192,7 +199,7 @@ impl SearchDocumentRepository {
             query_builder = query_builder.bind(doc_id);
         }
 
-        let candidate_limit = offset + limit + 200;
+        let candidate_limit = offset + limit + CANDIDATE_PADDING;
         query_builder = query_builder
             .bind(candidate_limit)
             .bind(limit)
@@ -322,12 +329,11 @@ impl SearchDocumentRepository {
         }
 
         // Tokenize query via ParadeDB — same pipeline as search()
-        let raw_terms: Vec<String> = sqlx::query_scalar(
-            "SELECT unnest($1::pdb.simple('ascii_folding=true')::text[])"
-        )
-        .bind(query)
-        .fetch_all(&self.pool)
-        .await?;
+        let raw_terms: Vec<String> =
+            sqlx::query_scalar("SELECT unnest($1::pdb.simple('ascii_folding=true')::text[])")
+                .bind(query)
+                .fetch_all(&self.pool)
+                .await?;
 
         let mut seen = HashSet::new();
         // Cap at 12 terms — same reasoning as search().
@@ -373,6 +379,8 @@ impl SearchDocumentRepository {
             format!(" AND {}", filters.join(" AND "))
         };
 
+        let facet_limit_idx = param_idx;
+
         let query_str = format!(
             r#"
             WITH candidates AS (
@@ -380,7 +388,7 @@ impl SearchDocumentRepository {
                 FROM documents
                 WHERE id @@@ pdb.parse($1, lenient => true){filter_where}
                 ORDER BY score DESC
-                LIMIT 1000
+                LIMIT ${facet_limit_idx}
             )
             SELECT 'source_type' as facet, s.source_type as value, count(*) as count
             FROM candidates c
@@ -390,6 +398,7 @@ impl SearchDocumentRepository {
             ORDER BY count DESC
             "#,
             filter_where = filter_where,
+            facet_limit_idx = facet_limit_idx,
         );
 
         let mut query_builder =
@@ -402,6 +411,8 @@ impl SearchDocumentRepository {
                 query_builder = query_builder.bind(ct);
             }
         }
+
+        query_builder = query_builder.bind(FACET_CANDIDATE_LIMIT);
 
         let facet_rows = query_builder.fetch_all(&self.pool).await?;
         Ok(rows_to_facets(facet_rows))

--- a/services/searcher/src/search_repository.rs
+++ b/services/searcher/src/search_repository.rs
@@ -73,16 +73,18 @@ impl SearchDocumentRepository {
 
         let mut seen = HashSet::new();
         // Cap at 12 terms. Without stopword removal longer queries produce more
-        // tokens than before. Each unique term adds 3 UNION ALL branches plus one
-        // bind parameter, so this keeps query size and planner overhead bounded.
+        // tokens than before. Each term adds field-boosted clauses to the Tantivy
+        // query string, so this keeps query complexity bounded.
         let terms: Vec<String> = raw_terms
             .into_iter()
             .filter(|t| seen.insert(t.clone()))
             .take(12)
             .collect();
 
-        // Bind params: $1 = full query, $2..$(1+N) = individual terms, then filters
-        let mut param_idx = 2 + terms.len();
+        let tantivy_query = build_tantivy_query(&terms, query);
+
+        // Bind params: $1 = tantivy query string, $2 = original query (for snippets), then filters
+        let mut param_idx = 3;
 
         let mut filters = Vec::new();
         build_common_filters(
@@ -115,49 +117,19 @@ impl SearchDocumentRepository {
             }
         }
 
-        let common_where = if filters.is_empty() {
+        let filter_where = if filters.is_empty() {
             String::new()
         } else {
             format!(" AND {}", filters.join(" AND "))
         };
 
-        // Per-term: best score across all tokenizer paths.
-        // - title (simple): exact match on filenames/titles split by underscores etc.
-        // - title_secondary (source_code): CamelCase splitting for code identifiers
-        // - content (icu): Unicode word-boundary segmentation for any language
-        // MAX(score) picks the best path per document — no language detection needed.
-        let mut term_branches = Vec::new();
-        for (i, _term) in terms.iter().enumerate() {
-            let term_param = format!("${}", 2 + i);
-            term_branches.push(format!(
-                "SELECT id, MAX(score) as score FROM (\
-                    SELECT id, pdb.score(id) as score FROM documents \
-                    WHERE title ||| {term_param}::pdb.boost(2){common_where} \
-                    UNION ALL \
-                    SELECT id, pdb.score(id) as score FROM documents \
-                    WHERE title::pdb.alias('title_secondary') ||| {term_param}::pdb.boost(2){common_where} \
-                    UNION ALL \
-                    SELECT id, pdb.score(id) as score FROM documents \
-                    WHERE content ||| {term_param}{common_where}\
-                ) t{i} GROUP BY id"
-            ));
-        }
-
-        // Phrase branches: best of title phrase vs content phrase (using $1 = full query)
-        let phrase_branch = format!(
-            "SELECT id, MAX(score) as score FROM (\
-                SELECT id, pdb.score(id) as score FROM documents \
-                WHERE title ### $1::pdb.slop(2)::pdb.boost(10){common_where} \
-                UNION ALL \
-                SELECT id, pdb.score(id) as score FROM documents \
-                WHERE content ### $1::pdb.slop(2)::pdb.boost(5){common_where}\
-            ) p GROUP BY id"
-        );
-
-        // When the query tokenizes to zero terms (e.g. pure punctuation), fall
-        // back to phrase scoring only.
-        let weight_idx = param_idx + 2;
-        let half_life_idx = param_idx + 3;
+        // Bind order: $1=tantivy_query, $2=original_query, filters...,
+        // candidate_limit, limit, offset, recency_weight, recency_half_life
+        let candidate_limit_idx = param_idx;
+        let limit_idx = param_idx + 1;
+        let offset_idx = param_idx + 2;
+        let weight_idx = param_idx + 3;
+        let half_life_idx = param_idx + 4;
 
         let recency_expr = format!(
             "(1.0 + ${w}::double precision * EXP(-EXTRACT(EPOCH FROM (CURRENT_TIMESTAMP - COALESCE(\
@@ -169,88 +141,44 @@ impl SearchDocumentRepository {
             h = half_life_idx,
         );
 
-        let full_query = if terms.is_empty() {
-            format!(
-                r#"
-                WITH phrase_scores AS (
-                    {phrase_branch}
-                ),
-                ranked AS (
-                    SELECT ps.id, (ps.score * {recency_expr}) as score
-                    FROM phrase_scores ps
-                    JOIN documents d ON d.id = ps.id
-                    ORDER BY score DESC
-                    LIMIT ${limit_idx} OFFSET ${offset_idx}
-                )
-                SELECT r.id, r.score,
-                       d.source_id, d.external_id, d.title, d.content_id, d.content_type,
-                       d.file_size, d.file_extension, d.url,
-                       d.metadata, d.permissions, d.attributes, d.created_at, d.updated_at, d.last_indexed_at,
-                       COALESCE(snip.content_snippets, ARRAY[LEFT(d.content, 240)]) as content_snippets
-                FROM ranked r
-                JOIN documents d ON d.id = r.id
-                LEFT JOIN LATERAL (
-                    SELECT pdb.snippets(doc.content, start_tag => '**', end_tag => '**',
-                                        max_num_chars => 200, "limit" => 3, sort_by => 'score') as content_snippets
-                    FROM documents doc
-                    WHERE doc.content ||| $1 AND doc.id = r.id
-                    LIMIT 1
-                ) snip ON true
-                ORDER BY r.score DESC"#,
-                phrase_branch = phrase_branch,
-                recency_expr = recency_expr,
-                limit_idx = param_idx,
-                offset_idx = param_idx + 1,
+        let full_query = format!(
+            r#"
+            WITH candidates AS (
+                SELECT id, pdb.score(id) as bm25_score
+                FROM documents
+                WHERE id @@@ pdb.parse($1, lenient => true){filter_where}
+                ORDER BY bm25_score DESC
+                LIMIT ${candidate_limit_idx}
+            ),
+            ranked AS (
+                SELECT c.id, (c.bm25_score * {recency_expr}) as score
+                FROM candidates c
+                JOIN documents d ON d.id = c.id
+                ORDER BY score DESC
+                LIMIT ${limit_idx} OFFSET ${offset_idx}
             )
-        } else {
-            format!(
-                r#"
-                WITH term_scores AS (
-                    {term_union}
-                ),
-                phrase_scores AS (
-                    {phrase_branch}
-                ),
-                combined AS (
-                    SELECT id, SUM(score) as token_score FROM term_scores GROUP BY id
-                ),
-                ranked AS (
-                    SELECT c.id, ((c.token_score + COALESCE(p.score, 0)) * {recency_expr}) as score
-                    FROM combined c
-                    LEFT JOIN phrase_scores p ON c.id = p.id
-                    JOIN documents d ON d.id = c.id
-                    ORDER BY score DESC
-                    LIMIT ${limit_idx} OFFSET ${offset_idx}
-                )
-                SELECT r.id, r.score,
-                       d.source_id, d.external_id, d.title, d.content_id, d.content_type,
-                       d.file_size, d.file_extension, d.url,
-                       d.metadata, d.permissions, d.attributes, d.created_at, d.updated_at, d.last_indexed_at,
-                       COALESCE(snip.content_snippets, ARRAY[LEFT(d.content, 240)]) as content_snippets
-                FROM ranked r
-                JOIN documents d ON d.id = r.id
-                LEFT JOIN LATERAL (
-                    SELECT pdb.snippets(doc.content, start_tag => '**', end_tag => '**',
-                                        max_num_chars => 200, "limit" => 3, sort_by => 'score') as content_snippets
-                    FROM documents doc
-                    WHERE doc.content ||| $1 AND doc.id = r.id
-                    LIMIT 1
-                ) snip ON true
-                ORDER BY r.score DESC"#,
-                term_union = term_branches.join("\nUNION ALL\n"),
-                phrase_branch = phrase_branch,
-                recency_expr = recency_expr,
-                limit_idx = param_idx,
-                offset_idx = param_idx + 1,
-            )
-        };
+            SELECT r.id, r.score,
+                   d.source_id, d.external_id, d.title, d.content_id, d.content_type,
+                   d.file_size, d.file_extension, d.url,
+                   d.metadata, d.permissions, d.attributes, d.created_at, d.updated_at, d.last_indexed_at,
+                   ARRAY[ts_headline('english', d.content,
+                       plainto_tsquery('english', $2),
+                       'StartSel=**, StopSel=**, MaxFragments=3, MaxWords=30, MinWords=10'
+                   )] as content_snippets
+            FROM ranked r
+            JOIN documents d ON d.id = r.id
+            ORDER BY r.score DESC"#,
+            filter_where = filter_where,
+            recency_expr = recency_expr,
+            candidate_limit_idx = candidate_limit_idx,
+            limit_idx = limit_idx,
+            offset_idx = offset_idx,
+        );
         debug!("Full search query: {}", full_query);
 
-        let mut query_builder = sqlx::query_as::<_, SearchHit>(&full_query).bind(query);
-
-        for term in &terms {
-            query_builder = query_builder.bind(term.as_str());
-        }
+        let mut query_builder = sqlx::query_as::<_, SearchHit>(&full_query)
+            .bind(&tantivy_query)
+            .bind(query);
 
         query_builder = query_builder.bind(source_ids);
 
@@ -264,7 +192,9 @@ impl SearchDocumentRepository {
             query_builder = query_builder.bind(doc_id);
         }
 
+        let candidate_limit = offset + limit + 200;
         query_builder = query_builder
+            .bind(candidate_limit)
             .bind(limit)
             .bind(offset)
             .bind(recency_boost_weight as f64)
@@ -407,8 +337,10 @@ impl SearchDocumentRepository {
             .take(12)
             .collect();
 
-        // Bind params: $1 = full query, $2..$(1+N) = individual terms, then filters
-        let mut param_idx = 2 + terms.len();
+        let tantivy_query = build_tantivy_query(&terms, query);
+
+        // Bind params: $1 = tantivy query string, then filters
+        let mut param_idx = 2;
 
         let mut filters = Vec::new();
         build_common_filters(
@@ -435,97 +367,33 @@ impl SearchDocumentRepository {
             }
         }
 
-        let common_where = if filters.is_empty() {
+        let filter_where = if filters.is_empty() {
             String::new()
         } else {
             format!(" AND {}", filters.join(" AND "))
         };
 
-        // Per-term: best of title, title_secondary, content
-        let mut term_branches = Vec::new();
-        for (i, _term) in terms.iter().enumerate() {
-            let term_param = format!("${}", 2 + i);
-            term_branches.push(format!(
-                "SELECT id, MAX(score) as score FROM (\
-                    SELECT id, pdb.score(id) as score FROM documents \
-                    WHERE title ||| {term_param}::pdb.boost(2){common_where} \
-                    UNION ALL \
-                    SELECT id, pdb.score(id) as score FROM documents \
-                    WHERE title::pdb.alias('title_secondary') ||| {term_param}::pdb.boost(2){common_where} \
-                    UNION ALL \
-                    SELECT id, pdb.score(id) as score FROM documents \
-                    WHERE content ||| {term_param}{common_where}\
-                ) t{i} GROUP BY id"
-            ));
-        }
-
-        let phrase_branch = format!(
-            "SELECT id, MAX(score) as score FROM (\
-                SELECT id, pdb.score(id) as score FROM documents \
-                WHERE title ### $1::pdb.slop(2)::pdb.boost(10){common_where} \
-                UNION ALL \
-                SELECT id, pdb.score(id) as score FROM documents \
-                WHERE content ### $1::pdb.slop(2)::pdb.boost(5){common_where}\
-            ) p GROUP BY id"
+        let query_str = format!(
+            r#"
+            WITH candidates AS (
+                SELECT id, pdb.score(id) as score
+                FROM documents
+                WHERE id @@@ pdb.parse($1, lenient => true){filter_where}
+                ORDER BY score DESC
+                LIMIT 1000
+            )
+            SELECT 'source_type' as facet, s.source_type as value, count(*) as count
+            FROM candidates c
+            JOIN documents d ON d.id = c.id
+            JOIN sources s ON d.source_id = s.id
+            GROUP BY s.source_type
+            ORDER BY count DESC
+            "#,
+            filter_where = filter_where,
         );
 
-        let query_str = if terms.is_empty() {
-            // No terms after tokenization — phrase-only scoring
-            format!(
-                r#"
-                WITH phrase_scores AS (
-                    {phrase_branch}
-                ),
-                thresholded AS (
-                    SELECT id FROM phrase_scores
-                    WHERE score >= (SELECT MAX(score) FROM phrase_scores) * 0.15
-                )
-                SELECT 'source_type' as facet, s.source_type as value, count(*) as count
-                FROM thresholded t
-                JOIN documents d ON d.id = t.id
-                JOIN sources s ON d.source_id = s.id
-                GROUP BY s.source_type
-                ORDER BY count DESC
-                "#,
-            )
-        } else {
-            format!(
-                r#"
-                WITH term_scores AS (
-                    {term_union}
-                ),
-                phrase_scores AS (
-                    {phrase_branch}
-                ),
-                combined AS (
-                    SELECT id, SUM(score) as token_score FROM term_scores GROUP BY id
-                ),
-                scored AS (
-                    SELECT c.id, (c.token_score + COALESCE(p.score, 0)) as score
-                    FROM combined c
-                    LEFT JOIN phrase_scores p ON c.id = p.id
-                ),
-                thresholded AS (
-                    SELECT id FROM scored
-                    WHERE score >= (SELECT MAX(score) FROM scored) * 0.15
-                )
-                SELECT 'source_type' as facet, s.source_type as value, count(*) as count
-                FROM thresholded t
-                JOIN documents d ON d.id = t.id
-                JOIN sources s ON d.source_id = s.id
-                GROUP BY s.source_type
-                ORDER BY count DESC
-                "#,
-                term_union = term_branches.join("\nUNION ALL\n"),
-                phrase_branch = phrase_branch,
-            )
-        };
-
-        let mut query_builder = sqlx::query_as::<_, (String, String, i64)>(&query_str).bind(query);
-
-        for term in &terms {
-            query_builder = query_builder.bind(term.as_str());
-        }
+        let mut query_builder =
+            sqlx::query_as::<_, (String, String, i64)>(&query_str).bind(&tantivy_query);
 
         query_builder = query_builder.bind(source_ids);
 
@@ -594,6 +462,53 @@ fn rows_to_facets(rows: Vec<(String, String, i64)>) -> Vec<Facet> {
 
 fn generate_permission_filter(user_email: &str, user_groups: &[String]) -> String {
     document::generate_permission_filter(user_email, user_groups)
+}
+
+// TODO: use tantivy crate for query string validation
+fn build_tantivy_query(terms: &[String], original_query: &str) -> String {
+    let mut clauses = Vec::new();
+
+    for term in terms {
+        let escaped = escape_tantivy_term(term);
+        clauses.push(format!("title:{escaped}^2"));
+        clauses.push(format!("title_secondary:{escaped}^2"));
+        clauses.push(format!("content:{escaped}"));
+    }
+
+    // Phrase matching on the original query with slop and boost
+    let escaped_phrase = original_query.replace('\\', "\\\\").replace('"', "\\\"");
+    clauses.push(format!("title:\"{escaped_phrase}\"~2^10"));
+    clauses.push(format!("content:\"{escaped_phrase}\"~2^5"));
+
+    clauses.join(" ")
+}
+
+fn escape_tantivy_term(term: &str) -> String {
+    let mut escaped = String::with_capacity(term.len());
+    for ch in term.chars() {
+        if matches!(
+            ch,
+            '+' | '-'
+                | '('
+                | ')'
+                | '{'
+                | '}'
+                | '['
+                | ']'
+                | '^'
+                | '"'
+                | '~'
+                | '*'
+                | '?'
+                | '\\'
+                | '/'
+                | ':'
+        ) {
+            escaped.push('\\');
+        }
+        escaped.push(ch);
+    }
+    escaped
 }
 
 fn json_value_to_term_string(value: &JsonValue) -> String {

--- a/services/searcher/tests/integration_tests.rs
+++ b/services/searcher/tests/integration_tests.rs
@@ -114,15 +114,8 @@ async fn test_fulltext_search() -> Result<()> {
         "Expected Rust Programming Guide as first result, got: {:?}",
         titles
     );
-    // Cross-fields scoring: only "Rust Programming Guide" matches both terms;
-    // "Rust Prevention and Corrosion Control" is filtered by the score threshold
-    assert_eq!(
-        titles.len(),
-        1,
-        "Expected exactly 1 result for 'rust programming', got: {:?}",
-        titles
-    );
-    // Score ratio: cross-fields should produce a clear gap between #1 and #2
+    // "Rust Programming Guide" matches both terms; "Rust Prevention and Corrosion Control"
+    // matches only "rust" and should score significantly lower
     let results = response["results"].as_array().unwrap();
     if results.len() > 1 {
         let top_score = results[0]["score"].as_f64().unwrap();
@@ -217,17 +210,17 @@ async fn test_fulltext_search() -> Result<()> {
         .await?;
     assert_eq!(status, StatusCode::OK);
     let titles = result_titles(&response);
-    // Cross-fields + phrase bonus: BlueSquare NDA matches all 3 terms plus phrase "blue square".
-    // Square Root Mathematics matches "square" only. Geometry of Quadrilaterals matches "square"
-    // via content ("squaring the side length").
+    // BlueSquare NDA matches all 3 terms plus phrase "blue square", must rank first.
+    // Other documents matching "square" may or may not pass the score threshold.
+    assert!(
+        titles.len() >= 2,
+        "Expected at least 2 results for 'blue square nda', got: {:?}",
+        titles
+    );
     assert_eq!(
-        titles,
-        vec![
-            "BlueSquare NDA",
-            "Square Root Mathematics",
-            "Geometry of Quadrilaterals"
-        ],
-        "Expected exact ranking for 'blue square nda'"
+        titles[0], "BlueSquare NDA",
+        "BlueSquare NDA should rank first, got: {:?}",
+        titles
     );
     let results = response["results"].as_array().unwrap();
     let top_score = results[0]["score"].as_f64().unwrap();

--- a/services/searcher/tests/integration_tests.rs
+++ b/services/searcher/tests/integration_tests.rs
@@ -983,6 +983,56 @@ async fn test_people_search_endpoint() -> Result<()> {
 }
 
 // ============================================================================
+// Special Character / Tantivy Escaping Tests
+// ============================================================================
+
+#[tokio::test]
+async fn test_special_characters_in_queries() -> Result<()> {
+    let fixture = SearcherTestFixture::new().await?;
+    let pool = fixture.test_env.db_pool.pool();
+    fixture.seed_search_data().await?;
+
+    let cpp_title = "C++ Error: connection/refused (timeout)";
+    let cpp_content =
+        "The function(x) returned error~code 42. Check path/to/config.json for details.";
+
+    insert_group_test_document(
+        pool,
+        "special-chars-1",
+        cpp_title,
+        cpp_content,
+        DocumentPermissions {
+            public: true,
+            users: vec![],
+            groups: vec![],
+        },
+    )
+    .await;
+
+    // Each query contains Tantivy special chars and should match the document
+    let queries_that_should_match = vec![
+        ("connection refused timeout", "plain terms from title"),
+        ("error: connection", "colon in query"),
+        ("function(x)", "parentheses in query"),
+        ("path/to/config", "slashes in query"),
+        ("error~code", "tilde in query"),
+        ("config.json", "dot in query"),
+    ];
+
+    for (query, description) in queries_that_should_match {
+        let (status, response) = fixture.search(query, Some("fulltext"), Some(10)).await?;
+        assert_eq!(status, StatusCode::OK);
+        let titles = result_titles(&response);
+        assert!(
+            titles.iter().any(|t| t == cpp_title),
+            "{description}: expected to find '{cpp_title}', got: {titles:?}"
+        );
+    }
+
+    Ok(())
+}
+
+// ============================================================================
 // Group Permission Tests
 // ============================================================================
 
@@ -1413,10 +1463,7 @@ async fn test_multilingual_japanese_search() -> Result<()> {
         .await?;
     assert_eq!(status, StatusCode::OK);
     let titles = result_titles(&response);
-    assert!(
-        !titles.is_empty(),
-        "Japanese query should return results"
-    );
+    assert!(!titles.is_empty(), "Japanese query should return results");
     assert!(
         titles.iter().any(|t| t == "検索エンジン設計書"),
         "Japanese search engine design doc should be found, got: {:?}",
@@ -1437,10 +1484,7 @@ async fn test_multilingual_korean_search() -> Result<()> {
         .await?;
     assert_eq!(status, StatusCode::OK);
     let titles = result_titles(&response);
-    assert!(
-        !titles.is_empty(),
-        "Korean query should return results"
-    );
+    assert!(!titles.is_empty(), "Korean query should return results");
     assert!(
         titles.iter().any(|t| t.contains("검색시스템")),
         "Korean search system requirements doc should be found, got: {:?}",
@@ -1484,10 +1528,7 @@ async fn test_multilingual_portuguese_stopwords_preserved() -> Result<()> {
         .await?;
     assert_eq!(status, StatusCode::OK);
     let titles = result_titles(&response);
-    assert!(
-        !titles.is_empty(),
-        "Portuguese query should return results"
-    );
+    assert!(!titles.is_empty(), "Portuguese query should return results");
     assert!(
         titles.iter().any(|t| t.contains("relatorio")),
         "Portuguese report should be found, got: {:?}",
@@ -1532,7 +1573,11 @@ async fn test_multilingual_mixed_language_document() -> Result<()> {
 
     // Search with English terms
     let (status, response) = fixture
-        .search("development migration architecture", Some("fulltext"), Some(10))
+        .search(
+            "development migration architecture",
+            Some("fulltext"),
+            Some(10),
+        )
         .await?;
     assert_eq!(status, StatusCode::OK);
     let titles_en = result_titles(&response);
@@ -1669,7 +1714,11 @@ async fn test_multilingual_cross_script_no_interference() -> Result<()> {
 
     // German-only query should not match CJK documents
     let (status, response) = fixture
-        .search("Mitarbeiter Richtlinien Sicherheitsvorschriften", Some("fulltext"), Some(10))
+        .search(
+            "Mitarbeiter Richtlinien Sicherheitsvorschriften",
+            Some("fulltext"),
+            Some(10),
+        )
         .await?;
     assert_eq!(status, StatusCode::OK);
     let titles = result_titles(&response);

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -610,7 +610,8 @@ pub fn generate_permission_filter(user_email: &str, user_groups: &[String]) -> S
         format!("permissions->'users' ? '{}'", escaped_email),
     ];
 
-    // Domain-wide access: match user's email domain against groups array
+    // Domain-wide access: exact JSON containment check to avoid BM25 tokenizer
+    // splitting email addresses (e.g. "engineering@example.com" matching "example.com")
     if let Some(domain) = user_email.split('@').nth(1) {
         if !domain.is_empty() {
             let escaped_domain = domain.replace('\'', "''");

--- a/web/src/routes/(app)/search/+page.svelte
+++ b/web/src/routes/(app)/search/+page.svelte
@@ -11,6 +11,8 @@
 
     let { data }: { data: PageData } = $props()
 
+    const MAX_COUNTED_RESULTS = 10_000
+
     // Create sources lookup map for efficient access
     let sourcesLookup = $derived(
         data.sources ? new Map(data.sources.map((s: any) => [s.id, s.sourceType])) : new Map(),
@@ -166,7 +168,9 @@
 
         {#if data.searchResults}
             <div class="px-6 text-sm text-gray-600">
-                Found {data.searchResults.total_count} results in
+                Found {data.searchResults.total_count >= MAX_COUNTED_RESULTS
+                    ? `${MAX_COUNTED_RESULTS.toLocaleString()}+`
+                    : data.searchResults.total_count.toLocaleString()} results in
                 {data.searchResults.query_time_ms}ms for "{data.searchResults.query}"
                 {#if getTotalSelectedFilters() > 0}
                     <span


### PR DESCRIPTION
Our current search query impl creates multiple sub-queries per search query term, and is quite inefficient.

E.g., with a two-term query like "kubernetes deploylment", we make 8 paradedb scans: 3 scans per query term + 2 phrase matches. With a Tantivy query string, it's a single scan.

Benchmark run on the nfcorpus dataset:

```
  ┌───────────────────┬────────────────────┬──────────────────────┐
  │      Metric       │ UNION ALL (master) │ pdb.parse() (branch) │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ Queries completed │ 188/323            │ 323/323              │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ nDCG@10           │ 0.2871             │ 0.3354               │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ MRR               │ 0.4564             │ 0.4985               │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ MAP@10            │ 0.4103             │ 0.4540               │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ R@10              │ 0.1302             │ 0.1403               │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ Median latency    │ 166ms              │ 5ms                  │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ p95 latency       │ 333ms              │ 53ms                 │
  ├───────────────────┼────────────────────┼──────────────────────┤
  │ QPS               │ 14.45              │ 42.60                │
  └───────────────────┴────────────────────┴──────────────────────┘
```