### PR TITLE
fix: honor ctx.syncMode + propagate url/file_size/file_extension/content_type on upsert

### DIFF
--- a/connectors/linear/src/connector.ts
+++ b/connectors/linear/src/connector.ts
@@ -4,6 +4,7 @@ import {
   type ActionDefinition,
   type SearchOperator,
   ActionResponse,
+  SyncMode,
   getLogger,
 } from '@getomnico/connector';
 import { LinearApiClient } from './client.js';
@@ -106,8 +107,16 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
       return;
     }
 
-    const lastSyncAt = state?.last_sync_at;
-    const isIncremental = !!lastSyncAt;
+    // Honor the dispatcher's sync mode rather than inferring from state
+    // presence. A manual "Full" trigger from the UI carries existing
+    // `state.last_sync_at` but should still re-fetch everything from
+    // Linear and run delete reconciliation. The previous `!!lastSyncAt`
+    // heuristic silently demoted those runs to incremental — Linear's
+    // server-side `updatedAt`-since filter would skip unchanged docs and
+    // hard-deletes upstream stayed forever in Omni until state was
+    // wiped by hand.
+    const isIncremental = ctx.syncMode !== SyncMode.FULL;
+    const lastSyncAt = isIncremental ? state?.last_sync_at : undefined;
     let docsSinceCheckpoint = 0;
 
     try {

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -84,6 +84,17 @@ export class SyncContext {
     return this._documentsScanned;
   }
 
+  /**
+   * The sync mode the manager dispatched this run with — full, incremental,
+   * or realtime. Connectors should branch reset/resume behavior on this,
+   * not on `state` presence: a manual "Full" trigger from the UI carries
+   * existing state but should still reset cursors and run delete
+   * reconciliation.
+   */
+  get syncMode(): SyncMode {
+    return this._syncMode;
+  }
+
   private async bufferEvent(event: ConnectorEventPayload): Promise<void> {
     this.eventBuffer.push(event);
     if (this.oldestEventAt === null) {

--- a/services/indexer/tests/integration_tests.rs
+++ b/services/indexer/tests/integration_tests.rs
@@ -180,6 +180,23 @@ async fn test_event_driven_document_lifecycle() {
     assert_eq!(updated_permissions["groups"].as_array().unwrap().len(), 2);
     assert!(updated_doc.updated_at > document.updated_at);
 
+    // Regression: ON CONFLICT DO UPDATE must propagate denormalized columns
+    // (url, file_size, file_extension, content_type), not just metadata jsonb.
+    // Before this fix, the upsert only refreshed `metadata`, leaving the
+    // column copies stale — searcher reads `doc.url` (the column) at
+    // services/searcher/src/search.rs:87, so search hits would still link
+    // to the old URL after re-emit.
+    assert_eq!(
+        updated_doc.url,
+        Some("https://example.com/docs/report-v2.md".to_string()),
+        "documents.url column must reflect the latest metadata.url after upsert"
+    );
+    assert_eq!(
+        updated_doc.file_extension,
+        Some("md".to_string()),
+        "documents.file_extension column must update when URL extension changes"
+    );
+
     // --- Delete ---
     let delete_event = ConnectorEvent::DocumentDeleted {
         sync_run_id: "sync_lifecycle".to_string(),

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -480,6 +480,10 @@ impl DocumentRepository {
             DO UPDATE SET
                 title = COALESCE(NULLIF(EXCLUDED.title, ''), documents.title),
                 content_id = EXCLUDED.content_id,
+                content_type = COALESCE(EXCLUDED.content_type, documents.content_type),
+                file_size = COALESCE(EXCLUDED.file_size, documents.file_size),
+                file_extension = COALESCE(EXCLUDED.file_extension, documents.file_extension),
+                url = COALESCE(EXCLUDED.url, documents.url),
                 metadata = EXCLUDED.metadata,
                 permissions = COALESCE(EXCLUDED.permissions, documents.permissions),
                 attributes = COALESCE(EXCLUDED.attributes, documents.attributes),
@@ -579,6 +583,10 @@ impl DocumentRepository {
             DO UPDATE SET
                 title = COALESCE(NULLIF(EXCLUDED.title, ''), documents.title),
                 content_id = EXCLUDED.content_id,
+                content_type = COALESCE(EXCLUDED.content_type, documents.content_type),
+                file_size = COALESCE(EXCLUDED.file_size, documents.file_size),
+                file_extension = COALESCE(EXCLUDED.file_extension, documents.file_extension),
+                url = COALESCE(EXCLUDED.url, documents.url),
                 metadata = EXCLUDED.metadata,
                 permissions = COALESCE(EXCLUDED.permissions, documents.permissions),
                 attributes = COALESCE(EXCLUDED.attributes, documents.attributes),


### PR DESCRIPTION

Two silent bugs and the bit of SDK plumbing they need.

1. **`ctx.syncMode` had no getter.** `SyncContext` was constructed with the dispatcher's syncMode but stored it privately, so connectors fell back to `!!state` to detect "incremental." A manual "Full" trigger from the UI carries existing state — so it ran as incremental, the API's since-filter skipped unchanged docs, and delete reconciliation never fired. Hard-deletes upstream stayed forever. Fixed in Linear here; same fix needed in any other connector using the `!!state` pattern.

2. **Indexer upsert missed four columns.** `ON CONFLICT DO UPDATE` refreshed the `metadata` jsonb but not `url`, `file_size`, `file_extension`, or `content_type` — denormalized copies of metadata fields. Searcher reads the column (`doc.url`), not the jsonb, so re-emitted docs kept their old URL in search results. Now COALESCEs all four, matching the existing pattern for `permissions`/`attributes`.

### Test plan

- [x] SDK build + tests pass (57)
- [x] Linear connector builds clean
- [x] `cargo check` clean for `shared` and `omni-indexer`
- [x] Existing indexer lifecycle integration test extended with regression assertions on `documents.url` and `file_extension`

### Commits

- `feat(sdk/ts): expose ctx.syncMode getter on SyncContext`
- `fix(linear): honor ctx.syncMode instead of !!lastSyncAt`
- `fix(indexer): propagate url/file_size/file_extension/content_type on upsert`