### PR TITLE
Upgrade paradedb to 0.23.1

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -36,7 +36,7 @@ x-logging: &default-logging
 
 services:
   postgres:
-    image: paradedb/paradedb:0.20.6-pg17
+    image: paradedb/paradedb:0.23.1-pg17
     shm_size: 4gb
     container_name: omni-postgres
     command:

--- a/sdk/python/omni_connector/testing/harness.py
+++ b/sdk/python/omni_connector/testing/harness.py
@@ -17,7 +17,7 @@ from .seed import SeedHelper
 
 logger = logging.getLogger(__name__)
 
-PARADEDB_IMAGE = "paradedb/paradedb:0.20.6-pg17"
+PARADEDB_IMAGE = "paradedb/paradedb:0.23.1-pg17"
 POSTGRES_USER = "omni"
 POSTGRES_PASSWORD = "omni_password"
 POSTGRES_DB = "omni_test"

--- a/services/ai/tests/conftest.py
+++ b/services/ai/tests/conftest.py
@@ -74,7 +74,7 @@ def postgres_container():
     import time
 
     container = (
-        DockerContainer("paradedb/paradedb:0.20.6-pg17")
+        DockerContainer("paradedb/paradedb:0.23.1-pg17")
         .with_exposed_ports(5432)
         .with_env("POSTGRES_USER", "test")
         .with_env("POSTGRES_PASSWORD", "test")

--- a/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
+++ b/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
@@ -6,8 +6,21 @@
 -- Also switches the ICU tokenizer from ICU4C to the Rust-native icu_segmenter
 -- crate (changed in ParadeDB 0.22.0). REINDEX rebuilds all BM25 segments
 -- against the new tokenizer for consistent search results.
+--
+-- IMPORTANT: This migration must ship together with the Docker image bump
+-- to paradedb/paradedb:0.23.1-pg17. Running this migration on the old
+-- 0.20.6 image will fail because the 0.23.1 .so library won't be present.
 
 ALTER EXTENSION pg_search UPDATE TO '0.23.1';
 
--- Rebuild the BM25 index against the new tokenizer internals.
+-- Rebuild all BM25 indexes against the new extension internals.
+-- document_search_idx uses pdb.icu, whose tokenizer implementation switched
+-- from ICU4C to Rust-native icu_segmenter in 0.22.0 — rebuild is required.
+-- The other three indexes use tokenizers that haven't changed (pdb.simple,
+-- pdb.ngram, default) but are reindexed for consistency.
+-- Uses plain REINDEX (not CONCURRENTLY) because sqlx runs migrations in a
+-- transaction, and CONCURRENTLY cannot execute inside a transaction block.
 REINDEX INDEX document_search_idx;
+REINDEX INDEX people_search_idx;
+REINDEX INDEX chat_message_content_search_idx;
+REINDEX INDEX chat_title_search_idx;

--- a/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
+++ b/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
@@ -1,26 +1,60 @@
 -- Upgrade ParadeDB pg_search extension from 0.20.6 to 0.23.1.
 --
--- Fixes background merger bugs (segments not consolidating, deleted docs
--- accumulating) that cause query performance degradation (issue #209).
+-- Handles both fresh installs (extension already at 0.23.1 — no-op) and
+-- upgrades from 0.20.6 (ALTER EXTENSION + recreate ICU-backed index that
+-- the upgrade scripts drop).
 --
--- Also switches the ICU tokenizer from ICU4C to the Rust-native icu_segmenter
--- crate (changed in ParadeDB 0.22.0). REINDEX rebuilds all BM25 segments
--- against the new tokenizer for consistent search results.
---
--- IMPORTANT: This migration must ship together with the Docker image bump
--- to paradedb/paradedb:0.23.1-pg17. Running this migration on the old
--- 0.20.6 image will fail because the 0.23.1 .so library won't be present.
+-- 0.22.0 reimplemented the ICU tokenizer from ICU4C to Rust-native
+-- icu_segmenter, which invalidates any index using pdb.icu. Only
+-- document_search_idx is affected; the other three BM25 indexes survive.
 
-ALTER EXTENSION pg_search UPDATE TO '0.23.1';
+DO $$
+DECLARE
+    ext_ver TEXT;
+BEGIN
+    SELECT extversion INTO ext_ver FROM pg_extension WHERE extname = 'pg_search';
 
--- Rebuild all BM25 indexes against the new extension internals.
--- document_search_idx uses pdb.icu, whose tokenizer implementation switched
--- from ICU4C to Rust-native icu_segmenter in 0.22.0 — rebuild is required.
--- The other three indexes use tokenizers that haven't changed (pdb.simple,
--- pdb.ngram, default) but are reindexed for consistency.
--- Uses plain REINDEX (not CONCURRENTLY) because sqlx runs migrations in a
--- transaction, and CONCURRENTLY cannot execute inside a transaction block.
-REINDEX INDEX document_search_idx;
-REINDEX INDEX people_search_idx;
-REINDEX INDEX chat_message_content_search_idx;
-REINDEX INDEX chat_title_search_idx;
+    RAISE NOTICE 'pg_search current catalog version: %', ext_ver;
+
+    IF ext_ver = '0.23.1' THEN
+        RAISE NOTICE 'pg_search already at 0.23.1 — nothing to upgrade';
+        RETURN;
+    END IF;
+
+    IF ext_ver != '0.20.6' THEN
+        RAISE EXCEPTION 'pg_search at unexpected version %. Expected 0.20.6 or 0.23.1.',
+            ext_ver;
+    END IF;
+
+    -- Upgrade from 0.20.6
+    ALTER EXTENSION pg_search UPDATE TO '0.23.1';
+
+    -- Recreate the ICU-backed document index (dropped by the upgrade scripts)
+    CREATE INDEX document_search_idx ON documents
+    USING bm25 (
+        id,
+        (source_id::pdb.literal),
+        (external_id::pdb.literal),
+        (title::pdb.simple('ascii_folding=true')),
+        (title::pdb.source_code('alias=title_secondary', 'ascii_folding=true')),
+        (title::pdb.simple('alias=title_en', 'stemmer=english', 'ascii_folding=true')),
+        (content::pdb.icu('ascii_folding=true')),
+        (content::pdb.icu('alias=content_en', 'stemmer=english', 'ascii_folding=true')),
+        (content_type::pdb.literal),
+        file_size, file_extension, metadata, permissions, attributes, created_at, updated_at
+    )
+    WITH (
+        key_field = id,
+        background_layer_sizes = '100KB, 1MB, 10MB, 100MB, 1GB, 10GB',
+        target_segment_count = 2,
+        mutable_segment_rows = 5000
+    );
+
+    -- Rebuild surviving indexes for new tokenizer internals
+    REINDEX INDEX people_search_idx;
+    REINDEX INDEX chat_message_content_search_idx;
+    REINDEX INDEX chat_title_search_idx;
+
+    RAISE NOTICE 'pg_search upgraded to 0.23.1 — all BM25 indexes rebuilt';
+END;
+$$;

