### PR TITLE
fix(gc): make mark_orphans predictable on large content_blobs tables

### DIFF
--- a/shared/src/db/repositories/content_blob.rs
+++ b/shared/src/db/repositories/content_blob.rs
@@ -34,25 +34,39 @@ impl ContentBlobRepository {
     /// Mark blobs as orphaned if they are not referenced by any document
     /// or any pending/processing queue event.
     /// Returns the number of blobs marked.
+    ///
+    /// Bounded to MARK_ORPHANS_BATCH rows per call: the previous unbounded
+    /// `NOT IN` anti-joins against the full `content_blobs` table materialized
+    /// hash tables over every row and took 30+ hours to complete on production
+    /// data (5M+ blobs). NOT EXISTS plus an explicit row cap lets the planner
+    /// use an indexed anti-join and keeps each GC pass predictable — the
+    /// remainder gets picked up on the next scheduled tick.
     pub async fn mark_orphans(&self) -> Result<i64, DatabaseError> {
+        const MARK_ORPHANS_BATCH: i64 = 100_000;
+
         let result = sqlx::query(
             r#"
+            WITH candidates AS (
+                SELECT cb.id
+                FROM content_blobs cb
+                WHERE cb.orphaned_at IS NULL
+                  AND NOT EXISTS (
+                      SELECT 1 FROM documents d WHERE d.content_id = cb.id
+                  )
+                  AND NOT EXISTS (
+                      SELECT 1 FROM connector_events_queue q
+                      WHERE q.status IN ('pending', 'processing')
+                        AND q.payload->>'content_id' = cb.id::text
+                  )
+                LIMIT $1
+            )
             UPDATE content_blobs cb
             SET orphaned_at = CURRENT_TIMESTAMP
-            WHERE cb.id NOT IN (
-                SELECT DISTINCT content_id
-                FROM documents
-                WHERE content_id IS NOT NULL
-            )
-            AND cb.id NOT IN (
-                SELECT DISTINCT payload->>'content_id'
-                FROM connector_events_queue
-                WHERE status IN ('pending', 'processing')
-                AND payload->>'content_id' IS NOT NULL
-            )
-            AND cb.orphaned_at IS NULL
+            FROM candidates
+            WHERE cb.id = candidates.id
             "#,
         )
+        .bind(MARK_ORPHANS_BATCH)
         .execute(&self.pool)
         .await?;
 
@@ -67,19 +81,16 @@ impl ContentBlobRepository {
             UPDATE content_blobs cb
             SET orphaned_at = NULL
             WHERE cb.orphaned_at IS NOT NULL
-            AND (
-                cb.id IN (
-                    SELECT DISTINCT content_id
-                    FROM documents
-                    WHERE content_id IS NOT NULL
-                )
-                OR cb.id IN (
-                    SELECT DISTINCT payload->>'content_id'
-                    FROM connector_events_queue
-                    WHERE status IN ('pending', 'processing')
-                    AND payload->>'content_id' IS NOT NULL
-                )
-            )
+              AND (
+                  EXISTS (
+                      SELECT 1 FROM documents d WHERE d.content_id = cb.id
+                  )
+                  OR EXISTS (
+                      SELECT 1 FROM connector_events_queue q
+                      WHERE q.status IN ('pending', 'processing')
+                        AND q.payload->>'content_id' = cb.id::text
+                  )
+              )
             "#,
         )
         .execute(&self.pool)


### PR DESCRIPTION
Follow-up to #166 / #170. The spawned-task + per-call cap design from those PRs keeps the indexer's main `select!` loop alive under load, but the GC task itself turned out to be effectively non-functional on our production dataset because `mark_orphans` never completed a single invocation.

## Repro & observation

Production instance: ~5M rows in `content_blobs`, ~90K distinct `content_id` references in `connector_events_queue`'s pending/processing payloads.

`ContentBlobRepository::mark_orphans` has the form:

```sql
UPDATE content_blobs cb
SET orphaned_at = CURRENT_TIMESTAMP
WHERE cb.id NOT IN (SELECT DISTINCT content_id FROM documents WHERE content_id IS NOT NULL)
  AND cb.id NOT IN (
      SELECT DISTINCT payload->>'content_id'
      FROM connector_events_queue
      WHERE status IN ('pending', 'processing')
        AND payload->>'content_id' IS NOT NULL
  )
  AND cb.orphaned_at IS NULL
```

`EXPLAIN` under our data:

```
Update on content_blobs cb  (cost=790663.34..1701688.35 rows=0 width=0)
  ->  Seq Scan on content_blobs cb  (cost=790663.34..1701688.35 rows=1323876 width=14)
        Filter: ((orphaned_at IS NULL) AND (NOT (ANY (id = ((hashed SubPlan 1).col1)::bpchar))) AND (NOT (ANY ((id)::text = (hashed SubPlan 2).col1))))
        SubPlan 1  ->  Unique on documents  (rows=145113)
        SubPlan 2  ->  Unique on connector_events_queue  (rows=89783)
  JIT: Functions: 22, Inlining true, Optimization true
```

Under concurrent writes this ran for **30+ hours without completing** (caught one still live after 38 hours in `pg_stat_activity`). Meanwhile its psql backend and parallel workers held ~1.2 GB RSS each, contributing to swap pressure on the host. Because #166 runs GC on a spawned task, the indexer's main loop stayed healthy — but no blobs ever got marked, so the delete-expired-orphans path had nothing to do and the table kept growing.

`unmark_non_orphans` has the mirror `IN` pattern; it's typically scoped to a much smaller set (only rows with `orphaned_at IS NOT NULL`), so it hasn't shown up as a production problem yet, but the same rewrite applies.

## Fix

Two changes to `mark_orphans`:

1. `NOT IN (SELECT DISTINCT ...)` → `NOT EXISTS (SELECT 1 ...)`. The planner can use the existing `idx_documents_content_id` and `idx_queue_payload_content_id` indexes for an anti-join instead of materializing hashed SubPlans over the entire outer set. Semantically equivalent; the only quirk NOT IN handles that NOT EXISTS doesn't is SQL NULL propagation, which isn't applicable here — `content_id IS NOT NULL` / `payload->>'content_id' IS NOT NULL` were already in the original predicates as anti-null guards.

2. `LIMIT 100_000` via a CTE + `UPDATE ... FROM candidates`. Caps a single invocation at a predictable amount of work. GC runs every 6 hours, so at 100K marks per pass a 5M backlog drains in ~13 days, while each individual pass finishes in seconds instead of days. Larger caps are fine too — 100K is a conservative default that leaves plenty of headroom for concurrent writers.

Applied the same `EXISTS` rewrite to `unmark_non_orphans` for consistency. It already filters on `orphaned_at IS NOT NULL` (a small set post-#166), so it doesn't strictly need a `LIMIT`; left unbounded for now.

## Test plan

- [x] `cargo check -p shared` passes (rustc 1.91.1)
- [x] `mark_orphans` rewritten query verified to complete in seconds on the same dataset that hung the old query for 30+ hours
- [x] Existing retention / delete path (`delete_expired_orphans`, `fetch_expired_orphans`) unchanged
- [ ] Reviewer may want a migration/test for the new query shape, or a larger-scale benchmark

## Suggested follow-ups

- `MARK_ORPHANS_BATCH` as a `const` for now; happy to make it env-configurable if you prefer.
- Longer-term the underlying growth rate is capped by #166 so this should only matter for one-time backfills of pre-existing duplicates; after that the per-tick 100K headroom is likely overkill.

🤖 Generated with [Claude Code](https://claude.com/claude-code)