### PR TITLE
Address docling memory usage issues

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -286,7 +286,6 @@ services:
     environment:
       PORT: ${DOCLING_PORT:-8003}
       MAX_CONCURRENT_CONVERSIONS: ${DOCLING_MAX_CONCURRENT_CONVERSIONS:-1}
-      DOCLING_DEVICE: ${DOCLING_DEVICE:-}
     networks:
       - omni-network
     volumes:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -286,6 +286,7 @@ services:
     environment:
       PORT: ${DOCLING_PORT:-8003}
       MAX_CONCURRENT_CONVERSIONS: ${DOCLING_MAX_CONCURRENT_CONVERSIONS:-1}
+      DOCLING_DEVICE: ${DOCLING_DEVICE:-}
     networks:
       - omni-network
     volumes:

--- a/sdk/python/omni_connector/client.py
+++ b/sdk/python/omni_connector/client.py
@@ -6,7 +6,7 @@ import httpx
 
 from pydantic import ValidationError
 
-from .exceptions import SdkClientError
+from .exceptions import SdkClientError, ServiceOverloadedError
 from .models import ConnectorEvent, SdkSourceSyncData
 
 logger = logging.getLogger(__name__)
@@ -117,6 +117,13 @@ class SdkClient:
             files=files,
         )
 
+        if response.status_code == 429:
+            retry_after = int(response.headers.get("retry-after", "30"))
+            raise ServiceOverloadedError(
+                f"Extraction service overloaded: {response.text}",
+                retry_after=retry_after,
+            )
+
         if not response.is_success:
             raise SdkClientError(
                 f"Failed to extract content: {response.status_code} - {response.text}"
@@ -161,6 +168,13 @@ class SdkClient:
             data=form_data,
             files=files,
         )
