### PR TITLE
Handle interrupted syncs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4156,6 +4156,7 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-test",
+ "dashmap 6.1.0",
  "dotenvy",
  "futures",
  "redis",

--- a/sdk/python/omni_connector/client.py
+++ b/sdk/python/omni_connector/client.py
@@ -211,6 +211,23 @@ class SdkClient:
 
         return response.json()["content_id"]
 
+    async def update_connector_state(
+        self, source_id: str, state: dict[str, Any]
+    ) -> None:
+        """Persist connector state to the manager (used by save_state checkpoints)."""
+        logger.debug("SDK: Updating connector state for source=%s", source_id)
+
+        client = await self._get_client()
+        response = await client.put(
+            f"{self.base_url}/sdk/source/{source_id}/connector-state",
+            json=state,
+        )
+
+        if not response.is_success:
+            raise SdkClientError(
+                f"Failed to update connector state: {response.status_code} - {response.text}"
+            )
+
     async def heartbeat(self, sync_run_id: str) -> None:
         """Send heartbeat to update last_activity_at."""
         logger.debug("SDK: Heartbeat for sync_run=%s", sync_run_id)

--- a/sdk/python/omni_connector/context.py
+++ b/sdk/python/omni_connector/context.py
@@ -173,8 +173,15 @@ class SyncContext:
         await self._client.increment_scanned(self._sync_run_id)
 
     async def save_state(self, state: dict[str, Any]) -> None:
-        """Checkpoint state for resumability. Call periodically for long syncs."""
+        """Checkpoint state for resumability. Call periodically for long syncs.
+
+        Persists `state` to the manager so an interrupted sync can resume from
+        this point. Callers MUST `await` every `emit()` for documents covered
+        by `state` before calling this — otherwise a resume could skip events
+        that hadn't yet been enqueued.
+        """
         self._state = state
+        await self._client.update_connector_state(self._source_id, state)
         await self._client.heartbeat(self._sync_run_id)
 
     async def complete(self, new_state: dict[str, Any] | None = None) -> None:

--- a/sdk/python/omni_connector/server.py
+++ b/sdk/python/omni_connector/server.py
@@ -102,6 +102,13 @@ def create_app(connector: "Connector") -> FastAPI:
         m = await connector.get_manifest(connector_url=connector_url)
         return m.model_dump()
 
+    @app.get("/sync/{sync_run_id}")
+    async def sync_status(sync_run_id: str) -> dict[str, bool]:
+        running = any(
+            ctx.sync_run_id == sync_run_id for ctx in server.active_syncs.values()
+        )
+        return {"running": running}
+
     @app.post("/sync")
     async def trigger_sync(request: SyncRequest) -> JSONResponse:
         sync_run_id = request.sync_run_id

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -33,6 +33,10 @@ def mock_connector_manager():
             return_value=Response(200, json={"status": "ok"})
         )
 
+        respx_mock.put(path__regex=r"/sdk/source/.*/connector-state").mock(
+            return_value=Response(200, json={"status": "ok"})
+        )
+
         yield respx_mock
 
 

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -156,8 +156,8 @@ async def test_fail_sends_error_message(sdk_client, mock_connector_manager):
 
 
 @pytest.mark.asyncio
