### PR TITLE
fix: honor real document timestamps + expose filters to the agent API

### DIFF
--- a/services/searcher/src/search.rs
+++ b/services/searcher/src/search.rs
@@ -234,7 +234,24 @@ impl SearchEngine {
         let search_repo = SearchDocumentRepository::new(self.db_pool.pool());
         let limit = request.limit();
 
-        if request.query.trim().is_empty() && !has_parsed_filters {
+        // Empty query is allowed ONLY if some narrowing filter will scope the
+        // result set. Otherwise `filter_only_search` would scan the entire
+        // corpus. Accept either parser-extracted filters (from query operators)
+        // OR body-provided filters (attribute_filters, source_types, content_types)
+        // that were merged into `request` above.
+        let has_body_filters = request
+            .attribute_filters
+            .as_ref()
+            .map_or(false, |m| !m.is_empty())
+            || request
+                .source_types
+                .as_ref()
+                .map_or(false, |v| !v.is_empty())
+            || request
+                .content_types
+                .as_ref()
+                .map_or(false, |v| !v.is_empty());
+        if request.query.trim().is_empty() && !has_parsed_filters && !has_body_filters {
             return Err(anyhow::anyhow!("Search query cannot be empty"));
         }
 

--- a/services/searcher/src/search_repository.rs
+++ b/services/searcher/src/search_repository.rs
@@ -65,6 +65,7 @@ impl SearchDocumentRepository {
                     user_email,
                     user_groups,
                     date_filter,
+                    person_filters,
                 )
                 .await;
         }
@@ -222,6 +223,7 @@ impl SearchDocumentRepository {
         user_email: Option<&str>,
         user_groups: &[String],
         date_filter: Option<&DateFilter>,
+        person_filters: Option<&[String]>,
     ) -> Result<Vec<SearchHit>, DatabaseError> {
         let mut param_idx = 1;
         let mut filters = Vec::new();
@@ -235,6 +237,27 @@ impl SearchDocumentRepository {
             user_groups,
             date_filter,
         );
+
+        // Apply person filters (from `by:Name` operators) here too — without
+        // this, an empty-query browse with `by:Alice` silently ignores the
+        // person filter and returns everything.
+        //
+        // Uses plain JSONB ILIKE instead of the `metadata ||| 'author:X'` BM25
+        // operator because BM25 operators require a BM25 scoring context
+        // (the `@@@` operator elsewhere in the query). In the filter-only path
+        // there's no `@@@`, so BM25 operators are no-ops and every row matches.
+        if let Some(persons) = person_filters {
+            let conditions: Vec<String> = persons
+                .iter()
+                .map(|p| {
+                    let escaped = p.replace('\'', "''");
+                    format!("metadata->>'author' ILIKE '%{escaped}%'")
+                })
+                .collect();
+            if !conditions.is_empty() {
+                filters.push(format!("({})", conditions.join(" OR ")));
+            }
+        }
 
         let where_clause = if filters.is_empty() {
             String::new()
@@ -250,7 +273,11 @@ impl SearchDocumentRepository {
                    ARRAY[LEFT(content, 240)] as content_snippets
             FROM documents
             {where_clause}
-            ORDER BY updated_at DESC
+            ORDER BY COALESCE(
+                CASE WHEN metadata->>'updated_at' IS NOT NULL
+                     AND pg_input_is_valid(metadata->>'updated_at', 'timestamptz')
+                THEN (metadata->>'updated_at')::timestamptz END,
+                updated_at) DESC
             LIMIT ${limit_idx} OFFSET ${offset_idx}
             "#,
             where_clause = where_clause,

--- a/web/src/routes/api/v1/search/+server.ts
+++ b/web/src/routes/api/v1/search/+server.ts
@@ -17,8 +17,41 @@ export const POST: RequestHandler = async ({ request, fetch, locals }) => {
     }
 
     const query = typeof body.query === 'string' ? body.query.trim() : ''
-    if (!query) {
-        return json({ error: 'query is required' }, { status: 400 })
+
+    // Attribute filters: structured filters on indexed document attributes
+    // (e.g. {"chat_title": "Solv & ComputeLabs"}, {"sender": ["alice","bob"]},
+    // {"date": {"gte": "2024-01-01"}}). Forwarded as-is to the searcher which
+    // uses its AttributeFilter enum (untagged: exact / any-of / range).
+    // See shared/src/models.rs::AttributeFilter.
+    const attributeFilters =
+        body.attribute_filters && typeof body.attribute_filters === 'object'
+            ? (body.attribute_filters as Record<string, unknown>)
+            : undefined
+
+    // Empty query is allowed ONLY when there's some other filter driving the
+    // search — otherwise an empty `filter_only_search` against 150K docs is
+    // wasteful. Valid "empty query" cases:
+    //   1. Query string contains operators only ("last week in:telegram")
+    //      — the operator parser will extract them, leaving "" as the final query
+    //      BUT that parsing happens inside the searcher, so from our POV any
+    //      non-empty original body.query is fine.
+    //   2. attribute_filters narrows the search (e.g. one specific chat_title)
+    //   3. source_types is narrowly specified by the caller
+    // We accept case 1 by checking the RAW body.query (not the trimmed one),
+    // and cases 2+3 via explicit filters.
+    const rawQuery = typeof body.query === 'string' ? body.query : ''
+    const hasNonEmptyInput = rawQuery.trim().length > 0
+    const hasNarrowingFilter =
+        !!attributeFilters ||
+        (Array.isArray(body.source_types) && body.source_types.length > 0)
+    if (!hasNonEmptyInput && !hasNarrowingFilter) {
+        return json(
+            {
+                error:
+                    'query is required (or provide source_types / attribute_filters for filtered browsing)',
+            },
+            { status: 400 },
+        )
     }
 
     // Enforce API key source scoping
@@ -40,15 +73,17 @@ export const POST: RequestHandler = async ({ request, fetch, locals }) => {
         }
     }
 
-    const queryData = {
+    const queryData: Record<string, unknown> = {
         query,
         source_types: sourceTypes,
         content_types: Array.isArray(body.content_types) ? body.content_types : undefined,
+        attribute_filters: attributeFilters,
         limit: typeof body.limit === 'number' ? Math.min(body.limit, 100) : 20,
         offset: typeof body.offset === 'number' ? body.offset : 0,
         mode: ['fulltext', 'semantic', 'hybrid'].includes(body.mode as string)
             ? body.mode
             : 'hybrid',
+        include_facets: typeof body.include_facets === 'boolean' ? body.include_facets : undefined,
         // 'admin' scope: omit user_email → searcher skips permission filter → all docs
         // 'user'/'public' scope (or cookie auth): real user identity → user's permitted docs
         user_email:


### PR DESCRIPTION
## Problem

Searches for "what's recent" or "last week" across connector sources return very old results instead of recent ones. Root-caused to a stack of bugs from indexer through agent API.

### 1. Indexer drops real document timestamps

`documents.created_at` and `documents.updated_at` are hardcoded to `now()` at insert time, so every row's top-level timestamps reflect sync time rather than the actual message/email/file date. Connectors already populate `DocumentMetadata.created_at / updated_at` via the SDK, but those values were stored in the `metadata` JSONB and never surfaced to the top-level columns.

Affected call sites:
- `services/indexer/src/queue_processor.rs::create_document_from_event` (the main bulk path)
- `services/indexer/src/queue_processor.rs::handle_document_created`
- `services/indexer/src/lib.rs::create_document` and `process_create_operation` (the HTTP debug path)
- `shared/src/db/repositories/document.rs::create` — didn't even bind `created_at` / `updated_at`, relied on column `DEFAULT now()`, so the indexer's values were silently discarded.

### 2. `BEFORE UPDATE` trigger clobbers explicit values

`update_documents_updated_at` auto-bumps `updated_at = NOW()` on every UPDATE and upsert. This means:

- The indexer fix alone isn't enough — every incremental re-sync would re-corrupt the column.
- Any manual backfill (`UPDATE documents SET updated_at = metadata->>'updated_at'`) is silently overridden.

Other tables keep the trigger because the "row write time" convention is fine for them. `documents` is special: the column semantically means "real document date" (used by the searcher for `ORDER BY`, date filters, and recency boost), not "row write time".

### 3. Agent API silently drops structured filters

`web/src/routes/api/v1/search/+server.ts` only forwarded `query`, `source_types`, `content_types`, `mode`, `limit`, `offset`. It dropped:

- `attribute_filters` — prevented agents from scoping to a specific chat, channel, sender, etc.
- `include_facets` — no per-source distribution in responses.

It also rejected empty queries, so there was no way for an agent to do pure date-based or attribute-based browsing.

### 4. Searcher rejects empty query with body-only filters

`services/searcher/src/search.rs` computed `has_parsed_filters` only from query-operator extraction (`in:`, `by:`, `after:`, etc.). An empty query with `attribute_filters` in the JSON body returned a 500 "Search query cannot be empty" error even though the body carried the narrowing scope.

### 5. `filter_only_search` drops `person_filters`

The empty-query path (`services/searcher/src/search_repository.rs::filter_only_search`) silently dropped `person_filters`. A request like `"by:Lars"` (which parses to `query=""`, `person_filters=["Lars"]`) bypassed the filter and returned everything.

## Fix

### Indexer — read real timestamps from DocumentMetadata

```rust
// queue_processor.rs — both create_document_from_event and handle_document_created
let created_at = metadata.created_at.unwrap_or(now);
let updated_at = metadata.updated_at.unwrap_or(now);
// stabilize ordering when re-sync sets updated_at == existing now
let last_indexed_at = now.max(updated_at) + std::time::Duration::from_millis(1);
```

The HTTP-API path (`lib.rs`) receives `metadata` as `serde_json::Value`, so it uses a small helper:

```rust
fn extract_metadata_timestamp(metadata: &Value, key: &str) -> Option<OffsetDateTime> {
    let raw = metadata.get(key)?.as_str()?;
    OffsetDateTime::parse(raw, &Rfc3339).ok()
}
```

Added `time` as a direct dep of `omni-indexer` because `sqlx::types::time` doesn't re-export the format descriptor module.

### Repository::create — actually bind the timestamps

```rust
INSERT INTO documents (..., created_at, updated_at, last_indexed_at)
VALUES (..., $10, $11, $12)
```

Previously relied on column DEFAULT `now()`, which meant indexer-supplied values were discarded.

### Migration 081 — drop the auto-bump trigger on `documents`

```sql
DROP TRIGGER IF EXISTS update_documents_updated_at ON documents;

COMMENT ON COLUMN documents.updated_at IS
  'Real document date (message sent, email received, file modified). '
  'Set by the indexer from DocumentMetadata.updated_at supplied by the '
  'connector. Must NOT be auto-bumped on UPDATE...';
```

Other tables' triggers are untouched.

### Searcher — accept empty query with body-only filters

```rust
let has_body_filters = request.attribute_filters.as_ref().map_or(false, |m| !m.is_empty())
    || request.source_types.as_ref().map_or(false, |v| !v.is_empty())
    || request.content_types.as_ref().map_or(false, |v| !v.is_empty());
if request.query.trim().is_empty() && !has_parsed_filters && !has_body_filters {
    return Err(anyhow::anyhow!("Search query cannot be empty"));
}
```

### `filter_only_search` — apply `person_filters`

```rust
if let Some(persons) = person_filters {
    let conditions: Vec<String> = persons.iter()
        .map(|p| format!("metadata->>'author' ILIKE '%{}%'", p.replace('\'', "''")))
        .collect();
    if !conditions.is_empty() {
        filters.push(format!("({})", conditions.join(" OR ")));
    }
}
```

Uses JSONB ILIKE instead of the `|||` BM25 operator (which requires a `@@@` scoring context that filter-only queries don't have).

### Web API — pass through `attribute_filters` + `include_facets`, allow filtered empty query

```typescript
const attributeFilters =
    body.attribute_filters && typeof body.attribute_filters === 'object'
        ? (body.attribute_filters as Record<string, unknown>)
        : undefined

const hasNarrowingFilter =
    !!attributeFilters || (Array.isArray(body.source_types) && body.source_types.length > 0)
if (!hasNonEmptyInput && !hasNarrowingFilter) {
    return json({ error: 'query is required (or provide source_types / attribute_filters for filtered browsing)' }, { status: 400 })
}

const queryData: Record<string, unknown> = {
    // ...
    attribute_filters: attributeFilters,
    include_facets: typeof body.include_facets === 'boolean' ? body.include_facets : undefined,
    // ...
}
```

## Backfill (operator action required)

After migration 081 lands, existing rows need a one-time UPDATE to pull real dates out of `metadata`. Scoped per source to bound BM25 segment churn:

```sql
-- Per source_id (repeat for each):
UPDATE documents
SET
  created_at = COALESCE(
    CASE WHEN metadata->>'created_at' IS NOT NULL
         AND pg_input_is_valid(metadata->>'created_at', 'timestamptz')
    THEN (metadata->>'created_at')::timestamptz END,
    created_at),
  updated_at = COALESCE(
    CASE WHEN metadata->>'updated_at' IS NOT NULL
         AND pg_input_is_valid(metadata->>'updated_at', 'timestamptz')
    THEN (metadata->>'updated_at')::timestamptz END,
    updated_at)
WHERE source_id = '<ULID>'
  AND (metadata->>'updated_at' IS NOT NULL OR metadata->>'created_at' IS NOT NULL);
```

**The trigger drop in migration 081 MUST land before the backfill**, otherwise the trigger clobbers every SET value with `NOW()` and the backfill appears to "succeed" but leaves every row at the current time.

Typical timing (measured on a 138K-doc production instance with `mutable_segment_rows=5000`):

| Source | Docs | Time |
|--------|------|------|
| Slack | 2,991 | ~260 ms |
| Google Drive | 3,531 | ~420 ms |
| Notion | 5,871 | ~600 ms |
| Telegram | 16,743 | ~1–2 s |
| Gmail | 33,251 | ~17 s |
| HubSpot | 75,809 | ~11 s |

## Testing

Smoke-tested on a production instance with 138K existing docs across Gmail, Drive, Slack, Notion, HubSpot, Telegram after applying the migration + backfill:

- [x] Empty query + `source_types=["telegram"]` + `content_types=["message"]` returns the 10 most recent messages in real-date DESC order (previously: arbitrary because all rows shared the sync timestamp).
- [x] `attribute_filters={"chat_title": "Solv & ComputeLabs"}` with empty query browses the chat end-to-end, date DESC (previously: 500 error because the empty-query check rejected body-only filters).
- [x] `"last week in:telegram"` (natural-language date + source operator) filters correctly to the last 7 days.
- [x] `"after:2026-03-01 before:2026-04-01 fundraise"` explicit range returns only docs in that window.
- [x] `"by:Lars"` with empty query returns 5 Lars-authored messages in date DESC (previously: returned all 16K+ docs because `filter_only_search` dropped `person_filters`).
- [x] `include_facets=true` returns per-source distribution in the response.

## Files

```
services/indexer/Cargo.toml                                  |  1 +
services/indexer/src/lib.rs                                  | 30 ++++++++++++---
services/indexer/src/queue_processor.rs                      | 24 +++++++++----
services/migrations/081_preserve_document_timestamps.sql     | 33 +++++++++++++++++
services/searcher/src/search.rs                              | 19 +++++++++-
services/searcher/src/search_repository.rs                   | 23 ++++++++++++
shared/src/db/repositories/document.rs                       |  7 ++--
web/src/routes/api/v1/search/+server.ts                      | 41 ++++++++++++++++++--
8 files changed, 162 insertions(+), 16 deletions(-)
```

## Note on defaults

The existing `RECENCY_BOOST_WEIGHT=0.2` / `RECENCY_HALF_LIFE_DAYS=30` defaults give only a ~1.2× multiplier for today's docs vs ~1.00× for year-old docs, so BM25 variance easily dominates even when the recency boost is wired correctly. Operators running chat-heavy or time-sensitive workloads will likely want to bump these (we run `2.0` / `60.0`). I'm not changing the defaults in this PR since it's a judgment call and easily overridable. Happy to add a default change to this PR if you'd prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)