### PR TITLE
Support remote MCP servers

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4155,6 +4155,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.31.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+]
+
+[[package]]
 name = "no-std-compat"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4441,8 +4453,10 @@ dependencies = [
  "axum",
  "axum-test",
  "dashmap 6.1.0",
+ "http 1.4.0",
  "mime",
  "reqwest 0.12.28",
+ "rmcp",
  "serde",
  "serde_json",
  "shared",
@@ -4617,7 +4631,7 @@ dependencies = [
  "dotenvy",
  "landlock",
  "mime_guess",
- "nix",
+ "nix 0.29.0",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -5001,6 +5015,12 @@ name = "paste"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
 
 [[package]]
 name = "pathdiff"
@@ -5432,6 +5452,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "process-wrap"
+version = "9.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e842efad9119158434d193c6682e2ebee4b44d6ad801d7b349623b3f57cdf55"
+dependencies = [
+ "futures",
+ "indexmap 2.14.0",
+ "nix 0.31.2",
+ "tokio",
+ "tracing",
+ "windows",
 ]
 
 [[package]]
@@ -5971,6 +6005,7 @@ dependencies = [
  "rustls-pki-types",
  "rustls-platform-verifier",
  "serde",
+ "serde_json",
  "serde_urlencoded",
  "sync_wrapper 1.0.2",
  "tokio",
@@ -6034,6 +6069,46 @@ dependencies = [
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rmcp"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67d69668de0b0ccd9cc435f700f3b39a7861863cf37a15e1f304ea78688a4826"
+dependencies = [
+ "async-trait",
+ "base64 0.22.1",
+ "chrono",
+ "futures",
+ "http 1.4.0",
+ "pastey",
+ "pin-project-lite",
+ "process-wrap",
+ "reqwest 0.13.2",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "sse-stream",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48fdc01c81097b0aed18633e676e269fefa3a78ec1df56b4fe597c1241b92025"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
 ]
 
 [[package]]
@@ -6287,10 +6362,24 @@ version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
 dependencies = [
+ "chrono",
  "dyn-clone",
  "ref-cast",
+ "schemars_derive",
  "serde",
  "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
 ]
 
 [[package]]
@@ -6468,6 +6557,17 @@ name = "serde_derive"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -7185,6 +7285,19 @@ dependencies = [
  "tracing",
  "url",
  "uuid",
+]
+
+[[package]]
+name = "sse-stream"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c5e6deb40826033bd7b11c7ef25ef71193fabd71f680f40dd16538a2704d2f4"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "http-body 1.0.1",
+ "http-body-util",
+ "pin-project-lite",
 ]
 
 [[package]]

--- a/connectors/github/github_connector/connector.py
+++ b/connectors/github/github_connector/connector.py
@@ -5,8 +5,7 @@ from __future__ import annotations
 import logging
 from typing import TYPE_CHECKING, Any
 
-from mcp.client.stdio import StdioServerParameters
-from omni_connector import Connector, SearchOperator, SyncContext
+from omni_connector import Connector, SearchOperator, StdioMcpServer, SyncContext
 
 from .client import AuthenticationError, GitHubClient, GitHubError, GitHubRepo
 from .models import GitHubCredentials, GitHubSourceConfig
@@ -69,8 +68,8 @@ class GitHubConnector(Connector):
         ]
 
     @property
-    def mcp_command(self) -> StdioServerParameters:
-        return StdioServerParameters(
+    def mcp_server(self) -> StdioMcpServer:
+        return StdioMcpServer(
             command="github-mcp-server",
             args=["stdio", "--toolsets", "all"],
         )

--- a/sdk/python/omni_connector/__init__.py
+++ b/sdk/python/omni_connector/__init__.py
@@ -7,6 +7,7 @@ from .exceptions import (
     SdkClientError,
     SyncCancelledError,
 )
+from .mcp_adapter import HttpMcpServer, McpServer, StdioMcpServer
 from .models import (
     ActionDefinition,
     ActionRequest,
@@ -61,6 +62,10 @@ __all__ = [
     "UserFilterMode",
     "CancelRequest",
     "CancelResponse",
+    # MCP server config
+    "McpServer",
+    "StdioMcpServer",
+    "HttpMcpServer",
     # MCP models
     "McpResourceDefinition",
     "McpPromptDefinition",

--- a/sdk/python/omni_connector/connector.py
+++ b/sdk/python/omni_connector/connector.py
@@ -4,6 +4,8 @@ import logging
 from abc import ABC, abstractmethod
 from typing import TYPE_CHECKING, Any
 
+from fastapi.responses import JSONResponse
+
 from .context import SyncContext
 from .models import (
     ActionDefinition,
@@ -13,11 +15,7 @@ from .models import (
 )
 
 if TYPE_CHECKING:
-    from mcp.client.stdio import StdioServerParameters
-
-    from fastapi.responses import JSONResponse
-
-    from .mcp_adapter import McpAdapter
+    from .mcp_adapter import McpAdapter, McpServer
 
 logger = logging.getLogger(__name__)
 
@@ -73,21 +71,28 @@ class Connector(ABC):
         return []
 
     @property
-    def mcp_command(self) -> StdioServerParameters | None:
-        """Return stdio params for an external MCP server binary.
+    def mcp_server(self) -> McpServer | None:
+        """Return MCP server config (stdio or Streamable HTTP).
 
-        Override this property to enable MCP support. The SDK will spawn the
-        server as a subprocess, communicate via stdio transport, and expose
-        its tools, resources, and prompts through the Omni protocol.
+        Override this property to enable MCP support. Return either a
+        ``StdioMcpServer`` to spawn a local subprocess MCP server, or an
+        ``HttpMcpServer`` to connect to a remote one. The SDK exposes the
+        server's tools, resources, and prompts through the Omni protocol.
 
-        Example::
+        Examples::
+
+            from omni_connector import StdioMcpServer, HttpMcpServer
 
             @property
-            def mcp_command(self):
-                return StdioServerParameters(
+            def mcp_server(self):
+                return StdioMcpServer(
                     command="github-mcp-server",
                     args=["stdio"],
                 )
+
+            @property
+            def mcp_server(self):
+                return HttpMcpServer(url="https://api.example.com/mcp")
         """
         return None
 
@@ -95,32 +100,43 @@ class Connector(ABC):
     def mcp_adapter(self) -> McpAdapter | None:
         if self._mcp_adapter is not None:
             return self._mcp_adapter
-        params = self.mcp_command
-        if params is None:
+        server = self.mcp_server
+        if server is None:
             return None
         from .mcp_adapter import McpAdapter
 
-        self._mcp_adapter = McpAdapter(params)
+        self._mcp_adapter = McpAdapter(server)
         return self._mcp_adapter
+
+    def _prepare_mcp_auth(self, credentials: dict[str, Any]) -> dict[str, Any]:
+        """Build the env-or-headers kwargs to pass to the MCP adapter.
+
+        Dispatches based on the configured transport: stdio servers receive
+        ``env=...`` (from ``prepare_mcp_env``); HTTP servers receive
+        ``headers=...`` (from ``prepare_mcp_headers``).
+        """
+        from .mcp_adapter import HttpMcpServer
+
+        server = self.mcp_server
+        if isinstance(server, HttpMcpServer):
+            return {"headers": self.prepare_mcp_headers(credentials)}
+        return {"env": self.prepare_mcp_env(credentials)}
 
     async def bootstrap_mcp(self, credentials: dict[str, Any]) -> None:
         """Discover MCP tools/resources/prompts and cache them.
 
         Called when credentials first become available (e.g., during initial sync).
-        Spawns a temporary subprocess, introspects it, caches the results, then
+        Opens a temporary session, introspects it, caches the results, then
         shuts down. Subsequent manifest builds use the cache.
         """
         adapter = self.mcp_adapter
         if adapter is None:
             logger.debug("bootstrap_mcp: no MCP adapter, skipping")
             return
-        env = self.prepare_mcp_env(credentials)
-        logger.info(
-            "Bootstrapping MCP: discovering tools (env keys: %s)",
-            sorted(env.keys()) if env else [],
-        )
+        auth = self._prepare_mcp_auth(credentials)
+        logger.info("Bootstrapping MCP: discovering tools")
         try:
-            await adapter.discover(env)
+            await adapter.discover(**auth)
         except Exception:
             logger.warning("MCP bootstrap failed", exc_info=True)
 
@@ -201,15 +217,30 @@ class Connector(ABC):
         return True
 
     def prepare_mcp_env(self, credentials: dict[str, Any]) -> dict[str, str]:
-        """Return env vars for the MCP subprocess given Omni credentials.
+        """Return env vars for a stdio MCP subprocess given Omni credentials.
 
         Override this to bridge Omni credentials to the env vars your MCP
-        server expects. The returned dict is merged into the subprocess env.
+        server expects. Used only when ``mcp_server`` returns a
+        ``StdioMcpServer``. The returned dict is merged into the subprocess env.
 
         Example::
 
             def prepare_mcp_env(self, credentials):
                 return {"GITHUB_PERSONAL_ACCESS_TOKEN": credentials["token"]}
+        """
+        return {}
+
+    def prepare_mcp_headers(self, credentials: dict[str, Any]) -> dict[str, str]:
+        """Return HTTP headers for a remote MCP server given Omni credentials.
+
+        Override this to inject auth headers (e.g., ``Authorization: Bearer ...``)
+        into Streamable HTTP requests. Used only when ``mcp_server`` returns
+        an ``HttpMcpServer``.
+
+        Example::
+
+            def prepare_mcp_headers(self, credentials):
+                return {"Authorization": f"Bearer {credentials['token']}"}
         """
         return {}
 
@@ -222,10 +253,12 @@ class Connector(ABC):
 
         adapter = self.mcp_adapter
         if adapter is not None:
-            env = self.prepare_mcp_env(credentials)
-            mcp_tool_names = {a.name for a in await adapter.get_action_definitions(env)}
+            auth = self._prepare_mcp_auth(credentials)
+            mcp_tool_names = {
+                a.name for a in await adapter.get_action_definitions(**auth)
+            }
             if action in mcp_tool_names:
-                response = await adapter.execute_tool(action, params, env)
+                response = await adapter.execute_tool(action, params, **auth)
                 return JSONResponse(content=response.model_dump())
         return ActionResponse.not_supported(action).to_response(status_code=404)
 

--- a/sdk/python/omni_connector/mcp_adapter.py
+++ b/sdk/python/omni_connector/mcp_adapter.py
@@ -1,7 +1,10 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+from datetime import timedelta
+from typing import Any, AsyncIterator, Union
 
 from mcp.client.session import ClientSession
 from mcp.client.stdio import StdioServerParameters, stdio_client
@@ -17,53 +20,108 @@ from .models import (
 logger = logging.getLogger(__name__)
 
 
+@dataclass(frozen=True)
+class StdioMcpServer:
+    """Configuration for an MCP server reached via stdio (subprocess)."""
+
+    command: str
+    args: list[str] = field(default_factory=list)
+    env: dict[str, str] | None = None
+    cwd: str | None = None
+
+
+@dataclass(frozen=True)
+class HttpMcpServer:
+    """Configuration for a remote MCP server reached via Streamable HTTP."""
+
+    url: str
+    headers: dict[str, str] = field(default_factory=dict)
+    timeout_seconds: float = 30.0
+    sse_read_timeout_seconds: float = 300.0
+
+
+McpServer = Union[StdioMcpServer, HttpMcpServer]
+
+
 class McpAdapter:
-    """Bridges an external MCP server (subprocess) into Omni's connector protocol.
+    """Bridges an external MCP server into Omni's connector protocol.
 
-    Spawns the MCP server as a subprocess, communicates via stdio transport
-    (newline-delimited JSON-RPC over stdin/stdout). Works with MCP servers
-    written in any language.
+    Supports two transports:
+    - stdio: spawns the MCP server as a subprocess and talks JSON-RPC over
+      stdin/stdout. Works with MCP servers written in any language.
+    - Streamable HTTP: connects to a remote MCP endpoint per the MCP spec.
 
-    Each operation starts a fresh subprocess and tears it down afterwards.
+    Each operation opens a fresh session and tears it down afterwards.
     Tool/resource/prompt definitions are cached after the first successful
-    discovery so that manifest builds don't require a running subprocess.
+    discovery so that manifest builds don't require live auth.
     """
 
-    def __init__(self, server_params: StdioServerParameters) -> None:
-        self._base_params = server_params
-        # Cache discovered definitions so manifest builds work without credentials
+    def __init__(self, server: McpServer) -> None:
+        self._server = server
         self._cached_actions: list[ActionDefinition] | None = None
         self._cached_resources: list[McpResourceDefinition] | None = None
         self._cached_prompts: list[McpPromptDefinition] | None = None
 
-    def _make_params(self, env: dict[str, str] | None = None) -> StdioServerParameters:
-        merged_env = {**(self._base_params.env or {}), **(env or {})}
-        return StdioServerParameters(
-            command=self._base_params.command,
-            args=self._base_params.args,
-            env=merged_env or None,
-            cwd=self._base_params.cwd,
-        )
+    @asynccontextmanager
+    async def _open_session(
+        self,
+        env: dict[str, str] | None,
+        headers: dict[str, str] | None,
+    ) -> AsyncIterator[ClientSession]:
+        if isinstance(self._server, StdioMcpServer):
+            merged_env = {**(self._server.env or {}), **(env or {})}
+            params = StdioServerParameters(
+                command=self._server.command,
+                args=list(self._server.args),
+                env=merged_env or None,
+                cwd=self._server.cwd,
+            )
+            logger.debug(
+                "Spawning MCP subprocess: %s %s (env keys: %s)",
+                params.command,
+                " ".join(params.args),
+                sorted(merged_env.keys()),
+            )
+            async with stdio_client(params) as (read_stream, write_stream):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    yield session
+        else:
+            from mcp.client.streamable_http import streamablehttp_client
 
-    async def _run(self, env: dict[str, str] | None, callback):
-        """Spawn subprocess, run callback with a live session, then shut down."""
-        params = self._make_params(env)
-        env_keys = sorted(params.env.keys()) if params.env else []
-        logger.debug(
-            "Spawning MCP subprocess: %s %s (env keys: %s)",
-            params.command,
-            " ".join(params.args),
-            env_keys,
-        )
-        async with stdio_client(params) as (read_stream, write_stream):
-            async with ClientSession(read_stream, write_stream) as session:
-                await session.initialize()
-                logger.debug("MCP session initialized, running callback")
-                result = await callback(session)
-                logger.debug("MCP callback complete, shutting down subprocess")
-                return result
+            merged_headers = {**self._server.headers, **(headers or {})}
+            logger.debug(
+                "Opening MCP HTTP session: %s (header keys: %s)",
+                self._server.url,
+                sorted(merged_headers.keys()),
+            )
+            async with streamablehttp_client(
+                self._server.url,
+                headers=merged_headers or None,
+                timeout=timedelta(seconds=self._server.timeout_seconds),
+                sse_read_timeout=timedelta(
+                    seconds=self._server.sse_read_timeout_seconds
+                ),
+            ) as (read_stream, write_stream, _get_session_id):
+                async with ClientSession(read_stream, write_stream) as session:
+                    await session.initialize()
+                    yield session
 
-    async def discover(self, env: dict[str, str] | None = None) -> None:
+    async def _run(
+        self,
+        callback,
+        *,
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ):
+        async with self._open_session(env, headers) as session:
+            return await callback(session)
+
+    async def discover(
+        self,
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
+    ) -> None:
         """Connect to MCP server, discover tools/resources/prompts, cache them."""
 
         async def _discover(session: ClientSession) -> None:
@@ -71,7 +129,7 @@ class McpAdapter:
             self._cached_resources = await self._fetch_resources(session)
             self._cached_prompts = await self._fetch_prompts(session)
 
-        await self._run(env, _discover)
+        await self._run(_discover, env=env, headers=headers)
         logger.info(
             "MCP discovery complete: %d tools, %d resources, %d prompts",
             len(self._cached_actions or []),
@@ -80,9 +138,11 @@ class McpAdapter:
         )
 
     async def get_action_definitions(
-        self, env: dict[str, str] | None = None
+        self,
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[ActionDefinition]:
-        if env is not None:
+        if env is not None or headers is not None:
             try:
 
                 async def _fetch(session):
@@ -91,7 +151,7 @@ class McpAdapter:
                     logger.debug("Fetched %d action definitions (live)", len(actions))
                     return actions
 
-                return await self._run(env, _fetch)
+                return await self._run(_fetch, env=env, headers=headers)
             except Exception:
                 if self._cached_actions is not None:
                     logger.debug(
@@ -101,15 +161,17 @@ class McpAdapter:
                     return self._cached_actions
                 raise
         logger.debug(
-            "No env provided, returning %d cached actions",
+            "No auth provided, returning %d cached actions",
             len(self._cached_actions or []),
         )
         return self._cached_actions or []
 
     async def get_resource_definitions(
-        self, env: dict[str, str] | None = None
+        self,
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[McpResourceDefinition]:
-        if env is not None:
+        if env is not None or headers is not None:
             try:
 
                 async def _fetch(session):
@@ -117,7 +179,7 @@ class McpAdapter:
                     self._cached_resources = resources
                     return resources
 
-                return await self._run(env, _fetch)
+                return await self._run(_fetch, env=env, headers=headers)
             except Exception:
                 if self._cached_resources is not None:
                     return self._cached_resources
@@ -125,9 +187,11 @@ class McpAdapter:
         return self._cached_resources or []
 
     async def get_prompt_definitions(
-        self, env: dict[str, str] | None = None
+        self,
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> list[McpPromptDefinition]:
-        if env is not None:
+        if env is not None or headers is not None:
             try:
 
                 async def _fetch(session):
@@ -135,7 +199,7 @@ class McpAdapter:
                     self._cached_prompts = prompts
                     return prompts
 
-                return await self._run(env, _fetch)
+                return await self._run(_fetch, env=env, headers=headers)
             except Exception:
                 if self._cached_prompts is not None:
                     return self._cached_prompts
@@ -143,7 +207,11 @@ class McpAdapter:
         return self._cached_prompts or []
 
     async def execute_tool(
-        self, name: str, arguments: dict[str, Any], env: dict[str, str] | None = None
+        self,
+        name: str,
+        arguments: dict[str, Any],
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> ActionResponse:
         try:
 
@@ -162,13 +230,16 @@ class McpAdapter:
                     return ActionResponse.failure(content)
                 return ActionResponse.success({"content": content})
 
-            return await self._run(env, _call)
+            return await self._run(_call, env=env, headers=headers)
         except Exception as e:
             logger.error("MCP tool %s failed: %s", name, e)
             return ActionResponse.failure(str(e))
 
     async def read_resource(
-        self, uri: str, env: dict[str, str] | None = None
+        self,
+        uri: str,
+        env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         async def _read(session: ClientSession) -> dict[str, Any]:
             result = await session.read_resource(uri)
@@ -182,13 +253,14 @@ class McpAdapter:
                 items.append(entry)
             return {"contents": items}
 
-        return await self._run(env, _read)
+        return await self._run(_read, env=env, headers=headers)
 
     async def get_prompt(
         self,
         name: str,
         arguments: dict[str, Any] | None = None,
         env: dict[str, str] | None = None,
+        headers: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         async def _get(session: ClientSession) -> dict[str, Any]:
             result = await session.get_prompt(name, arguments)
@@ -202,7 +274,7 @@ class McpAdapter:
                 messages.append({"role": msg.role, "content": content_data})
             return {"description": result.description, "messages": messages}
 
-        return await self._run(env, _get)
+        return await self._run(_get, env=env, headers=headers)
 
     # -- internal helpers to convert MCP types to Omni models --
 

--- a/sdk/python/omni_connector/server.py
+++ b/sdk/python/omni_connector/server.py
@@ -237,8 +237,8 @@ def create_app(connector: "Connector") -> FastAPI:
             )
         logger.info("Resource requested: %s", request.uri)
         try:
-            env = connector.prepare_mcp_env(request.credentials)
-            result = await adapter.read_resource(request.uri, env=env)
+            auth = connector._prepare_mcp_auth(request.credentials)
+            result = await adapter.read_resource(request.uri, **auth)
             return JSONResponse(status_code=status.HTTP_200_OK, content=result)
         except Exception as e:
             logger.error("Resource read failed for %s: %s", request.uri, e)
@@ -257,8 +257,8 @@ def create_app(connector: "Connector") -> FastAPI:
             )
         logger.info("Prompt requested: %s", request.name)
         try:
-            env = connector.prepare_mcp_env(request.credentials)
-            result = await adapter.get_prompt(request.name, request.arguments, env=env)
+            auth = connector._prepare_mcp_auth(request.credentials)
+            result = await adapter.get_prompt(request.name, request.arguments, **auth)
             return JSONResponse(status_code=status.HTTP_200_OK, content=result)
         except Exception as e:
             logger.error("Prompt get failed for %s: %s", request.name, e)

--- a/sdk/python/tests/test_mcp_adapter.py
+++ b/sdk/python/tests/test_mcp_adapter.py
@@ -1,29 +1,72 @@
-"""Tests for the MCP adapter (stdio transport)."""
+"""Tests for the MCP adapter (stdio + Streamable HTTP transports)."""
 
+import asyncio
 import os
+import socket
+import subprocess
 import sys
 from typing import Any
 
+import httpx
 import pytest
-from mcp.client.stdio import StdioServerParameters
 
-from omni_connector import Connector
+from omni_connector import Connector, HttpMcpServer, StdioMcpServer
 from omni_connector.mcp_adapter import McpAdapter
 
-# Path to the test MCP server script
+# Path to the test MCP server script (supports both stdio and http modes)
 TEST_SERVER = os.path.join(os.path.dirname(__file__), "test_mcp_server.py")
-TEST_PARAMS = StdioServerParameters(command=sys.executable, args=[TEST_SERVER])
+TEST_STDIO_SERVER = StdioMcpServer(command=sys.executable, args=[TEST_SERVER])
 # Dummy env to simulate having credentials (test server doesn't need real ones)
 TEST_ENV: dict[str, str] = {"TEST_MODE": "1"}
 
 
-class TestMcpAdapter:
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@pytest.fixture
+async def http_server_url():
+    """Spawn the test MCP server in Streamable HTTP mode on a random port."""
+    port = _free_port()
+    proc = subprocess.Popen(
+        [sys.executable, TEST_SERVER, "http", str(port)],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    url = f"http://127.0.0.1:{port}/mcp"
+
+    async def wait_ready():
+        async with httpx.AsyncClient() as client:
+            for _ in range(80):
+                try:
+                    # 4xx response means the server is up; the MCP endpoint
+                    # rejects bare GETs but a TCP-level reply is enough.
+                    await client.get(url, timeout=0.5)
+                    return
+                except (httpx.ConnectError, httpx.ReadError):
+                    await asyncio.sleep(0.1)
+        raise RuntimeError(f"HTTP MCP fixture did not start on {url}")
+
+    try:
+        await wait_ready()
+        yield url
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+
+
+class TestStdioAdapter:
     @pytest.fixture
     def adapter(self):
-        return McpAdapter(TEST_PARAMS)
+        return McpAdapter(TEST_STDIO_SERVER)
 
     async def test_get_action_definitions(self, adapter: McpAdapter):
-        actions = await adapter.get_action_definitions(TEST_ENV)
+        actions = await adapter.get_action_definitions(env=TEST_ENV)
         assert len(actions) == 2
         names = {a.name for a in actions}
         assert names == {"greet", "add"}
@@ -41,13 +84,13 @@ class TestMcpAdapter:
         assert add_action.mode == "write"
 
     async def test_get_resource_definitions(self, adapter: McpAdapter):
-        resources = await adapter.get_resource_definitions(TEST_ENV)
+        resources = await adapter.get_resource_definitions(env=TEST_ENV)
         assert len(resources) == 1
         assert resources[0].name == "get_item"
         assert resources[0].uri_template == "test://item/{item_id}"
 
     async def test_get_prompt_definitions(self, adapter: McpAdapter):
-        prompts = await adapter.get_prompt_definitions(TEST_ENV)
+        prompts = await adapter.get_prompt_definitions(env=TEST_ENV)
         assert len(prompts) == 1
         assert prompts[0].name == "summarize"
         assert prompts[0].description == "Summarize the given text."
@@ -82,9 +125,8 @@ class TestMcpAdapter:
         assert "hello world" in msg["content"]["text"]
 
     async def test_discover_caches_definitions(self, adapter: McpAdapter):
-        """discover() populates cache, then no-env calls return cached data."""
-        await adapter.discover(TEST_ENV)
-        # No env — returns from cache
+        """discover() populates cache, then no-auth calls return cached data."""
+        await adapter.discover(env=TEST_ENV)
         actions = await adapter.get_action_definitions()
         assert len(actions) == 2
         resources = await adapter.get_resource_definitions()
@@ -92,37 +134,88 @@ class TestMcpAdapter:
         prompts = await adapter.get_prompt_definitions()
         assert len(prompts) == 1
 
-    async def test_no_env_no_cache_returns_empty(self, adapter: McpAdapter):
-        """Without env and without cache, returns empty lists."""
+    async def test_no_auth_no_cache_returns_empty(self, adapter: McpAdapter):
+        """Without auth and without cache, returns empty lists."""
         assert await adapter.get_action_definitions() == []
         assert await adapter.get_resource_definitions() == []
         assert await adapter.get_prompt_definitions() == []
 
     async def test_cache_survives_connection_failure(self):
         """After successful discovery, cache is returned if subprocess can't start."""
-        adapter = McpAdapter(TEST_PARAMS)
-        await adapter.discover(TEST_ENV)
+        adapter = McpAdapter(TEST_STDIO_SERVER)
+        await adapter.discover(env=TEST_ENV)
         assert len(adapter._cached_actions or []) == 2
 
         # Replace command with something that will fail
-        adapter._base_params = StdioServerParameters(
-            command="nonexistent-binary", args=[]
-        )
-        # Should return cached actions instead of raising
-        cached = await adapter.get_action_definitions(TEST_ENV)
+        adapter._server = StdioMcpServer(command="nonexistent-binary", args=[])
+        cached = await adapter.get_action_definitions(env=TEST_ENV)
         assert len(cached) == 2
         assert {a.name for a in cached} == {"greet", "add"}
 
 
+class TestHttpAdapter:
+    """Streamable HTTP transport against the same fixture server."""
+
+    async def test_get_action_definitions(self, http_server_url: str):
+        adapter = McpAdapter(HttpMcpServer(url=http_server_url))
+        actions = await adapter.get_action_definitions(headers={"X-Test": "1"})
+        names = {a.name for a in actions}
+        assert names == {"greet", "add"}
+
+    async def test_execute_tool(self, http_server_url: str):
+        adapter = McpAdapter(HttpMcpServer(url=http_server_url))
+        result = await adapter.execute_tool(
+            "greet", {"name": "Remote"}, headers={"X-Test": "1"}
+        )
+        assert result.status == "success"
+        assert result.result is not None
+        assert "Hello, Remote!" in result.result.get("content", "")
+
+    async def test_read_resource(self, http_server_url: str):
+        adapter = McpAdapter(HttpMcpServer(url=http_server_url))
+        result = await adapter.read_resource("test://item/99", headers={"X-Test": "1"})
+        assert "contents" in result and len(result["contents"]) >= 1
+
+    async def test_get_prompt(self, http_server_url: str):
+        adapter = McpAdapter(HttpMcpServer(url=http_server_url))
+        result = await adapter.get_prompt(
+            "summarize", {"text": "remote text"}, headers={"X-Test": "1"}
+        )
+        assert "messages" in result and len(result["messages"]) >= 1
+
+    async def test_discover_caches_definitions(self, http_server_url: str):
+        adapter = McpAdapter(HttpMcpServer(url=http_server_url))
+        await adapter.discover(headers={"X-Test": "1"})
+        # No headers — returns cache
+        assert {a.name for a in await adapter.get_action_definitions()} == {
+            "greet",
+            "add",
+        }
+        assert len(await adapter.get_resource_definitions()) == 1
+        assert len(await adapter.get_prompt_definitions()) == 1
+
+    async def test_static_headers_merged_with_per_call_headers(
+        self, http_server_url: str
+    ):
+        """Static headers on HttpMcpServer + per-call headers both reach the server."""
+        adapter = McpAdapter(
+            HttpMcpServer(url=http_server_url, headers={"X-Static": "yes"})
+        )
+        # No assertion on headers here (the test fixture doesn't expose them);
+        # we just ensure the call succeeds with both sets configured.
+        actions = await adapter.get_action_definitions(headers={"X-Per-Call": "yes"})
+        assert len(actions) == 2
+
+
 class TestConnectorMcpIntegration:
-    """Test that a Connector with an MCP command properly delegates."""
+    """A Connector with an MCP server config delegates correctly."""
 
     @pytest.fixture
-    def mcp_connector(self) -> Connector:
-        class McpTestConnector(Connector):
+    def stdio_connector(self) -> Connector:
+        class StdioMcpConnector(Connector):
             @property
             def name(self) -> str:
-                return "mcp-test"
+                return "mcp-test-stdio"
 
             @property
             def version(self) -> str:
@@ -133,8 +226,8 @@ class TestConnectorMcpIntegration:
                 return ["mcp_test"]
 
             @property
-            def mcp_command(self) -> StdioServerParameters:
-                return TEST_PARAMS
+            def mcp_server(self) -> StdioMcpServer:
+                return TEST_STDIO_SERVER
 
             async def sync(
                 self,
@@ -145,41 +238,78 @@ class TestConnectorMcpIntegration:
             ) -> None:
                 pass
 
-        return McpTestConnector()
+        return StdioMcpConnector()
 
     async def test_manifest_includes_mcp_tools_as_actions(
-        self, mcp_connector: Connector
+        self, stdio_connector: Connector
     ):
-        await mcp_connector.bootstrap_mcp({"token": "test"})
-        manifest = await mcp_connector.get_manifest(connector_url="http://test:8000")
+        await stdio_connector.bootstrap_mcp({"token": "test"})
+        manifest = await stdio_connector.get_manifest(connector_url="http://test:8000")
         assert manifest.mcp_enabled is True
         action_names = {a.name for a in manifest.actions}
         assert "greet" in action_names
         assert "add" in action_names
 
-    async def test_manifest_includes_resources(self, mcp_connector: Connector):
-        await mcp_connector.bootstrap_mcp({"token": "test"})
-        manifest = await mcp_connector.get_manifest(connector_url="http://test:8000")
+    async def test_manifest_includes_resources(self, stdio_connector: Connector):
+        await stdio_connector.bootstrap_mcp({"token": "test"})
+        manifest = await stdio_connector.get_manifest(connector_url="http://test:8000")
         assert len(manifest.resources) == 1
         assert manifest.resources[0].uri_template == "test://item/{item_id}"
 
-    async def test_manifest_includes_prompts(self, mcp_connector: Connector):
-        await mcp_connector.bootstrap_mcp({"token": "test"})
-        manifest = await mcp_connector.get_manifest(connector_url="http://test:8000")
+    async def test_manifest_includes_prompts(self, stdio_connector: Connector):
+        await stdio_connector.bootstrap_mcp({"token": "test"})
+        manifest = await stdio_connector.get_manifest(connector_url="http://test:8000")
         assert len(manifest.prompts) == 1
         assert manifest.prompts[0].name == "summarize"
 
-    async def test_execute_action_delegates_to_mcp(self, mcp_connector: Connector):
-        result = await mcp_connector.execute_action("greet", {"name": "Omni"}, {})
-        assert result.status == "success"
-        assert result.result is not None
+    async def test_execute_action_delegates_to_mcp(self, stdio_connector: Connector):
+        result = await stdio_connector.execute_action("greet", {"name": "Omni"}, {})
+        assert result.status_code == 200
 
     async def test_execute_action_unknown_returns_not_supported(
-        self, mcp_connector: Connector
+        self, stdio_connector: Connector
     ):
-        result = await mcp_connector.execute_action("unknown_action", {}, {})
-        assert result.status == "error"
-        assert "not supported" in (result.error or "").lower()
+        result = await stdio_connector.execute_action("unknown_action", {}, {})
+        assert result.status_code == 404
+
+    async def test_http_connector_round_trip(self, http_server_url: str):
+        """A Connector pointing at an HttpMcpServer surfaces tools and dispatches."""
+
+        class HttpMcpConnector(Connector):
+            @property
+            def name(self) -> str:
+                return "mcp-test-http"
+
+            @property
+            def version(self) -> str:
+                return "0.1.0"
+
+            @property
+            def source_types(self) -> list[str]:
+                return ["mcp_test_http"]
+
+            @property
+            def mcp_server(self) -> HttpMcpServer:
+                return HttpMcpServer(url=http_server_url)
+
+            def prepare_mcp_headers(
+                self, credentials: dict[str, Any]
+            ) -> dict[str, str]:
+                return {"Authorization": f"Bearer {credentials.get('token', '')}"}
+
+            async def sync(self, *args: Any, **kwargs: Any) -> None:
+                pass
+
+        connector = HttpMcpConnector()
+        await connector.bootstrap_mcp({"token": "abc"})
+        manifest = await connector.get_manifest(connector_url="http://test:8000")
+        assert manifest.mcp_enabled is True
+        assert {a.name for a in manifest.actions} >= {"greet", "add"}
+
+        result = await connector.execute_action(
+            "greet", {"name": "HTTP"}, {"token": "abc"}
+        )
+        assert result.status_code == 200
 
     async def test_non_mcp_connector_manifest(self):
         class PlainConnector(Connector):

--- a/sdk/python/tests/test_mcp_server.py
+++ b/sdk/python/tests/test_mcp_server.py
@@ -1,4 +1,10 @@
-"""A minimal MCP server used as a subprocess for testing the stdio adapter."""
+"""A minimal MCP server used as a subprocess for testing the SDK's adapter.
+
+Supports both transports:
+
+- ``python test_mcp_server.py``                     # stdio (default)
+- ``python test_mcp_server.py http <port>``         # Streamable HTTP
+"""
 
 import sys
 
@@ -33,4 +39,10 @@ def summarize(text: str) -> str:
 
 
 if __name__ == "__main__":
-    server.run(transport="stdio")
+    if len(sys.argv) > 1 and sys.argv[1] == "http":
+        port = int(sys.argv[2]) if len(sys.argv) > 2 else 8765
+        server.settings.host = "127.0.0.1"
+        server.settings.port = port
+        server.run(transport="streamable-http")
+    else:
+        server.run(transport="stdio")

--- a/sdk/rust/Cargo.toml
+++ b/sdk/rust/Cargo.toml
@@ -13,8 +13,15 @@ path = "src/lib.rs"
 anyhow = { workspace = true }
 async-trait = { workspace = true }
 axum = { workspace = true }
+http = "1"
 mime = "0.3"
 dashmap = { workspace = true }
+reqwest = { workspace = true }
+rmcp = { version = "1.5", features = [
+    "client",
+    "transport-child-process",
+    "transport-streamable-http-client-reqwest",
+] }
 serde = { workspace = true }
 serde_json = { workspace = true }
 shared = { path = "../../shared" }

--- a/sdk/rust/src/connector.rs
+++ b/sdk/rust/src/connector.rs
@@ -1,4 +1,7 @@
+use std::collections::HashMap;
+
 use crate::context::SyncContext;
+use crate::mcp_adapter::{McpCredentials, McpServer};
 use crate::models::ActionResponse;
 use crate::models::OAuthManifestConfig;
 use anyhow::Result;
@@ -9,8 +12,8 @@ use serde::de::DeserializeOwned;
 use serde::Serialize;
 use serde_json::Value as JsonValue;
 use shared::models::{
-    ActionDefinition, ConnectorManifest, McpPromptDefinition, McpResourceDefinition,
-    SearchOperator, ServiceCredential, Source, SourceType, SyncType,
+    ActionDefinition, ConnectorManifest, SearchOperator, ServiceCredential, Source, SourceType,
+    SyncType,
 };
 
 #[async_trait]
@@ -67,16 +70,25 @@ pub trait Connector: Send + Sync + 'static {
         None
     }
 
-    fn mcp_enabled(&self) -> bool {
-        false
+    /// Return MCP server config (stdio or Streamable HTTP) to enable MCP
+    /// support. Returning `None` (the default) disables MCP for this connector.
+    fn mcp_server(&self) -> Option<McpServer> {
+        None
     }
 
-    fn mcp_resources(&self) -> Vec<McpResourceDefinition> {
-        vec![]
+    /// Return env vars for a stdio MCP subprocess. Used only when
+    /// `mcp_server()` returns `Some(McpServer::Stdio(_))`. The `credentials`
+    /// argument is the wire-format wrapper forwarded by the connector-manager
+    /// (`{credentials, config, principal_email}`). Connectors typically
+    /// deserialize `credentials.credentials` into their own typed struct.
+    fn prepare_mcp_env(&self, _credentials: &McpCredentials) -> HashMap<String, String> {
+        HashMap::new()
     }
 
-    fn mcp_prompts(&self) -> Vec<McpPromptDefinition> {
-        vec![]
+    /// Return HTTP headers for a remote MCP server. Used only when
+    /// `mcp_server()` returns `Some(McpServer::Http(_))`.
+    fn prepare_mcp_headers(&self, _credentials: &McpCredentials) -> HashMap<String, String> {
+        HashMap::new()
     }
 
     /// Declarative OAuth2 config consumed by the web app's generic OAuth
@@ -108,6 +120,11 @@ pub trait Connector: Send + Sync + 'static {
         Ok(ActionResponse::not_supported(action).into_response_with_status(StatusCode::NOT_FOUND))
     }
 
+    /// Build the connector's static manifest (its name, version, manually-defined
+    /// actions, search operators, etc.). When `mcp_server()` is `Some`, the SDK's
+    /// `/manifest` handler additionally layers MCP-discovered tools, resources,
+    /// and prompts on top of the value returned here — connectors don't need to
+    /// override this method to surface MCP data.
     async fn build_manifest(&self, connector_url: String) -> ConnectorManifest {
         ConnectorManifest {
             name: self.name().to_string(),
@@ -123,9 +140,9 @@ pub trait Connector: Send + Sync + 'static {
             read_only: self.read_only(),
             extra_schema: self.extra_schema(),
             attributes_schema: self.attributes_schema(),
-            mcp_enabled: self.mcp_enabled(),
-            resources: self.mcp_resources(),
-            prompts: self.mcp_prompts(),
+            mcp_enabled: self.mcp_server().is_some(),
+            resources: vec![],
+            prompts: vec![],
             oauth: self
                 .oauth_config()
                 .and_then(|c| serde_json::to_value(c).ok()),

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -1,13 +1,15 @@
 pub mod connector;
 pub mod context;
+pub mod mcp_adapter;
 pub mod models;
 pub mod server;
 
 pub use connector::Connector;
 pub use context::SyncContext;
+pub use mcp_adapter::{HttpMcpServer, McpAdapter, McpCredentials, McpServer, StdioMcpServer};
 pub use models::{
     ActionRequest, ActionResponse, CancelRequest, CancelResponse, OAuthManifestConfig,
-    OAuthScopeSet, SyncRequest, SyncResponse, SyncStatusResponse,
+    OAuthScopeSet, PromptRequest, ResourceRequest, SyncRequest, SyncResponse, SyncStatusResponse,
 };
 pub use server::{create_router, serve, serve_with_config, serve_with_extra_routes, ServerConfig};
 

--- a/sdk/rust/src/mcp_adapter.rs
+++ b/sdk/rust/src/mcp_adapter.rs
@@ -1,0 +1,533 @@
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use rmcp::model::{
+    CallToolRequestParams, GetPromptRequestParams, PaginatedRequestParams, PromptMessageContent,
+    RawContent, ReadResourceRequestParams, ResourceContents,
+};
+use rmcp::service::RunningService;
+use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
+use rmcp::transport::{StreamableHttpClientTransport, TokioChildProcess};
+use rmcp::ServiceExt;
+use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
+use shared::models::{
+    ActionDefinition, ActionMode, McpPromptArgument, McpPromptDefinition, McpResourceDefinition,
+    ServiceCredential,
+};
+use tokio::process::Command;
+use tokio::sync::RwLock;
+use tracing::{debug, info, warn};
+
+use crate::models::ActionResponse;
+
+/// Wire-format credentials forwarded by the connector-manager to `/resource`,
+/// `/prompt`, and (via the SDK's bootstrap path) to the connector's
+/// `prepare_mcp_*` methods. Mirrors the JSON shape produced by
+/// `services/connector-manager/src/handlers.rs:read_resource`/`get_prompt`:
+/// `{credentials, config, principal_email}`.
+///
+/// Connectors typically deserialize `credentials` further into their own
+/// typed credentials struct.
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct McpCredentials {
+    /// The provider-specific credentials blob (e.g. `{token: "..."}`).
+    #[serde(default)]
+    pub credentials: JsonValue,
+    /// The provider-specific service config blob.
+    #[serde(default)]
+    pub config: JsonValue,
+    /// Optional acting-user email (for delegated/principal-aware connectors).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub principal_email: Option<String>,
+}
+
+impl McpCredentials {
+    /// Convert a typed `ServiceCredential` into the wrapper shape that
+    /// `prepare_mcp_*` expects, matching what the connector-manager would
+    /// send to `/resource` and `/prompt`.
+    pub fn from_service_credential(creds: &ServiceCredential) -> Self {
+        Self {
+            credentials: creds.credentials.clone(),
+            config: creds.config.clone(),
+            principal_email: creds.principal_email.clone(),
+        }
+    }
+}
+
+/// Configuration for an MCP server reached via stdio (subprocess).
+#[derive(Debug, Clone)]
+pub struct StdioMcpServer {
+    pub command: String,
+    pub args: Vec<String>,
+    pub env: HashMap<String, String>,
+    pub cwd: Option<PathBuf>,
+}
+
+impl StdioMcpServer {
+    pub fn new(command: impl Into<String>) -> Self {
+        Self {
+            command: command.into(),
+            args: Vec::new(),
+            env: HashMap::new(),
+            cwd: None,
+        }
+    }
+
+    pub fn with_args<I, S>(mut self, args: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args = args.into_iter().map(Into::into).collect();
+        self
+    }
+}
+
+/// Configuration for a remote MCP server reached via Streamable HTTP.
+#[derive(Debug, Clone)]
+pub struct HttpMcpServer {
+    pub url: String,
+    pub headers: HashMap<String, String>,
+    pub timeout: Duration,
+}
+
+impl HttpMcpServer {
+    pub fn new(url: impl Into<String>) -> Self {
+        Self {
+            url: url.into(),
+            headers: HashMap::new(),
+            timeout: Duration::from_secs(30),
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum McpServer {
+    Stdio(StdioMcpServer),
+    Http(HttpMcpServer),
+}
+
+/// Bridges an external MCP server into Omni's connector protocol.
+///
+/// Each operation opens a fresh client/transport pair and tears it down
+/// afterwards. Tool/resource/prompt definitions are cached after the first
+/// successful discovery so manifest builds don't require live auth.
+pub struct McpAdapter {
+    server: McpServer,
+    cached_actions: RwLock<Option<Vec<ActionDefinition>>>,
+    cached_resources: RwLock<Option<Vec<McpResourceDefinition>>>,
+    cached_prompts: RwLock<Option<Vec<McpPromptDefinition>>>,
+}
+
+type RmcpClient = RunningService<rmcp::RoleClient, ()>;
+
+impl McpAdapter {
+    pub fn new(server: McpServer) -> Self {
+        Self {
+            server,
+            cached_actions: RwLock::new(None),
+            cached_resources: RwLock::new(None),
+            cached_prompts: RwLock::new(None),
+        }
+    }
+
+    async fn connect(
+        &self,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<RmcpClient> {
+        match &self.server {
+            McpServer::Stdio(stdio) => {
+                let mut cmd = Command::new(&stdio.command);
+                cmd.args(&stdio.args);
+                for (k, v) in &stdio.env {
+                    cmd.env(k, v);
+                }
+                if let Some(extra) = env {
+                    for (k, v) in extra {
+                        cmd.env(k, v);
+                    }
+                }
+                if let Some(cwd) = &stdio.cwd {
+                    cmd.current_dir(cwd);
+                }
+                debug!(
+                    "Spawning MCP subprocess: {} {}",
+                    stdio.command,
+                    stdio.args.join(" ")
+                );
+                let transport =
+                    TokioChildProcess::new(cmd).context("failed to spawn MCP child process")?;
+                ().serve(transport)
+                    .await
+                    .context("MCP stdio handshake failed")
+            }
+            McpServer::Http(http) => {
+                let mut header_map: HashMap<http::HeaderName, http::HeaderValue> = HashMap::new();
+                for (k, v) in &http.headers {
+                    header_map.insert(
+                        http::HeaderName::from_bytes(k.as_bytes())
+                            .with_context(|| format!("invalid header name '{}'", k))?,
+                        http::HeaderValue::from_str(v)
+                            .with_context(|| format!("invalid header value for '{}'", k))?,
+                    );
+                }
+                if let Some(extra) = headers {
+                    for (k, v) in extra {
+                        header_map.insert(
+                            http::HeaderName::from_bytes(k.as_bytes())
+                                .with_context(|| format!("invalid header name '{}'", k))?,
+                            http::HeaderValue::from_str(&v)
+                                .with_context(|| format!("invalid header value for '{}'", k))?,
+                        );
+                    }
+                }
+                let config = StreamableHttpClientTransportConfig::with_uri(http.url.clone())
+                    .custom_headers(header_map);
+                debug!("Opening MCP HTTP session: {}", http.url);
+                let transport = StreamableHttpClientTransport::from_config(config);
+                ().serve(transport)
+                    .await
+                    .context("MCP streamable-http handshake failed")
+            }
+        }
+    }
+
+    pub async fn discover(
+        &self,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<()> {
+        let client = self.connect(env, headers).await?;
+        let actions = fetch_actions(&client).await?;
+        let resources = fetch_resources(&client).await?;
+        let prompts = fetch_prompts(&client).await?;
+        let _ = client.cancel().await;
+        info!(
+            "MCP discovery complete: {} tools, {} resources, {} prompts",
+            actions.len(),
+            resources.len(),
+            prompts.len()
+        );
+        *self.cached_actions.write().await = Some(actions);
+        *self.cached_resources.write().await = Some(resources);
+        *self.cached_prompts.write().await = Some(prompts);
+        Ok(())
+    }
+
+    pub async fn get_action_definitions(
+        &self,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Vec<ActionDefinition>> {
+        if env.is_none() && headers.is_none() {
+            return Ok(self.cached_actions.read().await.clone().unwrap_or_default());
+        }
+        match self.connect(env, headers).await {
+            Ok(client) => {
+                let actions = fetch_actions(&client).await?;
+                let _ = client.cancel().await;
+                *self.cached_actions.write().await = Some(actions.clone());
+                Ok(actions)
+            }
+            Err(err) => {
+                if let Some(cached) = self.cached_actions.read().await.clone() {
+                    warn!(
+                        "Live MCP fetch failed, returning {} cached actions: {}",
+                        cached.len(),
+                        err
+                    );
+                    Ok(cached)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    pub async fn get_resource_definitions(
+        &self,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Vec<McpResourceDefinition>> {
+        if env.is_none() && headers.is_none() {
+            return Ok(self
+                .cached_resources
+                .read()
+                .await
+                .clone()
+                .unwrap_or_default());
+        }
+        match self.connect(env, headers).await {
+            Ok(client) => {
+                let resources = fetch_resources(&client).await?;
+                let _ = client.cancel().await;
+                *self.cached_resources.write().await = Some(resources.clone());
+                Ok(resources)
+            }
+            Err(err) => {
+                if let Some(cached) = self.cached_resources.read().await.clone() {
+                    Ok(cached)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    pub async fn get_prompt_definitions(
+        &self,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Vec<McpPromptDefinition>> {
+        if env.is_none() && headers.is_none() {
+            return Ok(self.cached_prompts.read().await.clone().unwrap_or_default());
+        }
+        match self.connect(env, headers).await {
+            Ok(client) => {
+                let prompts = fetch_prompts(&client).await?;
+                let _ = client.cancel().await;
+                *self.cached_prompts.write().await = Some(prompts.clone());
+                Ok(prompts)
+            }
+            Err(err) => {
+                if let Some(cached) = self.cached_prompts.read().await.clone() {
+                    Ok(cached)
+                } else {
+                    Err(err)
+                }
+            }
+        }
+    }
+
+    pub async fn execute_tool(
+        &self,
+        name: &str,
+        arguments: JsonValue,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> ActionResponse {
+        let client = match self.connect(env, headers).await {
+            Ok(c) => c,
+            Err(e) => return ActionResponse::failure(e.to_string()),
+        };
+        let args_obj = match arguments {
+            JsonValue::Object(map) => Some(map),
+            JsonValue::Null => None,
+            other => {
+                let _ = client.cancel().await;
+                return ActionResponse::failure(format!(
+                    "tool arguments must be an object, got {}",
+                    type_of(&other)
+                ));
+            }
+        };
+        let mut params = CallToolRequestParams::new(name.to_string());
+        if let Some(args) = args_obj {
+            params = params.with_arguments(args);
+        }
+        let result = client.call_tool(params).await;
+        let _ = client.cancel().await;
+        match result {
+            Ok(call_result) => {
+                let mut text_parts = Vec::new();
+                for block in &call_result.content {
+                    match &block.raw {
+                        RawContent::Text(t) => text_parts.push(t.text.clone()),
+                        RawContent::Image(img) => {
+                            text_parts.push(format!("[binary: {}]", img.mime_type));
+                        }
+                        _ => {}
+                    }
+                }
+                let content = text_parts.join("\n");
+                if call_result.is_error.unwrap_or(false) {
+                    ActionResponse::failure(content)
+                } else {
+                    ActionResponse::success(serde_json::json!({ "content": content }))
+                }
+            }
+            Err(e) => ActionResponse::failure(e.to_string()),
+        }
+    }
+
+    pub async fn read_resource(
+        &self,
+        uri: &str,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<JsonValue> {
+        let client = self.connect(env, headers).await?;
+        let result = client
+            .read_resource(ReadResourceRequestParams::new(uri.to_string()))
+            .await;
+        let _ = client.cancel().await;
+        let result = result?;
+        let mut items = Vec::new();
+        for c in result.contents {
+            let mut entry = serde_json::Map::new();
+            match c {
+                ResourceContents::TextResourceContents {
+                    uri,
+                    mime_type,
+                    text,
+                    ..
+                } => {
+                    entry.insert("uri".into(), JsonValue::String(uri));
+                    entry.insert("text".into(), JsonValue::String(text));
+                    if let Some(mt) = mime_type {
+                        entry.insert("mime_type".into(), JsonValue::String(mt));
+                    }
+                }
+                ResourceContents::BlobResourceContents {
+                    uri,
+                    mime_type,
+                    blob,
+                    ..
+                } => {
+                    entry.insert("uri".into(), JsonValue::String(uri));
+                    entry.insert("blob".into(), JsonValue::String(blob));
+                    if let Some(mt) = mime_type {
+                        entry.insert("mime_type".into(), JsonValue::String(mt));
+                    }
+                }
+            }
+            items.push(JsonValue::Object(entry));
+        }
+        Ok(serde_json::json!({ "contents": items }))
+    }
+
+    pub async fn get_prompt(
+        &self,
+        name: &str,
+        arguments: Option<JsonValue>,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<JsonValue> {
+        let client = self.connect(env, headers).await?;
+        let mut params = GetPromptRequestParams::new(name.to_string());
+        if let Some(JsonValue::Object(map)) = arguments {
+            params.arguments = Some(map);
+        }
+        let result = client.get_prompt(params).await;
+        let _ = client.cancel().await;
+        let result = result?;
+        let mut messages = Vec::new();
+        for msg in result.messages {
+            let role = format!("{:?}", msg.role).to_lowercase();
+            let content = match msg.content {
+                PromptMessageContent::Text { text } => {
+                    serde_json::json!({ "type": "text", "text": text })
+                }
+                PromptMessageContent::Image { image } => {
+                    serde_json::json!({
+                        "type": "image",
+                        "mime_type": image.mime_type,
+                    })
+                }
+                _ => serde_json::json!({ "type": "unknown" }),
+            };
+            messages.push(serde_json::json!({ "role": role, "content": content }));
+        }
+        Ok(serde_json::json!({
+            "description": result.description,
+            "messages": messages,
+        }))
+    }
+}
+
+fn type_of(v: &JsonValue) -> &'static str {
+    match v {
+        JsonValue::Null => "null",
+        JsonValue::Bool(_) => "bool",
+        JsonValue::Number(_) => "number",
+        JsonValue::String(_) => "string",
+        JsonValue::Array(_) => "array",
+        JsonValue::Object(_) => "object",
+    }
+}
+
+async fn fetch_actions(client: &RmcpClient) -> Result<Vec<ActionDefinition>> {
+    let result = client
+        .list_tools(Some(PaginatedRequestParams::default()))
+        .await?;
+    let mut actions = Vec::with_capacity(result.tools.len());
+    for tool in result.tools {
+        let read_only = tool
+            .annotations
+            .as_ref()
+            .and_then(|a| a.read_only_hint)
+            .unwrap_or(false);
+        let input_schema: JsonValue = serde_json::to_value(tool.input_schema.as_ref())
+            .unwrap_or_else(|_| serde_json::json!({ "type": "object", "properties": {} }));
+        actions.push(ActionDefinition {
+            name: tool.name.to_string(),
+            description: tool.description.map(|c| c.to_string()).unwrap_or_default(),
+            input_schema,
+            mode: if read_only {
+                ActionMode::Read
+            } else {
+                ActionMode::Write
+            },
+        });
+    }
+    Ok(actions)
+}
+
+async fn fetch_resources(client: &RmcpClient) -> Result<Vec<McpResourceDefinition>> {
+    let mut definitions = Vec::new();
+
+    let templates = client
+        .list_resource_templates(Some(PaginatedRequestParams::default()))
+        .await?;
+    for tmpl in templates.resource_templates {
+        definitions.push(McpResourceDefinition {
+            uri_template: tmpl.uri_template.clone(),
+            name: tmpl.raw.name.clone(),
+            description: tmpl.raw.description.clone(),
+            mime_type: tmpl.raw.mime_type.clone(),
+        });
+    }
+
+    let resources = client
+        .list_resources(Some(PaginatedRequestParams::default()))
+        .await?;
+    for res in resources.resources {
+        definitions.push(McpResourceDefinition {
+            uri_template: res.raw.uri.clone(),
+            name: res.raw.name.clone(),
+            description: res.raw.description.clone(),
+            mime_type: res.raw.mime_type.clone(),
+        });
+    }
+
+    Ok(definitions)
+}
+
+async fn fetch_prompts(client: &RmcpClient) -> Result<Vec<McpPromptDefinition>> {
+    let result = client
+        .list_prompts(Some(PaginatedRequestParams::default()))
+        .await?;
+    let mut definitions = Vec::with_capacity(result.prompts.len());
+    for prompt in result.prompts {
+        let arguments = prompt
+            .arguments
+            .unwrap_or_default()
+            .into_iter()
+            .map(|arg| McpPromptArgument {
+                name: arg.name,
+                description: arg.description,
+                required: arg.required.unwrap_or(false),
+            })
+            .collect();
+        definitions.push(McpPromptDefinition {
+            name: prompt.name,
+            description: prompt.description,
+            arguments,
+        });
+    }
+    Ok(definitions)
+}

--- a/sdk/rust/src/models.rs
+++ b/sdk/rust/src/models.rs
@@ -61,6 +61,8 @@ fn default_scope_separator() -> String {
     " ".to_string()
 }
 
+use crate::mcp_adapter::McpCredentials;
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SyncRequest {
     pub sync_run_id: String,
@@ -115,6 +117,22 @@ pub struct ActionRequest {
     pub params: JsonValue,
     #[serde(default)]
     pub credentials: Option<ServiceCredential>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ResourceRequest {
+    pub uri: String,
+    #[serde(default)]
+    pub credentials: McpCredentials,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PromptRequest {
+    pub name: String,
+    #[serde(default)]
+    pub arguments: Option<JsonValue>,
+    #[serde(default)]
+    pub credentials: McpCredentials,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -1,8 +1,9 @@
 use crate::connector::Connector;
 use crate::context::SyncContext;
+use crate::mcp_adapter::{McpAdapter, McpCredentials, McpServer};
 use crate::models::{
-    ActionRequest, ActionResponse, CancelRequest, CancelResponse, SyncRequest, SyncResponse,
-    SyncStatusResponse,
+    ActionRequest, ActionResponse, CancelRequest, CancelResponse, PromptRequest, ResourceRequest,
+    SyncRequest, SyncResponse, SyncStatusResponse,
 };
 use anyhow::{Context, Result};
 use axum::{
@@ -18,8 +19,9 @@ use dashmap::DashMap;
 use serde::de::DeserializeOwned;
 use shared::telemetry;
 use shared::{SdkClient, SdkError};
+use std::collections::HashMap;
 use std::sync::atomic::AtomicBool;
-use std::sync::Arc;
+use std::sync::{Arc, OnceLock};
 use tokio::time::{interval, Duration};
 use tower::ServiceBuilder;
 use tower_http::cors::CorsLayer;
@@ -102,6 +104,7 @@ struct ServerState<C: Connector> {
     sdk_client: SdkClient,
     connector_url: String,
     active_syncs: ActiveSyncs,
+    mcp_adapter: OnceLock<Option<Arc<McpAdapter>>>,
 }
 
 impl<C: Connector> ServerState<C> {
@@ -111,7 +114,34 @@ impl<C: Connector> ServerState<C> {
             sdk_client,
             connector_url,
             active_syncs: Arc::new(DashMap::new()),
+            mcp_adapter: OnceLock::new(),
         }
+    }
+
+    fn mcp_adapter(&self) -> Option<&Arc<McpAdapter>> {
+        self.mcp_adapter
+            .get_or_init(|| {
+                self.connector
+                    .mcp_server()
+                    .map(|server| Arc::new(McpAdapter::new(server)))
+            })
+            .as_ref()
+    }
+}
+
+/// Build the env-vs-headers tuple to pass to the MCP adapter, dispatching
+/// based on the configured transport variant.
+fn build_mcp_auth<C: Connector>(
+    connector: &C,
+    credentials: &McpCredentials,
+) -> (
+    Option<HashMap<String, String>>,
+    Option<HashMap<String, String>>,
+) {
+    match connector.mcp_server() {
+        Some(McpServer::Http(_)) => (None, Some(connector.prepare_mcp_headers(credentials))),
+        Some(McpServer::Stdio(_)) => (Some(connector.prepare_mcp_env(credentials)), None),
+        None => (None, None),
     }
 }
 
@@ -125,7 +155,9 @@ where
         .route("/sync", post(trigger_sync::<C>))
         .route("/sync/:sync_run_id", get(sync_status::<C>))
         .route("/cancel", post(cancel_sync::<C>))
-        .route("/action", post(execute_action::<C>));
+        .route("/action", post(execute_action::<C>))
+        .route("/resource", post(read_resource::<C>))
+        .route("/prompt", post(get_prompt::<C>));
 
     router
         .layer(
@@ -157,7 +189,8 @@ where
 /// Start the connector server with additional HTTP routes merged in alongside
 /// the SDK-provided routes. Extra paths must not collide with the SDK's
 /// reserved paths (`/health`, `/manifest`, `/sync`, `/sync/:sync_run_id`,
-/// `/cancel`, `/action`) — collisions cause axum to panic at startup.
+/// `/cancel`, `/action`, `/resource`, `/prompt`) — collisions cause axum to
+/// panic at startup.
 ///
 /// Connectors that need to return binary data from actions should return
 /// `ActionResult::Binary` from `execute_action` instead of using extra routes
@@ -237,12 +270,37 @@ async fn manifest<C>(State(state): State<Arc<ServerState<C>>>) -> impl IntoRespo
 where
     C: Connector,
 {
-    Json(
-        state
-            .connector
-            .build_manifest(state.connector_url.clone())
-            .await,
-    )
+    let mut manifest = state
+        .connector
+        .build_manifest(state.connector_url.clone())
+        .await;
+
+    // If MCP is configured, layer the cached tools/resources/prompts from the
+    // adapter on top of any actions the connector defined manually.
+    if let Some(adapter) = state.mcp_adapter() {
+        match adapter.get_action_definitions(None, None).await {
+            Ok(mcp_actions) => {
+                let manual: std::collections::HashSet<String> =
+                    manifest.actions.iter().map(|a| a.name.clone()).collect();
+                for action in mcp_actions {
+                    if !manual.contains(&action.name) {
+                        manifest.actions.push(action);
+                    }
+                }
+            }
+            Err(e) => warn!("Failed to merge MCP actions into manifest: {}", e),
+        }
+        match adapter.get_resource_definitions(None, None).await {
+            Ok(resources) => manifest.resources = resources,
+            Err(e) => warn!("Failed to fetch MCP resources for manifest: {}", e),
+        }
+        match adapter.get_prompt_definitions(None, None).await {
+            Ok(prompts) => manifest.prompts = prompts,
+            Err(e) => warn!("Failed to fetch MCP prompts for manifest: {}", e),
+        }
+    }
+
+    Json(manifest)
 }
 
 async fn sync_status<C>(
@@ -337,6 +395,20 @@ where
             },
         )?;
 
+    // Bootstrap MCP discovery now that we have credentials. Populates the
+    // adapter's cache so subsequent /manifest reads (which run without creds)
+    // can return the live tool/resource/prompt list.
+    if let Some(adapter) = state.mcp_adapter() {
+        let creds = credentials
+            .as_ref()
+            .map(McpCredentials::from_service_credential)
+            .unwrap_or_default();
+        let (env, headers) = build_mcp_auth(&*state.connector, &creds);
+        if let Err(e) = adapter.discover(env, headers).await {
+            warn!("MCP bootstrap failed: {}", e);
+        }
+    }
+
     state
         .sdk_client
         .register_sync(&sync_run_id, request.sync_mode)
@@ -407,6 +479,36 @@ where
     C: Connector,
 {
     info!("Action requested: {}", request.action);
+
+    // MCP-first dispatch: if the action matches a tool exposed by the
+    // connector's MCP server, delegate to the adapter. Falls through to the
+    // connector's own `execute_action` for connector-defined actions.
+    if let Some(adapter) = state.mcp_adapter() {
+        let creds = request
+            .credentials
+            .as_ref()
+            .map(McpCredentials::from_service_credential)
+            .unwrap_or_default();
+        let (env, headers) = build_mcp_auth(&*state.connector, &creds);
+        match adapter
+            .get_action_definitions(env.clone(), headers.clone())
+            .await
+        {
+            Ok(actions) if actions.iter().any(|a| a.name == request.action) => {
+                let response = adapter
+                    .execute_tool(&request.action, request.params.clone(), env, headers)
+                    .await;
+                let status = match response.status.as_str() {
+                    "success" => StatusCode::OK,
+                    _ => StatusCode::BAD_REQUEST,
+                };
+                return Ok(response.into_response_with_status(status));
+            }
+            Ok(_) => { /* not an MCP tool — fall through */ }
+            Err(e) => warn!("MCP action lookup failed; falling back to connector: {}", e),
+        }
+    }
+
     state
         .connector
         .execute_action(&request.action, request.params, request.credentials)
@@ -415,6 +517,62 @@ where
             (
                 StatusCode::INTERNAL_SERVER_ERROR,
                 Json(ActionResponse::failure(error.to_string())),
+            )
+        })
+}
+
+async fn read_resource<C>(
+    State(state): State<Arc<ServerState<C>>>,
+    Json(request): Json<ResourceRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)>
+where
+    C: Connector,
+{
+    info!("Resource requested: {}", request.uri);
+    let adapter = state.mcp_adapter().ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "MCP not enabled for this connector" })),
+        )
+    })?;
+    let (env, headers) = build_mcp_auth(&*state.connector, &request.credentials);
+    adapter
+        .read_resource(&request.uri, env, headers)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            error!("Resource read failed for {}: {}", request.uri, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
+            )
+        })
+}
+
+async fn get_prompt<C>(
+    State(state): State<Arc<ServerState<C>>>,
+    Json(request): Json<PromptRequest>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<serde_json::Value>)>
+where
+    C: Connector,
+{
+    info!("Prompt requested: {}", request.name);
+    let adapter = state.mcp_adapter().ok_or_else(|| {
+        (
+            StatusCode::NOT_FOUND,
+            Json(serde_json::json!({ "error": "MCP not enabled for this connector" })),
+        )
+    })?;
+    let (env, headers) = build_mcp_auth(&*state.connector, &request.credentials);
+    adapter
+        .get_prompt(&request.name, request.arguments, env, headers)
+        .await
+        .map(Json)
+        .map_err(|e| {
+            error!("Prompt get failed for {}: {}", request.name, e);
+            (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                Json(serde_json::json!({ "error": e.to_string() })),
             )
         })
 }

--- a/sdk/rust/tests/mcp_adapter_test.rs
+++ b/sdk/rust/tests/mcp_adapter_test.rs
@@ -1,0 +1,248 @@
+use std::collections::HashMap;
+use std::net::{TcpListener, TcpStream};
+use std::path::PathBuf;
+use std::process::{Child, Command, Stdio};
+use std::time::Duration;
+
+use omni_connector_sdk::mcp_adapter::{HttpMcpServer, McpAdapter, McpServer, StdioMcpServer};
+
+fn fixture_path() -> PathBuf {
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    PathBuf::from(manifest_dir).join("../python/tests/test_mcp_server.py")
+}
+
+fn python_executable() -> String {
+    // Use the python that lives in the SDK's uv-managed venv if present, else
+    // fall back to plain `python` on PATH.
+    let manifest_dir = env!("CARGO_MANIFEST_DIR");
+    let venv = PathBuf::from(manifest_dir).join("../python/.venv/bin/python");
+    if venv.exists() {
+        venv.to_string_lossy().into_owned()
+    } else {
+        "python3".to_string()
+    }
+}
+
+fn stdio_server() -> StdioMcpServer {
+    StdioMcpServer::new(python_executable())
+        .with_args([fixture_path().to_string_lossy().into_owned()])
+}
+
+struct HttpFixture {
+    child: Child,
+    url: String,
+}
+
+impl HttpFixture {
+    fn spawn() -> Self {
+        let port = {
+            let listener = TcpListener::bind("127.0.0.1:0").unwrap();
+            listener.local_addr().unwrap().port()
+        };
+        let child = Command::new(python_executable())
+            .arg(fixture_path())
+            .arg("http")
+            .arg(port.to_string())
+            .stdout(Stdio::null())
+            .stderr(Stdio::null())
+            .spawn()
+            .expect("failed to spawn http MCP fixture");
+        let url = format!("http://127.0.0.1:{}/mcp", port);
+
+        // Poll until the TCP socket is open. We don't need to send a real
+        // HTTP request — opening a connection means uvicorn is up.
+        let addr = format!("127.0.0.1:{}", port);
+        let deadline = std::time::Instant::now() + Duration::from_secs(15);
+        loop {
+            if std::time::Instant::now() >= deadline {
+                panic!("HTTP fixture did not become ready at {}", url);
+            }
+            if TcpStream::connect_timeout(&addr.parse().unwrap(), Duration::from_millis(200))
+                .is_ok()
+            {
+                break;
+            }
+            std::thread::sleep(Duration::from_millis(100));
+        }
+
+        Self { child, url }
+    }
+
+    fn server(&self) -> McpServer {
+        McpServer::Http(HttpMcpServer::new(self.url.clone()))
+    }
+}
+
+impl Drop for HttpFixture {
+    fn drop(&mut self) {
+        let _ = self.child.kill();
+        let _ = self.child.wait();
+    }
+}
+
+#[tokio::test]
+async fn stdio_lists_tools() {
+    let adapter = McpAdapter::new(McpServer::Stdio(stdio_server()));
+    let actions = adapter
+        .get_action_definitions(Some(HashMap::new()), None)
+        .await
+        .expect("list_tools");
+    let names: Vec<String> = actions.iter().map(|a| a.name.clone()).collect();
+    assert!(names.contains(&"greet".to_string()));
+    assert!(names.contains(&"add".to_string()));
+    let greet = actions.iter().find(|a| a.name == "greet").unwrap();
+    assert_eq!(greet.mode, "read");
+    let add = actions.iter().find(|a| a.name == "add").unwrap();
+    assert_eq!(add.mode, "write");
+}
+
+#[tokio::test]
+async fn stdio_lists_resources_and_prompts() {
+    let adapter = McpAdapter::new(McpServer::Stdio(stdio_server()));
+    let resources = adapter
+        .get_resource_definitions(Some(HashMap::new()), None)
+        .await
+        .unwrap();
+    assert_eq!(resources.len(), 1);
+    assert_eq!(resources[0].uri_template, "test://item/{item_id}");
+
+    let prompts = adapter
+        .get_prompt_definitions(Some(HashMap::new()), None)
+        .await
+        .unwrap();
+    assert_eq!(prompts.len(), 1);
+    assert_eq!(prompts[0].name, "summarize");
+    assert!(prompts[0]
+        .arguments
+        .iter()
+        .any(|a| a.name == "text" && a.required));
+}
+
+#[tokio::test]
+async fn stdio_executes_tool() {
+    let adapter = McpAdapter::new(McpServer::Stdio(stdio_server()));
+    let response = adapter
+        .execute_tool(
+            "greet",
+            serde_json::json!({ "name": "World" }),
+            Some(HashMap::new()),
+            None,
+        )
+        .await;
+    assert_eq!(response.status, "success");
+    let result = response.result.expect("result");
+    assert!(result["content"]
+        .as_str()
+        .unwrap()
+        .contains("Hello, World!"));
+}
+
+#[tokio::test]
+async fn stdio_reads_resource_and_prompt() {
+    let adapter = McpAdapter::new(McpServer::Stdio(stdio_server()));
+    let resource = adapter
+        .read_resource("test://item/42", Some(HashMap::new()), None)
+        .await
+        .unwrap();
+    let contents = resource["contents"].as_array().unwrap();
+    assert!(!contents.is_empty());
+
+    let prompt = adapter
+        .get_prompt(
+            "summarize",
+            Some(serde_json::json!({ "text": "hello world" })),
+            Some(HashMap::new()),
+            None,
+        )
+        .await
+        .unwrap();
+    let messages = prompt["messages"].as_array().unwrap();
+    assert!(!messages.is_empty());
+    assert!(messages[0]["content"]["text"]
+        .as_str()
+        .unwrap()
+        .contains("hello world"));
+}
+
+#[tokio::test]
+async fn stdio_caches_after_discover() {
+    let adapter = McpAdapter::new(McpServer::Stdio(stdio_server()));
+    adapter
+        .discover(Some(HashMap::new()), None)
+        .await
+        .expect("discover");
+    let actions = adapter.get_action_definitions(None, None).await.unwrap();
+    assert_eq!(actions.len(), 2);
+    let resources = adapter.get_resource_definitions(None, None).await.unwrap();
+    assert_eq!(resources.len(), 1);
+    let prompts = adapter.get_prompt_definitions(None, None).await.unwrap();
+    assert_eq!(prompts.len(), 1);
+}
+
+#[tokio::test]
+async fn http_lists_tools_and_executes() {
+    let fixture = HttpFixture::spawn();
+    let adapter = McpAdapter::new(fixture.server());
+    let mut headers = HashMap::new();
+    headers.insert("X-Test".to_string(), "1".to_string());
+
+    let actions = adapter
+        .get_action_definitions(None, Some(headers.clone()))
+        .await
+        .unwrap();
+    let names: Vec<&str> = actions.iter().map(|a| a.name.as_str()).collect();
+    assert!(names.contains(&"greet"));
+    assert!(names.contains(&"add"));
+
+    let response = adapter
+        .execute_tool(
+            "greet",
+            serde_json::json!({ "name": "Remote" }),
+            None,
+            Some(headers),
+        )
+        .await;
+    assert_eq!(response.status, "success");
+    assert!(response
+        .result
+        .unwrap()
+        .get("content")
+        .and_then(|v| v.as_str())
+        .unwrap()
+        .contains("Hello, Remote!"));
+}
+
+#[tokio::test]
+async fn http_caches_after_discover() {
+    let fixture = HttpFixture::spawn();
+    let adapter = McpAdapter::new(fixture.server());
+    let mut headers = HashMap::new();
+    headers.insert("X-Test".to_string(), "1".to_string());
+
+    adapter
+        .discover(None, Some(headers))
+        .await
+        .expect("discover");
+    let actions = adapter.get_action_definitions(None, None).await.unwrap();
+    assert_eq!(actions.len(), 2);
+}
+
+#[tokio::test]
+async fn no_auth_no_cache_returns_empty() {
+    let adapter = McpAdapter::new(McpServer::Stdio(stdio_server()));
+    assert!(adapter
+        .get_action_definitions(None, None)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(adapter
+        .get_resource_definitions(None, None)
+        .await
+        .unwrap()
+        .is_empty());
+    assert!(adapter
+        .get_prompt_definitions(None, None)
+        .await
+        .unwrap()
+        .is_empty());
+}

--- a/sdk/typescript/src/connector.ts
+++ b/sdk/typescript/src/connector.ts
@@ -1,4 +1,5 @@
 import type { SyncContext } from './context.js';
+import type { McpAdapter, McpServer } from './mcp-adapter.js';
 import type {
   ConnectorManifest,
   ActionDefinition,
@@ -8,17 +9,7 @@ import { ActionResponse } from './models.js';
 import { createServer } from './server.js';
 import { getLogger } from './logger.js';
 
-export interface McpAdapter {
-  getActionDefinitions(): Promise<ActionDefinition[]>;
-  getResourceDefinitions(): Promise<unknown[]>;
-  getPromptDefinitions(): Promise<unknown[]>;
-  executeTool(
-    name: string,
-    params: Record<string, unknown>,
-  ): Promise<ActionResponse>;
-  readResource(uri: string): Promise<unknown>;
-  getPrompt(name: string, args?: Record<string, string>): Promise<unknown>;
-}
+const logger = getLogger('sdk:connector');
 
 export interface ServeOptions {
   port?: number;
@@ -51,25 +42,64 @@ export abstract class Connector<
   readonly attributesSchema?: Record<string, unknown>;
 
   /**
-   * Return an MCP McpServer instance if this connector supports MCP.
-   * Override this getter to enable MCP support.
+   * Return MCP server config (stdio or Streamable HTTP) if this connector
+   * supports MCP. Override this getter to enable MCP support.
    * Requires @modelcontextprotocol/sdk as a dependency.
+   *
+   * @example
+   * get mcpServer(): McpServer {
+   *   return { transport: 'stdio', command: 'github-mcp-server', args: ['stdio'] };
+   * }
+   *
+   * @example
+   * get mcpServer(): McpServer {
+   *   return { transport: 'http', url: 'https://api.example.com/mcp' };
+   * }
    */
-  get mcpServer(): unknown | undefined {
+  get mcpServer(): McpServer | undefined {
     return undefined;
   }
 
   async getMcpAdapter(): Promise<McpAdapter | undefined> {
     if (this._mcpAdapter !== null) {
-      return this._mcpAdapter as ReturnType<typeof this.getMcpAdapter> extends Promise<infer T> ? T : never;
+      return this._mcpAdapter as McpAdapter;
     }
     const server = this.mcpServer;
     if (!server) {
       return undefined;
     }
     const { McpAdapter } = await import('./mcp-adapter.js');
-    this._mcpAdapter = new McpAdapter(server as any);
-    return this._mcpAdapter as any;
+    this._mcpAdapter = new McpAdapter(server);
+    return this._mcpAdapter as McpAdapter;
+  }
+
+  /**
+   * Discover MCP tools/resources/prompts and cache them. Called when
+   * credentials first become available (e.g., during initial sync).
+   */
+  async bootstrapMcp(credentials: TCredentials): Promise<void> {
+    const adapter = await this.getMcpAdapter();
+    if (!adapter) {
+      return;
+    }
+    const { env, headers } = this.prepareMcpAuth(credentials);
+    logger.info('Bootstrapping MCP: discovering tools');
+    try {
+      await adapter.discover(env, headers);
+    } catch (err) {
+      logger.warn({ err }, 'MCP bootstrap failed');
+    }
+  }
+
+  prepareMcpAuth(credentials: TCredentials): {
+    env?: Record<string, string>;
+    headers?: Record<string, string>;
+  } {
+    const server = this.mcpServer;
+    if (server?.transport === 'http') {
+      return { headers: this.prepareMcpHeaders(credentials) };
+    }
+    return { env: this.prepareMcpEnv(credentials) };
   }
 
   private async getAllActions(): Promise<ActionDefinition[]> {
@@ -99,8 +129,8 @@ export abstract class Connector<
       extra_schema: this.extraSchema,
       attributes_schema: this.attributesSchema,
       mcp_enabled: adapter !== undefined,
-      resources: adapter ? await adapter.getResourceDefinitions() as any[] : [],
-      prompts: adapter ? await adapter.getPromptDefinitions() as any[] : [],
+      resources: adapter ? await adapter.getResourceDefinitions() : [],
+      prompts: adapter ? await adapter.getPromptDefinitions() : [],
     };
   }
 
@@ -116,11 +146,29 @@ export abstract class Connector<
   }
 
   /**
-   * Set up environment for MCP tool/resource/prompt calls.
-   * Override to bridge Omni credentials to the env vars your MCP server expects.
+   * Return env vars for a stdio MCP subprocess. Used only when
+   * `mcpServer` returns a `StdioMcpServer`.
+   *
+   * @example
+   * prepareMcpEnv(credentials) {
+   *   return { GITHUB_PERSONAL_ACCESS_TOKEN: credentials.token };
+   * }
    */
-  prepareMcpEnv(_credentials: TCredentials): void {
-    // no-op by default
+  prepareMcpEnv(_credentials: TCredentials): Record<string, string> {
+    return {};
+  }
+
+  /**
+   * Return HTTP headers for a remote MCP server. Used only when
+   * `mcpServer` returns an `HttpMcpServer`.
+   *
+   * @example
+   * prepareMcpHeaders(credentials) {
+   *   return { Authorization: `Bearer ${credentials.token}` };
+   * }
+   */
+  prepareMcpHeaders(_credentials: TCredentials): Record<string, string> {
+    return {};
   }
 
   async executeAction(
@@ -130,11 +178,11 @@ export abstract class Connector<
   ): Promise<Response> {
     const adapter = await this.getMcpAdapter();
     if (adapter) {
-      const mcpActions = await adapter.getActionDefinitions();
+      const { env, headers } = this.prepareMcpAuth(credentials);
+      const mcpActions = await adapter.getActionDefinitions(env, headers);
       const mcpToolNames = new Set(mcpActions.map((a) => a.name));
       if (mcpToolNames.has(action)) {
-        this.prepareMcpEnv(credentials);
-        const response = await adapter.executeTool(action, params);
+        const response = await adapter.executeTool(action, params, env, headers);
         return response.toResponse();
       }
     }

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -2,8 +2,16 @@ export { Connector, type ServeOptions } from './connector.js';
 export { SyncContext } from './context.js';
 export { ContentStorage } from './storage.js';
 export { SdkClient } from './client.js';
-// McpAdapter is not re-exported here to avoid requiring @modelcontextprotocol/sdk
-// as a mandatory dependency. Import directly from './mcp-adapter.js' when needed.
+// McpAdapter (the runtime class) is not re-exported here to avoid requiring
+// @modelcontextprotocol/sdk as a mandatory dependency. Import directly from
+// './mcp-adapter.js' when needed. Type-only exports for the server config
+// types are safe to surface here since they have no runtime cost.
+export type {
+  HttpMcpServer,
+  McpAdapter,
+  McpServer,
+  StdioMcpServer,
+} from './mcp-adapter.js';
 export { createServer } from './server.js';
 
 export {

--- a/sdk/typescript/src/mcp-adapter.ts
+++ b/sdk/typescript/src/mcp-adapter.ts
@@ -1,8 +1,4 @@
-// TODO: Rewrite to use StdioClientTransport (subprocess) instead of InMemoryTransport.
-// The Python SDK has already been migrated. See sdk/python/omni_connector/mcp_adapter.py.
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
-import type { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
 import type {
   ActionDefinition,
   McpPromptDefinition,
@@ -14,35 +10,286 @@ import { getLogger } from './logger.js';
 const logger = getLogger('sdk:mcp-adapter');
 
 /**
- * Bridges an MCP McpServer into Omni's connector protocol.
+ * Configuration for an MCP server reached via stdio (subprocess).
+ */
+export interface StdioMcpServer {
+  transport: 'stdio';
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  cwd?: string;
+}
+
+/**
+ * Configuration for a remote MCP server reached via Streamable HTTP.
+ */
+export interface HttpMcpServer {
+  transport: 'http';
+  url: string;
+  headers?: Record<string, string>;
+  /** Forwarded to StreamableHTTPClientTransport's `requestInit` (merged with `headers`). */
+  requestInit?: RequestInit;
+}
+
+export type McpServer = StdioMcpServer | HttpMcpServer;
+
+/**
+ * Bridges an external MCP server into Omni's connector protocol.
  *
- * Uses InMemoryTransport to create an in-process client-server pair,
- * then interacts with the server through the standard MCP Client API.
+ * Supports two transports:
+ * - stdio: spawns the MCP server as a subprocess and talks JSON-RPC over
+ *   stdin/stdout.
+ * - Streamable HTTP: connects to a remote MCP endpoint per the MCP spec.
+ *
+ * Each operation opens a fresh client/transport pair and tears it down
+ * afterwards. Tool/resource/prompt definitions are cached after the first
+ * successful discovery so manifest builds don't require live auth.
  */
 export class McpAdapter {
   private server: McpServer;
-  private client: Client | null = null;
+  private cachedActions: ActionDefinition[] | null = null;
+  private cachedResources: McpResourceDefinition[] | null = null;
+  private cachedPrompts: McpPromptDefinition[] | null = null;
 
-  constructor(mcpServer: McpServer) {
-    this.server = mcpServer;
+  constructor(server: McpServer) {
+    this.server = server;
   }
 
-  private async ensureConnected(): Promise<Client> {
-    if (this.client) {
-      return this.client;
+  private async withSession<T>(
+    env: Record<string, string> | undefined,
+    headers: Record<string, string> | undefined,
+    fn: (client: Client) => Promise<T>
+  ): Promise<T> {
+    const client = new Client({ name: 'omni-mcp-adapter', version: '1.0.0' });
+    if (this.server.transport === 'stdio') {
+      const { StdioClientTransport } = await import(
+        '@modelcontextprotocol/sdk/client/stdio.js'
+      );
+      const mergedEnv = { ...(this.server.env ?? {}), ...(env ?? {}) };
+      const transport = new StdioClientTransport({
+        command: this.server.command,
+        args: this.server.args,
+        env: Object.keys(mergedEnv).length > 0 ? mergedEnv : undefined,
+        cwd: this.server.cwd,
+      });
+      logger.debug(
+        `Spawning MCP subprocess: ${this.server.command} ${(this.server.args ?? []).join(' ')}`
+      );
+      await client.connect(transport);
+      try {
+        return await fn(client);
+      } finally {
+        await client.close();
+      }
+    } else {
+      const { StreamableHTTPClientTransport } = await import(
+        '@modelcontextprotocol/sdk/client/streamableHttp.js'
+      );
+      const mergedHeaders = { ...(this.server.headers ?? {}), ...(headers ?? {}) };
+      const baseInit = this.server.requestInit ?? {};
+      const baseHeaders = (baseInit.headers ?? {}) as Record<string, string>;
+      const transport = new StreamableHTTPClientTransport(new URL(this.server.url), {
+        requestInit: {
+          ...baseInit,
+          headers: { ...baseHeaders, ...mergedHeaders },
+        },
+      });
+      logger.debug(`Opening MCP HTTP session: ${this.server.url}`);
+      await client.connect(transport);
+      try {
+        return await fn(client);
+      } finally {
+        await client.close();
+      }
     }
-    const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-    await this.server.connect(serverTransport);
-    this.client = new Client({ name: 'omni-mcp-adapter', version: '1.0.0' });
-    await this.client.connect(clientTransport);
-    return this.client;
   }
 
-  async getActionDefinitions(): Promise<ActionDefinition[]> {
-    const client = await this.ensureConnected();
+  async discover(
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<void> {
+    await this.withSession(env, headers, async (client) => {
+      this.cachedActions = await this.fetchActions(client);
+      this.cachedResources = await this.fetchResources(client);
+      this.cachedPrompts = await this.fetchPrompts(client);
+    });
+    logger.info(
+      `MCP discovery complete: ${this.cachedActions?.length ?? 0} tools, ` +
+        `${this.cachedResources?.length ?? 0} resources, ` +
+        `${this.cachedPrompts?.length ?? 0} prompts`
+    );
+  }
+
+  async getActionDefinitions(
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<ActionDefinition[]> {
+    if (env !== undefined || headers !== undefined) {
+      try {
+        const actions = await this.withSession(env, headers, (c) =>
+          this.fetchActions(c)
+        );
+        this.cachedActions = actions;
+        return actions;
+      } catch (err) {
+        if (this.cachedActions !== null) {
+          logger.debug(
+            `Live action fetch failed, returning ${this.cachedActions.length} cached`
+          );
+          return this.cachedActions;
+        }
+        throw err;
+      }
+    }
+    return this.cachedActions ?? [];
+  }
+
+  async getResourceDefinitions(
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<McpResourceDefinition[]> {
+    if (env !== undefined || headers !== undefined) {
+      try {
+        const resources = await this.withSession(env, headers, (c) =>
+          this.fetchResources(c)
+        );
+        this.cachedResources = resources;
+        return resources;
+      } catch (err) {
+        if (this.cachedResources !== null) {
+          return this.cachedResources;
+        }
+        throw err;
+      }
+    }
+    return this.cachedResources ?? [];
+  }
+
+  async getPromptDefinitions(
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<McpPromptDefinition[]> {
+    if (env !== undefined || headers !== undefined) {
+      try {
+        const prompts = await this.withSession(env, headers, (c) =>
+          this.fetchPrompts(c)
+        );
+        this.cachedPrompts = prompts;
+        return prompts;
+      } catch (err) {
+        if (this.cachedPrompts !== null) {
+          return this.cachedPrompts;
+        }
+        throw err;
+      }
+    }
+    return this.cachedPrompts ?? [];
+  }
+
+  async executeTool(
+    name: string,
+    args: Record<string, unknown>,
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<ActionResponse> {
+    try {
+      return await this.withSession(env, headers, async (client) => {
+        const result = await client.callTool({ name, arguments: args });
+        if (result.isError) {
+          const errorText = (
+            result.content as Array<{ type: string; text?: string }>
+          )
+            .filter((c) => c.type === 'text')
+            .map((c) => c.text ?? '')
+            .join('\n');
+          return ActionResponse.failure(errorText || 'Tool execution failed');
+        }
+
+        if (
+          result.structuredContent &&
+          typeof result.structuredContent === 'object'
+        ) {
+          return ActionResponse.success(
+            result.structuredContent as Record<string, unknown>
+          );
+        }
+
+        const textParts: string[] = [];
+        for (const block of result.content as Array<{
+          type: string;
+          text?: string;
+          mimeType?: string;
+        }>) {
+          if (block.type === 'text' && block.text) {
+            textParts.push(block.text);
+          } else if (block.type === 'image') {
+            textParts.push(`[binary: ${block.mimeType ?? 'unknown'}]`);
+          }
+        }
+        return ActionResponse.success({ content: textParts.join('\n') });
+      });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      logger.error({ err }, `MCP tool ${name} failed`);
+      return ActionResponse.failure(message);
+    }
+  }
+
+  async readResource(
+    uri: string,
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<{ contents: Array<Record<string, unknown>> }> {
+    return await this.withSession(env, headers, async (client) => {
+      const result = await client.readResource({ uri });
+      const items: Array<Record<string, unknown>> = [];
+      for (const item of result.contents) {
+        const entry: Record<string, unknown> = { uri: item.uri ?? uri };
+        if ('text' in item && item.text != null) {
+          entry.text = item.text;
+        }
+        if ('blob' in item && item.blob != null) {
+          entry.blob = item.blob;
+        }
+        if (item.mimeType) {
+          entry.mime_type = item.mimeType;
+        }
+        items.push(entry);
+      }
+      return { contents: items };
+    });
+  }
+
+  async getPrompt(
+    name: string,
+    args?: Record<string, unknown>,
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<{ description?: string; messages: Array<Record<string, unknown>> }> {
+    return await this.withSession(env, headers, async (client) => {
+      const result = await client.getPrompt({
+        name,
+        arguments: args as Record<string, string> | undefined,
+      });
+      const messages: Array<Record<string, unknown>> = [];
+      for (const msg of result.messages) {
+        let contentData: Record<string, unknown>;
+        if (msg.content.type === 'text') {
+          contentData = { type: 'text', text: msg.content.text };
+        } else {
+          contentData = { type: msg.content.type };
+        }
+        messages.push({ role: msg.role, content: contentData });
+      }
+      return { description: result.description, messages };
+    });
+  }
+
+  // -- internal helpers --
+
+  private async fetchActions(client: Client): Promise<ActionDefinition[]> {
     const { tools } = await client.listTools();
     const actions: ActionDefinition[] = [];
-
     for (const tool of tools) {
       const isReadOnly = tool.annotations?.readOnlyHint === true;
       actions.push({
@@ -52,12 +299,10 @@ export class McpAdapter {
         mode: isReadOnly ? 'read' : 'write',
       });
     }
-
     return actions;
   }
 
-  async getResourceDefinitions(): Promise<McpResourceDefinition[]> {
-    const client = await this.ensureConnected();
+  private async fetchResources(client: Client): Promise<McpResourceDefinition[]> {
     const definitions: McpResourceDefinition[] = [];
 
     const { resourceTemplates } = await client.listResourceTemplates();
@@ -83,8 +328,7 @@ export class McpAdapter {
     return definitions;
   }
 
-  async getPromptDefinitions(): Promise<McpPromptDefinition[]> {
-    const client = await this.ensureConnected();
+  private async fetchPrompts(client: Client): Promise<McpPromptDefinition[]> {
     const { prompts } = await client.listPrompts();
     return prompts.map((prompt) => ({
       name: prompt.name,
@@ -95,88 +339,5 @@ export class McpAdapter {
         required: arg.required ?? false,
       })),
     }));
-  }
-
-  async executeTool(
-    name: string,
-    args: Record<string, unknown>
-  ): Promise<ActionResponse> {
-    const client = await this.ensureConnected();
-
-    try {
-      const result = await client.callTool({ name, arguments: args });
-      if (result.isError) {
-        const errorText = (result.content as Array<{ type: string; text?: string }>)
-          .filter((c) => c.type === 'text')
-          .map((c) => c.text ?? '')
-          .join('\n');
-        return ActionResponse.failure(errorText || 'Tool execution failed');
-      }
-
-      if (result.structuredContent && typeof result.structuredContent === 'object') {
-        return ActionResponse.success(
-          result.structuredContent as Record<string, unknown>
-        );
-      }
-
-      const textParts: string[] = [];
-      for (const block of result.content as Array<{ type: string; text?: string; mimeType?: string }>) {
-        if (block.type === 'text' && block.text) {
-          textParts.push(block.text);
-        } else if (block.type === 'image') {
-          textParts.push(`[binary: ${block.mimeType ?? 'unknown'}]`);
-        }
-      }
-      return ActionResponse.success({ content: textParts.join('\n') });
-    } catch (err) {
-      const message = err instanceof Error ? err.message : String(err);
-      logger.error({ err }, `MCP tool ${name} failed`);
-      return ActionResponse.failure(message);
-    }
-  }
-
-  async readResource(
-    uri: string
-  ): Promise<{ contents: Array<Record<string, unknown>> }> {
-    const client = await this.ensureConnected();
-    const result = await client.readResource({ uri });
-    const items: Array<Record<string, unknown>> = [];
-
-    for (const item of result.contents) {
-      const entry: Record<string, unknown> = { uri: item.uri ?? uri };
-      if ('text' in item && item.text != null) {
-        entry.text = item.text;
-      }
-      if ('blob' in item && item.blob != null) {
-        entry.blob = item.blob;
-      }
-      if (item.mimeType) {
-        entry.mime_type = item.mimeType;
-      }
-      items.push(entry);
-    }
-    return { contents: items };
-  }
-
-  async getPrompt(
-    name: string,
-    args?: Record<string, unknown>
-  ): Promise<{ description?: string; messages: Array<Record<string, unknown>> }> {
-    const client = await this.ensureConnected();
-    const result = await client.getPrompt({
-      name,
-      arguments: args as Record<string, string> | undefined,
-    });
-    const messages: Array<Record<string, unknown>> = [];
-    for (const msg of result.messages) {
-      let contentData: Record<string, unknown>;
-      if (msg.content.type === 'text') {
-        contentData = { type: 'text', text: msg.content.text };
-      } else {
-        contentData = { type: msg.content.type };
-      }
-      messages.push({ role: msg.role, content: contentData });
-    }
-    return { description: result.description, messages };
   }
 }

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -249,8 +249,8 @@ export function createServer(connector: Connector): Express {
     logger.info(`Resource requested: ${uri}`);
 
     try {
-      connector.prepareMcpEnv(credentials as any);
-      const result = await adapter.readResource(uri);
+      const { env, headers } = connector.prepareMcpAuth(credentials);
+      const result = await adapter.readResource(uri, env, headers);
       res.json(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
@@ -276,8 +276,13 @@ export function createServer(connector: Connector): Express {
     logger.info(`Prompt requested: ${name}`);
 
     try {
-      connector.prepareMcpEnv(credentials as any);
-      const result = await adapter.getPrompt(name, args as Record<string, string> | undefined);
+      const { env, headers } = connector.prepareMcpAuth(credentials);
+      const result = await adapter.getPrompt(
+        name,
+        args as Record<string, string> | undefined,
+        env,
+        headers
+      );
       res.json(result);
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);

--- a/sdk/typescript/tests/fixtures/test-mcp-server.mjs
+++ b/sdk/typescript/tests/fixtures/test-mcp-server.mjs
@@ -1,0 +1,119 @@
+// Minimal MCP server used as a subprocess for testing the SDK's adapter.
+// Supports both transports:
+//   node test-mcp-server.mjs                  # stdio (default)
+//   node test-mcp-server.mjs http <port>      # Streamable HTTP
+import { McpServer, ResourceTemplate } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { StdioServerTransport } from '@modelcontextprotocol/sdk/server/stdio.js';
+import { z } from 'zod';
+
+function buildServer() {
+  const server = new McpServer({ name: 'test', version: '1.0.0' });
+
+  server.registerTool(
+    'greet',
+    {
+      description: 'Greet someone by name',
+      annotations: { readOnlyHint: true },
+      inputSchema: { name: z.string().describe('Person to greet') },
+    },
+    async (args) => ({
+      content: [{ type: 'text', text: `Hello, ${args.name}!` }],
+    })
+  );
+
+  server.tool(
+    'add',
+    'Add two numbers',
+    { a: z.number(), b: z.number() },
+    async (args) => ({
+      content: [{ type: 'text', text: String(args.a + args.b) }],
+    })
+  );
+
+  server.resource(
+    'item',
+    new ResourceTemplate('test://item/{item_id}', { list: undefined }),
+    async (uri, args) => ({
+      contents: [
+        {
+          uri: uri.href,
+          text: `Item ${args.item_id}`,
+          mimeType: 'text/plain',
+        },
+      ],
+    })
+  );
+
+  server.prompt(
+    'summarize',
+    'Summarize the given text',
+    { text: z.string() },
+    async (args) => ({
+      messages: [
+        {
+          role: 'user',
+          content: { type: 'text', text: `Please summarize: ${args.text}` },
+        },
+      ],
+    })
+  );
+
+  return server;
+}
+
+async function runStdio() {
+  const server = buildServer();
+  const transport = new StdioServerTransport();
+  await server.connect(transport);
+}
+
+async function runHttp(port) {
+  const { StreamableHTTPServerTransport } = await import(
+    '@modelcontextprotocol/sdk/server/streamableHttp.js'
+  );
+  const http = await import('node:http');
+
+  const httpServer = http.createServer(async (req, res) => {
+    if (!req.url || !req.url.startsWith('/mcp')) {
+      res.statusCode = 404;
+      res.end('not found');
+      return;
+    }
+    const chunks = [];
+    for await (const chunk of req) {
+      chunks.push(chunk);
+    }
+    const bodyRaw = Buffer.concat(chunks).toString('utf8');
+    const body = bodyRaw ? JSON.parse(bodyRaw) : undefined;
+
+    // Stateless: spin up a fresh server + transport per request. Simpler than
+    // tracking sessions across requests for a test fixture.
+    const transport = new StreamableHTTPServerTransport({
+      sessionIdGenerator: undefined,
+    });
+    const server = buildServer();
+    await server.connect(transport);
+    res.on('close', () => {
+      transport.close();
+      server.close();
+    });
+    await transport.handleRequest(req, res, body);
+  });
+
+  await new Promise((resolve) => httpServer.listen(port, '127.0.0.1', resolve));
+  process.stdin.resume();
+}
+
+const mode = process.argv[2];
+if (mode === 'http') {
+  const port = Number(process.argv[3] ?? 8765);
+  runHttp(port).catch((err) => {
+    console.error('http fixture error:', err);
+    process.exit(1);
+  });
+} else {
+  runStdio().catch((err) => {
+    console.error('stdio fixture error:', err);
+    process.exit(1);
+  });
+}

--- a/sdk/typescript/tests/mcp-adapter.test.ts
+++ b/sdk/typescript/tests/mcp-adapter.test.ts
@@ -1,164 +1,261 @@
-import { describe, it, expect, beforeEach } from 'vitest';
-import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { z } from 'zod';
-import { McpAdapter } from '../src/mcp-adapter.js';
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { spawn, type ChildProcess } from 'node:child_process';
+import { createServer as createNetServer } from 'node:net';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import { McpAdapter, type HttpMcpServer, type StdioMcpServer } from '../src/mcp-adapter.js';
 import { Connector } from '../src/connector.js';
 import type { ConnectorManifest } from '../src/models.js';
 
-function createTestMcpServer(): McpServer {
-  const server = new McpServer({ name: 'test', version: '1.0.0' });
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const FIXTURE = join(__dirname, 'fixtures', 'test-mcp-server.mjs');
 
-  server.registerTool(
-    'greet',
-    {
-      description: 'Greet someone by name',
-      annotations: { readOnlyHint: true },
-      inputSchema: { name: z.string().describe('Person to greet') },
-    },
-    async (args) => ({
-      content: [{ type: 'text' as const, text: `Hello, ${args.name}!` }],
-    })
-  );
+const STDIO_SERVER: StdioMcpServer = {
+  transport: 'stdio',
+  command: process.execPath,
+  args: [FIXTURE],
+};
 
-  server.tool(
-    'add',
-    'Add two numbers',
-    { a: z.number(), b: z.number() },
-    async (args) => ({
-      content: [{ type: 'text' as const, text: String(args.a + args.b) }],
-    })
-  );
-
-  server.resource(
-    'item',
-    'test://item/{item_id}',
-    async (uri) => ({
-      contents: [{ uri: uri.href, text: `Item content`, mimeType: 'text/plain' }],
-    })
-  );
-
-  server.prompt(
-    'summarize',
-    'Summarize the given text',
-    { text: z.string() },
-    async (args) => ({
-      messages: [
-        {
-          role: 'user' as const,
-          content: { type: 'text' as const, text: `Please summarize: ${args.text}` },
-        },
-      ],
-    })
-  );
-
-  return server;
+function freePort(): Promise<number> {
+  return new Promise((resolve, reject) => {
+    const srv = createNetServer();
+    srv.unref();
+    srv.on('error', reject);
+    srv.listen(0, () => {
+      const addr = srv.address();
+      if (addr && typeof addr === 'object') {
+        const { port } = addr;
+        srv.close(() => resolve(port));
+      } else {
+        reject(new Error('could not get port'));
+      }
+    });
+  });
 }
 
-describe('McpAdapter', () => {
-  let adapter: McpAdapter;
+async function waitForHttp(url: string, timeoutMs = 8000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    try {
+      // Any TCP-level reply means the server is up. The MCP endpoint rejects
+      // bare GETs but that's fine — we only need to confirm the socket is open.
+      await fetch(url, { method: 'GET' });
+      return;
+    } catch {
+      await new Promise((r) => setTimeout(r, 100));
+    }
+  }
+  throw new Error(`HTTP fixture did not become ready at ${url}`);
+}
 
-  beforeEach(() => {
-    const server = createTestMcpServer();
-    adapter = new McpAdapter(server);
-  });
-
-  it('converts MCP tools to action definitions', async () => {
-    const actions = await adapter.getActionDefinitions();
-    expect(actions.length).toBe(2);
-    const names = actions.map((a) => a.name);
-    expect(names).toContain('greet');
-    expect(names).toContain('add');
-
+describe('McpAdapter (stdio)', () => {
+  it('lists tools', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    const actions = await adapter.getActionDefinitions({ TEST_MODE: '1' });
+    const names = actions.map((a) => a.name).sort();
+    expect(names).toEqual(['add', 'greet']);
     const greet = actions.find((a) => a.name === 'greet')!;
-    expect(greet.description).toBe('Greet someone by name');
-    expect(greet.input_schema.properties.name).toBeDefined();
-    expect(greet.input_schema.properties.name.type).toBe('string');
-    expect(greet.input_schema.required).toContain('name');
     expect(greet.mode).toBe('read');
-
+    expect(greet.description).toBe('Greet someone by name');
     const add = actions.find((a) => a.name === 'add')!;
     expect(add.mode).toBe('write');
   });
 
-  it('converts MCP resources to resource definitions', async () => {
-    const resources = await adapter.getResourceDefinitions();
-    expect(resources.length).toBe(1);
-    expect(resources[0].name).toBe('item');
+  it('lists resources', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    const resources = await adapter.getResourceDefinitions({ TEST_MODE: '1' });
+    expect(resources).toHaveLength(1);
     expect(resources[0].uri_template).toBe('test://item/{item_id}');
   });
 
-  it('converts MCP prompts to prompt definitions', async () => {
-    const prompts = await adapter.getPromptDefinitions();
-    expect(prompts.length).toBe(1);
+  it('lists prompts', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    const prompts = await adapter.getPromptDefinitions({ TEST_MODE: '1' });
+    expect(prompts).toHaveLength(1);
     expect(prompts[0].name).toBe('summarize');
-    expect(prompts[0].description).toBe('Summarize the given text');
+    expect(prompts[0].arguments[0].name).toBe('text');
+    expect(prompts[0].arguments[0].required).toBe(true);
   });
 
-  it('executes a tool and returns success', async () => {
-    const result = await adapter.executeTool('greet', { name: 'World' });
+  it('executes a tool', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    const result = await adapter.executeTool('greet', { name: 'World' }, {
+      TEST_MODE: '1',
+    });
     expect(result.status).toBe('success');
-    expect(result.result).toBeDefined();
-    expect(result.result!.content).toContain('Hello, World!');
+    expect(result.result?.content).toContain('Hello, World!');
   });
 
-  it('returns failure for nonexistent tool', async () => {
-    const result = await adapter.executeTool('nonexistent', {});
+  it('returns error for nonexistent tool', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    const result = await adapter.executeTool('nonexistent', {}, { TEST_MODE: '1' });
     expect(result.status).toBe('error');
   });
 
+  it('reads a resource', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    const result = await adapter.readResource('test://item/42', { TEST_MODE: '1' });
+    expect(result.contents.length).toBeGreaterThanOrEqual(1);
+  });
+
   it('gets a prompt', async () => {
-    const result = await adapter.getPrompt('summarize', { text: 'hello world' });
+    const adapter = new McpAdapter(STDIO_SERVER);
+    const result = await adapter.getPrompt(
+      'summarize',
+      { text: 'hello world' },
+      { TEST_MODE: '1' }
+    );
     expect(result.messages.length).toBeGreaterThanOrEqual(1);
     const msg = result.messages[0];
     expect(msg.role).toBe('user');
     expect((msg.content as { text: string }).text).toContain('hello world');
   });
+
+  it('caches discovered definitions', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    await adapter.discover({ TEST_MODE: '1' });
+    // No env — returns from cache without spawning
+    const actions = await adapter.getActionDefinitions();
+    expect(actions.map((a) => a.name).sort()).toEqual(['add', 'greet']);
+    const resources = await adapter.getResourceDefinitions();
+    expect(resources).toHaveLength(1);
+    const prompts = await adapter.getPromptDefinitions();
+    expect(prompts).toHaveLength(1);
+  });
+
+  it('returns empty without auth and without cache', async () => {
+    const adapter = new McpAdapter(STDIO_SERVER);
+    expect(await adapter.getActionDefinitions()).toEqual([]);
+    expect(await adapter.getResourceDefinitions()).toEqual([]);
+    expect(await adapter.getPromptDefinitions()).toEqual([]);
+  });
+});
+
+describe('McpAdapter (Streamable HTTP)', () => {
+  let proc: ChildProcess | null = null;
+  let url: string;
+
+  beforeAll(async () => {
+    const port = await freePort();
+    proc = spawn(process.execPath, [FIXTURE, 'http', String(port)], {
+      stdio: ['ignore', 'ignore', 'ignore'],
+    });
+    url = `http://127.0.0.1:${port}/mcp`;
+    await waitForHttp(url);
+  }, 15000);
+
+  afterAll(async () => {
+    if (proc && proc.pid !== undefined) {
+      proc.kill('SIGTERM');
+      await new Promise((r) => setTimeout(r, 100));
+      if (!proc.killed) {
+        proc.kill('SIGKILL');
+      }
+    }
+  });
+
+  it('lists tools', async () => {
+    const adapter = new McpAdapter({ transport: 'http', url });
+    const actions = await adapter.getActionDefinitions(undefined, { 'X-Test': '1' });
+    expect(actions.map((a) => a.name).sort()).toEqual(['add', 'greet']);
+  });
+
+  it('executes a tool', async () => {
+    const adapter = new McpAdapter({ transport: 'http', url });
+    const result = await adapter.executeTool(
+      'greet',
+      { name: 'Remote' },
+      undefined,
+      { 'X-Test': '1' }
+    );
+    expect(result.status).toBe('success');
+    expect(result.result?.content).toContain('Hello, Remote!');
+  });
+
+  it('reads a resource', async () => {
+    const adapter = new McpAdapter({ transport: 'http', url });
+    const result = await adapter.readResource('test://item/99', undefined, {
+      'X-Test': '1',
+    });
+    expect(result.contents.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('gets a prompt', async () => {
+    const adapter = new McpAdapter({ transport: 'http', url });
+    const result = await adapter.getPrompt(
+      'summarize',
+      { text: 'remote text' },
+      undefined,
+      { 'X-Test': '1' }
+    );
+    expect(result.messages.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('caches discovered definitions', async () => {
+    const adapter = new McpAdapter({ transport: 'http', url });
+    await adapter.discover(undefined, { 'X-Test': '1' });
+    expect(
+      (await adapter.getActionDefinitions()).map((a) => a.name).sort()
+    ).toEqual(['add', 'greet']);
+    expect(await adapter.getResourceDefinitions()).toHaveLength(1);
+    expect(await adapter.getPromptDefinitions()).toHaveLength(1);
+  });
+
+  it('merges static + per-call headers', async () => {
+    const server: HttpMcpServer = {
+      transport: 'http',
+      url,
+      headers: { 'X-Static': 'yes' },
+    };
+    const adapter = new McpAdapter(server);
+    const actions = await adapter.getActionDefinitions(undefined, {
+      'X-Per-Call': 'yes',
+    });
+    expect(actions).toHaveLength(2);
+  });
 });
 
 describe('Connector MCP integration', () => {
-  it('includes MCP tools in manifest as actions', async () => {
-    class McpTestConnector extends Connector {
-      readonly name = 'mcp-test';
+  it('stdio: includes MCP tools in manifest', async () => {
+    class StdioMcpConnector extends Connector {
+      readonly name = 'mcp-test-stdio';
       readonly version = '0.1.0';
       readonly sourceTypes = ['mcp_test'];
 
-      get mcpServer(): McpServer {
-        return createTestMcpServer();
+      get mcpServer(): StdioMcpServer {
+        return STDIO_SERVER;
       }
 
       async sync(): Promise<void> {}
     }
 
-    const connector = new McpTestConnector();
+    const connector = new StdioMcpConnector();
+    await connector.bootstrapMcp({});
     const manifest: ConnectorManifest = await connector.getManifest('http://test:8000');
-
     expect(manifest.mcp_enabled).toBe(true);
     const actionNames = manifest.actions.map((a) => a.name);
     expect(actionNames).toContain('greet');
     expect(actionNames).toContain('add');
-    expect(manifest.resources.length).toBe(1);
-    expect(manifest.prompts.length).toBe(1);
+    expect(manifest.resources).toHaveLength(1);
+    expect(manifest.prompts).toHaveLength(1);
   });
 
-  it('delegates action execution to MCP tool', async () => {
-    class McpTestConnector extends Connector {
-      readonly name = 'mcp-test';
+  it('stdio: delegates action execution to MCP tool', async () => {
+    class StdioMcpConnector extends Connector {
+      readonly name = 'mcp-test-stdio';
       readonly version = '0.1.0';
       readonly sourceTypes = ['mcp_test'];
 
-      get mcpServer(): McpServer {
-        return createTestMcpServer();
+      get mcpServer(): StdioMcpServer {
+        return STDIO_SERVER;
       }
 
       async sync(): Promise<void> {}
     }
 
-    const connector = new McpTestConnector();
-    const result = await connector.executeAction(
-      'greet',
-      { name: 'Omni' },
-      {} as Record<string, unknown>
-    );
+    const connector = new StdioMcpConnector();
+    const result = await connector.executeAction('greet', { name: 'Omni' }, {});
     expect(result).toBeInstanceOf(Response);
     expect(result.status).toBe(200);
     const body = JSON.parse(await result.text());
@@ -166,28 +263,22 @@ describe('Connector MCP integration', () => {
   });
 
   it('returns not supported for unknown actions', async () => {
-    class McpTestConnector extends Connector {
-      readonly name = 'mcp-test';
+    class StdioMcpConnector extends Connector {
+      readonly name = 'mcp-test-stdio';
       readonly version = '0.1.0';
       readonly sourceTypes = ['mcp_test'];
 
-      get mcpServer(): McpServer {
-        return createTestMcpServer();
+      get mcpServer(): StdioMcpServer {
+        return STDIO_SERVER;
       }
 
       async sync(): Promise<void> {}
     }
 
-    const connector = new McpTestConnector();
-    const result = await connector.executeAction(
-      'unknown',
-      {},
-      {} as Record<string, unknown>
-    );
-    expect(result).toBeInstanceOf(Response);
+    const connector = new StdioMcpConnector();
+    const result = await connector.executeAction('unknown', {}, {});
     expect(result.status).toBe(404);
     const body = JSON.parse(await result.text());
-    expect(body.status).toBe('error');
     expect(body.error).toContain('not supported');
   });
 


### PR DESCRIPTION
- bring all 3 SDKs to parity in terms of supporting mcp servers
- add support for both locally running and remote mcp servers (via stdio and http transports respectively)

enables #208 