### PR TITLE
Fix/sdk body and orphan dequeue

### DIFF
--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -184,7 +184,16 @@ export class SdkClient {
   }
 
   async incrementScanned(syncRunId: string): Promise<void> {
-    const response = await this.post(`/sdk/sync/${syncRunId}/scanned`);
+    // Send an explicit `{ count: 1 }` body. The connector-manager handler
+    // extracts `Json<SdkIncrementScannedRequest>`, which fails to parse an
+    // empty body even though the struct uses `#[serde(default)]` — the
+    // default applies to a missing field within a parsed JSON object, not
+    // to a missing body. Without this, every call returns 400 "EOF while
+    // parsing a value" and the catch block in connectors mis-logs the
+    // failure as if the preceding emit failed.
+    const response = await this.post(`/sdk/sync/${syncRunId}/scanned`, {
+      count: 1,
+    });
     if (!response.ok) {
       const text = await response.text();
       throw new SdkClientError(

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -184,13 +184,6 @@ export class SdkClient {
   }
 
   async incrementScanned(syncRunId: string): Promise<void> {
-    // Send an explicit `{ count: 1 }` body. The connector-manager handler
-    // extracts `Json<SdkIncrementScannedRequest>`, which fails to parse an
-    // empty body even though the struct uses `#[serde(default)]` — the
-    // default applies to a missing field within a parsed JSON object, not
-    // to a missing body. Without this, every call returns 400 "EOF while
-    // parsing a value" and the catch block in connectors mis-logs the
-    // failure as if the preceding emit failed.
     const response = await this.post(`/sdk/sync/${syncRunId}/scanned`, {
       count: 1,
     });

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -137,12 +137,14 @@ describe('SdkClient', () => {
   });
 
   describe('incrementScanned', () => {
-    it('calls correct endpoint', async () => {
+    it('calls correct endpoint with { count: 1 } body', async () => {
       let calledPath = '';
+      let capturedBody: unknown;
 
       server.use(
-        http.post(`${BASE_URL}/sdk/sync/:id/scanned`, ({ params }) => {
+        http.post(`${BASE_URL}/sdk/sync/:id/scanned`, async ({ params, request }) => {
           calledPath = `/sdk/sync/${params.id}/scanned`;
+          capturedBody = await request.json();
           return HttpResponse.json({ success: true });
         })
       );
@@ -151,6 +153,10 @@ describe('SdkClient', () => {
       await client.incrementScanned('sync-run-abc');
 
       expect(calledPath).toBe('/sdk/sync/sync-run-abc/scanned');
+      // Body MUST be sent — connector-manager's Json<T> extractor rejects
+      // an empty body with 400 even though the underlying struct has a
+      // serde default for `count`.
+      expect(capturedBody).toEqual({ count: 1 });
     });
   });
 

--- a/shared/src/queue.rs
+++ b/shared/src/queue.rs
@@ -131,6 +131,12 @@ impl EventQueue {
         batch_size: i32,
         sync_type: SyncType,
     ) -> Result<Vec<ConnectorEventQueueItem>> {
+        // `FOR UPDATE OF q` scopes the row lock to the queue rows we're
+        // about to mark as 'processing'. The inner join to sync_runs is
+        // read-only metadata; locking those rows would create needless
+        // contention with concurrent sync_run status updates. Same scoping
+        // we use in dequeue_batch_orphans, where it's mandatory rather
+        // than just hygienic.
         let rows = sqlx::query(
             r#"
             WITH batch AS (
@@ -141,7 +147,7 @@ impl EventQueue {
                 AND s.sync_type = $2
                 ORDER BY q.id
                 LIMIT $1
-                FOR UPDATE SKIP LOCKED
+                FOR UPDATE OF q SKIP LOCKED
             )
             UPDATE connector_events_queue q
             SET status = 'processing',
@@ -174,6 +180,15 @@ impl EventQueue {
         &self,
         batch_size: i32,
     ) -> Result<Vec<ConnectorEventQueueItem>> {
+        // `FOR UPDATE OF q` (not bare `FOR UPDATE`) is mandatory here:
+        // Postgres rejects `FOR UPDATE` on a query whose FROM list contains
+        // the nullable side of an outer join — and our filter is literally
+        // `s.id IS NULL`, so by definition the s side has no row to lock.
+        // We only need a lock on the queue rows we're about to mark as
+        // 'processing' anyway. Without `OF q` the planner errors with
+        // "FOR UPDATE cannot be applied to the nullable side of an outer
+        // join" and the entire process_batch tick fails — which also
+        // starves the non-orphan dequeue path that runs after this one.
         let rows = sqlx::query(
             r#"
             WITH batch AS (
@@ -184,7 +199,7 @@ impl EventQueue {
                 AND s.id IS NULL
                 ORDER BY q.id
                 LIMIT $1
-                FOR UPDATE SKIP LOCKED
+                FOR UPDATE OF q SKIP LOCKED
             )
             UPDATE connector_events_queue q
             SET status = 'processing',

--- a/shared/src/queue.rs
+++ b/shared/src/queue.rs
@@ -131,12 +131,6 @@ impl EventQueue {
         batch_size: i32,
         sync_type: SyncType,
     ) -> Result<Vec<ConnectorEventQueueItem>> {
-        // `FOR UPDATE OF q` scopes the row lock to the queue rows we're
-        // about to mark as 'processing'. The inner join to sync_runs is
-        // read-only metadata; locking those rows would create needless
-        // contention with concurrent sync_run status updates. Same scoping
-        // we use in dequeue_batch_orphans, where it's mandatory rather
-        // than just hygienic.
         let rows = sqlx::query(
             r#"
             WITH batch AS (
@@ -180,15 +174,6 @@ impl EventQueue {
         &self,
         batch_size: i32,
     ) -> Result<Vec<ConnectorEventQueueItem>> {
-        // `FOR UPDATE OF q` (not bare `FOR UPDATE`) is mandatory here:
-        // Postgres rejects `FOR UPDATE` on a query whose FROM list contains
-        // the nullable side of an outer join — and our filter is literally
-        // `s.id IS NULL`, so by definition the s side has no row to lock.
-        // We only need a lock on the queue rows we're about to mark as
-        // 'processing' anyway. Without `OF q` the planner errors with
-        // "FOR UPDATE cannot be applied to the nullable side of an outer
-        // join" and the entire process_batch tick fails — which also
-        // starves the non-orphan dequeue path that runs after this one.
         let rows = sqlx::query(
             r#"
             WITH batch AS (

--- a/shared/tests/event_queue_test.rs
+++ b/shared/tests/event_queue_test.rs
@@ -252,4 +252,92 @@ mod tests {
         queue.dequeue_batch(2).await.unwrap();
         assert_eq!(queue.get_pending_count().await.unwrap(), 3);
     }
+
+    /// Regression test: events whose `sync_run_id` no longer exists in
+    /// `sync_runs` (e.g. because the sync_run row was GC'd or the source
+    /// was deleted but the queue rows weren't) must be drainable via
+    /// `dequeue_batch_orphans`. Before the `FOR UPDATE OF q SKIP LOCKED`
+    /// fix, this query failed at parse time with "FOR UPDATE cannot be
+    /// applied to the nullable side of an outer join", which propagated
+    /// up through `process_batch` and starved the entire indexer.
+    #[tokio::test]
+    async fn test_dequeue_batch_orphans_drains_events_with_missing_sync_run() {
+        let env = TestEnvironment::new().await.unwrap();
+        let queue = EventQueue::new(env.db_pool.pool().clone());
+
+        // Enqueue events under sync_run_ids that have no row in sync_runs —
+        // exactly the orphan condition produced when a source is deleted
+        // and its sync_runs cascade away faster than the queue is drained.
+        for i in 0..3 {
+            let event = make_event("nonexistent-run", &format!("orphan-doc-{}", i));
+            queue.enqueue(TEST_SOURCE_ID, &event).await.unwrap();
+        }
+
+        let batch = queue.dequeue_batch_orphans(10).await.unwrap();
+        assert_eq!(batch.len(), 3);
+        for item in &batch {
+            assert!(matches!(item.status, EventStatus::Processing));
+        }
+
+        // Re-running should return empty — claimed rows are now `processing`.
+        let again = queue.dequeue_batch_orphans(10).await.unwrap();
+        assert!(again.is_empty());
+    }
+
+    /// Companion: `dequeue_batch_by_sync_type` must continue to work for
+    /// events whose sync_run row exists. We applied the same `FOR UPDATE
+    /// OF q` scoping there for hygiene; this test pins that the inner
+    /// join + per-sync-type filter still routes correctly.
+    #[tokio::test]
+    async fn test_dequeue_batch_by_sync_type_routes_by_sync_runs() {
+        use shared::models::SyncType;
+
+        let env = TestEnvironment::new().await.unwrap();
+        let pool = env.db_pool.pool().clone();
+        let queue = EventQueue::new(pool.clone());
+
+        // Insert two sync_runs with different sync_types.
+        let full_run = ulid::Ulid::new().to_string();
+        let inc_run = ulid::Ulid::new().to_string();
+        for (id, sync_type) in [(&full_run, "full"), (&inc_run, "incremental")] {
+            sqlx::query(
+                r#"
+                INSERT INTO sync_runs (id, source_id, sync_type, status, started_at, created_at, updated_at)
+                VALUES ($1, $2, $3, 'running', NOW(), NOW(), NOW())
+                "#,
+            )
+            .bind(id)
+            .bind(TEST_SOURCE_ID)
+            .bind(sync_type)
+            .execute(&pool)
+            .await
+            .unwrap();
+        }
+
+        // Two events under the full sync_run, one under incremental.
+        for i in 0..2 {
+            let event = make_event(&full_run, &format!("full-doc-{}", i));
+            queue.enqueue(TEST_SOURCE_ID, &event).await.unwrap();
+        }
+        let event_inc = make_event(&inc_run, "inc-doc-1");
+        queue.enqueue(TEST_SOURCE_ID, &event_inc).await.unwrap();
+
+        // Asking for `Full` should pick up only the full-run events.
+        let full_batch = queue
+            .dequeue_batch_by_sync_type(10, SyncType::Full)
+            .await
+            .unwrap();
+        assert_eq!(full_batch.len(), 2);
+        for item in &full_batch {
+            assert_eq!(item.sync_run_id, full_run);
+        }
+
+        // The incremental event remains and is picked up by its own filter.
+        let inc_batch = queue
+            .dequeue_batch_by_sync_type(10, SyncType::Incremental)
+            .await
+            .unwrap();
+        assert_eq!(inc_batch.len(), 1);
+        assert_eq!(inc_batch[0].sync_run_id, inc_run);
+    }
 }


### PR DESCRIPTION
# Unblock document indexing: TS SDK body + orphan-dequeue lock

Two independent regressions that together stalled every TS-SDK connector's documents in the queue. Each is one line of real change. Both shipped in recent merges and went unnoticed because no test exercised the failing path end-to-end.

This PR has two atomic commits — one per bug, each with its own integration test — so they can be reviewed (or reverted) independently.

---

## 1. `fix(sdk-typescript): send { count: 1 } body on incrementScanned`

`SdkClient.incrementScanned` POSTs to `/sdk/sync/{id}/scanned` with no body:

```ts
async incrementScanned(syncRunId: string): Promise<void> {
  const response = await this.post(`/sdk/sync/${syncRunId}/scanned`);   // body undefined
  ...
}
```

`this.post(path, body?)` skips `JSON.stringify` when `body` is `undefined`, so the wire request has zero bytes.

But the server-side handler `sdk_increment_scanned` extracts `Json<SdkIncrementScannedRequest>`:

```rust
pub struct SdkIncrementScannedRequest {
    #[serde(default = "default_count")]
    pub count: i32,
}
fn default_count() -> i32 { 1 }
```

Axum's `Json` extractor calls `serde_json::from_slice(&body)`. An empty body fails to parse with:

```
EOF while parsing a value at line 1 column 0
```

…and the handler returns 400. The `#[serde(default)]` only fills a missing **field inside a parsed JSON object** — never a missing body. (`{}` would work; nothing does not.)

### Why it stayed hidden

The TS SDK's existing test (`tests/client.test.ts`) only asserted the path, not the body, so it passed against `msw`'s default lenient matcher. The handler was tightened by adding the `Json<T>` extractor in #160 (`acf01a0b "Refactor Google connector to use SDK client"`); the corresponding SDK update only landed in the Python and Rust SDKs.

Verified parity:
- Python SDK (`sdk/python/omni_connector/client.py`) sends `json={"count": 1}`.
- Rust SDK (`sdk/rust/src/client.rs`) sends a `count: i32` body.
- TS SDK was the lone holdout.

### Symptom in production

Connectors typically wrap the emit + counter pair in one `try/catch`:

```ts
try {
  await this.emitDocument(...)        // ① queue INSERT — succeeds
  await ctx.incrementScanned();       // ② 400 EOF — throws
} catch (e) {
  logger.warn(`Failed to emit ${id}`); // ③ misattributes ② as ①
}
```

So every document logs `Failed to emit <id>` even though the queue row was already committed. Operators see thousands of "failures" in the logs while the queue has the events sitting there waiting. We hit this the moment our Huly connector tried to sync a non-empty workspace.

### Fix

Send `{ count: 1 }`. One line. Tightened the test to assert the body, not just the path, so this can't silently regress again.

---

## 2. `fix(indexer): scope dequeue locks with FOR UPDATE OF q`

`shared::queue::dequeue_batch_orphans` issues:

```sql
WITH batch AS (
    SELECT q.id
    FROM connector_events_queue q
    LEFT JOIN sync_runs s ON q.sync_run_id = s.id
    WHERE q.status = 'pending'
    AND s.id IS NULL
    ORDER BY q.id
    LIMIT $1
    FOR UPDATE SKIP LOCKED
)
```

Postgres rejects this at parse time:

```
ERROR: FOR UPDATE cannot be applied to the nullable side of an outer join
```

`FOR UPDATE` (un-scoped) acquires locks on every table in the FROM list. The right side of a `LEFT JOIN` can be NULL — and our filter `s.id IS NULL` is **literally** the case where there's no `s` row to lock. From the Postgres docs:

> It is not possible for SELECT FOR UPDATE to be applied to the result of an outer join when no rows from the inner table match.

### Why it kills the entire indexer

`queue_processor::process_batch` runs orphan dequeue first, then per-sync-type dequeue:

```rust
// Process orphan events first
while batches_dequeued < MAX_BATCHES_PER_CALL && orphan_count > 0 {
    let events = self
        .event_queue
        .dequeue_batch_orphans(self.batch_size)
        .await?;                                        // ← `?` propagates Err
    ...
}

// THIS NEVER RUNS when there are orphans:
for (sync_type, reason) in ready {
    let events = self.event_queue.dequeue_batch_by_sync_type(...).await?;
    ...
}
```

The moment `orphan_count > 0`, `dequeue_batch_orphans` throws, `?` returns Err, `process_batch` exits, and the working `dequeue_batch_by_sync_type` is never even attempted.

So a single deleted source whose `sync_runs` rows cascade away **stops the indexer for every other source too**. We watched our production indexer go from `Completed: 1625` to `Completed: 1625` for hours while pending climbed past 270, with this error in the logs every minute:

```
ERROR Failed to process batch: error returned from database:
       FOR UPDATE cannot be applied to the nullable side of an outer join
```

### Why it stayed hidden

The existing tests in `shared/tests/event_queue_test.rs` only call `dequeue_batch` (the simple variant with no join). `dequeue_batch_orphans` and `dequeue_batch_by_sync_type` were added in #169 (`c589c34a "Simplify batching in indexer"`) without test coverage. Dev environments typically have no orphans (orphans appear in production after a source is deleted), so the bug was invisible locally.

### Fix

Scope the lock to just the queue rows:

```sql
LIMIT $1
FOR UPDATE OF q SKIP LOCKED   -- not bare FOR UPDATE
```

`OF q` tells Postgres to only lock rows from `q`. The `s` side is read-only metadata for the `IS NULL` filter — no lock needed, and locking it isn't possible on the nullable side anyway.

Applied the same `OF q` scoping to `dequeue_batch_by_sync_type` for symmetry. Its inner join lets bare `FOR UPDATE` parse today, but locking `sync_runs` rows is wasteful — concurrent `sync_run` status updates would block on locks they don't need.

Added integration tests for both dequeue variants. The orphan test is a strict regression — it fails at SQL parse time without the fix.

---

## Test plan

- [x] `cd sdk/typescript && npm test` — 48/48 pass; new body-content assertion in `incrementScanned` test.
- [x] `cargo test -p shared --test event_queue_test` — both new tests pass; the orphan test fails at SQL parse with bare `FOR UPDATE` and passes with `FOR UPDATE OF q`.

## Compatibility / migrations

None. Both changes are pure code; no schema, config, or wire-protocol changes. Old SDK clients (no body) talking to a new server still 400; new SDK clients (with body) talking to an old server (no `Json<T>` extractor) work fine — the server ignored the body before #160. So the rollout sequence is just "upgrade clients to match the server" and there's no flag-day.

## Related history

- Server-side regression: #160 (`acf01a0b`) added `Json<SdkIncrementScannedRequest>` to the handler; only Python and Rust SDKs were updated to match.
- Indexer regression: #169 (`c589c34a`) introduced `dequeue_batch_orphans` and `dequeue_batch_by_sync_type` without tests.