### PR TITLE
# fix(sdk/ts): catch up to upstream — title shim, user filter, /updated, complete()

### DIFF
--- a/connectors/linear/src/connector.ts
+++ b/connectors/linear/src/connector.ts
@@ -164,6 +164,7 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
             } else {
               await ctx.emit(doc);
             }
+            await ctx.incrementUpdated(1);
             docsSinceCheckpoint++;
             if (docsSinceCheckpoint >= CHECKPOINT_INTERVAL) {
               await ctx.saveState({ last_sync_at: new Date().toISOString() });
@@ -200,6 +201,7 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
           } else {
             await ctx.emit(doc);
           }
+          await ctx.incrementUpdated(1);
           docsSinceCheckpoint++;
 
           // Sync project updates as separate documents
@@ -215,6 +217,7 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
               } else {
                 await ctx.emit(updateDoc);
               }
+              await ctx.incrementUpdated(1);
               docsSinceCheckpoint++;
             } catch (e) {
               const eid = `linear:project_update:${update.id}`;
@@ -261,6 +264,7 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
           } else {
             await ctx.emit(omniDoc);
           }
+          await ctx.incrementUpdated(1);
           docsSinceCheckpoint++;
           if (docsSinceCheckpoint >= CHECKPOINT_INTERVAL) {
             await ctx.saveState({ last_sync_at: new Date().toISOString() });

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -200,6 +200,17 @@ export class SdkClient {
     }
   }
 