--- a/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
+++ b/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
@@ -1,0 +1,19 @@
+-- Upgrade ParadeDB pg_search extension from 0.20.6 to 0.23.1.
+--
+-- Fixes background merger bugs (segments not consolidating, deleted docs
+-- accumulating) that cause query performance degradation (issue #209).
+--
+-- Also switches the ICU tokenizer from ICU4C to the Rust-native icu_segmenter
+-- crate (changed in ParadeDB 0.22.0). REINDEX rebuilds all BM25 segments
+-- against the new tokenizer for consistent search results.
+--
+-- IMPORTANT: This migration must ship together with the Docker image bump
+-- to paradedb/paradedb:0.23.1-pg17. Running this migration on the old
+-- 0.20.6 image will fail because the 0.23.1 .so library won't be present.
+
+ALTER EXTENSION pg_search UPDATE TO '0.23.1';
+
+-- Rebuild the BM25 index against the new tokenizer internals.
+-- Uses plain REINDEX (not CONCURRENTLY) because sqlx runs migrations in a
+-- transaction, and CONCURRENTLY cannot execute inside a transaction block.
+REINDEX INDEX document_search_idx;

--- a/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
+++ b/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
@@ -56,5 +56,8 @@ BEGIN
     REINDEX INDEX chat_title_search_idx;
 
     RAISE NOTICE 'pg_search upgraded to 0.23.1 — all BM25 indexes rebuilt';
+
+    -- Silence collation version mismatch after OS/libc bump between images
+    EXECUTE format('ALTER DATABASE %I REFRESH COLLATION VERSION', current_database());
 END;
 $$;

--- a/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
+++ b/services/migrations/085_upgrade_paradedb_to_0.23.1.sql
@@ -6,14 +6,8 @@
 -- Also switches the ICU tokenizer from ICU4C to the Rust-native icu_segmenter
 -- crate (changed in ParadeDB 0.22.0). REINDEX rebuilds all BM25 segments
 -- against the new tokenizer for consistent search results.
---
--- IMPORTANT: This migration must ship together with the Docker image bump
--- to paradedb/paradedb:0.23.1-pg17. Running this migration on the old
--- 0.20.6 image will fail because the 0.23.1 .so library won't be present.
 
 ALTER EXTENSION pg_search UPDATE TO '0.23.1';
 
 -- Rebuild the BM25 index against the new tokenizer internals.
--- Uses plain REINDEX (not CONCURRENTLY) because sqlx runs migrations in a
--- transaction, and CONCURRENTLY cannot execute inside a transaction block.
 REINDEX INDEX document_search_idx;

--- a/shared/src/test_environment.rs
+++ b/shared/src/test_environment.rs
@@ -35,7 +35,7 @@ impl TestEnvironment {
         tracing_subscriber::fmt::try_init().ok();
 
         // Start PostgreSQL with pgvector and pg_bm25 extensions (ParadeDB image)
-        let postgres_image = GenericImage::new("paradedb/paradedb", "0.20.6-pg17")
+        let postgres_image = GenericImage::new("paradedb/paradedb", "0.23.1-pg17")
             .with_wait_for(WaitFor::message_on_stderr(
                 "database system is ready to accept connections",
             ))


### PR DESCRIPTION
- 0.22.6 (what we use currently) suffers from some issues with the background compaction that cause query performance to tank under a mixed insert/update/delete workload
- 0.23.1 appears to fix some of these issues, during indexing, search query perf still degrades but in steady state we achieve acceptable query latencies  