-async def test_save_state_sends_heartbeat(sdk_client, mock_connector_manager):
-    """Verify save_state() triggers a heartbeat."""
+async def test_save_state_persists_and_heartbeats(sdk_client, mock_connector_manager):
+    """Verify save_state() persists state to manager and triggers a heartbeat."""
     ctx = SyncContext(
         sdk_client=sdk_client,
         sync_run_id="sync-123",
@@ -167,7 +167,16 @@ async def test_save_state_sends_heartbeat(sdk_client, mock_connector_manager):
 
     await ctx.save_state({"page": 2, "cursor": "abc"})
 
-    # Should have made a heartbeat call
+    state_calls = [
+        c
+        for c in mock_connector_manager.calls
+        if "connector-state" in str(c.request.url)
+    ]
+    assert len(state_calls) == 1
+    assert "source-456" in str(state_calls[0].request.url)
+    assert state_calls[0].request.method == "PUT"
+    assert json.loads(state_calls[0].request.content) == {"page": 2, "cursor": "abc"}
+
     heartbeat_calls = [
         c for c in mock_connector_manager.calls if "heartbeat" in str(c.request.url)
     ]

--- a/sdk/python/tests/test_server.py
+++ b/sdk/python/tests/test_server.py
@@ -155,6 +155,82 @@ class TestCancelEndpoint:
         assert data["status"] == "not_found"
 
 
+class TestSyncStatusEndpoint:
+    def test_sync_status_not_running(self, client):
+        """Returns running=false when sync_run_id is unknown."""
+        response = client.get("/sync/unknown-run")
+        assert response.status_code == 200
+        assert response.json() == {"running": False}
+
+    @patch("omni_connector.client.SdkClient.fetch_source_sync_data")
+    def test_sync_status_running_then_finished(self, mock_fetch, monkeypatch):
+        """Returns running=true while sync is in flight, false after it finishes."""
+        import asyncio
+        import threading
+
+        monkeypatch.setenv("CONNECTOR_MANAGER_URL", "http://localhost:9000")
+        monkeypatch.setenv("CONNECTOR_HOST_NAME", "localhost")
+        monkeypatch.setenv("PORT", "8000")
+
+        sync_started = threading.Event()
+        sync_can_finish = threading.Event()
+
+        class BlockingConnector(Connector):
+            @property
+            def name(self) -> str:
+                return "blocking"
+
+            @property
+            def version(self) -> str:
+                return "1.0.0"
+
+            @property
+            def source_types(self) -> list[str]:
+                return ["blocking"]
+
+            async def sync(self, source_config, credentials, state, ctx):
+                sync_started.set()
+                while not sync_can_finish.is_set():
+                    await asyncio.sleep(0.01)
+                await ctx.complete()
+
+        mock_fetch.return_value = SdkSourceSyncData(
+            config={},
+            credentials={},
+            connector_state=None,
+        )
+
+        app = create_app(BlockingConnector())
+
+        with TestClient(app) as client:
+            client.post(
+                "/sync",
+                json={
+                    "sync_run_id": "sync-status-1",
+                    "source_id": "src-status",
+                    "sync_mode": "full",
+                },
+            )
+            sync_started.wait(timeout=2.0)
+
+            response = client.get("/sync/sync-status-1")
+            assert response.status_code == 200
+            assert response.json() == {"running": True}
+
+            sync_can_finish.set()
+
+            # Allow background task to complete
+            import time
+
+            for _ in range(200):
+                if client.get("/sync/sync-status-1").json()["running"] is False:
+                    break
+                time.sleep(0.01)
+
+            response = client.get("/sync/sync-status-1")
+            assert response.json() == {"running": False}
+
+
 class TestActionEndpoint:
     def test_action_executes_successfully(self, client, mock_connector):
         response = client.post(

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -130,6 +130,23 @@ export class SdkClient {
     return data.content_id;
   }
 
+  async updateConnectorState(
+    sourceId: string,
+    state: Record<string, unknown>
+  ): Promise<void> {
+    const response = await this.put(
+      `/sdk/source/${sourceId}/connector-state`,
+      state
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new SdkClientError(
+        `Failed to update connector state: ${response.status} - ${text}`,
+        response.status
+      );
+    }
+  }
+
   async heartbeat(syncRunId: string): Promise<void> {
     const response = await this.post(`/sdk/sync/${syncRunId}/heartbeat`);
     if (!response.ok) {
@@ -224,6 +241,21 @@ export class SdkClient {
       method: 'GET',
       signal: AbortSignal.timeout(this.timeout),
     });
+  }
+
+  private async put(path: string, body?: unknown): Promise<Response> {
+    const url = `${this.baseUrl}${path}`;
+    const options: RequestInit = {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      signal: AbortSignal.timeout(this.timeout),
+    };
+    if (body !== undefined) {
+      options.body = JSON.stringify(body);
+    }
+    return fetch(url, options);
   }
 
   private async post(path: string, body?: unknown): Promise<Response> {

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -129,8 +129,17 @@ export class SyncContext {
     await this.client.incrementScanned(this._syncRunId);
   }
 
+  /**
+   * Checkpoint state for resumability. Call periodically for long syncs.
+   *
+   * Persists `state` to the manager so an interrupted sync can resume from
+   * this point. Callers MUST `await` every `emit()` for documents covered
+   * by `state` before calling this — otherwise a resume could skip events
+   * that hadn't yet been enqueued.
+   */
   async saveState(state: Record<string, unknown>): Promise<void> {
     this._state = state;
+    await this.client.updateConnectorState(this._sourceId, state);
     await this.client.heartbeat(this._syncRunId);
   }
 

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -72,6 +72,18 @@ export function createServer(connector: Connector): Express {
     res.json(manifest);
   });
 
+  app.get('/sync/:syncRunId', (req: Request, res: Response) => {
+    const { syncRunId } = req.params;
+    let running = false;
+    for (const ctx of activeSyncs.values()) {
+      if (ctx.syncRunId === syncRunId) {
+        running = true;
+        break;
+      }
+    }
+    res.json({ running });
+  });
+
   app.post('/sync', async (req: Request, res: Response) => {
     const parseResult = SyncRequestSchema.safeParse(req.body);
     if (!parseResult.success) {

--- a/sdk/typescript/tests/server.test.ts
+++ b/sdk/typescript/tests/server.test.ts
@@ -45,6 +45,8 @@ const mockServer = setupServer(
 
 beforeAll(() => {
   vi.stubEnv('CONNECTOR_MANAGER_URL', MANAGER_URL);
+  vi.stubEnv('CONNECTOR_HOST_NAME', 'localhost');
+  vi.stubEnv('PORT', '8000');
   mockServer.listen({ onUnhandledRequest: 'bypass' });
 });
 
@@ -115,6 +117,18 @@ describe('Connector Server', () => {
 
       expect(response.status).toBe(200);
       expect(response.body.status).toBe('started');
+    });
+  });
+
+  describe('GET /sync/:syncRunId', () => {
+    it('returns running=false for unknown sync', async () => {
+      const connector = new MockConnector();
+      const app = createServer(connector);
+
+      const response = await request(app).get('/sync/unknown-sync');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ running: false });
     });
   });
 

--- a/services/connector-manager/Cargo.toml
+++ b/services/connector-manager/Cargo.toml
@@ -34,6 +34,7 @@ futures = { workspace = true }
 async-trait = { workspace = true }
 async-stream = "0.3"
 time = { workspace = true }
+dashmap = { workspace = true }
 shared = { path = "../../shared" }
 
 [dev-dependencies]

--- a/services/connector-manager/src/connector_client.rs
+++ b/services/connector-manager/src/connector_client.rs
@@ -1,6 +1,6 @@
 use crate::models::{
     ActionRequest, ActionResponse, ConnectorManifest, PromptRequest, ResourceRequest, SyncRequest,
-    SyncResponse,
+    SyncResponse, SyncStatusResponse,
 };
 use reqwest::Client;
 use std::time::Duration;
@@ -74,6 +74,37 @@ impl ConnectorClient {
             let status = response.status();
             let body = response.text().await.unwrap_or_default();
             error!("Failed to trigger sync: {} - {}", status, body);
+            return Err(ClientError::ConnectorError {
+                status: status.as_u16(),
+                message: body,
+            });
+        }
+
+        response
+            .json()
+            .await
+            .map_err(|e| ClientError::InvalidResponse(e.to_string()))
+    }
+
+    pub async fn get_sync_status(
+        &self,
+        connector_url: &str,
+        sync_run_id: &str,
+    ) -> Result<SyncStatusResponse, ClientError> {
+        let url = format!("{}/sync/{}", connector_url, sync_run_id);
+        debug!("Probing sync status at {}", url);
+
+        let response = self
+            .client
+            .get(&url)
+            .timeout(Duration::from_secs(5))
+            .send()
+            .await
+            .map_err(|e| ClientError::RequestFailed(e.to_string()))?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
             return Err(ClientError::ConnectorError {
                 status: status.as_u16(),
                 message: body,

--- a/services/connector-manager/src/lib.rs
+++ b/services/connector-manager/src/lib.rs
@@ -24,7 +24,7 @@ use std::sync::Arc;
 use sync_manager::SyncManager;
 use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
-use tracing::info;
+use tracing::{info, warn};
 
 #[derive(Clone)]
 pub struct AppState {
@@ -149,6 +149,12 @@ pub async fn run_server() -> AnyhowResult<()> {
         sync_manager: sync_manager.clone(),
         content_storage,
     };
+
+    // Reconcile any sync_runs left in 'running' state from a previous
+    // manager process before starting the scheduler.
+    if let Err(e) = sync_manager.monitor_running_syncs().await {
+        warn!("Startup sync reconciliation failed: {}", e);
+    }
 
     // Start scheduler in background
     let scheduler = scheduler::Scheduler::new(db_pool.pool().clone(), config.clone(), sync_manager);

--- a/services/connector-manager/src/models.rs
+++ b/services/connector-manager/src/models.rs
@@ -29,7 +29,6 @@ pub enum TriggerType {
     Scheduled,
     Manual,
     Webhook,
-    AutoResume,
 }
 
 impl std::fmt::Display for TriggerType {
@@ -38,7 +37,6 @@ impl std::fmt::Display for TriggerType {
             TriggerType::Scheduled => write!(f, "scheduled"),
             TriggerType::Manual => write!(f, "manual"),
             TriggerType::Webhook => write!(f, "webhook"),
-            TriggerType::AutoResume => write!(f, "auto_resume"),
         }
     }
 }

--- a/services/connector-manager/src/models.rs
+++ b/services/connector-manager/src/models.rs
@@ -29,6 +29,7 @@ pub enum TriggerType {
     Scheduled,
     Manual,
     Webhook,
+    AutoResume,
 }
 
 impl std::fmt::Display for TriggerType {
@@ -37,8 +38,14 @@ impl std::fmt::Display for TriggerType {
             TriggerType::Scheduled => write!(f, "scheduled"),
             TriggerType::Manual => write!(f, "manual"),
             TriggerType::Webhook => write!(f, "webhook"),
+            TriggerType::AutoResume => write!(f, "auto_resume"),
         }
     }
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SyncStatusResponse {
+    pub running: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/services/connector-manager/src/scheduler.rs
+++ b/services/connector-manager/src/scheduler.rs
@@ -52,6 +52,11 @@ impl Scheduler {
             error!("Error processing due sources: {}", e);
         }
 
+        // Probe in-flight syncs and reconcile any the connector has lost
+        if let Err(e) = self.sync_manager.monitor_running_syncs().await {
+            error!("Error monitoring running syncs: {}", e);
+        }
+
         // Detect and handle stale syncs
         match self.sync_manager.detect_stale_syncs().await {
             Ok(stale) => {

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -11,7 +11,7 @@ use sqlx::PgPool;
 use std::sync::Arc;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-use tracing::{debug, error, info, warn};
+use tracing::{error, info, warn};
 
 const MAX_RESUME_ATTEMPTS: usize = 3;
 
@@ -232,28 +232,24 @@ impl SyncManager {
                 None => continue,
             };
 
-            let connector_url = match get_connector_url_for_source(
-                &self.redis_client,
-                source.source_type,
-            )
-            .await
-            {
-                Some(url) => url,
-                None => {
-                    // Connector isn't registered in Redis — either it's
-                    // down long enough for the 90s TTL to have expired,
-                    // or it never came up. Treat as a lost sync so we
-                    // count attempts and eventually mark the row failed
-                    // (instead of waiting for the 60-min stale timeout).
-                    warn!(
+            let connector_url =
+                match get_connector_url_for_source(&self.redis_client, source.source_type).await {
+                    Some(url) => url,
+                    None => {
+                        // Connector isn't registered in Redis — either it's
+                        // down long enough for the 90s TTL to have expired,
+                        // or it never came up. Treat as a lost sync so we
+                        // count attempts and eventually mark the row failed
+                        // (instead of waiting for the 60-min stale timeout).
+                        warn!(
                         "No registered connector for sync {} (source_type={:?}); treating as lost",
                         sync_run.id, source.source_type
                     );
-                    self.handle_lost_sync(&sync_run.id, &sync_run.source_id)
-                        .await;
-                    continue;
-                }
-            };
+                        self.handle_lost_sync(&sync_run.id, &sync_run.source_id)
+                            .await;
+                        continue;
+                    }
+                };
 
             match self
                 .connector_client
@@ -261,7 +257,9 @@ impl SyncManager {
                 .await
             {
                 Ok(status) if status.running => {
-                    // Connector still working on it; nothing to do.
+                    // Healthy observation — clear any prior lost-signal count
+                    // so the attempt cap tracks consecutive failures.
+                    self.resume_attempts.remove(&sync_run.id);
                 }
                 Ok(_) => {
                     warn!(
@@ -277,10 +275,15 @@ impl SyncManager {
                     // Fall through to existing stale-detection.
                 }
                 Err(e) => {
-                    debug!(
-                        "Sync status probe failed for {} ({}): {}",
+                    // Connector reachable-via-Redis but not responding
+                    // (connection refused, timeout, 5xx). Treat same as
+                    // "lost" — attempt counter absorbs transient blips.
+                    warn!(
+                        "Sync status probe failed for {} ({}): {}; treating as lost",
                         sync_run.id, connector_url, e
                     );
+                    self.handle_lost_sync(&sync_run.id, &sync_run.source_id)
+                        .await;
                 }
             }
         }
@@ -337,7 +340,16 @@ impl SyncManager {
         let connector_url =
             match get_connector_url_for_source(&self.redis_client, source.source_type).await {
                 Some(url) => url,
-                None => return,
+                None => {
+                    // Connector is still unregistered. Attempt was counted
+                    // above; after MAX_RESUME_ATTEMPTS the cap above will
+                    // mark the row failed.
+                    warn!(
+                        "Cannot resume sync {} — connector for {:?} not registered (attempt {}/{})",
+                        sync_run_id, source.source_type, attempts, MAX_RESUME_ATTEMPTS
+                    );
+                    return;
+                }
             };
 
         // Look up the existing run to recover sync_type and the right

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -2,16 +2,18 @@ use crate::config::ConnectorManagerConfig;
 use crate::connector_client::{ClientError, ConnectorClient};
 use crate::handlers::get_connector_url_for_source;
 use crate::models::{SyncRequest, TriggerType};
+use dashmap::DashMap;
 use redis::Client as RedisClient;
 use shared::db::repositories::SyncRunRepository;
 use shared::models::{SourceType, SyncStatus, SyncType};
 use shared::{DatabasePool, Repository, SourceRepository};
 use sqlx::PgPool;
+use std::sync::Arc;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
 use tracing::{debug, error, info, warn};
 
-const MAX_CONSECUTIVE_AUTO_RESUMES: usize = 3;
+const MAX_RESUME_ATTEMPTS: usize = 3;
 
 #[derive(Clone)]
 pub struct SyncManager {
@@ -20,6 +22,10 @@ pub struct SyncManager {
     redis_client: RedisClient,
     connector_client: ConnectorClient,
     sync_run_repo: SyncRunRepository,
+    /// In-memory tally of resume attempts per sync_run_id. Cleared when a
+    /// sync transitions out of `running`. Bounds resume churn for chronically
+    /// crashing connectors without needing schema changes.
+    resume_attempts: Arc<DashMap<String, usize>>,
 }
 
 impl SyncManager {
@@ -34,6 +40,7 @@ impl SyncManager {
             redis_client,
             connector_client: ConnectorClient::new(),
             sync_run_repo: SyncRunRepository::new(db_pool.pool()),
+            resume_attempts: Arc::new(DashMap::new()),
         }
     }
 
@@ -172,6 +179,7 @@ impl SyncManager {
             .await
             .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
 
+        self.resume_attempts.remove(sync_run_id);
         info!("Sync {} cancelled", sync_run_id);
         Ok(())
     }
@@ -263,74 +271,119 @@ impl SyncManager {
         Ok(())
     }
 
-    /// Reconcile a sync that the connector no longer knows about: mark it
-    /// failed and (subject to loop protection) trigger a fresh resume run.
+    /// Re-trigger `/sync` on the connector for an existing `running` sync_run
+    /// whose connector has lost track of it (typically due to a restart). The
+    /// row stays in `running`; the connector will resume from the
+    /// incrementally-persisted `connector_state`. If we exceed
+    /// MAX_RESUME_ATTEMPTS or the connector keeps refusing, mark the row
+    /// failed so we stop churning.
     async fn handle_lost_sync(&self, sync_run_id: &str, source_id: &str) {
-        let reason = "Connector no longer running this sync (likely restarted); auto-resuming";
-        if let Err(e) = self.mark_sync_failed(sync_run_id, reason).await {
-            error!("Failed to mark lost sync {} as failed: {}", sync_run_id, e);
+        let attempts = {
+            let mut entry = self
+                .resume_attempts
+                .entry(sync_run_id.to_string())
+                .or_insert(0);
+            *entry += 1;
+            *entry
+        };
+
+        if attempts > MAX_RESUME_ATTEMPTS {
+            warn!(
+                "Sync {} exceeded {} resume attempts; marking failed",
+                sync_run_id, MAX_RESUME_ATTEMPTS
+            );
+            if let Err(e) = self
+                .mark_sync_failed(
+                    sync_run_id,
+                    "Connector repeatedly lost sync; auto-resume gave up",
+                )
+                .await
+            {
+                error!("Failed to mark sync {} as failed: {}", sync_run_id, e);
+            }
+            self.resume_attempts.remove(sync_run_id);
             return;
         }
 
-        match self.recent_auto_resume_failures(source_id).await {
-            Ok(count) if count >= MAX_CONSECUTIVE_AUTO_RESUMES => {
-                warn!(
-                    "Source {} has {} consecutive auto-resume failures; not resuming again",
-                    source_id, count
-                );
-                return;
-            }
-            Ok(_) => {}
-            Err(e) => {
-                error!(
-                    "Failed to check auto-resume history for source {}: {}",
-                    source_id, e
-                );
-                return;
-            }
-        }
-
-        match self
-            .trigger_sync(source_id, SyncType::Incremental, TriggerType::AutoResume)
+        let source = match SourceRepository::new(&self.pool)
+            .find_by_id(source_id.to_string())
             .await
         {
-            Ok(new_run_id) => info!(
-                "Auto-resumed sync for source {} as {}",
-                source_id, new_run_id
-            ),
-            Err(e) => warn!("Failed to auto-resume sync for source {}: {}", source_id, e),
-        }
-    }
+            Ok(Some(s)) => s,
+            Ok(None) => return,
+            Err(e) => {
+                error!("Failed to load source {}: {}", source_id, e);
+                return;
+            }
+        };
 
-    /// Count the previous consecutive runs (most-recent first) for `source_id`
-    /// that were both `auto_resume`-triggered and ended in the failed state.
-    /// Stops at the first run that breaks the streak.
-    async fn recent_auto_resume_failures(&self, source_id: &str) -> Result<usize, SyncError> {
-        let rows: Vec<(String, String)> = sqlx::query_as(
-            r#"
-            SELECT trigger_type, status::text
-            FROM sync_runs
-            WHERE source_id = $1
-              AND status IN ('failed', 'completed', 'cancelled')
-            ORDER BY created_at DESC
-            LIMIT $2
-            "#,
-        )
-        .bind(source_id)
-        .bind(MAX_CONSECUTIVE_AUTO_RESUMES as i64)
-        .fetch_all(&self.pool)
-        .await
-        .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+        let connector_url =
+            match get_connector_url_for_source(&self.redis_client, source.source_type).await {
+                Some(url) => url,
+                None => return,
+            };
 
-        let mut streak = 0usize;
-        for (trigger_type, status) in rows {
-            if trigger_type == TriggerType::AutoResume.to_string() && status == "failed" {
-                streak += 1;
-            } else {
-                break;
+        // Look up the existing run to recover sync_type and the right
+        // last_sync_at to send.
+        let sync_run = match self.sync_run_repo.find_by_id(sync_run_id).await {
+            Ok(Some(r)) => r,
+            Ok(None) => return,
+            Err(e) => {
+                error!("Failed to load sync_run {}: {}", sync_run_id, e);
+                return;
+            }
+        };
+
+        let last_sync_at = if sync_run.sync_type == SyncType::Incremental {
+            match self
+                .sync_run_repo
+                .get_last_completed_for_source(source_id, None)
+                .await
+            {
+                Ok(Some(r)) => r.completed_at.and_then(|ts| ts.format(&Rfc3339).ok()),
+                _ => None,
+            }
+        } else {
+            None
+        };
+
+        let sync_request = SyncRequest {
+            sync_run_id: sync_run_id.to_string(),
+            source_id: source_id.to_string(),
+            sync_mode: match sync_run.sync_type {
+                SyncType::Full => "full",
+                SyncType::Incremental => "incremental",
+            }
+            .to_string(),
+            last_sync_at,
+        };
+
+        match self
+            .connector_client
+            .trigger_sync(&connector_url, &sync_request)
+            .await
+        {
+            Ok(_) => {
+                info!(
+                    "Auto-resumed sync {} on connector (attempt {}/{})",
+                    sync_run_id, attempts, MAX_RESUME_ATTEMPTS
+                );
+                // Reset staleness clock so detect_stale_syncs doesn't fire
+                // before the resumed sync starts emitting.
+                if let Err(e) = self.sync_run_repo.update_activity(sync_run_id).await {
+                    warn!(
+                        "Failed to bump activity for resumed sync {}: {}",
+                        sync_run_id, e
+                    );
+                }
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to re-trigger sync {} on connector (attempt {}/{}): {}",
+                    sync_run_id, attempts, MAX_RESUME_ATTEMPTS, e
+                );
             }
         }
-        Ok(streak)
     }
 
     pub async fn detect_stale_syncs(&self) -> Result<Vec<String>, SyncError> {
@@ -396,6 +449,7 @@ impl SyncManager {
             .await
             .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
 
+        self.resume_attempts.remove(sync_run_id);
         Ok(())
     }
 }

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -232,11 +232,28 @@ impl SyncManager {
                 None => continue,
             };
 
-            let connector_url =
-                match get_connector_url_for_source(&self.redis_client, source.source_type).await {
-                    Some(url) => url,
-                    None => continue,
-                };
+            let connector_url = match get_connector_url_for_source(
+                &self.redis_client,
+                source.source_type,
+            )
+            .await
+            {
+                Some(url) => url,
+                None => {
+                    // Connector isn't registered in Redis — either it's
+                    // down long enough for the 90s TTL to have expired,
+                    // or it never came up. Treat as a lost sync so we
+                    // count attempts and eventually mark the row failed
+                    // (instead of waiting for the 60-min stale timeout).
+                    warn!(
+                        "No registered connector for sync {} (source_type={:?}); treating as lost",
+                        sync_run.id, source.source_type
+                    );
+                    self.handle_lost_sync(&sync_run.id, &sync_run.source_id)
+                        .await;
+                    continue;
+                }
+            };
 
             match self
                 .connector_client

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -9,7 +9,9 @@ use shared::{DatabasePool, Repository, SourceRepository};
 use sqlx::PgPool;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-use tracing::{error, info, warn};
+use tracing::{debug, error, info, warn};
+
+const MAX_CONSECUTIVE_AUTO_RESUMES: usize = 3;
 
 #[derive(Clone)]
 pub struct SyncManager {
@@ -188,6 +190,147 @@ impl SyncManager {
             .await
             .map(|r| r.len())
             .map_err(|e| SyncError::DatabaseError(e.to_string()))
+    }
+
+    /// Probe each running sync's connector to confirm it is actually running.
+    ///
+    /// For every `sync_runs` row with status='running', ask the connector via
+    /// `GET /sync/{sync_run_id}` whether it still has the sync in flight. If the
+    /// connector reports `running: false` (typically because it restarted and
+    /// lost its in-memory state), mark the row as failed and immediately
+    /// trigger a fresh run that resumes from the last persisted
+    /// `connector_state`. Tolerates probe errors / 404s / unregistered
+    /// connectors as no-ops; existing stale-detection is the fallback.
+    pub async fn monitor_running_syncs(&self) -> Result<(), SyncError> {
+        let running = self
+            .sync_run_repo
+            .find_all_running()
+            .await
+            .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+
+        if running.is_empty() {
+            return Ok(());
+        }
+
+        let source_repo = SourceRepository::new(&self.pool);
+
+        for sync_run in running {
+            let source = match source_repo
+                .find_by_id(sync_run.source_id.clone())
+                .await
+                .map_err(|e| SyncError::DatabaseError(e.to_string()))?
+            {
+                Some(s) => s,
+                None => continue,
+            };
+
+            let connector_url =
+                match get_connector_url_for_source(&self.redis_client, source.source_type).await {
+                    Some(url) => url,
+                    None => continue,
+                };
+
+            match self
+                .connector_client
+                .get_sync_status(&connector_url, &sync_run.id)
+                .await
+            {
+                Ok(status) if status.running => {
+                    // Connector still working on it; nothing to do.
+                }
+                Ok(_) => {
+                    warn!(
+                        "Connector reports sync {} no longer running; reconciling",
+                        sync_run.id
+                    );
+                    self.handle_lost_sync(&sync_run.id, &sync_run.source_id)
+                        .await;
+                }
+                Err(ClientError::ConnectorError { status: 404, .. }) => {
+                    // Connector hasn't implemented the status endpoint
+                    // (e.g., Rust connectors prior to follow-up PR).
+                    // Fall through to existing stale-detection.
+                }
+                Err(e) => {
+                    debug!(
+                        "Sync status probe failed for {} ({}): {}",
+                        sync_run.id, connector_url, e
+                    );
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    /// Reconcile a sync that the connector no longer knows about: mark it
+    /// failed and (subject to loop protection) trigger a fresh resume run.
+    async fn handle_lost_sync(&self, sync_run_id: &str, source_id: &str) {
+        let reason = "Connector no longer running this sync (likely restarted); auto-resuming";
+        if let Err(e) = self.mark_sync_failed(sync_run_id, reason).await {
+            error!("Failed to mark lost sync {} as failed: {}", sync_run_id, e);
+            return;
+        }
+
+        match self.recent_auto_resume_failures(source_id).await {
+            Ok(count) if count >= MAX_CONSECUTIVE_AUTO_RESUMES => {
+                warn!(
+                    "Source {} has {} consecutive auto-resume failures; not resuming again",
+                    source_id, count
+                );
+                return;
+            }
+            Ok(_) => {}
+            Err(e) => {
+                error!(
+                    "Failed to check auto-resume history for source {}: {}",
+                    source_id, e
+                );
+                return;
+            }
+        }
+
+        match self
+            .trigger_sync(source_id, SyncType::Incremental, TriggerType::AutoResume)
+            .await
+        {
+            Ok(new_run_id) => info!(
+                "Auto-resumed sync for source {} as {}",
+                source_id, new_run_id
+            ),
+            Err(e) => warn!("Failed to auto-resume sync for source {}: {}", source_id, e),
+        }
+    }
+
+    /// Count the previous consecutive runs (most-recent first) for `source_id`
+    /// that were both `auto_resume`-triggered and ended in the failed state.
+    /// Stops at the first run that breaks the streak.
+    async fn recent_auto_resume_failures(&self, source_id: &str) -> Result<usize, SyncError> {
+        let rows: Vec<(String, String)> = sqlx::query_as(
+            r#"
+            SELECT trigger_type, status::text
+            FROM sync_runs
+            WHERE source_id = $1
+              AND status IN ('failed', 'completed', 'cancelled')
+            ORDER BY created_at DESC
+            LIMIT $2
+            "#,
+        )
+        .bind(source_id)
+        .bind(MAX_CONSECUTIVE_AUTO_RESUMES as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+
+        let mut streak = 0usize;
+        for (trigger_type, status) in rows {
+            if trigger_type == TriggerType::AutoResume.to_string() && status == "failed" {
+                streak += 1;
+            } else {
+                break;
+            }
+        }
+        Ok(streak)
     }
 
     pub async fn detect_stale_syncs(&self) -> Result<Vec<String>, SyncError> {

--- a/services/connector-manager/tests/common/mock_connector.rs
+++ b/services/connector-manager/tests/common/mock_connector.rs
@@ -107,13 +107,11 @@ impl MockConnector {
         } else {
             false
         };
-        eprintln!("DEBUG stop: shutdown signal sent={}", sent);
         let handle = {
             let mut h = self.server_handle.lock().unwrap();
             std::mem::replace(&mut *h, tokio::spawn(async {}))
         };
         let res = tokio::time::timeout(Duration::from_secs(2), handle).await;
-        eprintln!("DEBUG stop: handle.await timed_out={}", res.is_err());
     }
 
     /// Kill and restart the HTTP server on the same port. In-memory state

--- a/services/connector-manager/tests/common/mock_connector.rs
+++ b/services/connector-manager/tests/common/mock_connector.rs
@@ -10,6 +10,7 @@ use serde_json::{json, Value as JsonValue};
 use std::collections::HashSet;
 use std::sync::{Arc, Mutex};
 use tokio::net::TcpListener;
+use tokio::sync::oneshot;
 use tokio::time::{sleep, Duration};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -49,6 +50,7 @@ pub struct MockConnector {
     active_syncs: Arc<Mutex<HashSet<String>>>,
     status_endpoint_enabled: Arc<Mutex<bool>>,
     server_handle: Mutex<tokio::task::JoinHandle<()>>,
+    shutdown_tx: Mutex<Option<oneshot::Sender<()>>>,
 }
 
 impl MockConnector {
@@ -64,8 +66,10 @@ impl MockConnector {
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let port = listener.local_addr()?.port();
 
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let server_handle = spawn_server(
             listener,
+            shutdown_rx,
             sync_requests.clone(),
             cancel_requests.clone(),
             sync_response_status.clone(),
@@ -86,7 +90,30 @@ impl MockConnector {
             active_syncs,
             status_endpoint_enabled,
             server_handle: Mutex::new(server_handle),
+            shutdown_tx: Mutex::new(Some(shutdown_tx)),
         })
+    }
+
+    /// Kill the HTTP server without restarting. Simulates a connector that
+    /// is down but whose registration is still live in Redis (i.e. within
+    /// the 90s TTL window). Probes will fail with connection-refused.
+    ///
+    /// Uses graceful_shutdown (not `abort()`) so axum actually closes
+    /// pooled keep-alive connections — otherwise reqwest's idle conn on the
+    /// caller side would happily roundtrip to still-alive handler tasks.
+    pub async fn stop(&self) {
+        let sent = if let Some(tx) = self.shutdown_tx.lock().unwrap().take() {
+            tx.send(()).is_ok()
+        } else {
+            false
+        };
+        eprintln!("DEBUG stop: shutdown signal sent={}", sent);
+        let handle = {
+            let mut h = self.server_handle.lock().unwrap();
+            std::mem::replace(&mut *h, tokio::spawn(async {}))
+        };
+        let res = tokio::time::timeout(Duration::from_secs(2), handle).await;
+        eprintln!("DEBUG stop: handle.await timed_out={}", res.is_err());
     }
 
     /// Kill and restart the HTTP server on the same port. In-memory state
@@ -94,7 +121,7 @@ impl MockConnector {
     /// loses on restart. Recorded history (`sync_requests`, `cancel_requests`)
     /// is preserved so tests can still inspect it.
     pub async fn restart(&self) -> anyhow::Result<()> {
-        self.server_handle.lock().unwrap().abort();
+        self.stop().await;
         self.active_syncs.lock().unwrap().clear();
 
         // Give the kernel a moment to release the port.
@@ -105,8 +132,10 @@ impl MockConnector {
             }
         };
 
+        let (shutdown_tx, shutdown_rx) = oneshot::channel();
         let new_handle = spawn_server(
             listener,
+            shutdown_rx,
             self.sync_requests.clone(),
             self.cancel_requests.clone(),
             self.sync_response_status.clone(),
@@ -115,6 +144,7 @@ impl MockConnector {
             self.status_endpoint_enabled.clone(),
         );
         *self.server_handle.lock().unwrap() = new_handle;
+        *self.shutdown_tx.lock().unwrap() = Some(shutdown_tx);
         sleep(Duration::from_millis(50)).await;
         Ok(())
     }
@@ -140,6 +170,7 @@ impl MockConnector {
 #[allow(clippy::too_many_arguments)]
 fn spawn_server(
     listener: TcpListener,
+    shutdown_rx: oneshot::Receiver<()>,
     sync_requests: Arc<Mutex<Vec<RecordedSyncRequest>>>,
     cancel_requests: Arc<Mutex<Vec<RecordedCancelRequest>>>,
     sync_response_status: Arc<Mutex<StatusCode>>,
@@ -175,7 +206,11 @@ fn spawn_server(
         .with_state(state);
 
     tokio::spawn(async move {
-        let _ = axum::serve(listener, app).await;
+        let _ = axum::serve(listener, app)
+            .with_graceful_shutdown(async move {
+                let _ = shutdown_rx.await;
+            })
+            .await;
     })
 }
 

--- a/services/connector-manager/tests/common/mock_connector.rs
+++ b/services/connector-manager/tests/common/mock_connector.rs
@@ -1,5 +1,5 @@
 use axum::{
-    extract::State,
+    extract::{Path, State},
     http::StatusCode,
     response::Json,
     routing::{get, post},
@@ -33,15 +33,22 @@ struct MockState {
     sync_response_status: Arc<Mutex<StatusCode>>,
     sync_response_body: Arc<Mutex<JsonValue>>,
     active_syncs: Arc<Mutex<HashSet<String>>>,
+    /// When false, `GET /sync/{id}` returns 404 — lets a test exercise the
+    /// "connector hasn't implemented the status endpoint" path (current
+    /// Rust connectors).
+    status_endpoint_enabled: Arc<Mutex<bool>>,
 }
 
 pub struct MockConnector {
     pub base_url: String,
+    port: u16,
     pub sync_requests: Arc<Mutex<Vec<RecordedSyncRequest>>>,
     pub cancel_requests: Arc<Mutex<Vec<RecordedCancelRequest>>>,
     sync_response_status: Arc<Mutex<StatusCode>>,
     sync_response_body: Arc<Mutex<JsonValue>>,
-    _server_handle: tokio::task::JoinHandle<()>,
+    active_syncs: Arc<Mutex<HashSet<String>>>,
+    status_endpoint_enabled: Arc<Mutex<bool>>,
+    server_handle: Mutex<tokio::task::JoinHandle<()>>,
 }
 
 impl MockConnector {
@@ -52,54 +59,73 @@ impl MockConnector {
         let sync_response_status = Arc::new(Mutex::new(StatusCode::OK));
         let sync_response_body = Arc::new(Mutex::new(json!({"status": "accepted"})));
         let active_syncs = Arc::new(Mutex::new(HashSet::new()));
-
-        let state = MockState {
-            sync_requests: sync_requests.clone(),
-            cancel_requests: cancel_requests.clone(),
-            sync_response_status: sync_response_status.clone(),
-            sync_response_body: sync_response_body.clone(),
-            active_syncs: active_syncs.clone(),
-        };
-
-        let app = Router::new()
-            .route("/health", get(health))
-            .route(
-                "/manifest",
-                get(|| async {
-                    Json(json!({
-                        "name": "mock-connector",
-                        "version": "1.0.0",
-                        "sync_modes": ["full", "incremental"],
-                        "actions": []
-                    }))
-                }),
-            )
-            .route("/sync", post(handle_sync))
-            .route("/cancel", post(handle_cancel))
-            .with_state(state);
+        let status_endpoint_enabled = Arc::new(Mutex::new(true));
 
         let listener = TcpListener::bind("127.0.0.1:0").await?;
         let port = listener.local_addr()?.port();
 
-        let server_handle = tokio::spawn(async move {
-            axum::serve(listener, app).await.unwrap();
-        });
+        let server_handle = spawn_server(
+            listener,
+            sync_requests.clone(),
+            cancel_requests.clone(),
+            sync_response_status.clone(),
+            sync_response_body.clone(),
+            active_syncs.clone(),
+            status_endpoint_enabled.clone(),
+        );
 
         sleep(Duration::from_millis(50)).await;
 
         Ok(Self {
             base_url: format!("http://127.0.0.1:{}", port),
+            port,
             sync_requests,
             cancel_requests,
             sync_response_status,
             sync_response_body,
-            _server_handle: server_handle,
+            active_syncs,
+            status_endpoint_enabled,
+            server_handle: Mutex::new(server_handle),
         })
+    }
+
+    /// Kill and restart the HTTP server on the same port. In-memory state
+    /// (`active_syncs`) is cleared — matching what a real connector process
+    /// loses on restart. Recorded history (`sync_requests`, `cancel_requests`)
+    /// is preserved so tests can still inspect it.
+    pub async fn restart(&self) -> anyhow::Result<()> {
+        self.server_handle.lock().unwrap().abort();
+        self.active_syncs.lock().unwrap().clear();
+
+        // Give the kernel a moment to release the port.
+        let listener = loop {
+            match TcpListener::bind(format!("127.0.0.1:{}", self.port)).await {
+                Ok(l) => break l,
+                Err(_) => sleep(Duration::from_millis(20)).await,
+            }
+        };
+
+        let new_handle = spawn_server(
+            listener,
+            self.sync_requests.clone(),
+            self.cancel_requests.clone(),
+            self.sync_response_status.clone(),
+            self.sync_response_body.clone(),
+            self.active_syncs.clone(),
+            self.status_endpoint_enabled.clone(),
+        );
+        *self.server_handle.lock().unwrap() = new_handle;
+        sleep(Duration::from_millis(50)).await;
+        Ok(())
     }
 
     pub fn set_sync_response(&self, status: StatusCode, body: JsonValue) {
         *self.sync_response_status.lock().unwrap() = status;
         *self.sync_response_body.lock().unwrap() = body;
+    }
+
+    pub fn set_status_endpoint_enabled(&self, enabled: bool) {
+        *self.status_endpoint_enabled.lock().unwrap() = enabled;
     }
 
     pub fn get_sync_requests(&self) -> Vec<RecordedSyncRequest> {
@@ -109,6 +135,48 @@ impl MockConnector {
     pub fn get_cancel_requests(&self) -> Vec<RecordedCancelRequest> {
         self.cancel_requests.lock().unwrap().clone()
     }
+}
+
+#[allow(clippy::too_many_arguments)]
+fn spawn_server(
+    listener: TcpListener,
+    sync_requests: Arc<Mutex<Vec<RecordedSyncRequest>>>,
+    cancel_requests: Arc<Mutex<Vec<RecordedCancelRequest>>>,
+    sync_response_status: Arc<Mutex<StatusCode>>,
+    sync_response_body: Arc<Mutex<JsonValue>>,
+    active_syncs: Arc<Mutex<HashSet<String>>>,
+    status_endpoint_enabled: Arc<Mutex<bool>>,
+) -> tokio::task::JoinHandle<()> {
+    let state = MockState {
+        sync_requests,
+        cancel_requests,
+        sync_response_status,
+        sync_response_body,
+        active_syncs,
+        status_endpoint_enabled,
+    };
+
+    let app = Router::new()
+        .route("/health", get(health))
+        .route(
+            "/manifest",
+            get(|| async {
+                Json(json!({
+                    "name": "mock-connector",
+                    "version": "1.0.0",
+                    "sync_modes": ["full", "incremental"],
+                    "actions": []
+                }))
+            }),
+        )
+        .route("/sync", post(handle_sync))
+        .route("/sync/:sync_run_id", get(handle_sync_status))
+        .route("/cancel", post(handle_cancel))
+        .with_state(state);
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    })
 }
 
 async fn health() -> StatusCode {
@@ -134,6 +202,26 @@ async fn handle_sync(
     let status = *state.sync_response_status.lock().unwrap();
     let body = state.sync_response_body.lock().unwrap().clone();
     (status, Json(body))
+}
+
+async fn handle_sync_status(
+    State(state): State<MockState>,
+    Path(sync_run_id): Path<String>,
+) -> (StatusCode, Json<JsonValue>) {
+    if !*state.status_endpoint_enabled.lock().unwrap() {
+        return (StatusCode::NOT_FOUND, Json(json!({"error": "not found"})));
+    }
+    let source_id = state
+        .sync_requests
+        .lock()
+        .unwrap()
+        .iter()
+        .find(|r| r.sync_run_id == sync_run_id)
+        .map(|r| r.source_id.clone());
+    let running = source_id
+        .map(|s| state.active_syncs.lock().unwrap().contains(&s))
+        .unwrap_or(false);
+    (StatusCode::OK, Json(json!({"running": running})))
 }
 
 async fn handle_cancel(

--- a/services/connector-manager/tests/integration_tests.rs
+++ b/services/connector-manager/tests/integration_tests.rs
@@ -651,7 +651,48 @@ async fn test_monitor_marks_failed_when_connector_unregistered() {
 }
 
 // ============================================================================
-// 13. test_source_cleanup — deleted source document + row cleanup
+// 13. test_monitor_treats_unreachable_connector_as_lost
+// ============================================================================
+#[tokio::test]
+async fn test_monitor_treats_unreachable_connector_as_lost() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+    let sync_run_repo = SyncRunRepository::new(pool);
+
+    let sync_run_id = trigger_sync(&server).await;
+
+    // Connector is down but its Redis registration is still present — the
+    // situation during the first 90s of a connector outage.
+    fixture.mock_connector.stop().await;
+
+    for _ in 0..4 {
+        fixture
+            .state
+            .sync_manager
+            .monitor_running_syncs()
+            .await
+            .unwrap();
+    }
+
+    let run = sync_run_repo
+        .find_by_id(&sync_run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, SyncStatus::Failed);
+    assert!(
+        run.error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("auto-resume gave up"),
+        "unexpected error: {:?}",
+        run.error_message
+    );
+}
+
+// ============================================================================
+// 14. test_source_cleanup — deleted source document + row cleanup
 // ============================================================================
 
 async fn seed_deleted_source_with_documents(

--- a/services/connector-manager/tests/integration_tests.rs
+++ b/services/connector-manager/tests/integration_tests.rs
@@ -449,7 +449,156 @@ async fn test_stale_sync_detection() {
 }
 
 // ============================================================================
-// 8. test_source_cleanup — deleted source document + row cleanup
+// 8. test_monitor_resumes_lost_sync — connector restart mid-sync
+// ============================================================================
+#[tokio::test]
+async fn test_monitor_resumes_lost_sync() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+    let sync_run_repo = SyncRunRepository::new(pool);
+
+    let sync_run_id = trigger_sync(&server).await;
+    assert_eq!(fixture.mock_connector.get_sync_requests().len(), 1);
+
+    // Simulate connector crash + restart: kills the HTTP server, rebinds on
+    // the same port, drops in-memory active_syncs. Recorded history is kept.
+    fixture.mock_connector.restart().await.unwrap();
+
+    fixture
+        .state
+        .sync_manager
+        .monitor_running_syncs()
+        .await
+        .unwrap();
+
+    // Existing row should still be running (not failed), and the connector
+    // should have received a second /sync for the same sync_run_id.
+    let run = sync_run_repo
+        .find_by_id(&sync_run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, SyncStatus::Running);
+
+    let requests = fixture.mock_connector.get_sync_requests();
+    assert_eq!(requests.len(), 2, "expected an auto-resume /sync call");
+    assert_eq!(requests[1].sync_run_id, sync_run_id);
+    assert_eq!(requests[1].source_id, TEST_SOURCE_ID);
+}
+
+// ============================================================================
+// 9. test_monitor_gives_up_after_max_resume_attempts
+// ============================================================================
+#[tokio::test]
+async fn test_monitor_gives_up_after_max_resume_attempts() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+    let sync_run_repo = SyncRunRepository::new(pool);
+
+    let sync_run_id = trigger_sync(&server).await;
+
+    // Each restart drops active_syncs, so every monitor pass sees
+    // running=false and attempts a resume. After 3 resumes, the 4th pass
+    // should mark the row failed.
+    for _ in 0..4 {
+        fixture.mock_connector.restart().await.unwrap();
+        fixture
+            .state
+            .sync_manager
+            .monitor_running_syncs()
+            .await
+            .unwrap();
+    }
+
+    let run = sync_run_repo
+        .find_by_id(&sync_run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, SyncStatus::Failed);
+    assert!(
+        run.error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("auto-resume gave up"),
+        "unexpected error message: {:?}",
+        run.error_message
+    );
+
+    // 3 successful resume attempts + 1 original trigger = 4 /sync calls.
+    let requests = fixture.mock_connector.get_sync_requests();
+    assert_eq!(requests.len(), 4);
+}
+
+// ============================================================================
+// 10. test_monitor_noop_when_connector_reports_running
+// ============================================================================
+#[tokio::test]
+async fn test_monitor_noop_when_connector_reports_running() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+    let sync_run_repo = SyncRunRepository::new(pool);
+
+    let sync_run_id = trigger_sync(&server).await;
+
+    fixture
+        .state
+        .sync_manager
+        .monitor_running_syncs()
+        .await
+        .unwrap();
+
+    let run = sync_run_repo
+        .find_by_id(&sync_run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, SyncStatus::Running);
+    assert_eq!(
+        fixture.mock_connector.get_sync_requests().len(),
+        1,
+        "monitor must not re-trigger when connector says sync is running"
+    );
+}
+
+// ============================================================================
+// 11. test_monitor_tolerates_404_status_endpoint
+// ============================================================================
+#[tokio::test]
+async fn test_monitor_tolerates_404_status_endpoint() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+    let sync_run_repo = SyncRunRepository::new(pool);
+
+    let sync_run_id = trigger_sync(&server).await;
+
+    // Simulates a connector that doesn't implement GET /sync/{id}
+    // (current Rust connectors). Monitor must treat 404 as a no-op and
+    // leave the row alone.
+    fixture.mock_connector.set_status_endpoint_enabled(false);
+
+    fixture
+        .state
+        .sync_manager
+        .monitor_running_syncs()
+        .await
+        .unwrap();
+
+    let run = sync_run_repo
+        .find_by_id(&sync_run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, SyncStatus::Running);
+    assert_eq!(fixture.mock_connector.get_sync_requests().len(), 1);
+}
+
+// ============================================================================
+// 12. test_source_cleanup — deleted source document + row cleanup
 // ============================================================================
 
 async fn seed_deleted_source_with_documents(

--- a/services/connector-manager/tests/integration_tests.rs
+++ b/services/connector-manager/tests/integration_tests.rs
@@ -4,6 +4,7 @@ use axum::http::StatusCode;
 use axum_test::{TestServer, TestServerConfig};
 use common::TEST_SOURCE_ID;
 use omni_connector_manager::source_cleanup::SourceCleanup;
+use redis::AsyncCommands;
 use serde_json::json;
 use shared::db::repositories::SyncRunRepository;
 use shared::models::{ConnectorEvent, DocumentMetadata, DocumentPermissions, SyncStatus};
@@ -598,7 +599,59 @@ async fn test_monitor_tolerates_404_status_endpoint() {
 }
 
 // ============================================================================
-// 12. test_source_cleanup — deleted source document + row cleanup
+// 12. test_monitor_marks_failed_when_connector_unregistered
+// ============================================================================
+#[tokio::test]
+async fn test_monitor_marks_failed_when_connector_unregistered() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+    let sync_run_repo = SyncRunRepository::new(pool);
+
+    let sync_run_id = trigger_sync(&server).await;
+
+    // Simulate the Redis registration TTL expiring: the connector has been
+    // down long enough that the manager no longer knows its URL.
+    let mut redis_conn = fixture
+        .state
+        .redis_client
+        .get_multiplexed_async_connection()
+        .await
+        .unwrap();
+    let _: () = redis_conn
+        .del("connector:manifest:filesystem")
+        .await
+        .unwrap();
+
+    // MAX_RESUME_ATTEMPTS = 3, so 4 monitor passes should exceed the cap
+    // and mark the row failed.
+    for _ in 0..4 {
+        fixture
+            .state
+            .sync_manager
+            .monitor_running_syncs()
+            .await
+            .unwrap();
+    }
+
+    let run = sync_run_repo
+        .find_by_id(&sync_run_id)
+        .await
+        .unwrap()
+        .unwrap();
+    assert_eq!(run.status, SyncStatus::Failed);
+    assert!(
+        run.error_message
+            .as_deref()
+            .unwrap_or("")
+            .contains("auto-resume gave up"),
+        "unexpected error: {:?}",
+        run.error_message
+    );
+}
+
+// ============================================================================
+// 13. test_source_cleanup — deleted source document + row cleanup
 // ============================================================================
 
 async fn seed_deleted_source_with_documents(


### PR DESCRIPTION
The connector manager now polls individual connectors to check liveness of a sync run. If a connector is no longer working on a given sync run, (e.g., after a connector restart), then the mgr will detect this and attempt to resume it from last checkpoint.