### PR TITLE
fix: implement URL normalization to strip fragments and web connector document_id mismatch

### DIFF
--- a/connectors/web/src/models.rs
+++ b/connectors/web/src/models.rs
@@ -114,6 +114,7 @@ impl WebPage {
 
     /// Create a WebPage from raw HTML content
     pub fn from_html(url: String, html: &str) -> Result<Self> {
+        let url = Self::normalize_url(&url);
         let document = Html::parse_document(html);
         let text_content = Self::extract_text_content(&document)?;
         let content_hash = Self::compute_content_hash(&text_content);
@@ -201,7 +202,31 @@ impl WebPage {
         format!("{:x}", hasher.finalize())
     }
 
-    fn url_to_document_id(url: &str) -> String {
+    pub fn normalize_url(url: &str) -> String {
+        let Ok(mut parsed) = url::Url::parse(url) else {
+            return url.to_string();
+        };
+        // Strip fragment — #anchors are client-side only, not part of the resource identity
+        parsed.set_fragment(None);
+        // Drop utm_* tracking params; keep everything else
+        let filtered: Vec<(String, String)> = parsed
+            .query_pairs()
+            .filter(|(k, _)| !k.starts_with("utm_"))
+            .map(|(k, v)| (k.into_owned(), v.into_owned()))
+            .collect();
+        if filtered.is_empty() {
+            parsed.set_query(None);
+        } else {
+            parsed
+                .query_pairs_mut()
+                .clear()
+                .extend_pairs(filtered.iter().map(|(k, v)| (k.as_str(), v.as_str())));
+        }
+        // scheme+host are already lowercased by the url crate during parsing
+        parsed.to_string()
+    }
+
+    pub fn url_to_document_id(url: &str) -> String {
         use base64::Engine;
         base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(url)
     }
@@ -387,6 +412,44 @@ mod tests {
 
         assert_eq!(hash1, hash2);
         assert_ne!(hash1, hash3);
+    }
+
+    #[test]
+    fn test_normalize_url() {
+        // Strips fragment
+        assert_eq!(
+            WebPage::normalize_url("https://example.com/page#section"),
+            "https://example.com/page"
+        );
+        // Drops utm_* params, preserves others
+        assert_eq!(
+            WebPage::normalize_url(
+                "https://example.com/page?ref=home&utm_source=google&utm_medium=cpc"
+            ),
+            "https://example.com/page?ref=home"
+        );
+        // Drops all query params when only utm_* remain
+        assert_eq!(
+            WebPage::normalize_url("https://example.com/page?utm_campaign=spring"),
+            "https://example.com/page"
+        );
+        // Lowercases scheme+host (url crate does this automatically)
+        assert_eq!(
+            WebPage::normalize_url("HTTPS://Example.COM/Path"),
+            "https://example.com/Path"
+        );
+        // Fragment + utm together
+        assert_eq!(
+            WebPage::normalize_url("https://example.com/page?utm_source=x#anchor"),
+            "https://example.com/page"
+        );
+        // Unchanged when already clean
+        assert_eq!(
+            WebPage::normalize_url("https://example.com/docs/intro"),
+            "https://example.com/docs/intro"
+        );
+        // Invalid URL passes through unchanged
+        assert_eq!(WebPage::normalize_url("not-a-url"), "not-a-url");
     }
 
     #[test]

--- a/connectors/web/src/sync.rs
+++ b/connectors/web/src/sync.rs
@@ -140,9 +140,9 @@ impl SyncState {
         use redis::AsyncCommands;
         let mut conn = self.redis_client.get_multiplexed_async_connection().await?;
         let key = self.get_urls_set_key(source_id);
-        let url_hash = format!("{:x}", md5::compute(url));
+        let document_id = WebPage::url_to_document_id(url);
 
-        let _: () = conn.sadd(&key, url_hash).await?;
+        let _: () = conn.sadd(&key, document_id).await?;
         let _: () = conn.expire(&key, 90 * 24 * 60 * 60).await?;
         Ok(())
     }
@@ -402,7 +402,7 @@ impl SyncManager {
         sdk_client: &SdkClient,
     ) -> Result<()> {
         let url = &web_page.url;
-        let url_hash = format!("{:x}", md5::compute(url));
+        let url_hash = WebPage::url_to_document_id(url);
 
         {
             let mut urls = current_urls.lock().await;

--- a/connectors/web/tests/sync_state_test.rs
+++ b/connectors/web/tests/sync_state_test.rs
@@ -108,12 +108,13 @@ async fn test_url_set_operations() -> Result<()> {
     let synced_urls = sync_state.get_all_synced_urls(source_id).await?;
     assert_eq!(synced_urls.len(), 3);
 
-    // Compute expected hashes
-    let expected_hashes: HashSet<String> = urls
+    // Compute expected document IDs (base64 of URL, same as url_to_document_id)
+    use base64::Engine;
+    let expected_ids: HashSet<String> = urls
         .iter()
-        .map(|url| format!("{:x}", md5::compute(url)))
+        .map(|url| base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(url))
         .collect();
-    assert_eq!(synced_urls, expected_hashes);
+    assert_eq!(synced_urls, expected_ids);
 
     Ok(())
 }
@@ -135,16 +136,16 @@ async fn test_remove_url_from_set() -> Result<()> {
     let urls = sync_state.get_all_synced_urls(source_id).await?;
     assert_eq!(urls.len(), 2);
 
-    // Remove one URL (by hash)
-    let url2_hash = format!("{:x}", md5::compute(url2));
-    sync_state
-        .remove_url_from_set(source_id, &url2_hash)
-        .await?;
+    // Remove one URL (by document_id — base64 of URL)
+    use base64::Engine;
+    let url2_id = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(url2);
+    sync_state.remove_url_from_set(source_id, &url2_id).await?;
 
     // Verify only one remains
     let urls = sync_state.get_all_synced_urls(source_id).await?;
     assert_eq!(urls.len(), 1);
-    assert!(urls.contains(&format!("{:x}", md5::compute(url1))));
+    let url1_id = base64::engine::general_purpose::URL_SAFE_NO_PAD.encode(url1);
+    assert!(urls.contains(&url1_id));
 
     Ok(())
 }


### PR DESCRIPTION
### Changes

**Bug fix: create/delete document_id mismatch**

`to_connector_event` used `base64(url)` as `document_id` while `publish_deletion_event` used `md5(url)`. Deletion events therefore never matched any indexed document. Both now use `base64(url)` consistently — the Redis URL set stores document IDs instead of MD5 hashes.

**URL normalization**

Added `WebPage::normalize_url` applied at `from_html` entry point:
- Strips `#fragment` (client-side only, not part of resource identity)
- Removes `utm_*` query params
- Scheme+host lowercasing handled automatically by the `url` crate

Prevents the same page from getting multiple Redis/DB rows when reached via URLs that differ only in tracking params or anchors.

### Test changes

Updated `test_url_set_operations` and `test_remove_url_from_set` to expect base64 document IDs instead of MD5 hashes. Added `test_normalize_url` unit test.