+  async incrementUpdated(syncRunId: string, count: number): Promise<void> {
+    const response = await this.post(`/sdk/sync/${syncRunId}/updated`, { count });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new SdkClientError(
+        `Failed to increment updated: ${response.status} - ${text}`,
+        response.status
+      );
+    }
+  }
+
   async complete(
     syncRunId: string,
     documentsScanned: number,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -1,6 +1,10 @@
 import { SdkClientError, ConfigurationError } from './errors.js';
-import type { ConnectorEventPayload } from './models.js';
-import { serializeConnectorEvent } from './models.js';
+import {
+  SdkSourceSyncDataSchema,
+  serializeConnectorEvent,
+  type ConnectorEventPayload,
+  type SdkSourceSyncData,
+} from './models.js';
 
 export class SdkClient {
   private readonly baseUrl: string;
@@ -242,11 +246,7 @@ export class SdkClient {
     }
   }
 
-  async fetchSourceConfig(sourceId: string): Promise<{
-    config: Record<string, unknown>;
-    credentials: Record<string, unknown>;
-    connector_state: Record<string, unknown> | null;
-  }> {
+  async fetchSourceConfig(sourceId: string): Promise<SdkSourceSyncData> {
     const response = await this.get(`/sdk/source/${sourceId}/sync-config`);
     if (!response.ok) {
       const text = await response.text();
@@ -255,11 +255,8 @@ export class SdkClient {
         response.status
       );
     }
-    return response.json() as Promise<{
-      config: Record<string, unknown>;
-      credentials: Record<string, unknown>;
-      connector_state: Record<string, unknown> | null;
-    }>;
+    const raw = (await response.json()) as unknown;
+    return SdkSourceSyncDataSchema.parse(raw);
   }
 
   private async get(path: string): Promise<Response> {

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -211,21 +211,8 @@ export class SdkClient {
     }
   }
 
-  async complete(
-    syncRunId: string,
-    documentsScanned: number,
-    documentsUpdated: number,
-    newState?: Record<string, unknown>
-  ): Promise<void> {
-    const payload: Record<string, unknown> = {
-      documents_scanned: documentsScanned,
-      documents_updated: documentsUpdated,
-    };
-    if (newState !== undefined) {
-      payload.new_state = newState;
-    }
-
-    const response = await this.post(`/sdk/sync/${syncRunId}/complete`, payload);
+  async complete(syncRunId: string): Promise<void> {
+    const response = await this.post(`/sdk/sync/${syncRunId}/complete`);
     if (!response.ok) {
       const text = await response.text();
       throw new SdkClientError(

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -111,13 +111,21 @@ export class SyncContext {
   }
 
   async emit(doc: Document): Promise<void> {
+    // Shim Document.title into metadata.title — the indexer reads only
+    // metadata.title and falls back to "Untitled" otherwise. Non-mutating
+    // spread so the caller's Document is never modified (broader than
+    // Python's conditional shim, which skips bare-metadata docs).
+    const metadata: DocumentMetadata = { ...(doc.metadata ?? {}) };
+    if (!metadata.title) {
+      metadata.title = doc.title;
+    }
     const event: ConnectorEventPayload = {
       type: EventType.DOCUMENT_CREATED,
       sync_run_id: this._syncRunId,
       source_id: this._sourceId,
       document_id: doc.external_id,
       content_id: doc.content_id,
-      metadata: doc.metadata,
+      metadata,
       permissions: doc.permissions,
       attributes: doc.attributes,
     };
@@ -126,13 +134,17 @@ export class SyncContext {
   }
 
   async emitUpdated(doc: Document): Promise<void> {
+    const metadata: DocumentMetadata = { ...(doc.metadata ?? {}) };
+    if (!metadata.title) {
+      metadata.title = doc.title;
+    }
     const event: ConnectorEventPayload = {
       type: EventType.DOCUMENT_UPDATED,
       sync_run_id: this._syncRunId,
       source_id: this._sourceId,
       document_id: doc.external_id,
       content_id: doc.content_id,
-      metadata: doc.metadata,
+      metadata,
       permissions: doc.permissions,
       attributes: doc.attributes,
     };

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -2,6 +2,7 @@ import type { SdkClient } from './client.js';
 import {
   EventType,
   SyncMode,
+  UserFilterMode,
   type Document,
   type DocumentMetadata,
   type DocumentPermissions,
@@ -34,6 +35,10 @@ export class SyncContext {
   private readonly bufferTimeThresholdMs: number | null;
   private eventBuffer: ConnectorEventPayload[] = [];
   private oldestEventAt: number | null = null;
+  private readonly _sourceType: string | null;
+  private readonly _userFilterMode: UserFilterMode;
+  private readonly _userWhitelist: ReadonlySet<string>;
+  private readonly _userBlacklist: ReadonlySet<string>;
 
   constructor(
     client: SdkClient,
@@ -42,7 +47,13 @@ export class SyncContext {
     state?: Record<string, unknown>,
     syncMode: SyncMode = SyncMode.INCREMENTAL,
     documentsScanned = 0,
-    documentsUpdated = 0
+    documentsUpdated = 0,
+    options?: {
+      sourceType?: string | null;
+      userFilterMode?: UserFilterMode;
+      userWhitelist?: string[] | null;
+      userBlacklist?: string[] | null;
+    }
   ) {
     this.client = client;
     this._syncRunId = syncRunId;
@@ -58,6 +69,17 @@ export class SyncContext {
     // the manager's running tally rather than restarting at zero.
     this._documentsScanned = documentsScanned;
     this._documentsEmitted = documentsUpdated;
+    this._sourceType = options?.sourceType ?? null;
+    this._userFilterMode = options?.userFilterMode ?? UserFilterMode.ALL;
+    // Store as lowercased set so shouldIndexUser is case-insensitive
+    // (mirrors Python's should_index_user; deliberately differs from
+    // Rust's case-sensitive Source::should_index_user).
+    this._userWhitelist = new Set(
+      (options?.userWhitelist ?? []).map((e) => e.toLowerCase())
+    );
+    this._userBlacklist = new Set(
+      (options?.userBlacklist ?? []).map((e) => e.toLowerCase())
+    );
   }
 
   get syncRunId(): string {
@@ -82,6 +104,10 @@ export class SyncContext {
 
   get documentsScanned(): number {
     return this._documentsScanned;
+  }
+
+  get sourceType(): string | null {
+    return this._sourceType;
   }
 
   private async bufferEvent(event: ConnectorEventPayload): Promise<void> {
@@ -185,6 +211,32 @@ export class SyncContext {
   async incrementScanned(): Promise<void> {
     this._documentsScanned++;
     await this.client.incrementScanned(this._syncRunId);
+  }
+
+  /**
+   * Check whether a user should be indexed under this source's user-filter
+   * settings. Mirrors the Python SDK's should_index_user.
+   *
+   * Connectors call this themselves before emitting per-user records — the
+   * SDK does NOT auto-skip on emit, since the connector knows whether a
+   * given doc is "owned by a user" or workspace-shared.
+   *
+   * Empty email: ALL admits, WHITELIST/BLACKLIST reject (matches Python).
+   * Comparison is case-insensitive (Rust's equivalent is case-sensitive —
+   * deliberate divergence; lowercasing here is the friendlier default and
+   * matches operator expectations).
+   */
+  shouldIndexUser(userEmail: string): boolean {
+    if (this._userFilterMode === UserFilterMode.ALL) return true;
+    const email = userEmail.toLowerCase();
+    if (!email) return false;
+    if (this._userFilterMode === UserFilterMode.WHITELIST) {
+      return this._userWhitelist.has(email);
+    }
+    if (this._userFilterMode === UserFilterMode.BLACKLIST) {
+      return !this._userBlacklist.has(email);
+    }
+    return true;
   }
 
   /**

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -214,6 +214,20 @@ export class SyncContext {
   }
 
   /**
+   * Bump the server-side documents_updated counter for this sync run.
+   *
+   * Mirrors Rust SDK's increment_updated. The connector author chooses
+   * what counts as "updated" — typically called once per successfully
+   * persisted emit/emitUpdated, or batched (e.g. once per processed
+   * chunk). Errors propagate so the caller can decide whether a stat
+   * miss should fail the sync or be swallowed.
+   */
+  async incrementUpdated(count: number): Promise<void> {
+    if (count <= 0) return;
+    await this.client.incrementUpdated(this._syncRunId, count);
+  }
+
+  /**
    * Check whether a user should be indexed under this source's user-filter
    * settings. Mirrors the Python SDK's should_index_user.
    *

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -269,12 +269,14 @@ export class SyncContext {
 
   async complete(newState?: Record<string, unknown>): Promise<void> {
     await this.flush();
-    await this.client.complete(
-      this._syncRunId,
-      this._documentsScanned,
-      this._documentsEmitted,
-      newState
-    );
+    // sdk_complete is body-less since 7c21fd10 — newState in the /complete
+    // body is silently dropped server-side. Persist via the connector-state
+    // endpoint instead (same path saveState() takes).
+    if (newState !== undefined) {
+      this._state = newState;
+      await this.client.updateConnectorState(this._sourceId, newState);
+    }
+    await this.client.complete(this._syncRunId);
   }
 
   async fail(error: string): Promise<void> {

--- a/sdk/typescript/src/index.ts
+++ b/sdk/typescript/src/index.ts
@@ -37,6 +37,8 @@ export {
   createSyncResponseError,
   ActionResponse,
   serializeConnectorEvent,
+  UserFilterMode,
+  SdkSourceSyncDataSchema,
   type DocumentMetadata,
   type DocumentPermissions,
   type Document,
@@ -53,6 +55,7 @@ export {
   type CancelResponse,
   type ActionRequest,
   type ConnectorEventPayload,
+  type SdkSourceSyncData,
 } from './models.js';
 
 export {

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -275,3 +275,31 @@ export function serializeConnectorEvent(event: ConnectorEventPayload): Record<st
 
   return base;
 }
+
+export const UserFilterMode = {
+  ALL: 'all',
+  WHITELIST: 'whitelist',
+  BLACKLIST: 'blacklist',
+} as const;
+export type UserFilterMode = (typeof UserFilterMode)[keyof typeof UserFilterMode];
+
+/**
+ * Wire shape of GET /sdk/source/:source_id/sync-config from connector-manager.
+ *
+ * Defaults match the manager's own defaults: `user_filter_mode = 'all'` admits
+ * every user; `user_whitelist` / `user_blacklist` are nullable since the
+ * server stores them as `Option<JsonValue>`. `source_type` is nullable to
+ * tolerate older payload shapes — connector-manager always sets it today.
+ */
+export const SdkSourceSyncDataSchema = z.object({
+  config: z.record(z.unknown()).default({}),
+  credentials: z.record(z.unknown()).default({}),
+  connector_state: z.record(z.unknown()).nullable().default(null),
+  source_type: z.string().nullable().default(null),
+  user_filter_mode: z
+    .enum([UserFilterMode.ALL, UserFilterMode.WHITELIST, UserFilterMode.BLACKLIST])
+    .default(UserFilterMode.ALL),
+  user_whitelist: z.array(z.string()).nullable().default(null),
+  user_blacklist: z.array(z.string()).nullable().default(null),
+});
+export type SdkSourceSyncData = z.infer<typeof SdkSourceSyncDataSchema>;

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -13,6 +13,7 @@ import {
   createSyncResponseStarted,
   createSyncResponseError,
   ActionResponse,
+  type SdkSourceSyncData,
 } from './models.js';
 import { getLogger } from './logger.js';
 
@@ -119,7 +120,7 @@ export function createServer(connector: Connector): Express {
       return;
     }
 
-    let sourceData: import('./models.js').SdkSourceSyncData;
+    let sourceData: SdkSourceSyncData;
     try {
       sourceData = await getSdkClient().fetchSourceConfig(sourceId);
     } catch (error) {

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -119,18 +119,9 @@ export function createServer(connector: Connector): Express {
       return;
     }
 
-    let sourceData: {
-      config: Record<string, unknown>;
-      credentials: Record<string, unknown>;
-      state: Record<string, unknown> | null;
-    };
+    let sourceData: import('./models.js').SdkSourceSyncData;
     try {
-      const data = await getSdkClient().fetchSourceConfig(sourceId);
-      sourceData = {
-        config: data.config,
-        credentials: data.credentials,
-        state: data.connector_state,
-      };
+      sourceData = await getSdkClient().fetchSourceConfig(sourceId);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
       if (message.includes('404')) {
@@ -148,10 +139,16 @@ export function createServer(connector: Connector): Express {
       getSdkClient(),
       syncRunId,
       sourceId,
-      sourceData.state ?? undefined,
+      sourceData.connector_state ?? undefined,
       syncMode,
       documentsScanned,
-      documentsUpdated
+      documentsUpdated,
+      {
+        sourceType: sourceData.source_type,
+        userFilterMode: sourceData.user_filter_mode,
+        userWhitelist: sourceData.user_whitelist,
+        userBlacklist: sourceData.user_blacklist,
+      }
     );
     activeSyncs.set(sourceId, ctx);
 
@@ -160,7 +157,7 @@ export function createServer(connector: Connector): Express {
         await connector.sync(
           sourceData.config,
           sourceData.credentials,
-          sourceData.state,
+          sourceData.connector_state,
           ctx
         );
       } catch (error) {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -160,45 +160,27 @@ describe('SdkClient', () => {
     });
   });
 
-  describe('complete', () => {
-    it('sends correct payload with state', async () => {
+  describe('complete (status-flip-only post-7c21fd10)', () => {
+    it('POSTs an empty body to /sdk/sync/:id/complete', async () => {
       let capturedBody: unknown;
+      let capturedMethod: string | null = null;
 
       server.use(
-        http.post(`${BASE_URL}/sdk/sync/:id/complete`, async ({ request }) => {
-          capturedBody = await request.json();
-          return HttpResponse.json({ success: true });
+        http.post(`${BASE_URL}/sdk/sync/sync-1/complete`, async ({ request }) => {
+          capturedMethod = request.method;
+          const text = await request.text();
+          capturedBody = text === '' ? null : JSON.parse(text);
+          return HttpResponse.json({ status: 'ok' });
         })
       );
 
       const client = new SdkClient(BASE_URL);
-      await client.complete('sync-123', 100, 50, { cursor: 'abc123' });
+      await client.complete('sync-1');
 
-      expect(capturedBody).toEqual({
-        documents_scanned: 100,
-        documents_updated: 50,
-        new_state: { cursor: 'abc123' },
-      });
-    });
-
-    it('sends payload without state when not provided', async () => {
-      let capturedBody: unknown;
-
-      server.use(
-        http.post(`${BASE_URL}/sdk/sync/:id/complete`, async ({ request }) => {
-          capturedBody = await request.json();
-          return HttpResponse.json({ success: true });
-        })
-      );
-
-      const client = new SdkClient(BASE_URL);
-      await client.complete('sync-123', 100, 50);
-
-      expect(capturedBody).toEqual({
-        documents_scanned: 100,
-        documents_updated: 50,
-      });
-      expect((capturedBody as Record<string, unknown>).new_state).toBeUndefined();
+      expect(capturedMethod).toBe('POST');
+      // Body is either absent or an empty object — server ignores it either way.
+      // Plan picks "no body sent" to match Rust SDK's complete signature.
+      expect(capturedBody).toBeNull();
     });
   });
 

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -202,6 +202,33 @@ describe('SdkClient', () => {
     });
   });
 
+  describe('incrementUpdated', () => {
+    it('POSTs {count} to /sdk/sync/:id/updated', async () => {
+      let captured: unknown;
+      server.use(
+        http.post(`${BASE_URL}/sdk/sync/sync-1/updated`, async ({ request }) => {
+          captured = await request.json();
+          return HttpResponse.json({ status: 'ok' });
+        })
+      );
+      const client = new SdkClient(BASE_URL);
+      await client.incrementUpdated('sync-1', 7);
+      expect(captured).toEqual({ count: 7 });
+    });
+
+    it('throws SdkClientError on non-OK response', async () => {
+      server.use(
+        http.post(`${BASE_URL}/sdk/sync/sync-1/updated`, () =>
+          HttpResponse.text('boom', { status: 500 })
+        )
+      );
+      const client = new SdkClient(BASE_URL);
+      await expect(client.incrementUpdated('sync-1', 1)).rejects.toThrow(
+        /Failed to increment updated/
+      );
+    });
+  });
+
   describe('fail', () => {
     it('sends correct error payload', async () => {
       let capturedBody: unknown;

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -239,7 +239,7 @@ describe('SdkClient', () => {
       const client = new SdkClient(BASE_URL);
       const result = await client.fetchSourceConfig('source-123');
 
-      expect(result).toEqual(mockData);
+      expect(result).toMatchObject(mockData);
     });
 
     it('throws SdkClientError on 404', async () => {
@@ -256,6 +256,69 @@ describe('SdkClient', () => {
       await expect(
         client.fetchSourceConfig('nonexistent')
       ).rejects.toThrow('Failed to fetch source config: 404');
+    });
+
+    it('defaults missing user-filter fields to ALL/null', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/source/source-min/sync-config`, () =>
+          HttpResponse.json({
+            config: {},
+            credentials: {},
+            connector_state: null,
+          })
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      const cfg = await client.fetchSourceConfig('source-min');
+
+      expect(cfg.user_filter_mode).toBe('all');
+      expect(cfg.user_whitelist).toBeNull();
+      expect(cfg.user_blacklist).toBeNull();
+      expect(cfg.source_type).toBeNull();
+    });
+
+    it('rejects an unknown user_filter_mode at parse time', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/source/source-bad/sync-config`, () =>
+          HttpResponse.json({
+            config: {},
+            credentials: {},
+            connector_state: null,
+            user_filter_mode: 'invalid_mode',
+          })
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      await expect(client.fetchSourceConfig('source-bad')).rejects.toThrow();
+    });
+
+    it('parses a fully populated sync-config', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/source/source-full/sync-config`, () =>
+          HttpResponse.json({
+            config: { workspaces: ['ws1'] },
+            credentials: { token: 'redacted' },
+            connector_state: { cursor: 'abc' },
+            source_type: 'linear',
+            user_filter_mode: 'whitelist',
+            user_whitelist: ['alice@example.com', 'bob@example.com'],
+            user_blacklist: null,
+          })
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      const cfg = await client.fetchSourceConfig('source-full');
+
+      expect(cfg.config).toEqual({ workspaces: ['ws1'] });
+      expect(cfg.credentials).toEqual({ token: 'redacted' });
+      expect(cfg.connector_state).toEqual({ cursor: 'abc' });
+      expect(cfg.source_type).toBe('linear');
+      expect(cfg.user_filter_mode).toBe('whitelist');
+      expect(cfg.user_whitelist).toEqual(['alice@example.com', 'bob@example.com']);
+      expect(cfg.user_blacklist).toBeNull();
     });
   });
 

--- a/sdk/typescript/tests/context.test.ts
+++ b/sdk/typescript/tests/context.test.ts
@@ -1,0 +1,151 @@
+import { describe, it, expect, beforeAll, afterAll, afterEach, vi } from 'vitest';
+import { http, HttpResponse } from 'msw';
+import { setupServer } from 'msw/node';
+import { SdkClient } from '../src/client.js';
+import { SyncContext } from '../src/context.js';
+import {
+  EventType,
+  SyncMode,
+  type ConnectorEventPayload,
+  type Document,
+} from '../src/models.js';
+
+const BASE_URL = 'http://test-cm:8080';
+const server = setupServer();
+
+beforeAll(() => {
+  vi.stubEnv('CONNECTOR_MANAGER_URL', BASE_URL);
+  server.listen({ onUnhandledRequest: 'error' });
+});
+afterEach(() => server.resetHandlers());
+afterAll(() => {
+  vi.unstubAllEnvs();
+  server.close();
+});
+
+function captureEvents(): ConnectorEventPayload[] {
+  const captured: ConnectorEventPayload[] = [];
+  server.use(
+    http.post(`${BASE_URL}/sdk/events`, async ({ request }) => {
+      const body = (await request.json()) as { event: ConnectorEventPayload };
+      captured.push(body.event);
+      return HttpResponse.json({ success: true });
+    }),
+    http.post(`${BASE_URL}/sdk/events/batch`, async ({ request }) => {
+      const body = (await request.json()) as { events: ConnectorEventPayload[] };
+      captured.push(...body.events);
+      return HttpResponse.json({ success: true });
+    })
+  );
+  return captured;
+}
+
+describe('SyncContext.emit — title shim', () => {
+  it('copies Document.title into metadata.title when metadata.title is missing', async () => {
+    const captured = captureEvents();
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-1',
+      'source-1',
+      undefined,
+      SyncMode.REALTIME // size=1, flush-on-emit
+    );
+    const doc: Document = {
+      external_id: 'ext-1',
+      title: 'Real Title',
+      content_id: 'content-1',
+      metadata: { content_type: 'card', mime_type: 'text/markdown' },
+    };
+
+    await ctx.emit(doc);
+
+    expect(captured).toHaveLength(1);
+    expect(captured[0].metadata?.title).toBe('Real Title');
+  });
+
+  it('does not mutate the caller\'s Document', async () => {
+    captureEvents();
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-2',
+      'source-2',
+      undefined,
+      SyncMode.REALTIME
+    );
+    const originalMetadata = { content_type: 'card' };
+    const doc: Document = {
+      external_id: 'ext-2',
+      title: 'Title',
+      content_id: 'content-2',
+      metadata: originalMetadata,
+    };
+
+    await ctx.emit(doc);
+
+    expect(originalMetadata).toEqual({ content_type: 'card' });
+    expect(doc.metadata).toBe(originalMetadata);
+  });
+
+  it('preserves an explicit metadata.title set by the connector', async () => {
+    const captured = captureEvents();
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-3',
+      'source-3',
+      undefined,
+      SyncMode.REALTIME
+    );
+    const doc: Document = {
+      external_id: 'ext-3',
+      title: 'Wire Title',
+      content_id: 'content-3',
+      metadata: { title: 'Explicit Metadata Title', content_type: 'card' },
+    };
+
+    await ctx.emit(doc);
+
+    expect(captured[0].metadata?.title).toBe('Explicit Metadata Title');
+  });
+
+  it('handles missing metadata by creating it with title set', async () => {
+    const captured = captureEvents();
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-4',
+      'source-4',
+      undefined,
+      SyncMode.REALTIME
+    );
+    const doc: Document = {
+      external_id: 'ext-4',
+      title: 'Bare Doc',
+      content_id: 'content-4',
+    };
+
+    await ctx.emit(doc);
+
+    expect(captured[0].metadata?.title).toBe('Bare Doc');
+  });
+
+  it('emitUpdated applies the same shim', async () => {
+    const captured = captureEvents();
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-5',
+      'source-5',
+      undefined,
+      SyncMode.REALTIME
+    );
+    const doc: Document = {
+      external_id: 'ext-5',
+      title: 'Updated Title',
+      content_id: 'content-5',
+      metadata: { content_type: 'document' },
+    };
+
+    await ctx.emitUpdated(doc);
+
+    expect(captured[0].type).toBe(EventType.DOCUMENT_UPDATED);
+    expect(captured[0].metadata?.title).toBe('Updated Title');
+  });
+});

--- a/sdk/typescript/tests/context.test.ts
+++ b/sdk/typescript/tests/context.test.ts
@@ -149,3 +149,87 @@ describe('SyncContext.emit — title shim', () => {
     expect(captured[0].metadata?.title).toBe('Updated Title');
   });
 });
+
+describe('SyncContext.shouldIndexUser', () => {
+  function makeCtx(opts: {
+    mode?: 'all' | 'whitelist' | 'blacklist';
+    whitelist?: string[] | null;
+    blacklist?: string[] | null;
+  }): SyncContext {
+    return new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync',
+      'source',
+      undefined,
+      SyncMode.INCREMENTAL,
+      0,
+      0,
+      {
+        userFilterMode: opts.mode ?? 'all',
+        userWhitelist: opts.whitelist ?? null,
+        userBlacklist: opts.blacklist ?? null,
+      }
+    );
+  }
+
+  it('returns true for everyone in ALL mode (including empty email)', () => {
+    const ctx = makeCtx({ mode: 'all' });
+    expect(ctx.shouldIndexUser('alice@example.com')).toBe(true);
+    expect(ctx.shouldIndexUser('bob@example.com')).toBe(true);
+    expect(ctx.shouldIndexUser('')).toBe(true);
+  });
+
+  it('admits only whitelist members in WHITELIST mode (case-insensitive)', () => {
+    const ctx = makeCtx({
+      mode: 'whitelist',
+      whitelist: ['Alice@Example.COM'],
+    });
+    expect(ctx.shouldIndexUser('alice@example.com')).toBe(true);
+    expect(ctx.shouldIndexUser('ALICE@example.com')).toBe(true);
+    expect(ctx.shouldIndexUser('bob@example.com')).toBe(false);
+    expect(ctx.shouldIndexUser('')).toBe(false);
+  });
+
+  it('rejects only blacklist members in BLACKLIST mode (case-insensitive)', () => {
+    const ctx = makeCtx({
+      mode: 'blacklist',
+      blacklist: ['ex@example.com'],
+    });
+    expect(ctx.shouldIndexUser('ex@example.com')).toBe(false);
+    expect(ctx.shouldIndexUser('EX@example.com')).toBe(false);
+    expect(ctx.shouldIndexUser('alice@example.com')).toBe(true);
+    expect(ctx.shouldIndexUser('')).toBe(false);
+  });
+
+  it('treats null lists as empty', () => {
+    const wl = makeCtx({ mode: 'whitelist', whitelist: null });
+    expect(wl.shouldIndexUser('alice@example.com')).toBe(false);
+    const bl = makeCtx({ mode: 'blacklist', blacklist: null });
+    expect(bl.shouldIndexUser('alice@example.com')).toBe(true);
+  });
+});
+
+describe('SyncContext.sourceType', () => {
+  it('exposes source_type passed via the optional bag', () => {
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync',
+      'source',
+      undefined,
+      SyncMode.INCREMENTAL,
+      0,
+      0,
+      { sourceType: 'linear' }
+    );
+    expect(ctx.sourceType).toBe('linear');
+  });
+
+  it('defaults to null when not provided', () => {
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync',
+      'source'
+    );
+    expect(ctx.sourceType).toBeNull();
+  });
+});

--- a/sdk/typescript/tests/context.test.ts
+++ b/sdk/typescript/tests/context.test.ts
@@ -258,6 +258,75 @@ describe('SyncContext.incrementUpdated', () => {
   });
 });
 
+describe('SyncContext.complete', () => {
+  it('persists newState via updateConnectorState before the status flip', async () => {
+    let stateUpdate: { sourceId: string; body: unknown } | null = null;
+    let completeCalled = false;
+    let completeAfterStateUpdate = false;
+
+    server.use(
+      http.post(`${BASE_URL}/sdk/events/batch`, () =>
+        HttpResponse.json({ success: true })
+      ),
+      http.put(
+        `${BASE_URL}/sdk/source/:sourceId/connector-state`,
+        async ({ request, params }) => {
+          stateUpdate = {
+            sourceId: params.sourceId as string,
+            body: await request.json(),
+          };
+          return HttpResponse.json({ success: true });
+        }
+      ),
+      http.post(`${BASE_URL}/sdk/sync/:syncRunId/complete`, () => {
+        completeCalled = true;
+        completeAfterStateUpdate = stateUpdate !== null;
+        return HttpResponse.json({ status: 'ok' });
+      })
+    );
+
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-c',
+      'source-c'
+    );
+    await ctx.complete({ last_sync_at: '2026-04-28T00:00:00Z' });
+
+    expect(stateUpdate).toEqual({
+      sourceId: 'source-c',
+      body: { last_sync_at: '2026-04-28T00:00:00Z' },
+    });
+    expect(completeCalled).toBe(true);
+    expect(completeAfterStateUpdate).toBe(true);
+  });
+
+  it('skips the state update when no newState is provided', async () => {
+    let stateUpdated = false;
+
+    server.use(
+      http.post(`${BASE_URL}/sdk/events/batch`, () =>
+        HttpResponse.json({ success: true })
+      ),
+      http.put(`${BASE_URL}/sdk/source/:sourceId/connector-state`, () => {
+        stateUpdated = true;
+        return HttpResponse.json({ success: true });
+      }),
+      http.post(`${BASE_URL}/sdk/sync/:syncRunId/complete`, () =>
+        HttpResponse.json({ status: 'ok' })
+      )
+    );
+
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-d',
+      'source-d'
+    );
+    await ctx.complete();
+
+    expect(stateUpdated).toBe(false);
+  });
+});
+
 describe('SyncContext.sourceType', () => {
   it('exposes source_type passed via the optional bag', () => {
     const ctx = new SyncContext(

--- a/sdk/typescript/tests/context.test.ts
+++ b/sdk/typescript/tests/context.test.ts
@@ -209,6 +209,55 @@ describe('SyncContext.shouldIndexUser', () => {
   });
 });
 
+describe('SyncContext.incrementUpdated', () => {
+  it('POSTs the count to /sdk/sync/:id/updated', async () => {
+    const calls: Array<{ syncRunId: string; count: number }> = [];
+    server.use(
+      http.post(
+        `${BASE_URL}/sdk/sync/:syncRunId/updated`,
+        async ({ request, params }) => {
+          const body = (await request.json()) as { count: number };
+          calls.push({
+            syncRunId: params.syncRunId as string,
+            count: body.count,
+          });
+          return HttpResponse.json({ status: 'ok' });
+        }
+      )
+    );
+
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-9',
+      'source-9'
+    );
+
+    await ctx.incrementUpdated(3);
+    await ctx.incrementUpdated(5);
+
+    expect(calls).toEqual([
+      { syncRunId: 'sync-9', count: 3 },
+      { syncRunId: 'sync-9', count: 5 },
+    ]);
+  });
+
+  it('propagates HTTP errors to the caller', async () => {
+    server.use(
+      http.post(`${BASE_URL}/sdk/sync/:syncRunId/updated`, () =>
+        HttpResponse.text('boom', { status: 500 })
+      )
+    );
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-10',
+      'source-10'
+    );
+    await expect(ctx.incrementUpdated(1)).rejects.toThrow(
+      /Failed to increment updated/
+    );
+  });
+});
+
 describe('SyncContext.sourceType', () => {
   it('exposes source_type passed via the optional bag', () => {
     const ctx = new SyncContext(

--- a/sdk/typescript/tests/server.test.ts
+++ b/sdk/typescript/tests/server.test.ts
@@ -125,6 +125,60 @@ describe('Connector Server', () => {
       expect(response.status).toBe(200);
       expect(response.body.status).toBe('started');
     });
+
+    it('plumbs user_filter_mode/whitelist into SyncContext.shouldIndexUser', async () => {
+      let recorded: { alice: boolean; bob: boolean; sourceType: string | null } | null = null;
+
+      const connector = new MockConnector();
+      connector.syncFn = async (ctx) => {
+        recorded = {
+          alice: ctx.shouldIndexUser('alice@example.com'),
+          bob: ctx.shouldIndexUser('bob@example.com'),
+          sourceType: ctx.sourceType,
+        };
+      };
+      const app = createServer(connector);
+
+      // Override the default sync-config handler with a payload that
+      // pins user_filter_mode=whitelist and only admits alice.
+      mockServer.use(
+        http.get(
+          `${MANAGER_URL}/sdk/source/source-filter/sync-config`,
+          () =>
+            HttpResponse.json({
+              config: {},
+              credentials: {},
+              connector_state: null,
+              source_type: 'linear',
+              user_filter_mode: 'whitelist',
+              user_whitelist: ['alice@example.com'],
+              user_blacklist: null,
+            })
+        )
+      );
+
+      const response = await request(app)
+        .post('/sync')
+        .send({
+          sync_run_id: 'sync-filter',
+          source_id: 'source-filter',
+          sync_mode: 'incremental',
+        });
+
+      expect(response.status).toBe(200);
+
+      // sync runs in the background; poll briefly for completion.
+      for (let i = 0; i < 50; i++) {
+        if (recorded !== null) break;
+        await new Promise((r) => setTimeout(r, 10));
+      }
+
+      expect(recorded).toEqual({
+        alice: true,
+        bob: false,
+        sourceType: 'linear',
+      });
+    });
   });
 
   describe('GET /sync/:syncRunId', () => {


### PR DESCRIPTION
## Why

The TypeScript SDK has been silently out of sync with the connector-manager contract since the upstream merge `7c21fd10`. Four real bugs land in production for every TS-SDK-based connector:

1. **Every doc lands as `"Untitled"`.** The indexer reads only `metadata.title` and falls back to `"Untitled"` when missing ([`queue_processor.rs:1026`](services/indexer/src/queue_processor.rs)). The TS SDK's `serializeConnectorEvent` only writes `metadata` to the wire — `doc.title` is dropped. The Python SDK has had a partial shim since inception; the TS SDK never did.

2. **`user_filter_mode` / `user_whitelist` / `user_blacklist` / `source_type` are silently ignored.** `connector-manager` returns all four on `/sdk/source/:id/sync-config` ([`handlers.rs:1533-1541`](services/connector-manager/src/handlers.rs)), but the TS `fetchSourceConfig` typed only `config/credentials/connector_state`. They evaporated at the type boundary; `SyncContext` had no `shouldIndexUser`. Configuring a whitelist on a TS-connector source had **zero runtime effect**.

3. **`documents_updated` has been pinned at 0 since the upstream merge.** `7c21fd10` made `sdk_complete` a body-less status-flip handler and added `POST /sdk/sync/:id/updated` for accumulating the counter server-side. The Rust SDK migrated in the same merge ([`sdk/rust/src/context.rs:116`](sdk/rust/src/context.rs)). The TS SDK was not migrated — every TS-connector sync since `.11` reports `documents_updated = 0` regardless of how many docs actually moved.

4. **`ctx.complete(newState)` silently drops `newState`.** `sdk_complete` no longer parses the body. The TS client kept serializing `{new_state: ...}`; on a zero-emit sync the source's cursor never advances, leading to slower-and-slower delta scans over time.

## What changed

- **Title shim** — non-mutating spread in `emit`/`emitUpdated` copies `doc.title` into `metadata.title` when missing. Caller's `Document` is never modified. Broader than Python's conditional shim (Python skips bare-metadata docs — residual gap tracked separately).
- **User filter + `source_type`** — `fetchSourceConfig` now parses through `SdkSourceSyncDataSchema` (zod-validated, applies sane defaults). `SyncContext` exposes `shouldIndexUser(email)` (case-insensitive — mirrors Python; deliberately differs from Rust's case-sensitive equivalent) and a `sourceType` getter. `server.ts` plumbs all four fields into the constructor.
- **Explicit `incrementUpdated`** — added to both `SdkClient` and `SyncContext`. Mirrors the Rust SDK's API exactly: connector authors call it with whatever count semantics they want, errors propagate so the caller chooses the policy. The Linear connector now calls `ctx.incrementUpdated(1)` after each successful `emit`/`emitUpdated`.
- **`complete()` migration** — `client.complete` shrunk to a path-only POST (mirrors Rust SDK). `ctx.complete(newState?)` keeps its convenience signature but now routes `newState` through `updateConnectorState` (the path that actually persists) before the status flip — back-compat for connector callers, semantically correct.

## Coverage

- 20 new SDK tests in `sdk/typescript/tests/` (new `context.test.ts` file plus extensions to `client.test.ts` and `server.test.ts`). Every behavioural change is covered fail-first → pass.
- Full SDK suite goes from 57 → 77 passing tests; SDK + Linear builds clean.

## Verification after merge / deploy

- `SELECT title FROM documents WHERE source_id = '<linear-source-id>' LIMIT 5;` — non-`Untitled`.
- `SELECT documents_scanned, documents_processed, documents_updated FROM sync_runs WHERE source_id = '<linear-source-id>' ORDER BY started_at DESC LIMIT 1;` — `documents_updated` is non-zero.
- Set `user_filter_mode='whitelist'` on a test source; confirm `ctx.shouldIndexUser(email)` reflects it.
- `SELECT connector_state FROM sources WHERE id = '<linear-source-id>';` — `last_sync_at` advances after each sync (was frozen on zero-emit syncs).

## Follow-ups (out of scope)

- The Python SDK has the equivalent `documents_updated` gap (no `/updated` call) and the bare-metadata title-drop case — separate Python-SDK PR.