### PR TITLE
fix(indexer): cap process_batch to N iterations per call

### DIFF
--- a/services/indexer/src/queue_processor.rs
+++ b/services/indexer/src/queue_processor.rs
@@ -380,9 +380,15 @@ impl QueueProcessor {
     }
 
     async fn process_batch(&self) -> Result<()> {
+        // Cap iterations per invocation so a full queue cannot hold this future
+        // for arbitrarily long, which would starve every other branch of the
+        // main select! loop (GC, retry, stale-recovery, heartbeat). Subsequent
+        // calls are driven by check_interval and poll_interval in the main loop.
+        const MAX_BATCHES_PER_CALL: usize = 3;
+
         let mut total_processed = 0;
 
-        loop {
+        for _ in 0..MAX_BATCHES_PER_CALL {
             let events = self.event_queue.dequeue_batch(self.batch_size).await?;
 
             if events.is_empty() {
@@ -518,6 +524,14 @@ impl QueueProcessor {
                 }
             }
         }
+
+        if total_processed > 0 {
+            info!(
+                "Processed {} events this call (cap reached, continuing next tick)",
+                total_processed
+            );
+        }
+        Ok(())
     }
 
     async fn group_events_by_type(


### PR DESCRIPTION
Follow-up to #166 — the dedup + GC-spawn fixes landed cleanly (thanks @prvnsmpth for the fast merge!), but when verifying in production I noticed another branch of the same bug class: `process_batch` is still unbounded, and because it's awaited inline from the main `tokio::select!` loop, a large queue or sustained inflow starves every other branch — GC included.

## Repro

After restarting the indexer with the #166 fixes against a ~2.7M-event pending queue on our deployment:

- 10+ hours of operation
- Queue actively draining (`Batch processed 1000 documents successfully` logs appearing steadily)
- **Zero** `Queue stats`, `Starting content blob garbage collection`, `Retried N failed events`, or `Recovered N stale processing items` logs

The main select was never entered. Looking at `queue_processor.rs::start`:

```rust
// Process any existing events first
if let Err(e) = self.process_batch_safe().await {  // ← holds the future
    error!("Failed to process initial batch: {}", e);
}

loop {
    tokio::select! { ... }   // ← never reached under sustained load
}
```

And inside `process_batch`:

```rust
loop {
    let events = self.event_queue.dequeue_batch(self.batch_size).await?;
    if events.is_empty() { return Ok(()); }
    // ... process ...
}
```

With a deep queue and continuous inflow from active connectors, `dequeue_batch` never returns empty, so the outer `loop` never exits. The startup call blocks forever; subsequent calls from `check_interval` / `poll_interval` would block the same way once reached. Housekeeping silently stops.

## Fix

Cap `process_batch` at 3 batches per invocation. With the default `batch_size=1000` that's up to 3K events per call (~15–60s depending on DB latency). Subsequent calls are driven by the existing `check_interval` and `poll_interval` ticks, and `MAX_BATCHES_PER_CALL` is small enough that the main `select!` cycles every few seconds and fairly schedules GC, retry, stale-recovery, and heartbeat.

## Verified in prod

After deploying the patch:

```
11:20:39 Processed 3000 events this call (cap reached)
11:21:47 Processed 3000 events this call (cap reached)
11:22:49 Processed 3000 events this call (cap reached)
11:23:50 Processed 3000 events this call (cap reached)
11:23:51 Starting content blob garbage collection        ← GC fires!
11:23:56 Queue stats - Pending: ..., Processing: ..., ...  ← heartbeat fires!
```

Four iterations of the main loop in ~3 minutes, with GC and heartbeat both firing inside that window. Throughput drop from the cap is ~20% (≈50 events/sec vs ≈63/sec previously) in exchange for housekeeping that actually runs.

## Test plan

- [x] `cargo check -p shared -p omni-indexer` passes (rustc 1.91.1)
- [x] Deployed to production, confirmed GC + heartbeat + retry branches all fire
- [x] Drain continues at acceptable throughput (~50 events/sec sustained)
- [ ] Reviewer may want a test that exercises `process_batch` with a simulated large backlog

## Alternative considered

Spawning `process_batch` on its own tokio task (as #166 did for GC) would also work. I went with the capped-iteration approach because `process_batch` already serializes via `processing_mutex` and the main loop already has timer-driven branches that retrigger it — no extra infrastructure needed, just bound the existing loop.

## Tuning

`MAX_BATCHES_PER_CALL` is a `const` for now. Happy to make it configurable via env var if you'd prefer; I kept it simple since the only real constraint is "small enough to let select! breathe."

🤖 Generated with [Claude Code](https://claude.com/claude-code)