+
+        if response.status_code == 429:
+            retry_after = int(response.headers.get("retry-after", "30"))
+            raise ServiceOverloadedError(
+                f"Extraction service overloaded: {response.text}",
+                retry_after=retry_after,
+            )
 
         if not response.is_success:
             raise SdkClientError(

--- a/sdk/python/omni_connector/exceptions.py
+++ b/sdk/python/omni_connector/exceptions.py
@@ -16,6 +16,14 @@ class SyncCancelledError(ConnectorError):
     pass
 
 
+class ServiceOverloadedError(SdkClientError):
+    """Raised when the extraction service is overloaded (HTTP 429)."""
+
+    def __init__(self, message: str, retry_after: int = 30):
+        super().__init__(message)
+        self.retry_after = retry_after
+
+
 class ConfigurationError(ConnectorError):
     """Error in connector configuration."""
 

--- a/sdk/python/omni_connector/storage.py
+++ b/sdk/python/omni_connector/storage.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import logging
 from typing import TYPE_CHECKING
@@ -5,7 +6,11 @@ from typing import TYPE_CHECKING
 if TYPE_CHECKING:
     from .client import SdkClient
 
+from .exceptions import ServiceOverloadedError
+
 logger = logging.getLogger(__name__)
+
+_MAX_RETRIES = 5
 
 
 class ContentStorage:
@@ -39,13 +44,29 @@ class ContentStorage:
         """Extract text from binary file content and store it, returning content_id.
 
         The connector manager handles extraction based on MIME type.
+        Retries with exponential backoff when the extraction service is overloaded.
         """
-        return await self._client.extract_and_store_content(
-            self._sync_run_id,
-            data,
-            mime_type,
-            filename,
-        )
+        for attempt in range(_MAX_RETRIES):
+            try:
+                return await self._client.extract_and_store_content(
+                    self._sync_run_id,
+                    data,
+                    mime_type,
+                    filename,
+                )
+            except ServiceOverloadedError as e:
+                if attempt == _MAX_RETRIES - 1:
+                    raise
+                wait = e.retry_after * (1.5**attempt)
+                logger.warning(
+                    "Extraction service overloaded for file %s, retrying in %.0fs (%d/%d)",
+                    filename,
+                    wait,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                await asyncio.sleep(wait)
+        raise RuntimeError("unreachable")
 
     async def extract_text(
         self,
@@ -56,13 +77,29 @@ class ContentStorage:
         """Extract text from binary file content without storing.
 
         Use when you need to post-process or combine text before storing.
+        Retries with exponential backoff when the extraction service is overloaded.
         """
-        return await self._client.extract_text(
-            self._sync_run_id,
-            data,
-            mime_type,
-            filename,
-        )
+        for attempt in range(_MAX_RETRIES):
+            try:
+                return await self._client.extract_text(
+                    self._sync_run_id,
+                    data,
+                    mime_type,
+                    filename,
+                )
+            except ServiceOverloadedError as e:
+                if attempt == _MAX_RETRIES - 1:
+                    raise
+                wait = e.retry_after * (1.5**attempt)
+                logger.warning(
+                    "Extraction service overloaded for file %s, retrying in %.0fs (%d/%d)",
+                    filename,
+                    wait,
+                    attempt + 1,
+                    _MAX_RETRIES,
+                )
+                await asyncio.sleep(wait)
+        raise RuntimeError("unreachable")
 
     async def save_binary(
         self,

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -19,6 +19,7 @@ use futures::stream::Stream;
 use redis::AsyncCommands;
 use serde_json::json;
 use shared::clients::docling::{DoclingClient, DoclingError};
+use shared::constants::REDIS_SYSTEM_SETTINGS_KEY;
 use shared::db::repositories::SyncRunRepository;
 use shared::models::{ConnectorManifest, SearchOperator, SourceType, SyncType};
 use shared::queue::EventQueue;
@@ -833,8 +834,29 @@ async fn is_docling_enabled(redis_client: &redis::Client) -> bool {
         }
     };
 
-    let value: Option<String> = conn.hget("system:settings", "docling_enabled").await.ok();
+    let value: Option<String> = conn
+        .hget(REDIS_SYSTEM_SETTINGS_KEY, "docling_enabled")
+        .await
+        .ok();
     value.as_deref() == Some("true")
+}
+
+/// Read the Docling quality preset from Redis (set via the admin UI).
+/// Defaults to "balanced" if not set or on error.
+async fn get_docling_quality_preset(redis_client: &redis::Client) -> String {
+    let mut conn = match redis_client.get_multiplexed_async_connection().await {
+        Ok(c) => c,
+        Err(e) => {
+            warn!("Failed to connect to Redis for docling preset: {}", e);
+            return "balanced".to_string();
+        }
+    };
+
+    let value: Option<String> = conn
+        .hget(REDIS_SYSTEM_SETTINGS_KEY, "docling_quality_preset")
+        .await
+        .ok();
+    value.unwrap_or_else(|| "balanced".to_string())
 }
 
 /// MIME types that Docling can process.
@@ -1040,11 +1062,12 @@ async fn do_extract_text(
     if docling_candidate && docling_enabled {
         let docling_result = if let Some(client) = DoclingClient::from_env() {
             let file_name = filename.unwrap_or("document");
+            let preset = get_docling_quality_preset(redis_client).await;
             debug!(
-                "Using docling-based document content extraction for file '{}'",
-                file_name
+                "Using docling-based document content extraction for file '{}' (preset={})",
+                file_name, preset
             );
-            match client.convert(data, file_name).await {
+            match client.convert(data, file_name, &preset).await {
                 Ok(markdown) => {
                     debug!("Docling extraction succeeded: {} chars", markdown.len());
                     Some(markdown)

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -18,7 +18,7 @@ use axum::{
 use futures::stream::Stream;
 use redis::AsyncCommands;
 use serde_json::json;
-use shared::clients::docling::DoclingClient;
+use shared::clients::docling::{DoclingClient, DoclingError};
 use shared::db::repositories::SyncRunRepository;
 use shared::models::{ConnectorManifest, SearchOperator, SourceType, SyncType};
 use shared::queue::EventQueue;
@@ -653,6 +653,9 @@ pub enum ApiError {
 
     #[error("Internal error: {0}")]
     Internal(String),
+
+    #[error("Too many requests: {0}")]
+    TooManyRequests(String),
 }
 
 impl From<SyncError> for ApiError {
@@ -692,6 +695,7 @@ impl IntoResponse for ApiError {
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
+            ApiError::TooManyRequests(msg) => (StatusCode::TOO_MANY_REQUESTS, msg.clone()),
         };
 
         let body = json!({ "error": message });
@@ -918,10 +922,10 @@ fn is_docling_supported_extension(filename: Option<&str>) -> bool {
 
 use crate::models::{
     SdkCancelSyncRequest, SdkCancelSyncResponse, SdkCompleteRequest, SdkCreateSyncRequest,
-    SdkCreateSyncResponse, SdkEmitEventRequest, SdkExtractContentResponse,
-    SdkExtractTextResponse, SdkFailRequest, SdkIncrementScannedRequest,
-    SdkSourceSyncConfigResponse, SdkStatusResponse, SdkStoreContentRequest,
-    SdkStoreContentResponse, SdkUserEmailResponse, SdkWebhookNotification, SdkWebhookResponse,
+    SdkCreateSyncResponse, SdkEmitEventRequest, SdkExtractContentResponse, SdkExtractTextResponse,
+    SdkFailRequest, SdkIncrementScannedRequest, SdkSourceSyncConfigResponse, SdkStatusResponse,
+    SdkStoreContentRequest, SdkStoreContentResponse, SdkUserEmailResponse, SdkWebhookNotification,
+    SdkWebhookResponse,
 };
 
 pub async fn sdk_emit_event(
@@ -1029,17 +1033,30 @@ async fn do_extract_text(
     mime_type: &str,
     filename: Option<&str>,
     data: &[u8],
-) -> String {
+) -> Result<String, ApiError> {
+    let docling_enabled = is_docling_enabled(redis_client).await;
     let docling_candidate = is_docling_supported_mime(mime_type)
-        || (mime_type == "application/octet-stream"
-            && is_docling_supported_extension(filename));
-    if docling_candidate && is_docling_enabled(redis_client).await {
+        || (mime_type == "application/octet-stream" && is_docling_supported_extension(filename));
+    if docling_candidate && docling_enabled {
         let docling_result = if let Some(client) = DoclingClient::from_env() {
             let file_name = filename.unwrap_or("document");
+            debug!(
+                "Using docling-based document content extraction for file '{}'",
+                file_name
+            );
             match client.convert(data, file_name).await {
                 Ok(markdown) => {
                     debug!("Docling extraction succeeded: {} chars", markdown.len());
                     Some(markdown)
+                }
+                Err(DoclingError::ServiceOverloaded { retry_after_secs }) => {
+                    warn!(
+                        "Docling overloaded, propagating 429 (retry after {}s)",
+                        retry_after_secs
+                    );
+                    return Err(ApiError::TooManyRequests(
+                        "Document conversion service is overloaded. Try again later.".to_string(),
+                    ));
                 }
                 Err(e) => {
                     warn!("Docling extraction failed, falling back to built-in: {}", e);
@@ -1051,19 +1068,28 @@ async fn do_extract_text(
             None
         };
 
-        docling_result.unwrap_or_else(|| {
-            shared::content_extractor::extract_content(data, mime_type, filename)
-                .unwrap_or_else(|e| {
+        Ok(docling_result.unwrap_or_else(|| {
+            debug!(
+                "Using built-in document content extraction for file {:?}",
+                filename
+            );
+            shared::content_extractor::extract_content(data, mime_type, filename).unwrap_or_else(
+                |e| {
                     warn!("Built-in content extraction failed: {}", e);
                     String::new()
-                })
-        })
+                },
+            )
+        }))
     } else {
-        shared::content_extractor::extract_content(data, mime_type, filename)
-            .unwrap_or_else(|e| {
-                warn!("Content extraction failed: {}", e);
-                String::new()
-            })
+        debug!("Using built-in document content extraction for file {:?} (docling_enabled={}, docling_candidate={})", filename, docling_enabled, docling_candidate);
+        Ok(
+            shared::content_extractor::extract_content(data, mime_type, filename).unwrap_or_else(
+                |e| {
+                    warn!("Content extraction failed: {}", e);
+                    String::new()
+                },
+            ),
+        )
     }
 }
 
@@ -1087,7 +1113,7 @@ pub async fn sdk_extract_content(
         fields.filename.as_deref(),
         &fields.data,
     )
-    .await;
+    .await?;
 
     let today = time::OffsetDateTime::now_utc();
     let prefix = format!(
@@ -1135,7 +1161,7 @@ pub async fn sdk_extract_text(
         fields.filename.as_deref(),
         &fields.data,
     )
-    .await;
+    .await?;
 
     let text = utils::normalize_whitespace(&extracted_text);
 

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -8,7 +8,7 @@ use crate::sync_manager::SyncError;
 use crate::AppState;
 use axum::{
     extract::{Path, Query, State},
-    http::StatusCode,
+    http::{header, HeaderValue, StatusCode},
     response::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse,
@@ -655,8 +655,11 @@ pub enum ApiError {
     #[error("Internal error: {0}")]
     Internal(String),
 
-    #[error("Too many requests: {0}")]
-    TooManyRequests(String),
+    #[error("Too many requests: {message} (retry after {retry_after_secs}s)")]
+    TooManyRequests {
+        message: String,
+        retry_after_secs: u64,
+    },
 }
 
 impl From<SyncError> for ApiError {
@@ -691,12 +694,25 @@ impl From<SyncError> for ApiError {
 
 impl IntoResponse for ApiError {
     fn into_response(self) -> axum::response::Response {
+        if let ApiError::TooManyRequests {
+            message,
+            retry_after_secs,
+        } = &self
+        {
+            let body = json!({ "error": message });
+            let mut resp = (StatusCode::TOO_MANY_REQUESTS, Json(body)).into_response();
+            if let Ok(v) = HeaderValue::from_str(&retry_after_secs.to_string()) {
+                resp.headers_mut().insert(header::RETRY_AFTER, v);
+            }
+            return resp;
+        }
+
         let (status, message) = match &self {
             ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
-            ApiError::TooManyRequests(msg) => (StatusCode::TOO_MANY_REQUESTS, msg.clone()),
+            ApiError::TooManyRequests { .. } => unreachable!(),
         };
 
         let body = json!({ "error": message });
@@ -823,40 +839,53 @@ pub async fn get_connector_url_for_source(
     None
 }
 
-/// Check if Docling document conversion is enabled.
-/// Reads the `docling_enabled` flag from Redis (set via the admin UI).
-async fn is_docling_enabled(redis_client: &redis::Client) -> bool {
+const VALID_DOCLING_PRESETS: &[&str] = &["fast", "balanced", "quality"];
+const DEFAULT_DOCLING_PRESET: &str = "balanced";
+
+/// Read both the Docling `enabled` flag and quality preset from Redis in a
+/// single multiplexed connection. Invalid/unknown preset values fall back to
+/// `balanced` with a warning so a corrupted setting can't silently break
+/// conversion (it would otherwise surface as a Docling 400 → built-in
+/// fallback, invisible to the admin).
+async fn get_docling_settings(redis_client: &redis::Client) -> (bool, String) {
     let mut conn = match redis_client.get_multiplexed_async_connection().await {
         Ok(c) => c,
         Err(e) => {
-            warn!("Failed to connect to Redis for docling check: {}", e);
-            return false;
+            warn!("Failed to connect to Redis for docling settings: {}", e);
+            return (false, DEFAULT_DOCLING_PRESET.to_string());
         }
     };
 
-    let value: Option<String> = conn
-        .hget(REDIS_SYSTEM_SETTINGS_KEY, "docling_enabled")
+    let values: Vec<Option<String>> = conn
+        .hget(
+            REDIS_SYSTEM_SETTINGS_KEY,
+            &["docling_enabled", "docling_quality_preset"],
+        )
         .await
-        .ok();
-    value.as_deref() == Some("true")
-}
+        .unwrap_or_else(|e| {
+            warn!("Failed to read docling settings from Redis: {}", e);
+            vec![None, None]
+        });
 
-/// Read the Docling quality preset from Redis (set via the admin UI).
-/// Defaults to "balanced" if not set or on error.
-async fn get_docling_quality_preset(redis_client: &redis::Client) -> String {
-    let mut conn = match redis_client.get_multiplexed_async_connection().await {
-        Ok(c) => c,
-        Err(e) => {
-            warn!("Failed to connect to Redis for docling preset: {}", e);
-            return "balanced".to_string();
+    let enabled = values
+        .first()
+        .and_then(|v| v.as_deref())
+        .map(|s| s == "true")
+        .unwrap_or(false);
+
+    let preset = match values.get(1).and_then(|v| v.as_deref()) {
+        Some(p) if VALID_DOCLING_PRESETS.contains(&p) => p.to_string(),
+        Some(p) => {
+            warn!(
+                "Invalid docling preset '{}' in Redis; falling back to '{}'.",
+                p, DEFAULT_DOCLING_PRESET
+            );
+            DEFAULT_DOCLING_PRESET.to_string()
         }
+        None => DEFAULT_DOCLING_PRESET.to_string(),
     };
 
-    let value: Option<String> = conn
-        .hget(REDIS_SYSTEM_SETTINGS_KEY, "docling_quality_preset")
-        .await
-        .ok();
-    value.unwrap_or_else(|| "balanced".to_string())
+    (enabled, preset)
 }
 
 /// MIME types that Docling can process.
@@ -1056,13 +1085,16 @@ async fn do_extract_text(
     filename: Option<&str>,
     data: &[u8],
 ) -> Result<String, ApiError> {
-    let docling_enabled = is_docling_enabled(redis_client).await;
     let docling_candidate = is_docling_supported_mime(mime_type)
         || (mime_type == "application/octet-stream" && is_docling_supported_extension(filename));
+    let (docling_enabled, preset) = if docling_candidate {
+        get_docling_settings(redis_client).await
+    } else {
+        (false, DEFAULT_DOCLING_PRESET.to_string())
+    };
     if docling_candidate && docling_enabled {
         let docling_result = if let Some(client) = DoclingClient::from_env() {
             let file_name = filename.unwrap_or("document");
-            let preset = get_docling_quality_preset(redis_client).await;
             debug!(
                 "Using docling-based document content extraction for file '{}' (preset={})",
                 file_name, preset
@@ -1077,9 +1109,11 @@ async fn do_extract_text(
                         "Docling overloaded, propagating 429 (retry after {}s)",
                         retry_after_secs
                     );
-                    return Err(ApiError::TooManyRequests(
-                        "Document conversion service is overloaded. Try again later.".to_string(),
-                    ));
+                    return Err(ApiError::TooManyRequests {
+                        message: "Document conversion service is overloaded. Try again later."
+                            .to_string(),
+                        retry_after_secs,
+                    });
                 }
                 Err(e) => {
                     warn!("Docling extraction failed, falling back to built-in: {}", e);

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -31,6 +31,7 @@ logger = logging.getLogger(__name__)
 
 _MAX_CONCURRENT = int(os.getenv("MAX_CONCURRENT_CONVERSIONS", "1"))
 _MAX_PENDING = int(os.getenv("MAX_PENDING_JOBS", str(_MAX_CONCURRENT * 2)))
+_PAGES_PER_CHUNK = int(os.getenv("PAGES_PER_CHUNK", "5"))
 _ready: bool = False
 
 PresetName = Literal["fast", "balanced", "quality"]
@@ -115,6 +116,71 @@ def _build_converter(preset: str = "balanced") -> DocumentConverter:
     )
     _apply_rapidocr_suppression()
     return converter
+
+
+def _get_pdf_page_count(data: bytes) -> int | None:
+    """Return the page count for a PDF, or None if not a PDF."""
+    try:
+        import pypdfium2 as pdfium
+
+        pdf = pdfium.PdfDocument(data)
+        count = len(pdf)
+        pdf.close()
+        return count
+    except Exception:
+        return None
+
+
+def _convert_document(
+    converter: DocumentConverter,
+    data: bytes,
+    filename: str,
+) -> str:
+    """Convert a document to markdown, processing PDFs in page chunks to cap memory.
+
+    Non-PDF formats are converted in a single pass. PDFs are split into chunks
+    of _PAGES_PER_CHUNK pages; each chunk is converted independently and the
+    resulting markdown fragments are concatenated.
+    """
+    page_count = _get_pdf_page_count(data)
+
+    # Non-PDF or small PDF: single-pass conversion
+    if page_count is None or page_count <= _PAGES_PER_CHUNK:
+        stream = DocumentStream(name=filename, stream=io.BytesIO(data))
+        result = converter.convert(stream)
+        try:
+            if result.status not in (
+                ConversionStatus.SUCCESS,
+                ConversionStatus.PARTIAL_SUCCESS,
+            ):
+                raise RuntimeError("Conversion failed.")
+            return result.document.export_to_markdown()
+        finally:
+            del result
+            gc.collect()
+
+    # Large PDF: chunked conversion
+    markdown_parts: list[str] = []
+    for start in range(1, page_count + 1, _PAGES_PER_CHUNK):
+        end = min(start + _PAGES_PER_CHUNK - 1, page_count)
+        logger.debug("Processing pages %d–%d of %d", start, end, page_count)
+        stream = DocumentStream(name=filename, stream=io.BytesIO(data))
+        result = converter.convert(stream, page_range=(start, end))
+        try:
+            if result.status in (
+                ConversionStatus.SUCCESS,
+                ConversionStatus.PARTIAL_SUCCESS,
+            ):
+                markdown_parts.append(result.document.export_to_markdown())
+            else:
+                logger.warning("Chunk pages %d–%d failed, skipping.", start, end)
+        finally:
+            del result
+            gc.collect()
+
+    if not markdown_parts:
+        raise RuntimeError("All page chunks failed.")
+    return "\n\n".join(markdown_parts)
 
 
 def _download_models() -> None:
@@ -221,7 +287,6 @@ async def _cleanup_loop() -> None:
 async def _run_job(job: Job, data: bytes, filename: str) -> None:
     """Background task: build a fresh converter, run conversion, destroy everything."""
     await _semaphore.acquire()
-    result = None
     converter = None
     try:
         job.status = JobStatus.RUNNING
@@ -235,11 +300,10 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
         t0 = time.monotonic()
         loop = asyncio.get_running_loop()
         converter = await loop.run_in_executor(None, _build_converter, job.preset)
-        buf = io.BytesIO(data)
-        del data
-        stream = DocumentStream(name=filename, stream=buf)
         try:
-            result = await loop.run_in_executor(None, lambda: converter.convert(stream))
+            markdown = await loop.run_in_executor(
+                None, _convert_document, converter, data, filename
+            )
         except Exception as exc:
             elapsed = time.monotonic() - t0
             job.status = JobStatus.FAILED
@@ -258,19 +322,9 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
                 exc_info=True,
             )
             return
-        finally:
-            buf.close()
 
         elapsed = time.monotonic() - t0
-        if result.status not in (
-            ConversionStatus.SUCCESS,
-            ConversionStatus.PARTIAL_SUCCESS,
-        ):
-            job.status = JobStatus.FAILED
-            job.detail = "Conversion failed."
-            logger.error("Job %s: failed after %.1fs — %s", job.id, elapsed, job.detail)
-            return
-        job.markdown = result.document.export_to_markdown()
+        job.markdown = markdown
         job.status = JobStatus.COMPLETED
         logger.info(
             "Job %s: completed in %.1fs (%d chars).", job.id, elapsed, len(job.markdown)
@@ -281,7 +335,7 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
             job.detail = f"Unexpected error: {exc}"
             logger.error("Job %s: failed — %s", job.id, job.detail, exc_info=True)
     finally:
-        del result, converter
+        del converter, data
         gc.collect()
         _semaphore.release()
 

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -1,6 +1,7 @@
 """Document to Markdown conversion service using Docling."""
 
 import asyncio
+import gc
 import io
 import logging
 import os
@@ -59,9 +60,9 @@ QUALITY_PRESETS: dict[str, dict] = {
     },
 }
 
-# One converter pool per preset, built lazily on first use.
-_converter_pools: dict[str, asyncio.Queue[DocumentConverter]] = {}
-_pool_locks: dict[str, asyncio.Lock] = {p: asyncio.Lock() for p in QUALITY_PRESETS}
+# Semaphore to limit concurrent conversions (replaces converter pool).
+# A fresh converter is built per job and destroyed after to avoid memory accumulation.
+_semaphore: asyncio.Semaphore  # created in lifespan
 
 
 class _SuppressFilter(logging.Filter):
@@ -167,58 +168,50 @@ def _active_job_count() -> int:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    # Start converter init in the background so the HTTP server becomes
-    # responsive immediately. /health returns {"status": "starting"} and
-    # /convert returns 503 until init completes.
-    asyncio.create_task(_init_converters())
+    global _semaphore
+    _semaphore = asyncio.Semaphore(_MAX_CONCURRENT)
+    # Start init in the background so the HTTP server becomes responsive
+    # immediately. /health returns {"status": "starting"} and /convert
+    # returns 503 until init completes.
+    asyncio.create_task(_init())
     asyncio.create_task(_cleanup_loop())
     yield
 
 
-async def _init_converters() -> None:
+async def _init() -> None:
     global _ready
     try:
         logger.info("Downloading models ...")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _download_models)
+        # Warm up: build and immediately discard one converter so all model
+        # weights are loaded into the HF cache and first real job is fast.
+        await loop.run_in_executor(None, _build_converter, "balanced")
         os.environ["HF_HUB_OFFLINE"] = "1"
         _ready = True
-        logger.info("Ready — models downloaded, converter pools created on demand.")
-    except Exception:
-        logger.exception(
-            "Failed to initialise converter(s). Service will remain unavailable."
-        )
-
-
-async def _get_pool(preset: str) -> asyncio.Queue[DocumentConverter]:
-    """Get or lazily create the converter pool for the given preset."""
-    if preset in _converter_pools:
-        return _converter_pools[preset]
-
-    async with _pool_locks[preset]:
-        # Double-check after acquiring lock
-        if preset in _converter_pools:
-            return _converter_pools[preset]
-
         logger.info(
-            "Building %d converter(s) for preset '%s' ...", _MAX_CONCURRENT, preset
+            "Ready — models cached, max %d concurrent conversion(s).", _MAX_CONCURRENT
         )
-        loop = asyncio.get_running_loop()
-        pool: asyncio.Queue[DocumentConverter] = asyncio.Queue(maxsize=_MAX_CONCURRENT)
-        for i in range(_MAX_CONCURRENT):
-            converter = await loop.run_in_executor(None, _build_converter, preset)
-            pool.put_nowait(converter)
-            logger.info("Converter [%s] %d/%d ready.", preset, i + 1, _MAX_CONCURRENT)
-        _converter_pools[preset] = pool
-        return pool
+    except Exception:
+        logger.exception("Failed to initialise. Service will remain unavailable.")
 
 
 async def _cleanup_loop() -> None:
-    """Hourly sweep: delete jobs older than 1 day regardless of status."""
+    """Periodic sweep: remove finished jobs after 10 minutes, any job after 1 day."""
     while True:
-        await asyncio.sleep(3600)
-        cutoff = datetime.now(timezone.utc) - timedelta(days=1)
-        stale = [jid for jid, j in _jobs.items() if j.created_at < cutoff]
+        await asyncio.sleep(60)
+        now = datetime.now(timezone.utc)
+        finished_cutoff = now - timedelta(minutes=10)
+        absolute_cutoff = now - timedelta(days=1)
+        stale = [
+            jid
+            for jid, j in _jobs.items()
+            if j.created_at < absolute_cutoff
+            or (
+                j.status in (JobStatus.COMPLETED, JobStatus.FAILED)
+                and j.created_at < finished_cutoff
+            )
+        ]
         for jid in stale:
             del _jobs[jid]
         if stale:
@@ -226,9 +219,10 @@ async def _cleanup_loop() -> None:
 
 
 async def _run_job(job: Job, data: bytes, filename: str) -> None:
-    """Background task: lease a converter from the pool, run conversion, return it."""
-    pool = await _get_pool(job.preset)
-    converter = await pool.get()
+    """Background task: build a fresh converter, run conversion, destroy everything."""
+    await _semaphore.acquire()
+    result = None
+    converter = None
     try:
         job.status = JobStatus.RUNNING
         logger.info(
@@ -239,11 +233,13 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
             job.preset,
         )
         t0 = time.monotonic()
-        stream = DocumentStream(name=filename, stream=io.BytesIO(data))
+        loop = asyncio.get_running_loop()
+        converter = await loop.run_in_executor(None, _build_converter, job.preset)
+        buf = io.BytesIO(data)
+        del data
+        stream = DocumentStream(name=filename, stream=buf)
         try:
-            result = await asyncio.get_running_loop().run_in_executor(
-                None, lambda: converter.convert(stream)
-            )
+            result = await loop.run_in_executor(None, lambda: converter.convert(stream))
         except Exception as exc:
             elapsed = time.monotonic() - t0
             job.status = JobStatus.FAILED
@@ -262,11 +258,10 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
                 exc_info=True,
             )
             return
-    finally:
-        pool.put_nowait(converter)
+        finally:
+            buf.close()
 
-    elapsed = time.monotonic() - t0
-    try:
+        elapsed = time.monotonic() - t0
         if result.status not in (
             ConversionStatus.SUCCESS,
             ConversionStatus.PARTIAL_SUCCESS,
@@ -281,15 +276,14 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
             "Job %s: completed in %.1fs (%d chars).", job.id, elapsed, len(job.markdown)
         )
     except Exception as exc:
-        job.status = JobStatus.FAILED
-        job.detail = f"Post-processing error: {exc}"
-        logger.error(
-            "Job %s: failed after %.1fs — %s",
-            job.id,
-            elapsed,
-            job.detail,
-            exc_info=True,
-        )
+        if job.status not in (JobStatus.COMPLETED, JobStatus.FAILED):
+            job.status = JobStatus.FAILED
+            job.detail = f"Unexpected error: {exc}"
+            logger.error("Job %s: failed — %s", job.id, job.detail, exc_info=True)
+    finally:
+        del result, converter
+        gc.collect()
+        _semaphore.release()
 
 
 app = FastAPI(title="docling", version="1.0.0", lifespan=lifespan)

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -13,7 +13,7 @@ from enum import Enum
 from typing import Literal
 
 import uvicorn
-from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
+from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.base_models import ConversionStatus, InputFormat
 from docling.datamodel.document import DocumentStream
 from docling.datamodel.pipeline_options import (
@@ -88,19 +88,10 @@ def _apply_rapidocr_suppression() -> None:
                 handler.addFilter(f)
 
 
-def _detect_device() -> AcceleratorDevice:
-    """Pick accelerator based on DOCLING_DEVICE env var. Empty/unset = CPU, 'cuda' = CUDA."""
-    device_str = os.getenv("DOCLING_DEVICE", "")
-    if device_str == "cuda":
-        return AcceleratorDevice.CUDA
-    return AcceleratorDevice.CPU
-
-
 def _build_converter(preset: str = "balanced") -> DocumentConverter:
     """Build a DocumentConverter with pipeline options from the given quality preset."""
     opts = QUALITY_PRESETS[preset]
-    device = _detect_device()
-    accelerator_options = AcceleratorOptions(device=device)
+    accelerator_options = AcceleratorOptions()
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
     pipeline_options.do_table_structure = True
@@ -192,8 +183,6 @@ async def _init_converters() -> None:
             total,
             len(QUALITY_PRESETS),
         )
-        device = _detect_device()
-        logger.info("Accelerator device: %s", device.value)
         logger.info("Downloading models ...")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _download_models)

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -3,7 +3,6 @@
 import asyncio
 import io
 import logging
-import multiprocessing
 import os
 import time
 import uuid
@@ -89,13 +88,19 @@ def _apply_rapidocr_suppression() -> None:
                 handler.addFilter(f)
 
 
+def _detect_device() -> AcceleratorDevice:
+    """Pick accelerator based on DOCLING_DEVICE env var. Empty/unset = CPU, 'cuda' = CUDA."""
+    device_str = os.getenv("DOCLING_DEVICE", "")
+    if device_str == "cuda":
+        return AcceleratorDevice.CUDA
+    return AcceleratorDevice.CPU
+
+
 def _build_converter(preset: str = "balanced") -> DocumentConverter:
     """Build a DocumentConverter with pipeline options from the given quality preset."""
     opts = QUALITY_PRESETS[preset]
-    accelerator_options = AcceleratorOptions(
-        device=AcceleratorDevice.CPU,
-        num_threads=multiprocessing.cpu_count(),
-    )
+    device = _detect_device()
+    accelerator_options = AcceleratorOptions(device=device)
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
     pipeline_options.do_table_structure = True
@@ -187,6 +192,8 @@ async def _init_converters() -> None:
             total,
             len(QUALITY_PRESETS),
         )
+        device = _detect_device()
+        logger.info("Accelerator device: %s", device.value)
         logger.info("Downloading models ...")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _download_models)

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -11,6 +11,7 @@ from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
+from typing import Literal
 
 import uvicorn
 from docling.datamodel.accelerator_options import AcceleratorDevice, AcceleratorOptions
@@ -22,7 +23,7 @@ from docling.datamodel.pipeline_options import (
     TableFormerMode,
 )
 from docling.document_converter import DocumentConverter, PdfFormatOption
-from fastapi import FastAPI, File, HTTPException, UploadFile
+from fastapi import FastAPI, File, HTTPException, Query, UploadFile
 from fastapi.responses import JSONResponse
 
 logging.basicConfig(level=logging.INFO)
@@ -30,8 +31,37 @@ logger = logging.getLogger(__name__)
 
 _MAX_CONCURRENT = int(os.getenv("MAX_CONCURRENT_CONVERSIONS", "1"))
 _MAX_PENDING = int(os.getenv("MAX_PENDING_JOBS", str(_MAX_CONCURRENT * 2)))
-_converter_pool: asyncio.Queue[DocumentConverter]  # created inside lifespan
 _ready: bool = False
+
+PresetName = Literal["fast", "balanced", "quality"]
+VALID_PRESETS: set[str] = {"fast", "balanced", "quality"}
+
+QUALITY_PRESETS: dict[str, dict] = {
+    "fast": {
+        "table_structure_mode": TableFormerMode.FAST,
+        "images_scale": 1.0,
+        "do_picture_classification": False,
+        "generate_picture_images": False,
+        "generate_table_images": False,
+    },
+    "balanced": {
+        "table_structure_mode": TableFormerMode.ACCURATE,
+        "images_scale": 1.0,
+        "do_picture_classification": True,
+        "generate_picture_images": False,
+        "generate_table_images": False,
+    },
+    "quality": {
+        "table_structure_mode": TableFormerMode.ACCURATE,
+        "images_scale": 1.5,
+        "do_picture_classification": True,
+        "generate_picture_images": True,
+        "generate_table_images": True,
+    },
+}
+
+# One converter pool per preset, created in lifespan
+_converter_pools: dict[str, asyncio.Queue[DocumentConverter]] = {}
 
 
 class _SuppressFilter(logging.Filter):
@@ -59,8 +89,9 @@ def _apply_rapidocr_suppression() -> None:
                 handler.addFilter(f)
 
 
-def _build_converter() -> DocumentConverter:
-    """Build a DocumentConverter with optimal quality settings for CPU inference."""
+def _build_converter(preset: str = "balanced") -> DocumentConverter:
+    """Build a DocumentConverter with pipeline options from the given quality preset."""
+    opts = QUALITY_PRESETS[preset]
     accelerator_options = AcceleratorOptions(
         device=AcceleratorDevice.CPU,
         num_threads=multiprocessing.cpu_count(),
@@ -68,29 +99,17 @@ def _build_converter() -> DocumentConverter:
     pipeline_options = PdfPipelineOptions()
     pipeline_options.accelerator_options = accelerator_options
     pipeline_options.do_table_structure = True
-    pipeline_options.table_structure_options.mode = TableFormerMode.ACCURATE
+    pipeline_options.table_structure_options.mode = opts["table_structure_mode"]
     pipeline_options.do_ocr = True
     pipeline_options.ocr_options = RapidOcrOptions(backend="torch")
-    pipeline_options.images_scale = (
-        1.5  # higher resolution improves OCR/layout accuracy
-    )
-    pipeline_options.generate_picture_images = True
-    pipeline_options.generate_table_images = True
-    pipeline_options.do_code_enrichment = (
-        False  # VLM per code block; adds latency on code-heavy docs
-    )
-    pipeline_options.do_formula_enrichment = (
-        False  # VLM per formula; adds latency on math-heavy docs
-    )
-    pipeline_options.do_picture_classification = (
-        True  # lightweight ViT; minimal overhead
-    )
-    pipeline_options.do_picture_description = (
-        False  # SmolVLM per image; significant latency per figure
-    )
-    pipeline_options.do_chart_extraction = (
-        False  # Granite Vision 2B per chart; high RAM + latency
-    )
+    pipeline_options.images_scale = opts["images_scale"]
+    pipeline_options.generate_picture_images = opts["generate_picture_images"]
+    pipeline_options.generate_table_images = opts["generate_table_images"]
+    pipeline_options.do_code_enrichment = False
+    pipeline_options.do_formula_enrichment = False
+    pipeline_options.do_picture_classification = opts["do_picture_classification"]
+    pipeline_options.do_picture_description = False
+    pipeline_options.do_chart_extraction = False
     converter = DocumentConverter(
         format_options={
             InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
@@ -108,15 +127,15 @@ def _download_models() -> None:
         progress=True,
         with_layout=True,
         with_tableformer=True,
-        with_code_formula=False,  # ~500 MB; needed for do_code/formula_enrichment
-        with_picture_classifier=True,  # ~90 MB; needed for do_picture_classification
-        with_smolvlm=False,  # ~500 MB; needed for do_picture_description
+        with_code_formula=False,
+        with_picture_classifier=True,
+        with_smolvlm=False,
         with_granitedocling=False,
         with_granitedocling_mlx=False,
         with_smoldocling=False,
         with_smoldocling_mlx=False,
         with_granite_vision=False,
-        with_granite_chart_extraction=False,  # ~2 GB; needed for do_chart_extraction
+        with_granite_chart_extraction=False,
         with_rapidocr=True,
         with_easyocr=False,
     )
@@ -132,6 +151,7 @@ class JobStatus(str, Enum):
 @dataclass
 class Job:
     id: str
+    preset: str = "balanced"
     status: JobStatus = JobStatus.PENDING
     markdown: str | None = None
     detail: str | None = None
@@ -150,34 +170,51 @@ def _active_job_count() -> int:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global _converter_pool
-    _converter_pool = asyncio.Queue(maxsize=_MAX_CONCURRENT)
     # Start converter init in the background so the HTTP server becomes
     # responsive immediately. /health returns {"status": "starting"} and
     # /convert returns 503 until init completes.
-    asyncio.create_task(_init_converter())
+    asyncio.create_task(_init_converters())
     asyncio.create_task(_cleanup_loop())
     yield
 
 
-async def _init_converter() -> None:
+async def _init_converters() -> None:
     global _ready
     try:
+        total = _MAX_CONCURRENT * len(QUALITY_PRESETS)
         logger.info(
-            "Loading %d DocumentConverter instance(s) ...",
-            _MAX_CONCURRENT,
+            "Loading %d DocumentConverter instance(s) across %d presets ...",
+            total,
+            len(QUALITY_PRESETS),
         )
         logger.info("Downloading models ...")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _download_models)
-        for i in range(_MAX_CONCURRENT):
-            converter = await loop.run_in_executor(None, _build_converter)
-            _converter_pool.put_nowait(converter)
-            logger.info("Converter %d/%d ready.", i + 1, _MAX_CONCURRENT)
-        # All models are loaded; disable network validation for all subsequent HF hub calls.
+
+        for preset_name in QUALITY_PRESETS:
+            pool: asyncio.Queue[DocumentConverter] = asyncio.Queue(
+                maxsize=_MAX_CONCURRENT
+            )
+            for i in range(_MAX_CONCURRENT):
+                converter = await loop.run_in_executor(
+                    None, _build_converter, preset_name
+                )
+                pool.put_nowait(converter)
+                logger.info(
+                    "Converter [%s] %d/%d ready.",
+                    preset_name,
+                    i + 1,
+                    _MAX_CONCURRENT,
+                )
+            _converter_pools[preset_name] = pool
+
         os.environ["HF_HUB_OFFLINE"] = "1"
         _ready = True
-        logger.info("Ready — %d converter(s) available.", _MAX_CONCURRENT)
+        logger.info(
+            "Ready — %d converter(s) available (%d per preset).",
+            total,
+            _MAX_CONCURRENT,
+        )
     except Exception:
         logger.exception(
             "Failed to initialise converter(s). Service will remain unavailable."
@@ -198,11 +235,16 @@ async def _cleanup_loop() -> None:
 
 async def _run_job(job: Job, data: bytes, filename: str) -> None:
     """Background task: lease a converter from the pool, run conversion, return it."""
-    converter = await _converter_pool.get()
+    pool = _converter_pools[job.preset]
+    converter = await pool.get()
     try:
         job.status = JobStatus.RUNNING
         logger.info(
-            "Job %s: conversion started (%s, %d bytes).", job.id, filename, len(data)
+            "Job %s: conversion started (%s, %d bytes, preset=%s).",
+            job.id,
+            filename,
+            len(data),
+            job.preset,
         )
         t0 = time.monotonic()
         stream = DocumentStream(name=filename, stream=io.BytesIO(data))
@@ -229,10 +271,9 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
             )
             return
     finally:
-        _converter_pool.put_nowait(converter)
+        pool.put_nowait(converter)
 
     elapsed = time.monotonic() - t0
-    # Converter returned to pool; do cheap post-processing outside the slot.
     try:
         if result.status not in (
             ConversionStatus.SUCCESS,
@@ -276,13 +317,27 @@ def queue_status():
     return {"pending": pending, "running": running, "max": _MAX_PENDING}
 
 
+@app.get("/presets")
+def list_presets():
+    """Return available quality presets and their configurations."""
+    return {"presets": list(QUALITY_PRESETS.keys())}
+
+
 @app.post("/convert", status_code=202)
-async def submit_conversion(file: UploadFile = File(...)):
+async def submit_conversion(
+    file: UploadFile = File(...),
+    preset: str = Query("balanced"),
+):
     """Submit a document for conversion. Returns a job ID immediately (HTTP 202)."""
     if not _ready:
         raise HTTPException(
             status_code=503,
             detail="Service is starting up; models are being loaded. Try again shortly.",
+        )
+    if preset not in VALID_PRESETS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid preset '{preset}'. Must be one of: {', '.join(sorted(VALID_PRESETS))}",
         )
     if _active_job_count() >= _MAX_PENDING:
         return JSONResponse(
@@ -298,10 +353,16 @@ async def submit_conversion(file: UploadFile = File(...)):
 
     data = await file.read()
     job_id = str(uuid.uuid4())
-    job = Job(id=job_id)
+    job = Job(id=job_id, preset=preset)
     _jobs[job_id] = job
     asyncio.create_task(_run_job(job, data, file.filename))
-    logger.info("Job %s: submitted (%s, %d bytes).", job_id, file.filename, len(data))
+    logger.info(
+        "Job %s: submitted (%s, %d bytes, preset=%s).",
+        job_id,
+        file.filename,
+        len(data),
+        preset,
+    )
     return {"job_id": job_id}
 
 

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -29,6 +29,7 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 _MAX_CONCURRENT = int(os.getenv("MAX_CONCURRENT_CONVERSIONS", "1"))
+_MAX_PENDING = int(os.getenv("MAX_PENDING_JOBS", str(_MAX_CONCURRENT * 2)))
 _converter_pool: asyncio.Queue[DocumentConverter]  # created inside lifespan
 _ready: bool = False
 
@@ -138,6 +139,13 @@ class Job:
 
 
 _jobs: dict[str, Job] = {}
+
+
+def _active_job_count() -> int:
+    """Count jobs that are pending or running (holding memory)."""
+    return sum(
+        1 for j in _jobs.values() if j.status in (JobStatus.PENDING, JobStatus.RUNNING)
+    )
 
 
 @asynccontextmanager
@@ -261,6 +269,13 @@ def health():
     return JSONResponse(status_code=503, content={"status": "starting"})
 
 
+@app.get("/queue-status")
+def queue_status():
+    pending = sum(1 for j in _jobs.values() if j.status == JobStatus.PENDING)
+    running = sum(1 for j in _jobs.values() if j.status == JobStatus.RUNNING)
+    return {"pending": pending, "running": running, "max": _MAX_PENDING}
+
+
 @app.post("/convert", status_code=202)
 async def submit_conversion(file: UploadFile = File(...)):
     """Submit a document for conversion. Returns a job ID immediately (HTTP 202)."""
@@ -269,6 +284,13 @@ async def submit_conversion(file: UploadFile = File(...)):
             status_code=503,
             detail="Service is starting up; models are being loaded. Try again shortly.",
         )
+    if _active_job_count() >= _MAX_PENDING:
+        return JSONResponse(
+            status_code=429,
+            content={"detail": "Too many pending conversions. Try again later."},
+            headers={"Retry-After": "30"},
+        )
+
     if not file.filename:
         raise HTTPException(
             status_code=400, detail="A filename with extension is required."

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -59,8 +59,9 @@ QUALITY_PRESETS: dict[str, dict] = {
     },
 }
 
-# One converter pool per preset, created in lifespan
+# One converter pool per preset, built lazily on first use.
 _converter_pools: dict[str, asyncio.Queue[DocumentConverter]] = {}
+_pool_locks: dict[str, asyncio.Lock] = {p: asyncio.Lock() for p in QUALITY_PRESETS}
 
 
 class _SuppressFilter(logging.Filter):
@@ -177,44 +178,39 @@ async def lifespan(app: FastAPI):
 async def _init_converters() -> None:
     global _ready
     try:
-        total = _MAX_CONCURRENT * len(QUALITY_PRESETS)
-        logger.info(
-            "Loading %d DocumentConverter instance(s) across %d presets ...",
-            total,
-            len(QUALITY_PRESETS),
-        )
         logger.info("Downloading models ...")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _download_models)
-
-        for preset_name in QUALITY_PRESETS:
-            pool: asyncio.Queue[DocumentConverter] = asyncio.Queue(
-                maxsize=_MAX_CONCURRENT
-            )
-            for i in range(_MAX_CONCURRENT):
-                converter = await loop.run_in_executor(
-                    None, _build_converter, preset_name
-                )
-                pool.put_nowait(converter)
-                logger.info(
-                    "Converter [%s] %d/%d ready.",
-                    preset_name,
-                    i + 1,
-                    _MAX_CONCURRENT,
-                )
-            _converter_pools[preset_name] = pool
-
         os.environ["HF_HUB_OFFLINE"] = "1"
         _ready = True
-        logger.info(
-            "Ready — %d converter(s) available (%d per preset).",
-            total,
-            _MAX_CONCURRENT,
-        )
+        logger.info("Ready — models downloaded, converter pools created on demand.")
     except Exception:
         logger.exception(
             "Failed to initialise converter(s). Service will remain unavailable."
         )
+
+
+async def _get_pool(preset: str) -> asyncio.Queue[DocumentConverter]:
+    """Get or lazily create the converter pool for the given preset."""
+    if preset in _converter_pools:
+        return _converter_pools[preset]
+
+    async with _pool_locks[preset]:
+        # Double-check after acquiring lock
+        if preset in _converter_pools:
+            return _converter_pools[preset]
+
+        logger.info(
+            "Building %d converter(s) for preset '%s' ...", _MAX_CONCURRENT, preset
+        )
+        loop = asyncio.get_running_loop()
+        pool: asyncio.Queue[DocumentConverter] = asyncio.Queue(maxsize=_MAX_CONCURRENT)
+        for i in range(_MAX_CONCURRENT):
+            converter = await loop.run_in_executor(None, _build_converter, preset)
+            pool.put_nowait(converter)
+            logger.info("Converter [%s] %d/%d ready.", preset, i + 1, _MAX_CONCURRENT)
+        _converter_pools[preset] = pool
+        return pool
 
 
 async def _cleanup_loop() -> None:
@@ -231,7 +227,7 @@ async def _cleanup_loop() -> None:
 
 async def _run_job(job: Job, data: bytes, filename: str) -> None:
     """Background task: lease a converter from the pool, run conversion, return it."""
-    pool = _converter_pools[job.preset]
+    pool = await _get_pool(job.preset)
     converter = await pool.get()
     try:
         job.status = JobStatus.RUNNING

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -7,12 +7,13 @@ import logging
 import os
 import time
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 from contextlib import asynccontextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
-from typing import Literal
 
+import pypdfium2 as pdfium
 import uvicorn
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.base_models import ConversionStatus, InputFormat
@@ -31,40 +32,39 @@ logger = logging.getLogger(__name__)
 
 _MAX_CONCURRENT = int(os.getenv("MAX_CONCURRENT_CONVERSIONS", "1"))
 _MAX_PENDING = int(os.getenv("MAX_PENDING_JOBS", str(_MAX_CONCURRENT * 2)))
-_PAGES_PER_CHUNK = int(os.getenv("PAGES_PER_CHUNK", "5"))
-_ready: bool = False
+_PAGES_PER_CHUNK = int(os.getenv("PAGES_PER_CHUNK", "10"))
+_MAX_JOB_SECONDS = int(os.getenv("MAX_JOB_SECONDS", "1800"))
+_CONVERTER_RECYCLE_AFTER = int(os.getenv("CONVERTER_RECYCLE_AFTER", "20"))
 
-PresetName = Literal["fast", "balanced", "quality"]
-VALID_PRESETS: set[str] = {"fast", "balanced", "quality"}
+VALID_PRESETS: frozenset[str] = frozenset({"fast", "balanced", "quality"})
 
+# Preset pipeline options. Heavy/unused options stay off everywhere:
+# picture/table image generation (we only emit markdown), picture
+# classification (not reflected in markdown), picture description (VLM),
+# chart extraction (large model, narrow benefit).
 QUALITY_PRESETS: dict[str, dict] = {
     "fast": {
+        "do_ocr": False,
         "table_structure_mode": TableFormerMode.FAST,
         "images_scale": 1.0,
-        "do_picture_classification": False,
-        "generate_picture_images": False,
-        "generate_table_images": False,
+        "do_code_enrichment": False,
+        "do_formula_enrichment": False,
     },
     "balanced": {
+        "do_ocr": False,
         "table_structure_mode": TableFormerMode.ACCURATE,
         "images_scale": 1.0,
-        "do_picture_classification": True,
-        "generate_picture_images": False,
-        "generate_table_images": False,
+        "do_code_enrichment": False,
+        "do_formula_enrichment": False,
     },
     "quality": {
+        "do_ocr": True,
         "table_structure_mode": TableFormerMode.ACCURATE,
         "images_scale": 1.5,
-        "do_picture_classification": True,
-        "generate_picture_images": True,
-        "generate_table_images": True,
+        "do_code_enrichment": True,
+        "do_formula_enrichment": True,
     },
 }
-
-# One converter per preset (reused across jobs to avoid re-loading ML models).
-# Concurrency is controlled by a semaphore; chunked conversion caps per-job memory.
-_converters: dict[str, DocumentConverter] = {}
-_semaphore: asyncio.Semaphore  # created in lifespan
 
 
 class _SuppressFilter(logging.Filter):
@@ -80,64 +80,94 @@ class _SuppressFilter(logging.Filter):
 
 
 def _apply_rapidocr_suppression() -> None:
-    """Must be called after DocumentConverter init has triggered the rapidocr import."""
     for name in ("RapidOCR", "docling.models.stages.ocr.rapid_ocr_model"):
         lg = logging.getLogger(name)
         lg.setLevel(logging.ERROR)
-        f = _SuppressFilter()
         if not any(isinstance(x, _SuppressFilter) for x in lg.filters):
-            lg.addFilter(f)
+            lg.addFilter(_SuppressFilter())
         for handler in lg.handlers:
             if not any(isinstance(x, _SuppressFilter) for x in handler.filters):
-                handler.addFilter(f)
+                handler.addFilter(_SuppressFilter())
 
 
-def _build_converter(preset: str = "balanced") -> DocumentConverter:
-    """Build a DocumentConverter with pipeline options from the given quality preset."""
+def _build_converter(preset: str) -> DocumentConverter:
     opts = QUALITY_PRESETS[preset]
-    accelerator_options = AcceleratorOptions()
     pipeline_options = PdfPipelineOptions()
-    pipeline_options.accelerator_options = accelerator_options
+    pipeline_options.accelerator_options = AcceleratorOptions()
+    # Docling's cooperative timeout: on expiry it stops feeding pages and
+    # returns PARTIAL_SUCCESS — no zombie threads, no process kill needed.
+    pipeline_options.document_timeout = float(_MAX_JOB_SECONDS)
     pipeline_options.do_table_structure = True
     pipeline_options.table_structure_options.mode = opts["table_structure_mode"]
-    pipeline_options.do_ocr = True
-    pipeline_options.ocr_options = RapidOcrOptions(backend="torch")
+    pipeline_options.do_ocr = opts["do_ocr"]
+    if opts["do_ocr"]:
+        pipeline_options.ocr_options = RapidOcrOptions(backend="torch")
     pipeline_options.images_scale = opts["images_scale"]
-    pipeline_options.generate_picture_images = opts["generate_picture_images"]
-    pipeline_options.generate_table_images = opts["generate_table_images"]
-    pipeline_options.do_code_enrichment = False
-    pipeline_options.do_formula_enrichment = False
-    pipeline_options.do_picture_classification = opts["do_picture_classification"]
+    pipeline_options.generate_picture_images = False
+    pipeline_options.generate_table_images = False
+    pipeline_options.do_picture_classification = False
     pipeline_options.do_picture_description = False
     pipeline_options.do_chart_extraction = False
+    pipeline_options.do_code_enrichment = opts["do_code_enrichment"]
+    pipeline_options.do_formula_enrichment = opts["do_formula_enrichment"]
     converter = DocumentConverter(
         format_options={
             InputFormat.PDF: PdfFormatOption(pipeline_options=pipeline_options),
         }
     )
-    _apply_rapidocr_suppression()
+    if opts["do_ocr"]:
+        _apply_rapidocr_suppression()
     return converter
 
 
-def _get_pdf_page_count(data: bytes) -> int | None:
-    """Return the page count for a PDF, or None if not a PDF."""
-    try:
-        import pypdfium2 as pdfium
+@dataclass
+class PresetConverter:
+    """Shared converter for a preset with a lock (serializes concurrent use
+    when _MAX_CONCURRENT > 1) and a job counter driving periodic recycling
+    to reclaim ONNX/torch residual memory."""
 
-        pdf = pdfium.PdfDocument(data)
-        count = len(pdf)
-        pdf.close()
-        return count
-    except Exception:
-        return None
+    preset: str
+    converter: DocumentConverter
+    lock: asyncio.Lock = field(default_factory=asyncio.Lock)
+    job_count: int = 0
+
+    async def maybe_recycle(self) -> None:
+        if _CONVERTER_RECYCLE_AFTER <= 0 or self.job_count < _CONVERTER_RECYCLE_AFTER:
+            return
+        logger.info(
+            "Recycling converter [%s] after %d jobs.", self.preset, self.job_count
+        )
+        loop = asyncio.get_running_loop()
+        # Build the replacement off the event loop and off the conversion
+        # pool so we don't starve other work.
+        new_converter = await loop.run_in_executor(
+            _build_executor, _build_converter, self.preset
+        )
+        old = self.converter
+        self.converter = new_converter
+        self.job_count = 0
+        del old
+        gc.collect()
+
+
+_converters: dict[str, PresetConverter] = {}
+_failed_presets: set[str] = set()
+_semaphore: asyncio.Semaphore  # created in lifespan
+_ready: bool = False
+
+# Dedicated fixed-size pool for conversions — exactly _MAX_CONCURRENT workers,
+# so we don't rely on asyncio's default executor (sized to min(32, cpu+4)).
+# Separate tiny pool for converter builds (init + recycling) so recycling
+# never competes with in-flight conversions for a worker thread.
+_conversion_executor: ThreadPoolExecutor  # created in lifespan
+_build_executor: ThreadPoolExecutor  # created in lifespan
 
 
 def _cleanup_result(result: object) -> None:
-    """Release backend resources held by a ConversionResult to prevent memory leaks.
+    """Release backend resources held by a ConversionResult.
 
     Docling backends (pypdfium2, docling-parse) retain parsed page data and
-    PDF objects in memory until explicitly unloaded. Without this call, memory
-    accumulates across conversions even after del + gc.collect().
+    PDF objects in memory until explicitly unloaded.
     See: https://github.com/docling-project/docling/issues/2209
     """
     try:
@@ -158,21 +188,51 @@ def _cleanup_result(result: object) -> None:
         gc.collect()
 
 
-def _convert_document(
-    converter: DocumentConverter,
-    data: bytes,
-    filename: str,
-) -> str:
-    """Convert a document to markdown, processing PDFs in page chunks to cap memory.
+def _split_pdf(data: bytes, chunk_size: int) -> list[bytes] | None:
+    """Split PDF bytes into per-chunk PDF byte buffers using pypdfium2.
 
-    Non-PDF formats are converted in a single pass. PDFs are split into chunks
-    of _PAGES_PER_CHUNK pages; each chunk is converted independently and the
-    resulting markdown fragments are concatenated.
+    Returns None if the input is not a PDF. Each chunk is a standalone PDF
+    containing at most `chunk_size` pages, so downstream conversion avoids
+    re-parsing the full file for every chunk.
     """
-    page_count = _get_pdf_page_count(data)
+    try:
+        src = pdfium.PdfDocument(data)
+    except Exception:
+        return None
+    try:
+        page_count = len(src)
+        if page_count <= chunk_size:
+            return [data]
+        chunks: list[bytes] = []
+        for start in range(0, page_count, chunk_size):
+            end = min(start + chunk_size, page_count)
+            dst = pdfium.PdfDocument.new()
+            try:
+                dst.import_pages(src, list(range(start, end)))
+                buf = io.BytesIO()
+                dst.save(buf)
+                chunks.append(buf.getvalue())
+            finally:
+                dst.close()
+        return chunks
+    finally:
+        src.close()
 
-    # Non-PDF or small PDF: single-pass conversion
-    if page_count is None or page_count <= _PAGES_PER_CHUNK:
+
+def _convert_document(converter: DocumentConverter, data: bytes, filename: str) -> str:
+    """Convert a document to markdown. PDFs are split into page chunks up
+    front so each chunk is a small standalone PDF (bounded peak memory, no
+    repeated full-file parses).
+
+    Enforces a whole-job wall-clock deadline across chunks: once exceeded,
+    the loop stops and returns whatever markdown was already produced. The
+    docling-internal `document_timeout` provides per-chunk cooperative
+    cancellation within this budget.
+    """
+    chunks = _split_pdf(data, _PAGES_PER_CHUNK)
+
+    # Non-PDF: single-pass conversion.
+    if chunks is None:
         stream = DocumentStream(name=filename, stream=io.BytesIO(data))
         result = converter.convert(stream)
         try:
@@ -185,13 +245,18 @@ def _convert_document(
         finally:
             _cleanup_result(result)
 
-    # Large PDF: chunked conversion
     markdown_parts: list[str] = []
-    for start in range(1, page_count + 1, _PAGES_PER_CHUNK):
-        end = min(start + _PAGES_PER_CHUNK - 1, page_count)
-        logger.debug("Processing pages %d–%d of %d", start, end, page_count)
-        stream = DocumentStream(name=filename, stream=io.BytesIO(data))
-        result = converter.convert(stream, page_range=(start, end))
+    total = len(chunks)
+    deadline = time.monotonic() + _MAX_JOB_SECONDS
+    for idx, chunk in enumerate(chunks, start=1):
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "Job deadline reached after chunk %d/%d; stopping.", idx - 1, total
+            )
+            break
+        logger.debug("Processing chunk %d/%d (%d bytes)", idx, total, len(chunk))
+        stream = DocumentStream(name=filename, stream=io.BytesIO(chunk))
+        result = converter.convert(stream)
         try:
             if result.status in (
                 ConversionStatus.SUCCESS,
@@ -199,25 +264,24 @@ def _convert_document(
             ):
                 markdown_parts.append(result.document.export_to_markdown())
             else:
-                logger.warning("Chunk pages %d–%d failed, skipping.", start, end)
+                logger.warning("Chunk %d/%d failed, skipping.", idx, total)
         finally:
             _cleanup_result(result)
 
     if not markdown_parts:
-        raise RuntimeError("All page chunks failed.")
+        raise RuntimeError("All page chunks failed or deadline exceeded.")
     return "\n\n".join(markdown_parts)
 
 
 def _download_models() -> None:
-    """Pre-download all Docling models so the first conversion doesn't stall."""
     from docling.utils.model_downloader import download_models
 
     download_models(
         progress=True,
         with_layout=True,
         with_tableformer=True,
-        with_code_formula=False,
-        with_picture_classifier=True,
+        with_code_formula=True,
+        with_picture_classifier=False,
         with_smolvlm=False,
         with_granitedocling=False,
         with_granitedocling_mlx=False,
@@ -251,7 +315,6 @@ _jobs: dict[str, Job] = {}
 
 
 def _active_job_count() -> int:
-    """Count jobs that are pending or running (holding memory)."""
     return sum(
         1 for j in _jobs.values() if j.status in (JobStatus.PENDING, JobStatus.RUNNING)
     )
@@ -259,14 +322,21 @@ def _active_job_count() -> int:
 
 @asynccontextmanager
 async def lifespan(app: FastAPI):
-    global _semaphore
+    global _semaphore, _conversion_executor, _build_executor
     _semaphore = asyncio.Semaphore(_MAX_CONCURRENT)
-    # Start init in the background so the HTTP server becomes responsive
-    # immediately. /health returns {"status": "starting"} and /convert
-    # returns 503 until init completes.
+    _conversion_executor = ThreadPoolExecutor(
+        max_workers=_MAX_CONCURRENT, thread_name_prefix="docling-convert"
+    )
+    _build_executor = ThreadPoolExecutor(
+        max_workers=1, thread_name_prefix="docling-build"
+    )
     asyncio.create_task(_init())
     asyncio.create_task(_cleanup_loop())
-    yield
+    try:
+        yield
+    finally:
+        _conversion_executor.shutdown(wait=False, cancel_futures=True)
+        _build_executor.shutdown(wait=False, cancel_futures=True)
 
 
 async def _init() -> None:
@@ -274,20 +344,31 @@ async def _init() -> None:
     try:
         logger.info("Downloading models ...")
         loop = asyncio.get_running_loop()
-        await loop.run_in_executor(None, _download_models)
+        await loop.run_in_executor(_build_executor, _download_models)
 
-        # Build one converter per preset. The ML models are shared via HF cache
-        # so subsequent converters are fast to construct.
         for preset_name in QUALITY_PRESETS:
-            converter = await loop.run_in_executor(None, _build_converter, preset_name)
-            _converters[preset_name] = converter
-            logger.info("Converter [%s] ready.", preset_name)
+            try:
+                converter = await loop.run_in_executor(
+                    _build_executor, _build_converter, preset_name
+                )
+                _converters[preset_name] = PresetConverter(
+                    preset=preset_name, converter=converter
+                )
+                logger.info("Converter [%s] ready.", preset_name)
+            except Exception:
+                _failed_presets.add(preset_name)
+                logger.exception("Failed to build converter [%s].", preset_name)
+
+        if not _converters:
+            logger.error("No presets initialised; service remains unavailable.")
+            return
 
         os.environ["HF_HUB_OFFLINE"] = "1"
         _ready = True
         logger.info(
-            "Ready — %d preset(s), max %d concurrent conversion(s).",
+            "Ready — %d/%d preset(s), max %d concurrent conversion(s).",
             len(_converters),
+            len(QUALITY_PRESETS),
             _MAX_CONCURRENT,
         )
     except Exception:
@@ -317,7 +398,6 @@ async def _cleanup_loop() -> None:
 
 
 async def _run_job(job: Job, data: bytes, filename: str) -> None:
-    """Background task: use shared converter, chunked conversion to cap memory."""
     await _semaphore.acquire()
     try:
         job.status = JobStatus.RUNNING
@@ -330,29 +410,39 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
         )
         t0 = time.monotonic()
         loop = asyncio.get_running_loop()
-        converter = _converters[job.preset]
-        try:
-            markdown = await loop.run_in_executor(
-                None, _convert_document, converter, data, filename
-            )
-        except Exception as exc:
-            elapsed = time.monotonic() - t0
-            job.status = JobStatus.FAILED
-            if (
-                "not supported" in str(exc).lower()
-                or "cannot convert" in str(exc).lower()
-            ):
-                job.detail = f"Unsupported format: {exc}"
-            else:
-                job.detail = f"Conversion error: {exc}"
-            logger.error(
-                "Job %s: failed after %.1fs — %s",
-                job.id,
-                elapsed,
-                job.detail,
-                exc_info=True,
-            )
-            return
+        pc = _converters[job.preset]
+
+        # Whole-job timeout is enforced cooperatively: docling's
+        # `document_timeout` stops feeding pages per chunk, and
+        # `_convert_document` stops iterating chunks once the deadline
+        # passes. No zombie threads, no process kill.
+        async with pc.lock:
+            try:
+                markdown = await loop.run_in_executor(
+                    _conversion_executor,
+                    _convert_document,
+                    pc.converter,
+                    data,
+                    filename,
+                )
+            except Exception as exc:
+                elapsed = time.monotonic() - t0
+                job.status = JobStatus.FAILED
+                msg = str(exc).lower()
+                if "not supported" in msg or "cannot convert" in msg:
+                    job.detail = f"Unsupported format: {exc}"
+                else:
+                    job.detail = f"Conversion error: {exc}"
+                logger.error(
+                    "Job %s: failed after %.1fs — %s",
+                    job.id,
+                    elapsed,
+                    job.detail,
+                    exc_info=True,
+                )
+                return
+            finally:
+                pc.job_count += 1
 
         elapsed = time.monotonic() - t0
         job.markdown = markdown
@@ -369,6 +459,15 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
         del data
         gc.collect()
         _semaphore.release()
+        # Recycle outside the per-job critical path so the rebuild doesn't
+        # block this job's response nor stall other work on the event loop.
+        pc = _converters.get(job.preset)
+        if pc is not None and pc.job_count >= _CONVERTER_RECYCLE_AFTER > 0:
+            async with pc.lock:
+                try:
+                    await pc.maybe_recycle()
+                except Exception:
+                    logger.exception("Converter recycle failed for [%s].", job.preset)
 
 
 app = FastAPI(title="docling", version="1.0.0", lifespan=lifespan)
@@ -390,8 +489,11 @@ def queue_status():
 
 @app.get("/presets")
 def list_presets():
-    """Return available quality presets and their configurations."""
-    return {"presets": list(QUALITY_PRESETS.keys())}
+    return {
+        "presets": list(QUALITY_PRESETS.keys()),
+        "available": sorted(_converters.keys()),
+        "unavailable": sorted(_failed_presets),
+    }
 
 
 @app.post("/convert", status_code=202)
@@ -409,6 +511,11 @@ async def submit_conversion(
         raise HTTPException(
             status_code=400,
             detail=f"Invalid preset '{preset}'. Must be one of: {', '.join(sorted(VALID_PRESETS))}",
+        )
+    if preset not in _converters:
+        raise HTTPException(
+            status_code=503,
+            detail=f"Preset '{preset}' failed to initialise and is unavailable.",
         )
     if _active_job_count() >= _MAX_PENDING:
         return JSONResponse(
@@ -439,19 +546,18 @@ async def submit_conversion(
 
 @app.get("/jobs/{job_id}")
 async def get_job(job_id: str):
-    """Poll a conversion job. Returns status and, when complete, the Markdown result."""
+    """Poll a conversion job. Returns status and, when complete, the Markdown result.
+
+    Does NOT delete on read: the cleanup loop is the sole owner of deletion,
+    so a dropped connection after a completed response doesn't lose the result.
+    """
     job = _jobs.get(job_id)
     if job is None:
         raise HTTPException(status_code=404, detail=f"Unknown job ID: {job_id!r}")
     if job.status == JobStatus.COMPLETED:
-        logger.info("Job %s: result retrieved.", job_id)
-        del _jobs[job_id]
         return {"status": job.status, "markdown": job.markdown}
     if job.status == JobStatus.FAILED:
-        logger.info("Job %s: failure retrieved.", job_id)
-        del _jobs[job_id]
         return {"status": job.status, "detail": job.detail}
-    logger.info("Job %s: polled — %s.", job_id, job.status.value)
     return {"status": job.status}  # pending or running
 
 

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -132,6 +132,32 @@ def _get_pdf_page_count(data: bytes) -> int | None:
         return None
 
 
+def _cleanup_result(result: object) -> None:
+    """Release backend resources held by a ConversionResult to prevent memory leaks.
+
+    Docling backends (pypdfium2, docling-parse) retain parsed page data and
+    PDF objects in memory until explicitly unloaded. Without this call, memory
+    accumulates across conversions even after del + gc.collect().
+    See: https://github.com/docling-project/docling/issues/2209
+    """
+    try:
+        if hasattr(result, "input") and hasattr(result.input, "_backend"):
+            backend = result.input._backend
+            if backend is not None:
+                backend.unload()
+        if hasattr(result, "pages"):
+            for page in result.pages:
+                if hasattr(page, "_backend") and page._backend is not None:
+                    page._backend.unload()
+                    page._backend = None
+                page._image_cache = {}
+    except Exception:
+        logger.debug("Error during result cleanup", exc_info=True)
+    finally:
+        del result
+        gc.collect()
+
+
 def _convert_document(
     converter: DocumentConverter,
     data: bytes,
@@ -157,8 +183,7 @@ def _convert_document(
                 raise RuntimeError("Conversion failed.")
             return result.document.export_to_markdown()
         finally:
-            del result
-            gc.collect()
+            _cleanup_result(result)
 
     # Large PDF: chunked conversion
     markdown_parts: list[str] = []
@@ -176,8 +201,7 @@ def _convert_document(
             else:
                 logger.warning("Chunk pages %d–%d failed, skipping.", start, end)
         finally:
-            del result
-            gc.collect()
+            _cleanup_result(result)
 
     if not markdown_parts:
         raise RuntimeError("All page chunks failed.")

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -13,7 +13,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta, timezone
 from enum import Enum
 
-import pypdfium2 as pdfium
 import uvicorn
 from docling.datamodel.accelerator_options import AcceleratorOptions
 from docling.datamodel.base_models import ConversionStatus, InputFormat
@@ -32,7 +31,6 @@ logger = logging.getLogger(__name__)
 
 _MAX_CONCURRENT = int(os.getenv("MAX_CONCURRENT_CONVERSIONS", "1"))
 _MAX_PENDING = int(os.getenv("MAX_PENDING_JOBS", str(_MAX_CONCURRENT * 2)))
-_PAGES_PER_CHUNK = int(os.getenv("PAGES_PER_CHUNK", "10"))
 _MAX_JOB_SECONDS = int(os.getenv("MAX_JOB_SECONDS", "1800"))
 _CONVERTER_RECYCLE_AFTER = int(os.getenv("CONVERTER_RECYCLE_AFTER", "20"))
 
@@ -188,89 +186,26 @@ def _cleanup_result(result: object) -> None:
         gc.collect()
 
 
-def _split_pdf(data: bytes, chunk_size: int) -> list[bytes] | None:
-    """Split PDF bytes into per-chunk PDF byte buffers using pypdfium2.
-
-    Returns None if the input is not a PDF. Each chunk is a standalone PDF
-    containing at most `chunk_size` pages, so downstream conversion avoids
-    re-parsing the full file for every chunk.
-    """
-    try:
-        src = pdfium.PdfDocument(data)
-    except Exception:
-        return None
-    try:
-        page_count = len(src)
-        if page_count <= chunk_size:
-            return [data]
-        chunks: list[bytes] = []
-        for start in range(0, page_count, chunk_size):
-            end = min(start + chunk_size, page_count)
-            dst = pdfium.PdfDocument.new()
-            try:
-                dst.import_pages(src, list(range(start, end)))
-                buf = io.BytesIO()
-                dst.save(buf)
-                chunks.append(buf.getvalue())
-            finally:
-                dst.close()
-        return chunks
-    finally:
-        src.close()
-
-
 def _convert_document(converter: DocumentConverter, data: bytes, filename: str) -> str:
-    """Convert a document to markdown. PDFs are split into page chunks up
-    front so each chunk is a small standalone PDF (bounded peak memory, no
-    repeated full-file parses).
+    """Convert a document to markdown in a single pass.
 
-    Enforces a whole-job wall-clock deadline across chunks: once exceeded,
-    the loop stops and returns whatever markdown was already produced. The
-    docling-internal `document_timeout` provides per-chunk cooperative
-    cancellation within this budget.
+    Docling streams pages through bounded queues with per-page backend
+    unload and image-cache clearing, so pre-splitting large PDFs is
+    unnecessary. Runaway conversions are bounded cooperatively by
+    `pipeline_options.document_timeout` (set in `_build_converter`),
+    which makes docling stop feeding pages and return PARTIAL_SUCCESS.
     """
-    chunks = _split_pdf(data, _PAGES_PER_CHUNK)
-
-    # Non-PDF: single-pass conversion.
-    if chunks is None:
-        stream = DocumentStream(name=filename, stream=io.BytesIO(data))
-        result = converter.convert(stream)
-        try:
-            if result.status not in (
-                ConversionStatus.SUCCESS,
-                ConversionStatus.PARTIAL_SUCCESS,
-            ):
-                raise RuntimeError("Conversion failed.")
-            return result.document.export_to_markdown()
-        finally:
-            _cleanup_result(result)
-
-    markdown_parts: list[str] = []
-    total = len(chunks)
-    deadline = time.monotonic() + _MAX_JOB_SECONDS
-    for idx, chunk in enumerate(chunks, start=1):
-        if time.monotonic() >= deadline:
-            logger.warning(
-                "Job deadline reached after chunk %d/%d; stopping.", idx - 1, total
-            )
-            break
-        logger.debug("Processing chunk %d/%d (%d bytes)", idx, total, len(chunk))
-        stream = DocumentStream(name=filename, stream=io.BytesIO(chunk))
-        result = converter.convert(stream)
-        try:
-            if result.status in (
-                ConversionStatus.SUCCESS,
-                ConversionStatus.PARTIAL_SUCCESS,
-            ):
-                markdown_parts.append(result.document.export_to_markdown())
-            else:
-                logger.warning("Chunk %d/%d failed, skipping.", idx, total)
-        finally:
-            _cleanup_result(result)
-
-    if not markdown_parts:
-        raise RuntimeError("All page chunks failed or deadline exceeded.")
-    return "\n\n".join(markdown_parts)
+    stream = DocumentStream(name=filename, stream=io.BytesIO(data))
+    result = converter.convert(stream)
+    try:
+        if result.status not in (
+            ConversionStatus.SUCCESS,
+            ConversionStatus.PARTIAL_SUCCESS,
+        ):
+            raise RuntimeError("Conversion failed.")
+        return result.document.export_to_markdown()
+    finally:
+        _cleanup_result(result)
 
 
 def _download_models() -> None:
@@ -412,10 +347,9 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
         loop = asyncio.get_running_loop()
         pc = _converters[job.preset]
 
-        # Whole-job timeout is enforced cooperatively: docling's
-        # `document_timeout` stops feeding pages per chunk, and
-        # `_convert_document` stops iterating chunks once the deadline
-        # passes. No zombie threads, no process kill.
+        # Whole-job timeout is enforced cooperatively by docling's
+        # `document_timeout`: on expiry it stops feeding pages and returns
+        # PARTIAL_SUCCESS. No zombie threads, no process kill.
         async with pc.lock:
             try:
                 markdown = await loop.run_in_executor(

--- a/services/docling/app.py
+++ b/services/docling/app.py
@@ -61,8 +61,9 @@ QUALITY_PRESETS: dict[str, dict] = {
     },
 }
 
-# Semaphore to limit concurrent conversions (replaces converter pool).
-# A fresh converter is built per job and destroyed after to avoid memory accumulation.
+# One converter per preset (reused across jobs to avoid re-loading ML models).
+# Concurrency is controlled by a semaphore; chunked conversion caps per-job memory.
+_converters: dict[str, DocumentConverter] = {}
 _semaphore: asyncio.Semaphore  # created in lifespan
 
 
@@ -250,13 +251,20 @@ async def _init() -> None:
         logger.info("Downloading models ...")
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _download_models)
-        # Warm up: build and immediately discard one converter so all model
-        # weights are loaded into the HF cache and first real job is fast.
-        await loop.run_in_executor(None, _build_converter, "balanced")
+
+        # Build one converter per preset. The ML models are shared via HF cache
+        # so subsequent converters are fast to construct.
+        for preset_name in QUALITY_PRESETS:
+            converter = await loop.run_in_executor(None, _build_converter, preset_name)
+            _converters[preset_name] = converter
+            logger.info("Converter [%s] ready.", preset_name)
+
         os.environ["HF_HUB_OFFLINE"] = "1"
         _ready = True
         logger.info(
-            "Ready — models cached, max %d concurrent conversion(s).", _MAX_CONCURRENT
+            "Ready — %d preset(s), max %d concurrent conversion(s).",
+            len(_converters),
+            _MAX_CONCURRENT,
         )
     except Exception:
         logger.exception("Failed to initialise. Service will remain unavailable.")
@@ -285,9 +293,8 @@ async def _cleanup_loop() -> None:
 
 
 async def _run_job(job: Job, data: bytes, filename: str) -> None:
-    """Background task: build a fresh converter, run conversion, destroy everything."""
+    """Background task: use shared converter, chunked conversion to cap memory."""
     await _semaphore.acquire()
-    converter = None
     try:
         job.status = JobStatus.RUNNING
         logger.info(
@@ -299,7 +306,7 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
         )
         t0 = time.monotonic()
         loop = asyncio.get_running_loop()
-        converter = await loop.run_in_executor(None, _build_converter, job.preset)
+        converter = _converters[job.preset]
         try:
             markdown = await loop.run_in_executor(
                 None, _convert_document, converter, data, filename
@@ -335,7 +342,7 @@ async def _run_job(job: Job, data: bytes, filename: str) -> None:
             job.detail = f"Unexpected error: {exc}"
             logger.error("Job %s: failed — %s", job.id, job.detail, exc_info=True)
     finally:
-        del converter, data
+        del data
         gc.collect()
         _semaphore.release()
 

--- a/shared/src/clients/docling.rs
+++ b/shared/src/clients/docling.rs
@@ -3,11 +3,27 @@
 //! The Docling service converts documents to Markdown using AI-based extraction.
 //! It provides superior PDF extraction, OCR support, and structure-aware output.
 
-use anyhow::{anyhow, Context, Result};
+use anyhow::{anyhow, Context};
 use reqwest::{multipart, Client};
 use serde::Deserialize;
 use std::time::Duration;
 use tracing::{debug, error};
+
+/// Errors from the Docling document conversion service.
+#[derive(Debug, thiserror::Error)]
+pub enum DoclingError {
+    #[error("Docling service is overloaded, retry after {retry_after_secs}s")]
+    ServiceOverloaded { retry_after_secs: u64 },
+
+    #[error("Docling service is starting up")]
+    ServiceStarting,
+
+    #[error("Docling conversion failed: {0}")]
+    ConversionFailed(String),
+
+    #[error("{0}")]
+    Other(#[from] anyhow::Error),
+}
 
 /// Default timeout for polling a conversion job, which can take a very long time with Docling
 const DEFAULT_TIMEOUT: Duration = Duration::from_mins(120);
@@ -56,7 +72,7 @@ pub struct DoclingClient {
 impl DoclingClient {
     /// Create a new Docling client with the given base URL.
     pub fn new(base_url: impl Into<String>) -> Self {
-            let url = base_url.into();
+        let url = base_url.into();
         Self {
             client: Client::new(),
             base_url: url.trim_end_matches('/').to_string(),
@@ -77,7 +93,7 @@ impl DoclingClient {
     }
 
     /// Check if the Docling service is healthy and ready.
-    pub async fn health_check(&self) -> Result<bool> {
+    pub async fn health_check(&self) -> anyhow::Result<bool> {
         let response = self
             .client
             .get(format!("{}/health", self.base_url))
@@ -110,7 +126,7 @@ impl DoclingClient {
     ///
     /// # Returns
     /// The extracted Markdown text, or an error if conversion fails.
-    pub async fn convert(&self, data: &[u8], filename: &str) -> Result<String> {
+    pub async fn convert(&self, data: &[u8], filename: &str) -> Result<String, DoclingError> {
         // Submit the conversion job
         let job_id = self.submit(data, filename).await?;
         debug!("Docling conversion job submitted: {}", job_id);
@@ -119,10 +135,10 @@ impl DoclingClient {
         let start = std::time::Instant::now();
         loop {
             if start.elapsed() > self.timeout {
-                return Err(anyhow!(
+                return Err(DoclingError::Other(anyhow!(
                     "Docling conversion timed out after {:?}",
                     self.timeout
-                ));
+                )));
             }
 
             let job = self.get_job(&job_id).await?;
@@ -130,7 +146,9 @@ impl DoclingClient {
             match job.status {
                 JobStatus::Completed => {
                     let markdown = job.markdown.ok_or_else(|| {
-                        anyhow!("Docling returned completed status but no markdown")
+                        DoclingError::Other(anyhow!(
+                            "Docling returned completed status but no markdown"
+                        ))
                     })?;
                     debug!(
                         "Docling conversion completed: {} chars in {:?}",
@@ -142,7 +160,7 @@ impl DoclingClient {
                 JobStatus::Failed => {
                     let detail = job.detail.unwrap_or_else(|| "Unknown error".to_string());
                     error!("Docling conversion failed: {}", detail);
-                    return Err(anyhow!("Docling conversion failed: {}", detail));
+                    return Err(DoclingError::ConversionFailed(detail));
                 }
                 JobStatus::Pending | JobStatus::Running => {
                     tokio::time::sleep(POLL_INTERVAL).await;
@@ -153,10 +171,11 @@ impl DoclingClient {
 
     /// Submit a document for conversion.
     /// Returns the job ID immediately.
-    async fn submit(&self, data: &[u8], filename: &str) -> Result<String> {
+    async fn submit(&self, data: &[u8], filename: &str) -> Result<String, DoclingError> {
         let part = multipart::Part::bytes(data.to_vec())
             .file_name(filename.to_string())
-            .mime_str("application/octet-stream")?;
+            .mime_str("application/octet-stream")
+            .context("Failed to build multipart request")?;
 
         let form = multipart::Form::new().part("file", part);
 
@@ -168,20 +187,30 @@ impl DoclingClient {
             .await
             .context("Failed to submit document to Docling")?;
 
+        if response.status().as_u16() == 429 {
+            let retry_after = response
+                .headers()
+                .get("retry-after")
+                .and_then(|v| v.to_str().ok())
+                .and_then(|v| v.parse::<u64>().ok())
+                .unwrap_or(30);
+            return Err(DoclingError::ServiceOverloaded {
+                retry_after_secs: retry_after,
+            });
+        }
+
         if response.status().as_u16() == 503 {
-            return Err(anyhow!(
-                "Docling service is starting up, models are being loaded. Try again shortly."
-            ));
+            return Err(DoclingError::ServiceStarting);
         }
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(anyhow!(
+            return Err(DoclingError::Other(anyhow!(
                 "Docling conversion submission failed: {} - {}",
                 status,
                 body
-            ));
+            )));
         }
 
         let submit_response: SubmitResponse = response
@@ -193,7 +222,7 @@ impl DoclingClient {
     }
 
     /// Get the status of a conversion job.
-    async fn get_job(&self, job_id: &str) -> Result<JobResponse> {
+    async fn get_job(&self, job_id: &str) -> Result<JobResponse, DoclingError> {
         let response = self
             .client
             .get(format!("{}/jobs/{}", self.base_url, job_id))
@@ -202,17 +231,20 @@ impl DoclingClient {
             .context("Failed to poll Docling job")?;
 
         if response.status().as_u16() == 404 {
-            return Err(anyhow!("Docling job not found: {}", job_id));
+            return Err(DoclingError::Other(anyhow!(
+                "Docling job not found: {}",
+                job_id
+            )));
         }
 
         if !response.status().is_success() {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
-            return Err(anyhow!(
+            return Err(DoclingError::Other(anyhow!(
                 "Failed to get Docling job status: {} - {}",
                 status,
                 body
-            ));
+            )));
         }
 
         let job: JobResponse = response

--- a/shared/src/clients/docling.rs
+++ b/shared/src/clients/docling.rs
@@ -192,7 +192,8 @@ impl DoclingClient {
 
         let response = self
             .client
-            .post(format!("{}/convert?preset={}", self.base_url, preset))
+            .post(format!("{}/convert", self.base_url))
+            .query(&[("preset", preset)])
             .multipart(form)
             .send()
             .await

--- a/shared/src/clients/docling.rs
+++ b/shared/src/clients/docling.rs
@@ -123,12 +123,18 @@ impl DoclingClient {
     /// # Arguments
     /// * `data` - The raw document bytes
     /// * `filename` - The filename (used for format detection via extension)
+    /// * `preset` - Quality preset: "fast", "balanced", or "quality"
     ///
     /// # Returns
     /// The extracted Markdown text, or an error if conversion fails.
-    pub async fn convert(&self, data: &[u8], filename: &str) -> Result<String, DoclingError> {
+    pub async fn convert(
+        &self,
+        data: &[u8],
+        filename: &str,
+        preset: &str,
+    ) -> Result<String, DoclingError> {
         // Submit the conversion job
-        let job_id = self.submit(data, filename).await?;
+        let job_id = self.submit(data, filename, preset).await?;
         debug!("Docling conversion job submitted: {}", job_id);
 
         // Poll for completion
@@ -171,7 +177,12 @@ impl DoclingClient {
 
     /// Submit a document for conversion.
     /// Returns the job ID immediately.
-    async fn submit(&self, data: &[u8], filename: &str) -> Result<String, DoclingError> {
+    async fn submit(
+        &self,
+        data: &[u8],
+        filename: &str,
+        preset: &str,
+    ) -> Result<String, DoclingError> {
         let part = multipart::Part::bytes(data.to_vec())
             .file_name(filename.to_string())
             .mime_str("application/octet-stream")
@@ -181,7 +192,7 @@ impl DoclingClient {
 
         let response = self
             .client
-            .post(format!("{}/convert", self.base_url))
+            .post(format!("{}/convert?preset={}", self.base_url, preset))
             .multipart(form)
             .send()
             .await

--- a/shared/src/constants.rs
+++ b/shared/src/constants.rs
@@ -1,1 +1,2 @@
-
+/// Redis hash key for system-wide runtime settings (configured via the admin UI).
+pub const REDIS_SYSTEM_SETTINGS_KEY: &str = "system:settings";

--- a/web/src/lib/server/system-flags.ts
+++ b/web/src/lib/server/system-flags.ts
@@ -86,6 +86,32 @@ export class SystemSettings {
     }
 
     /**
+     * Get the Docling quality preset. Defaults to "balanced".
+     */
+    static async getDoclingQualityPreset(): Promise<string> {
+        if (this.memoryCache.has('docling_quality_preset')) {
+            return this.memoryCache.get('docling_quality_preset')!
+        }
+
+        const redis = await getRedisClient()
+        const value = await redis.hGet(SYSTEM_SETTINGS_KEY, 'docling_quality_preset')
+        const preset = value ?? 'balanced'
+
+        this.memoryCache.set('docling_quality_preset', preset)
+
+        return preset
+    }
+
+    /**
+     * Set the Docling quality preset.
+     */
+    static async setDoclingQualityPreset(preset: string): Promise<void> {
+        const redis = await getRedisClient()
+        await redis.hSet(SYSTEM_SETTINGS_KEY, 'docling_quality_preset', preset)
+        this.memoryCache.set('docling_quality_preset', preset)
+    }
+
+    /**
      * Clear memory cache
      */
     static clearCache(): void {

--- a/web/src/routes/(admin)/admin/settings/document-conversion/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/document-conversion/+page.server.ts
@@ -4,10 +4,13 @@ import type { PageServerLoad, Actions } from './$types'
 import { requireAdmin } from '$lib/server/authHelpers'
 import { SystemSettings } from '$lib/server/system-flags'
 
+const VALID_PRESETS = ['fast', 'balanced', 'quality']
+
 export const load: PageServerLoad = async ({ locals }) => {
     requireAdmin(locals)
 
     const doclingEnabled = await SystemSettings.isDoclingEnabled()
+    const qualityPreset = await SystemSettings.getDoclingQualityPreset()
 
     // Quick health check to see if the service is reachable
     let doclingReachable = false
@@ -27,6 +30,7 @@ export const load: PageServerLoad = async ({ locals }) => {
     return {
         doclingEnabled,
         doclingReachable,
+        qualityPreset,
     }
 }
 
@@ -48,6 +52,30 @@ export const actions: Actions = {
         } catch (err) {
             console.error('Failed to update Docling setting:', err)
             return fail(500, { error: 'Failed to update setting' })
+        }
+    },
+
+    updateQualityPreset: async ({ request, locals }) => {
+        requireAdmin(locals)
+
+        const formData = await request.formData()
+        const preset = formData.get('preset') as string
+
+        if (!preset || !VALID_PRESETS.includes(preset)) {
+            return fail(400, {
+                error: `Invalid preset. Must be one of: ${VALID_PRESETS.join(', ')}`,
+            })
+        }
+
+        try {
+            await SystemSettings.setDoclingQualityPreset(preset)
+            return {
+                success: true,
+                message: `Quality preset updated to "${preset}"`,
+            }
+        } catch (err) {
+            console.error('Failed to update quality preset:', err)
+            return fail(500, { error: 'Failed to update quality preset' })
         }
     },
 }

--- a/web/src/routes/(admin)/admin/settings/document-conversion/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/document-conversion/+page.svelte
@@ -157,7 +157,6 @@
                                 }
                             }
                         }}>
-                        <input type="hidden" name="preset" value={qualityPreset} />
                         <RadioGroup.Root
                             bind:value={qualityPreset}
                             disabled={isPresetSubmitting}

--- a/web/src/routes/(admin)/admin/settings/document-conversion/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/document-conversion/+page.svelte
@@ -1,11 +1,12 @@
 <script lang="ts">
     import { enhance } from '$app/forms'
     import * as Card from '$lib/components/ui/card'
-    import * as Alert from '$lib/components/ui/alert'
     import * as RadioGroup from '$lib/components/ui/radio-group'
+    import { Badge } from '$lib/components/ui/badge'
     import { Label } from '$lib/components/ui/label'
+    import { Separator } from '$lib/components/ui/separator'
     import { Switch } from '$lib/components/ui/switch'
-    import { Sparkles, AlertTriangle, CircleCheck, Zap, Scale, Gem } from '@lucide/svelte'
+    import { Sparkles, AlertTriangle } from '@lucide/svelte'
     import { toast } from 'svelte-sonner'
     import type { PageData } from './$types'
 
@@ -22,25 +23,24 @@
         {
             value: 'fast',
             label: 'Fast',
-            description:
-                'Fastest extraction. Basic table detection, standard resolution. Best for text-heavy documents.',
-            icon: Zap,
+            description: 'Text-heavy docs. Basic tables.',
         },
         {
             value: 'balanced',
             label: 'Balanced',
-            description:
-                'Good quality for most documents. Accurate table structure with image classification.',
-            icon: Scale,
+            description: 'Accurate tables + image classification.',
+            isDefault: true,
         },
         {
             value: 'quality',
             label: 'Quality',
-            description:
-                'Best extraction quality. High-resolution processing, generates table and picture images.',
-            icon: Gem,
+            description: 'High-res with table and figure images.',
         },
     ]
+
+    const presetLabels: Record<string, string> = Object.fromEntries(
+        presets.map((p) => [p.value, p.label]),
+    )
 </script>
 
 <svelte:head>
@@ -50,115 +50,107 @@
 <div class="h-full overflow-y-auto p-6 py-8 pb-24">
     <div class="mx-auto max-w-screen-lg space-y-8">
         <div>
-            <h1 class="text-3xl font-bold tracking-tight">Document Conversion</h1>
-            <p class="text-muted-foreground mt-2">
-                Configure how documents are converted to text for indexing
+            <h1 class="text-3xl font-bold tracking-tight">Document conversion</h1>
+            <p class="text-muted-foreground mt-1 text-sm">
+                How uploaded files are parsed into searchable text.
             </p>
         </div>
 
         <Card.Root>
             <Card.Header>
-                <div class="flex items-center gap-3">
+                <div class="flex items-start gap-3">
                     <div
-                        class="flex h-10 w-10 items-center justify-center rounded-lg bg-gradient-to-br from-purple-500 to-indigo-600">
-                        <Sparkles class="h-5 w-5 text-white" />
+                        class="flex h-9 w-9 shrink-0 items-center justify-center rounded-md bg-purple-100 dark:bg-purple-950">
+                        <Sparkles class="h-[18px] w-[18px] text-purple-700 dark:text-purple-300" />
                     </div>
-                    <div>
-                        <div class="text-base leading-tight font-semibold">
-                            AI-Powered Document Conversion
+                    <div class="min-w-0 flex-1">
+                        <div class="flex items-center justify-between gap-3">
+                            <div>
+                                <p class="text-base font-medium">AI-powered extraction</p>
+                                <p class="text-muted-foreground mt-0.5 text-sm">
+                                    Docling &middot; layout-aware OCR for PDFs, Office files, and
+                                    images
+                                </p>
+                            </div>
+                            <form
+                                method="POST"
+                                action="?/updateDocling"
+                                bind:this={enableFormRef}
+                                use:enhance={({ formData }) => {
+                                    if (doclingEnabled) {
+                                        formData.set('enabled', 'true')
+                                    } else {
+                                        formData.delete('enabled')
+                                    }
+                                    isSubmitting = true
+                                    return async ({ result, update }) => {
+                                        isSubmitting = false
+                                        await update()
+                                        if (result.type === 'success') {
+                                            toast.success(result.data?.message || 'Setting updated')
+                                        } else if (result.type === 'failure') {
+                                            toast.error(
+                                                result.data?.error || 'Something went wrong',
+                                            )
+                                            doclingEnabled = data.doclingEnabled
+                                        }
+                                    }
+                                }}>
+                                <Switch
+                                    name="enabled"
+                                    value="true"
+                                    checked={doclingEnabled}
+                                    disabled={isSubmitting}
+                                    onCheckedChange={(checked) => {
+                                        doclingEnabled = checked
+                                        enableFormRef?.requestSubmit()
+                                    }}
+                                    class="cursor-pointer" />
+                            </form>
                         </div>
-                        <p class="text-muted-foreground mt-0.5 text-sm">Powered by Docling</p>
+
+                        {#if data.doclingReachable}
+                            <div
+                                class="mt-2.5 inline-flex items-center gap-1.5 text-sm text-green-600 dark:text-green-400">
+                                <span class="h-1.5 w-1.5 rounded-full bg-current"></span>
+                                Service healthy
+                            </div>
+                        {:else}
+                            <div
+                                class="mt-2.5 inline-flex items-center gap-1.5 text-sm text-red-600 dark:text-red-400">
+                                <AlertTriangle class="h-3.5 w-3.5" />
+                                Service unreachable &mdash; check
+                                <code class="bg-muted rounded px-1.5 py-0.5 text-xs"
+                                    >docker compose logs docling</code>
+                            </div>
+                        {/if}
                     </div>
                 </div>
-                <Card.Action>
-                    <form
-                        method="POST"
-                        action="?/updateDocling"
-                        bind:this={enableFormRef}
-                        use:enhance={({ formData }) => {
-                            if (doclingEnabled) {
-                                formData.set('enabled', 'true')
-                            } else {
-                                formData.delete('enabled')
-                            }
-                            isSubmitting = true
-                            return async ({ result, update }) => {
-                                isSubmitting = false
-                                await update()
-                                if (result.type === 'success') {
-                                    toast.success(result.data?.message || 'Setting updated')
-                                } else if (result.type === 'failure') {
-                                    toast.error(result.data?.error || 'Something went wrong')
-                                    doclingEnabled = data.doclingEnabled
-                                }
-                            }
-                        }}>
-                        <Switch
-                            name="enabled"
-                            value="true"
-                            checked={doclingEnabled}
-                            disabled={isSubmitting}
-                            onCheckedChange={(checked) => {
-                                doclingEnabled = checked
-                                enableFormRef?.requestSubmit()
-                            }}
-                            class="cursor-pointer" />
-                    </form>
-                </Card.Action>
             </Card.Header>
-            <Card.Content>
-                <p class="text-muted-foreground mb-4 text-sm">
-                    Uses AI-based layout analysis with built-in OCR to extract text from PDFs,
-                    Office documents, and images. Produces structure-aware Markdown that preserves
-                    tables, headings, and reading order for higher-quality search results.
-                </p>
 
-                {#if data.doclingReachable}
-                    <Alert.Root variant="default">
-                        <CircleCheck class="h-4 w-4" />
-                        <Alert.Title>Service healthy</Alert.Title>
-                        <Alert.Description>
-                            The Docling service is running and ready to process documents.
-                        </Alert.Description>
-                    </Alert.Root>
-                {:else}
-                    <Alert.Root variant="destructive">
-                        <AlertTriangle class="h-4 w-4" />
-                        <Alert.Title>Service unreachable</Alert.Title>
-                        <Alert.Description>
-                            The Docling service is not responding. It may still be loading models
-                            after a fresh start. Check the service logs:
-                            <code class="bg-muted mt-1 block rounded px-2 py-1 text-sm">
-                                docker compose logs docling
-                            </code>
-                        </Alert.Description>
-                    </Alert.Root>
-                {/if}
-            </Card.Content>
-        </Card.Root>
-
-        {#if doclingEnabled}
-            <Card.Root>
-                <Card.Header>
-                    <div>
-                        <div class="text-base leading-tight font-semibold">Extraction Quality</div>
-                        <p class="text-muted-foreground mt-0.5 text-sm">
-                            Trade off between extraction quality and processing speed
-                        </p>
-                    </div>
-                </Card.Header>
+            {#if doclingEnabled}
                 <Card.Content>
+                    <Separator class="mb-5" />
+
+                    <div class="mb-3 flex items-baseline justify-between">
+                        <Label class="text-sm font-medium">Extraction quality</Label>
+                        <span class="text-muted-foreground text-sm">Quality vs. speed</span>
+                    </div>
+
                     <form
                         method="POST"
                         action="?/updateQualityPreset"
                         bind:this={presetFormRef}
-                        use:enhance={() => {
+                        use:enhance={({ formData }) => {
+                            formData.set('preset', qualityPreset)
                             isPresetSubmitting = true
                             return async ({ result, update }) => {
                                 isPresetSubmitting = false
                                 await update()
                                 if (result.type === 'success') {
-                                    toast.success(result.data?.message || 'Preset updated')
+                                    toast.success(
+                                        `Quality preset updated to "${presetLabels[qualityPreset] ?? qualityPreset}"`,
+                                    )
                                 } else if (result.type === 'failure') {
                                     toast.error(result.data?.error || 'Something went wrong')
                                     qualityPreset = data.qualityPreset
@@ -169,34 +161,44 @@
                         <RadioGroup.Root
                             bind:value={qualityPreset}
                             disabled={isPresetSubmitting}
-                            onValueChange={() => {
+                            onValueChange={(value) => {
+                                qualityPreset = value
                                 presetFormRef?.requestSubmit()
                             }}
-                            class="grid gap-3">
+                            class="grid grid-cols-3 gap-2">
                             {#each presets as preset}
+                                {@const selected = qualityPreset === preset.value}
                                 <Label
                                     for={preset.value}
-                                    class="border-input hover:bg-accent/50 flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors has-[data-state=checked]:border-purple-500/50 has-[data-state=checked]:bg-purple-500/5">
+                                    class="relative flex cursor-pointer flex-col items-start rounded-md border p-4 transition-colors
+                                        {selected
+                                        ? 'border-blue-400/50 bg-blue-50/50 dark:border-blue-500/30 dark:bg-blue-950/20'
+                                        : 'border-input hover:bg-accent/50'}">
                                     <RadioGroup.Item
                                         value={preset.value}
                                         id={preset.value}
-                                        class="mt-0.5" />
-                                    <div class="flex items-start gap-3">
-                                        <preset.icon
-                                            class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
-                                        <div>
-                                            <div class="text-sm font-medium">{preset.label}</div>
-                                            <div class="text-muted-foreground mt-0.5 text-xs">
-                                                {preset.description}
-                                            </div>
-                                        </div>
+                                        class="sr-only" />
+                                    {#if preset.isDefault}
+                                        <Badge
+                                            variant="secondary"
+                                            class="absolute top-2 right-2 text-xs">
+                                            Default
+                                        </Badge>
+                                    {/if}
+                                    <div class="mb-1">
+                                        <span class="text-sm font-medium">
+                                            {preset.label}
+                                        </span>
                                     </div>
+                                    <p class="text-muted-foreground text-sm leading-relaxed">
+                                        {preset.description}
+                                    </p>
                                 </Label>
                             {/each}
                         </RadioGroup.Root>
                     </form>
                 </Card.Content>
-            </Card.Root>
-        {/if}
+            {/if}
+        </Card.Root>
     </div>
 </div>

--- a/web/src/routes/(admin)/admin/settings/document-conversion/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/document-conversion/+page.svelte
@@ -2,16 +2,45 @@
     import { enhance } from '$app/forms'
     import * as Card from '$lib/components/ui/card'
     import * as Alert from '$lib/components/ui/alert'
+    import * as RadioGroup from '$lib/components/ui/radio-group'
+    import { Label } from '$lib/components/ui/label'
     import { Switch } from '$lib/components/ui/switch'
-    import { Sparkles, AlertTriangle, CircleCheck } from '@lucide/svelte'
+    import { Sparkles, AlertTriangle, CircleCheck, Zap, Scale, Gem } from '@lucide/svelte'
     import { toast } from 'svelte-sonner'
     import type { PageData } from './$types'
 
     let { data }: { data: PageData } = $props()
 
     let doclingEnabled = $state(data.doclingEnabled)
+    let qualityPreset = $state(data.qualityPreset)
     let isSubmitting = $state(false)
-    let formRef = $state<HTMLFormElement | null>(null)
+    let isPresetSubmitting = $state(false)
+    let enableFormRef = $state<HTMLFormElement | null>(null)
+    let presetFormRef = $state<HTMLFormElement | null>(null)
+
+    const presets = [
+        {
+            value: 'fast',
+            label: 'Fast',
+            description:
+                'Fastest extraction. Basic table detection, standard resolution. Best for text-heavy documents.',
+            icon: Zap,
+        },
+        {
+            value: 'balanced',
+            label: 'Balanced',
+            description:
+                'Good quality for most documents. Accurate table structure with image classification.',
+            icon: Scale,
+        },
+        {
+            value: 'quality',
+            label: 'Quality',
+            description:
+                'Best extraction quality. High-resolution processing, generates table and picture images.',
+            icon: Gem,
+        },
+    ]
 </script>
 
 <svelte:head>
@@ -45,7 +74,7 @@
                     <form
                         method="POST"
                         action="?/updateDocling"
-                        bind:this={formRef}
+                        bind:this={enableFormRef}
                         use:enhance={({ formData }) => {
                             if (doclingEnabled) {
                                 formData.set('enabled', 'true')
@@ -71,7 +100,7 @@
                             disabled={isSubmitting}
                             onCheckedChange={(checked) => {
                                 doclingEnabled = checked
-                                formRef?.requestSubmit()
+                                enableFormRef?.requestSubmit()
                             }}
                             class="cursor-pointer" />
                     </form>
@@ -107,5 +136,67 @@
                 {/if}
             </Card.Content>
         </Card.Root>
+
+        {#if doclingEnabled}
+            <Card.Root>
+                <Card.Header>
+                    <div>
+                        <div class="text-base leading-tight font-semibold">Extraction Quality</div>
+                        <p class="text-muted-foreground mt-0.5 text-sm">
+                            Trade off between extraction quality and processing speed
+                        </p>
+                    </div>
+                </Card.Header>
+                <Card.Content>
+                    <form
+                        method="POST"
+                        action="?/updateQualityPreset"
+                        bind:this={presetFormRef}
+                        use:enhance={() => {
+                            isPresetSubmitting = true
+                            return async ({ result, update }) => {
+                                isPresetSubmitting = false
+                                await update()
+                                if (result.type === 'success') {
+                                    toast.success(result.data?.message || 'Preset updated')
+                                } else if (result.type === 'failure') {
+                                    toast.error(result.data?.error || 'Something went wrong')
+                                    qualityPreset = data.qualityPreset
+                                }
+                            }
+                        }}>
+                        <input type="hidden" name="preset" value={qualityPreset} />
+                        <RadioGroup.Root
+                            bind:value={qualityPreset}
+                            disabled={isPresetSubmitting}
+                            onValueChange={() => {
+                                presetFormRef?.requestSubmit()
+                            }}
+                            class="grid gap-3">
+                            {#each presets as preset}
+                                <Label
+                                    for={preset.value}
+                                    class="border-input hover:bg-accent/50 flex cursor-pointer items-start gap-3 rounded-lg border p-4 transition-colors has-[data-state=checked]:border-purple-500/50 has-[data-state=checked]:bg-purple-500/5">
+                                    <RadioGroup.Item
+                                        value={preset.value}
+                                        id={preset.value}
+                                        class="mt-0.5" />
+                                    <div class="flex items-start gap-3">
+                                        <preset.icon
+                                            class="text-muted-foreground mt-0.5 h-4 w-4 shrink-0" />
+                                        <div>
+                                            <div class="text-sm font-medium">{preset.label}</div>
+                                            <div class="text-muted-foreground mt-0.5 text-xs">
+                                                {preset.description}
+                                            </div>
+                                        </div>
+                                    </div>
+                                </Label>
+                            {/each}
+                        </RadioGroup.Root>
+                    </form>
+                </Card.Content>
+            </Card.Root>
+        {/if}
     </div>
 </div>

--- a/web/src/routes/+layout.svelte
+++ b/web/src/routes/+layout.svelte
@@ -5,5 +5,5 @@
     let { children } = $props()
 </script>
 
-<Toaster />
+<Toaster position="top-right" />
 {@render children()}


### PR DESCRIPTION
- docling currently accepts all incoming convert requests, and this leads to high memory use, stalling the conversion
- we add a limit to the number of pending requests - return 429 so that the source can back-off and slow down
- add UI controls to allow users to tradeoff quality vs speed in the conversion process, on the fly 