### PR TITLE
Index and fetch Gmail attachments end-to-end

### DIFF
--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -19,61 +19,60 @@ use tracing::debug;
 
 /// Build the composite external_id we use for a Gmail attachment document.
 ///
-/// Format: `{thread_id}:att:{message_id}:{url_encoded_filename}:{size}`.
-/// Last two segments are stable across syncs; Gmail's per-request
-/// `attachmentId` is intentionally NOT in the id because it changes between
-/// `messages.get` calls and would cause the indexer to mint a fresh row on
-/// every sync.
-pub fn build_attachment_doc_id(
-    thread_id: &str,
-    message_id: &str,
-    filename: &str,
-    size: u64,
-) -> String {
+/// Format: `{url_encoded_rfc822_msgid}:att:{url_encoded_filename}:{size}`.
+///
+/// The `rfc822_msgid` is the canonical "Message-ID" header value of the
+/// message that holds the attachment, with surrounding `<>` stripped. It is
+/// stable across mailboxes (set by the sender), unlike Gmail's per-mailbox
+/// `messageId` and `attachmentId`. At fetch time we resolve it to the
+/// requesting user's local Gmail message id via
+/// `messages.list?q=rfc822msgid:<id>`, then walk parts to find the matching
+/// attachment by `(filename, size)` and use that part's live `attachmentId`.
+pub fn build_attachment_doc_id(rfc822_msgid: &str, filename: &str, size: u64) -> String {
     format!(
-        "{}:att:{}:{}:{}",
-        thread_id,
-        message_id,
+        "{}:att:{}:{}",
+        urlencoding::encode(rfc822_msgid),
         urlencoding::encode(filename),
         size,
     )
 }
 
 pub struct ParsedAttachmentDocId {
-    pub message_id: String,
+    pub rfc822_msgid: String,
     pub filename: String,
     pub size: u64,
 }
 
 fn parse_attachment_doc_id(composite: &str) -> Result<ParsedAttachmentDocId> {
-    let (_, right) = composite
+    let (enc_msgid, right) = composite
         .split_once(":att:")
         .ok_or_else(|| anyhow!("Invalid attachment id (missing ':att:'): {}", composite))?;
 
-    // Right side is `{message_id}:{enc_filename}:{size}`. Peel from the right —
-    // the size segment is unambiguous (no colons), the filename is
-    // url-encoded so it has no colons either, and message_id is whatever's left.
-    let (left_of_size, size_str) = right.rsplit_once(':').ok_or_else(|| {
+    // Right side is `{enc_filename}:{size}`. Filename is url-encoded so it
+    // contains no colons; size is a clean integer.
+    let (enc_filename, size_str) = right.rsplit_once(':').ok_or_else(|| {
         anyhow!(
-            "Invalid attachment id (expected message_id:filename:size after ':att:'): {}",
+            "Invalid attachment id (expected filename:size after ':att:'): {}",
             composite
         )
     })?;
-    let (message_id, enc_filename) = left_of_size.rsplit_once(':').ok_or_else(|| {
-        anyhow!(
-            "Invalid attachment id (expected message_id:filename:size after ':att:'): {}",
-            composite
-        )
-    })?;
-    if message_id.is_empty() || enc_filename.is_empty() || size_str.is_empty() {
+    if enc_msgid.is_empty() || enc_filename.is_empty() || size_str.is_empty() {
         return Err(anyhow!(
-            "Invalid attachment id (empty message_id, filename, or size): {}",
+            "Invalid attachment id (empty rfc822_msgid, filename, or size): {}",
             composite
         ));
     }
     let size = size_str
         .parse::<u64>()
         .with_context(|| format!("Invalid attachment id (size not a number): {}", composite))?;
+    let rfc822_msgid = urlencoding::decode(enc_msgid)
+        .with_context(|| {
+            format!(
+                "Invalid attachment id (rfc822_msgid not url-decodable): {}",
+                composite
+            )
+        })?
+        .into_owned();
     let filename = urlencoding::decode(enc_filename)
         .with_context(|| {
             format!(
@@ -83,7 +82,7 @@ fn parse_attachment_doc_id(composite: &str) -> Result<ParsedAttachmentDocId> {
         })?
         .into_owned();
     Ok(ParsedAttachmentDocId {
-        message_id: message_id.to_string(),
+        rfc822_msgid,
         filename,
         size,
     })
@@ -220,7 +219,7 @@ impl GoogleConnector {
             .ok_or_else(|| anyhow!("Missing required parameter: file_id"))?;
 
         let ParsedAttachmentDocId {
-            message_id,
+            rfc822_msgid,
             filename,
             size,
         } = parse_attachment_doc_id(composite_id)?;
@@ -236,26 +235,56 @@ impl GoogleConnector {
             .await?;
         let gmail = self.sync_manager.gmail_client();
 
+        // Hop 1: resolve the requesting user's local Gmail message_id via the
+        // canonical RFC 822 Message-ID. Gmail's own message_ids are per-mailbox,
+        // so we never persist them; only the rfc822 id is stable across users.
+        let query = format!("rfc822msgid:{}", rfc822_msgid);
+        let list = gmail
+            .list_messages(
+                &google_auth,
+                principal_email,
+                Some(&query),
+                Some(1),
+                None,
+                None,
+            )
+            .await
+            .context("Failed to search for message by rfc822msgid")?;
+        let local_msg_id = list
+            .messages
+            .as_ref()
+            .and_then(|m| m.first())
+            .map(|m| m.id.clone())
+            .ok_or_else(|| {
+                anyhow!(
+                    "Attachment '{}' not found in {}'s mailbox (rfc822msgid: {})",
+                    filename,
+                    principal_email,
+                    rfc822_msgid
+                )
+            })?;
+
+        // Hop 2: fetch the resolved message and walk parts to find the
+        // attachment matching (filename, size).
         let message = gmail
             .get_message(
                 &google_auth,
                 principal_email,
-                &message_id,
+                &local_msg_id,
                 MessageFormat::Full,
             )
             .await
             .context("Failed to read message metadata")?;
-
         let payload = message
             .payload
             .as_ref()
-            .ok_or_else(|| anyhow!("Message {} has no payload", message_id))?;
+            .ok_or_else(|| anyhow!("Message {} has no payload", local_msg_id))?;
         let part = find_attachment_part_by_name(payload, &filename, size).ok_or_else(|| {
             anyhow!(
-                "Attachment '{}' (size {}) not found in message {}",
+                "Attachment '{}' (size {}) not found in resolved message {}",
                 filename,
                 size,
-                message_id
+                local_msg_id
             )
         })?;
         let live_attachment_id = part
@@ -266,7 +295,7 @@ impl GoogleConnector {
                 anyhow!(
                     "Attachment '{}' in message {} has no attachmentId",
                     filename,
-                    message_id
+                    local_msg_id
                 )
             })?;
         let mime_type = part
@@ -274,11 +303,12 @@ impl GoogleConnector {
             .clone()
             .unwrap_or_else(|| "application/octet-stream".to_string());
 
+        // Hop 3: download bytes using the part's live attachmentId.
         let bytes = gmail
             .download_attachment(
                 &google_auth,
                 principal_email,
-                &message_id,
+                &local_msg_id,
                 live_attachment_id,
             )
             .await?;
@@ -524,51 +554,70 @@ mod tests {
     use super::{build_attachment_doc_id, parse_attachment_doc_id};
 
     #[test]
-    fn round_trips_simple_filename() {
-        let id = build_attachment_doc_id("thread123", "msg456", "report.pdf", 12345);
+    fn round_trips_simple_msgid() {
+        let id = build_attachment_doc_id("CABc123@mail.gmail.com", "report.pdf", 12345);
         let parsed = parse_attachment_doc_id(&id).unwrap();
-        assert_eq!(parsed.message_id, "msg456");
+        assert_eq!(parsed.rfc822_msgid, "CABc123@mail.gmail.com");
         assert_eq!(parsed.filename, "report.pdf");
         assert_eq!(parsed.size, 12345);
     }
 
     #[test]
-    fn round_trips_filename_with_special_chars() {
-        // Colons, slashes, spaces, unicode all need to survive encode/decode.
-        for filename in [
-            "weird:name.pdf",
-            "path/with slashes.docx",
-            "résumé final.pdf",
-            "name with spaces (1).pdf",
-        ] {
-            let id = build_attachment_doc_id("t", "m", filename, 42);
+    fn round_trips_msgid_and_filename_with_special_chars() {
+        // Real-world rfc822 Message-IDs contain @, +, =, .;
+        // filenames may contain colons, slashes, unicode, parens.
+        let cases = [
+            (
+                "MA0P287MB3036D91CF4E25D0F29D4941BF3262@MA0P287MB3036.INDP287.PROD.OUTLOOK.COM",
+                "weird:name.pdf",
+            ),
+            (
+                "0108019cd78ca34a-33533383-c422+42e2-9016-0632c1a2f408-000000@ap-southeast-2.amazonses.com",
+                "path/with slashes.docx",
+            ),
+            (
+                "<unique-id+tag=value@example.com>".trim_start_matches('<').trim_end_matches('>'),
+                "résumé final.pdf",
+            ),
+            (
+                "abc.def.ghi@example.com",
+                "name with spaces (1).pdf",
+            ),
+        ];
+        for (msgid, filename) in cases {
+            let id = build_attachment_doc_id(msgid, filename, 42);
             let parsed = parse_attachment_doc_id(&id).unwrap();
-            assert_eq!(parsed.message_id, "m");
-            assert_eq!(parsed.filename, filename);
+            assert_eq!(parsed.rfc822_msgid, msgid, "msgid round-trip failed");
+            assert_eq!(parsed.filename, filename, "filename round-trip failed");
             assert_eq!(parsed.size, 42);
         }
     }
 
     #[test]
     fn rejects_missing_att_marker() {
-        assert!(parse_attachment_doc_id("thread123:msg456:report.pdf:1234").is_err());
+        assert!(parse_attachment_doc_id("CABc123@mail.gmail.com:report.pdf:1234").is_err());
     }
 
     #[test]
     fn rejects_too_few_segments() {
-        assert!(parse_attachment_doc_id("thread123:att:msg456").is_err());
-        assert!(parse_attachment_doc_id("thread123:att:msg456:report.pdf").is_err());
+        // Missing filename:size after :att:
+        assert!(parse_attachment_doc_id("CABc123%40mail.gmail.com:att:report.pdf").is_err());
     }
 
     #[test]
     fn rejects_non_numeric_size() {
-        assert!(parse_attachment_doc_id("thread123:att:msg456:report.pdf:notanumber").is_err());
+        assert!(
+            parse_attachment_doc_id("CABc123%40mail.gmail.com:att:report.pdf:notanumber").is_err()
+        );
     }
 
     #[test]
     fn rejects_empty_segments() {
-        assert!(parse_attachment_doc_id("thread123:att::report.pdf:1234").is_err());
-        assert!(parse_attachment_doc_id("thread123:att:msg456::1234").is_err());
-        assert!(parse_attachment_doc_id("thread123:att:msg456:report.pdf:").is_err());
+        // Empty rfc822_msgid
+        assert!(parse_attachment_doc_id(":att:report.pdf:1234").is_err());
+        // Empty filename
+        assert!(parse_attachment_doc_id("CABc123%40mail.gmail.com:att::1234").is_err());
+        // Empty size
+        assert!(parse_attachment_doc_id("CABc123%40mail.gmail.com:att:report.pdf:").is_err());
     }
 }

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -17,42 +17,91 @@ use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 use tracing::debug;
 
-fn parse_attachment_doc_id(composite: &str) -> Result<(&str, &str)> {
+/// Build the composite external_id we use for a Gmail attachment document.
+///
+/// Format: `{thread_id}:att:{message_id}:{url_encoded_filename}:{size}`.
+/// Last two segments are stable across syncs; Gmail's per-request
+/// `attachmentId` is intentionally NOT in the id because it changes between
+/// `messages.get` calls and would cause the indexer to mint a fresh row on
+/// every sync.
+pub fn build_attachment_doc_id(
+    thread_id: &str,
+    message_id: &str,
+    filename: &str,
+    size: u64,
+) -> String {
+    format!(
+        "{}:att:{}:{}:{}",
+        thread_id,
+        message_id,
+        urlencoding::encode(filename),
+        size,
+    )
+}
+
+pub struct ParsedAttachmentDocId {
+    pub message_id: String,
+    pub filename: String,
+    pub size: u64,
+}
+
+fn parse_attachment_doc_id(composite: &str) -> Result<ParsedAttachmentDocId> {
     let (_, right) = composite
         .split_once(":att:")
         .ok_or_else(|| anyhow!("Invalid attachment id (missing ':att:'): {}", composite))?;
-    let (message_id, attachment_id) = right.split_once(':').ok_or_else(|| {
+
+    // Right side is `{message_id}:{enc_filename}:{size}`. Peel from the right —
+    // the size segment is unambiguous (no colons), the filename is
+    // url-encoded so it has no colons either, and message_id is whatever's left.
+    let (left_of_size, size_str) = right.rsplit_once(':').ok_or_else(|| {
         anyhow!(
-            "Invalid attachment id (expected message_id:attachment_id after ':att:'): {}",
+            "Invalid attachment id (expected message_id:filename:size after ':att:'): {}",
             composite
         )
     })?;
-    if message_id.is_empty() || attachment_id.is_empty() {
+    let (message_id, enc_filename) = left_of_size.rsplit_once(':').ok_or_else(|| {
+        anyhow!(
+            "Invalid attachment id (expected message_id:filename:size after ':att:'): {}",
+            composite
+        )
+    })?;
+    if message_id.is_empty() || enc_filename.is_empty() || size_str.is_empty() {
         return Err(anyhow!(
-            "Invalid attachment id (empty message_id or attachment_id): {}",
+            "Invalid attachment id (empty message_id, filename, or size): {}",
             composite
         ));
     }
-    Ok((message_id, attachment_id))
+    let size = size_str
+        .parse::<u64>()
+        .with_context(|| format!("Invalid attachment id (size not a number): {}", composite))?;
+    let filename = urlencoding::decode(enc_filename)
+        .with_context(|| {
+            format!(
+                "Invalid attachment id (filename not url-decodable): {}",
+                composite
+            )
+        })?
+        .into_owned();
+    Ok(ParsedAttachmentDocId {
+        message_id: message_id.to_string(),
+        filename,
+        size,
+    })
 }
 
-fn find_attachment_part(part: &MessagePart, attachment_id: &str) -> Option<(String, String)> {
+fn find_attachment_part_by_name<'a>(
+    part: &'a MessagePart,
+    filename: &str,
+    size: u64,
+) -> Option<&'a MessagePart> {
     if let Some(body) = &part.body {
-        if body.attachment_id.as_deref() == Some(attachment_id) {
-            let filename = part
-                .filename
-                .clone()
-                .unwrap_or_else(|| "attachment".to_string());
-            let mime_type = part
-                .mime_type
-                .clone()
-                .unwrap_or_else(|| "application/octet-stream".to_string());
-            return Some((filename, mime_type));
+        if part.filename.as_deref() == Some(filename) && body.size == Some(size) {
+            return Some(part);
         }
     }
     if let Some(parts) = &part.parts {
         for child in parts {
-            if let Some(found) = find_attachment_part(child, attachment_id) {
+            if let Some(found) = find_attachment_part_by_name(child, filename, size) {
                 return Some(found);
             }
         }
@@ -170,7 +219,11 @@ impl GoogleConnector {
             .and_then(|v| v.as_str())
             .ok_or_else(|| anyhow!("Missing required parameter: file_id"))?;
 
-        let (message_id, attachment_id) = parse_attachment_doc_id(composite_id)?;
+        let ParsedAttachmentDocId {
+            message_id,
+            filename,
+            size,
+        } = parse_attachment_doc_id(composite_id)?;
 
         let principal_email = creds
             .principal_email
@@ -187,7 +240,7 @@ impl GoogleConnector {
             .get_message(
                 &google_auth,
                 principal_email,
-                message_id,
+                &message_id,
                 MessageFormat::Full,
             )
             .await
@@ -197,17 +250,37 @@ impl GoogleConnector {
             .payload
             .as_ref()
             .ok_or_else(|| anyhow!("Message {} has no payload", message_id))?;
-        let (filename, mime_type) =
-            find_attachment_part(payload, attachment_id).ok_or_else(|| {
+        let part = find_attachment_part_by_name(payload, &filename, size).ok_or_else(|| {
+            anyhow!(
+                "Attachment '{}' (size {}) not found in message {}",
+                filename,
+                size,
+                message_id
+            )
+        })?;
+        let live_attachment_id = part
+            .body
+            .as_ref()
+            .and_then(|b| b.attachment_id.as_deref())
+            .ok_or_else(|| {
                 anyhow!(
-                    "Attachment {} not found in message {}",
-                    attachment_id,
+                    "Attachment '{}' in message {} has no attachmentId",
+                    filename,
                     message_id
                 )
             })?;
+        let mime_type = part
+            .mime_type
+            .clone()
+            .unwrap_or_else(|| "application/octet-stream".to_string());
 
         let bytes = gmail
-            .download_attachment(&google_auth, principal_email, message_id, attachment_id)
+            .download_attachment(
+                &google_auth,
+                principal_email,
+                &message_id,
+                live_attachment_id,
+            )
             .await?;
 
         let resp = Response::builder()
@@ -448,28 +521,54 @@ impl Connector for GoogleConnector {
 
 #[cfg(test)]
 mod tests {
-    use super::parse_attachment_doc_id;
+    use super::{build_attachment_doc_id, parse_attachment_doc_id};
 
     #[test]
-    fn parses_valid_composite_id() {
-        let (msg, att) = parse_attachment_doc_id("thread123:att:msg456:att789").unwrap();
-        assert_eq!(msg, "msg456");
-        assert_eq!(att, "att789");
+    fn round_trips_simple_filename() {
+        let id = build_attachment_doc_id("thread123", "msg456", "report.pdf", 12345);
+        let parsed = parse_attachment_doc_id(&id).unwrap();
+        assert_eq!(parsed.message_id, "msg456");
+        assert_eq!(parsed.filename, "report.pdf");
+        assert_eq!(parsed.size, 12345);
+    }
+
+    #[test]
+    fn round_trips_filename_with_special_chars() {
+        // Colons, slashes, spaces, unicode all need to survive encode/decode.
+        for filename in [
+            "weird:name.pdf",
+            "path/with slashes.docx",
+            "résumé final.pdf",
+            "name with spaces (1).pdf",
+        ] {
+            let id = build_attachment_doc_id("t", "m", filename, 42);
+            let parsed = parse_attachment_doc_id(&id).unwrap();
+            assert_eq!(parsed.message_id, "m");
+            assert_eq!(parsed.filename, filename);
+            assert_eq!(parsed.size, 42);
+        }
     }
 
     #[test]
     fn rejects_missing_att_marker() {
-        assert!(parse_attachment_doc_id("thread123:msg456:att789").is_err());
+        assert!(parse_attachment_doc_id("thread123:msg456:report.pdf:1234").is_err());
     }
 
     #[test]
-    fn rejects_missing_attachment_id() {
+    fn rejects_too_few_segments() {
         assert!(parse_attachment_doc_id("thread123:att:msg456").is_err());
+        assert!(parse_attachment_doc_id("thread123:att:msg456:report.pdf").is_err());
+    }
+
+    #[test]
+    fn rejects_non_numeric_size() {
+        assert!(parse_attachment_doc_id("thread123:att:msg456:report.pdf:notanumber").is_err());
     }
 
     #[test]
     fn rejects_empty_segments() {
-        assert!(parse_attachment_doc_id("thread123:att::att789").is_err());
-        assert!(parse_attachment_doc_id("thread123:att:msg456:").is_err());
+        assert!(parse_attachment_doc_id("thread123:att::report.pdf:1234").is_err());
+        assert!(parse_attachment_doc_id("thread123:att:msg456::1234").is_err());
+        assert!(parse_attachment_doc_id("thread123:att:msg456:report.pdf:").is_err());
     }
 }

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -1247,7 +1247,7 @@ mod tests {
         thread.participants.insert("alice@co.com".to_string());
 
         let attachments = vec![AttachmentPointer {
-            id: "thread123:att:msg1:report.pdf:12345".to_string(),
+            id: "CABc123%40mail.gmail.com:att:report.pdf:12345".to_string(),
             filename: "report.pdf".to_string(),
             mime_type: "application/pdf".to_string(),
             size: 12345,
@@ -1272,7 +1272,10 @@ mod tests {
                     .as_array()
                     .expect("attachments is array");
                 assert_eq!(arr.len(), 1);
-                assert_eq!(arr[0]["id"], "thread123:att:msg1:report.pdf:12345");
+                assert_eq!(
+                    arr[0]["id"],
+                    "CABc123%40mail.gmail.com:att:report.pdf:12345"
+                );
                 assert_eq!(arr[0]["filename"], "report.pdf");
                 assert_eq!(arr[0]["mime_type"], "application/pdf");
                 assert_eq!(arr[0]["size"], 12345);

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -1247,7 +1247,7 @@ mod tests {
         thread.participants.insert("alice@co.com".to_string());
 
         let attachments = vec![AttachmentPointer {
-            id: "thread123:att:msg1:att1".to_string(),
+            id: "thread123:att:msg1:report.pdf:12345".to_string(),
             filename: "report.pdf".to_string(),
             mime_type: "application/pdf".to_string(),
             size: 12345,
@@ -1272,7 +1272,7 @@ mod tests {
                     .as_array()
                     .expect("attachments is array");
                 assert_eq!(arr.len(), 1);
-                assert_eq!(arr[0]["id"], "thread123:att:msg1:att1");
+                assert_eq!(arr[0]["id"], "thread123:att:msg1:report.pdf:12345");
                 assert_eq!(arr[0]["filename"], "report.pdf");
                 assert_eq!(arr[0]["mime_type"], "application/pdf");
                 assert_eq!(arr[0]["size"], 12345);

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -433,6 +433,21 @@ pub struct GmailThread {
     pub message_id: Option<String>,
 }
 
+/// A back-reference from an email thread to one of its indexed attachments.
+/// Surfaced in the thread document's `metadata.extra.attachments`.
+///
+/// `id` is the attachment's external_id (composite: `{thread}:att:{msg}:{att}`),
+/// not the indexer-assigned ULID — that ULID isn't known when the thread is
+/// emitted. The AI service's `read_document` accepts either form, so the model
+/// can use this id without an extra resolution step.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct AttachmentPointer {
+    pub id: String,
+    pub filename: String,
+    pub mime_type: String,
+    pub size: u64,
+}
+
 impl GmailThread {
     pub fn new(thread_id: String) -> Self {
         Self {
@@ -631,6 +646,7 @@ impl GmailThread {
         source_id: &str,
         content_id: &str,
         known_groups: &HashSet<String>,
+        attachments: &[AttachmentPointer],
     ) -> Result<ConnectorEvent, anyhow::Error> {
         let mut extra = HashMap::new();
         extra.insert("thread_id".to_string(), json!(self.thread_id));
@@ -638,6 +654,9 @@ impl GmailThread {
             "participants".to_string(),
             json!(self.participants.iter().collect::<Vec<_>>()),
         );
+        if !attachments.is_empty() {
+            extra.insert("attachments".to_string(), json!(attachments));
+        }
 
         // Parse latest date for metadata
         let updated_at = if !self.latest_date.is_empty() {
@@ -1218,5 +1237,70 @@ mod tests {
     fn test_gmail_thread_new_has_no_message_id() {
         let thread = GmailThread::new("t1".to_string());
         assert!(thread.message_id.is_none());
+    }
+
+    #[test]
+    fn test_gmail_thread_to_connector_event_includes_attachment_pointers() {
+        let mut thread = GmailThread::new("thread123".to_string());
+        thread.subject = "Q3 Report".to_string();
+        thread.total_messages = 1;
+        thread.participants.insert("alice@co.com".to_string());
+
+        let attachments = vec![AttachmentPointer {
+            id: "thread123:att:msg1:att1".to_string(),
+            filename: "report.pdf".to_string(),
+            mime_type: "application/pdf".to_string(),
+            size: 12345,
+        }];
+
+        let event = thread
+            .to_connector_event(
+                "sync1",
+                "source1",
+                "content1",
+                &HashSet::new(),
+                &attachments,
+            )
+            .unwrap();
+
+        match event {
+            ConnectorEvent::DocumentCreated { metadata, .. } => {
+                let extra = metadata.extra.expect("extra populated");
+                let arr = extra
+                    .get("attachments")
+                    .expect("attachments key present")
+                    .as_array()
+                    .expect("attachments is array");
+                assert_eq!(arr.len(), 1);
+                assert_eq!(arr[0]["id"], "thread123:att:msg1:att1");
+                assert_eq!(arr[0]["filename"], "report.pdf");
+                assert_eq!(arr[0]["mime_type"], "application/pdf");
+                assert_eq!(arr[0]["size"], 12345);
+            }
+            _ => panic!("Expected DocumentCreated event"),
+        }
+    }
+
+    #[test]
+    fn test_gmail_thread_to_connector_event_omits_attachments_when_empty() {
+        let mut thread = GmailThread::new("thread123".to_string());
+        thread.subject = "No attachments".to_string();
+        thread.total_messages = 1;
+        thread.participants.insert("alice@co.com".to_string());
+
+        let event = thread
+            .to_connector_event("sync1", "source1", "content1", &HashSet::new(), &[])
+            .unwrap();
+
+        match event {
+            ConnectorEvent::DocumentCreated { metadata, .. } => {
+                let extra = metadata.extra.expect("extra populated");
+                assert!(
+                    extra.get("attachments").is_none(),
+                    "attachments key should be absent when no attachments were indexed"
+                );
+            }
+            _ => panic!("Expected DocumentCreated event"),
+        }
     }
 }

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -13,10 +13,10 @@ use crate::admin::AdminClient;
 use crate::auth::{GoogleAuth, OAuthAuth};
 use crate::cache::LruFolderCache;
 use crate::drive::{DriveClient, FileContent};
-use crate::gmail::{BatchThreadResult, GmailClient, MessageFormat};
+use crate::gmail::{BatchThreadResult, ExtractedAttachment, GmailClient, MessageFormat};
 use crate::models::{
-    mime_type_to_content_type, GmailThread, GoogleConnectorState, UserFile, WebhookChannel,
-    WebhookChannelResponse, WebhookNotification,
+    mime_type_to_content_type, AttachmentPointer, GmailThread, GoogleConnectorState, UserFile,
+    WebhookChannel, WebhookChannelResponse, WebhookNotification,
 };
 use serde_json::json;
 use shared::models::{
@@ -1914,41 +1914,6 @@ impl SyncManager {
             return false;
         }
 
-        let emit_result: Result<bool> = async {
-            let content = gmail_thread
-                .aggregate_content(&self.gmail_client, ctx.sdk_client(), ctx.sync_run_id())
-                .await
-                .context("aggregate content")?;
-            if content.trim().is_empty() {
-                debug!("Gmail thread {} has empty content, skipping", thread_id);
-                return Ok(false);
-            }
-            let content_id = ctx.store_content(&content).await.context("store content")?;
-            let event = gmail_thread
-                .to_connector_event(
-                    ctx.sync_run_id(),
-                    ctx.source_id(),
-                    &content_id,
-                    known_groups,
-                )
-                .context("build connector event")?;
-            ctx.emit_event(event).await.context("emit event")?;
-            Ok(true)
-        }
-        .await;
-
-        let updated = match emit_result {
-            Ok(true) => {
-                info!("Successfully queued Gmail thread {}", thread_id);
-                true
-            }
-            Ok(false) => false,
-            Err(e) => {
-                error!("Failed to process Gmail thread {}: {:#}", thread_id, e);
-                false
-            }
-        };
-
         let thread_url = gmail_thread.message_id.as_ref().map(|mid| {
             let clean_id = mid.trim_start_matches('<').trim_end_matches('>');
             let encoded = urlencoding::encode(clean_id);
@@ -1958,21 +1923,9 @@ impl SyncManager {
             )
         });
 
-        let mut att_users = Vec::new();
-        let mut att_groups = Vec::new();
-        for participant in &gmail_thread.participants {
-            if known_groups.contains(participant) {
-                att_groups.push(participant.clone());
-            } else {
-                att_users.push(participant.clone());
-            }
-        }
-        let att_permissions = DocumentPermissions {
-            public: false,
-            users: att_users,
-            groups: att_groups,
-        };
-
+        // Extract attachments and store their content first, so the thread
+        // document can carry pointers to its attachments in metadata.extra.
+        let mut stored_attachments: Vec<(ExtractedAttachment, String)> = Vec::new();
         for message in &gmail_thread.messages {
             let attachments = self
                 .gmail_client
@@ -2001,45 +1954,109 @@ impl SyncManager {
                     }
                 };
 
-                let att_doc_id =
-                    format!("{}:att:{}:{}", thread_id, att.message_id, att.attachment_id);
+                stored_attachments.push((att, att_content_id));
+            }
+        }
 
-                let mut att_extra = HashMap::new();
-                att_extra.insert("parent_thread_id".to_string(), json!(thread_id));
+        let attachment_pointers: Vec<AttachmentPointer> = stored_attachments
+            .iter()
+            .map(|(att, _)| AttachmentPointer {
+                id: format!("{}:att:{}:{}", thread_id, att.message_id, att.attachment_id),
+                filename: att.filename.clone(),
+                mime_type: att.mime_type.clone(),
+                size: att.size,
+            })
+            .collect();
 
-                let att_metadata = DocumentMetadata {
-                    title: Some(att.filename.clone()),
-                    author: None,
-                    created_at: None,
-                    updated_at: None,
-                    content_type: mime_type_to_content_type(&att.mime_type),
-                    mime_type: Some(att.mime_type.clone()),
-                    size: Some(att.size.to_string()),
-                    url: thread_url.clone(),
-                    path: Some(format!("/Gmail/{}/{}", gmail_thread.subject, att.filename)),
-                    extra: Some(att_extra),
-                };
+        let emit_result: Result<bool> = async {
+            let content = gmail_thread
+                .aggregate_content(&self.gmail_client, ctx.sdk_client(), ctx.sync_run_id())
+                .await
+                .context("aggregate content")?;
+            if content.trim().is_empty() {
+                debug!("Gmail thread {} has empty content, skipping", thread_id);
+                return Ok(false);
+            }
+            let content_id = ctx.store_content(&content).await.context("store content")?;
+            let event = gmail_thread
+                .to_connector_event(
+                    ctx.sync_run_id(),
+                    ctx.source_id(),
+                    &content_id,
+                    known_groups,
+                    &attachment_pointers,
+                )
+                .context("build connector event")?;
+            ctx.emit_event(event).await.context("emit event")?;
+            Ok(true)
+        }
+        .await;
 
-                let att_event = ConnectorEvent::DocumentCreated {
-                    sync_run_id: ctx.sync_run_id().to_string(),
-                    source_id: ctx.source_id().to_string(),
-                    document_id: att_doc_id.clone(),
-                    content_id: att_content_id,
-                    metadata: att_metadata,
-                    permissions: att_permissions.clone(),
-                    attributes: Some(HashMap::new()),
-                };
+        let updated = match emit_result {
+            Ok(true) => {
+                info!("Successfully queued Gmail thread {}", thread_id);
+                true
+            }
+            Ok(false) => false,
+            Err(e) => {
+                error!("Failed to process Gmail thread {}: {:#}", thread_id, e);
+                false
+            }
+        };
 
-                match ctx.emit_event(att_event).await {
-                    Ok(_) => debug!(
-                        "Queued attachment {} for thread {}",
-                        att.filename, thread_id
-                    ),
-                    Err(e) => error!(
-                        "Failed to queue attachment {} for thread {}: {}",
-                        att.filename, thread_id, e
-                    ),
-                }
+        let mut att_users = Vec::new();
+        let mut att_groups = Vec::new();
+        for participant in &gmail_thread.participants {
+            if known_groups.contains(participant) {
+                att_groups.push(participant.clone());
+            } else {
+                att_users.push(participant.clone());
+            }
+        }
+        let att_permissions = DocumentPermissions {
+            public: false,
+            users: att_users,
+            groups: att_groups,
+        };
+
+        for (att, att_content_id) in stored_attachments {
+            let att_doc_id = format!("{}:att:{}:{}", thread_id, att.message_id, att.attachment_id);
+
+            let mut att_extra = HashMap::new();
+            att_extra.insert("parent_thread_id".to_string(), json!(thread_id));
+
+            let att_metadata = DocumentMetadata {
+                title: Some(att.filename.clone()),
+                author: None,
+                created_at: None,
+                updated_at: None,
+                content_type: mime_type_to_content_type(&att.mime_type),
+                mime_type: Some(att.mime_type.clone()),
+                size: Some(att.size.to_string()),
+                url: thread_url.clone(),
+                path: Some(format!("/Gmail/{}/{}", gmail_thread.subject, att.filename)),
+                extra: Some(att_extra),
+            };
+
+            let att_event = ConnectorEvent::DocumentCreated {
+                sync_run_id: ctx.sync_run_id().to_string(),
+                source_id: ctx.source_id().to_string(),
+                document_id: att_doc_id.clone(),
+                content_id: att_content_id,
+                metadata: att_metadata,
+                permissions: att_permissions.clone(),
+                attributes: Some(HashMap::new()),
+            };
+
+            match ctx.emit_event(att_event).await {
+                Ok(_) => debug!(
+                    "Queued attachment {} for thread {}",
+                    att.filename, thread_id
+                ),
+                Err(e) => error!(
+                    "Failed to queue attachment {} for thread {}: {}",
+                    att.filename, thread_id, e
+                ),
             }
         }
 

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -12,6 +12,7 @@ use tracing::{debug, error, info, warn};
 use crate::admin::AdminClient;
 use crate::auth::{GoogleAuth, OAuthAuth};
 use crate::cache::LruFolderCache;
+use crate::connector::build_attachment_doc_id;
 use crate::drive::{DriveClient, FileContent};
 use crate::gmail::{BatchThreadResult, ExtractedAttachment, GmailClient, MessageFormat};
 use crate::models::{
@@ -1961,7 +1962,7 @@ impl SyncManager {
         let attachment_pointers: Vec<AttachmentPointer> = stored_attachments
             .iter()
             .map(|(att, _)| AttachmentPointer {
-                id: format!("{}:att:{}:{}", thread_id, att.message_id, att.attachment_id),
+                id: build_attachment_doc_id(thread_id, &att.message_id, &att.filename, att.size),
                 filename: att.filename.clone(),
                 mime_type: att.mime_type.clone(),
                 size: att.size,
@@ -2020,7 +2021,8 @@ impl SyncManager {
         };
 
         for (att, att_content_id) in stored_attachments {
-            let att_doc_id = format!("{}:att:{}:{}", thread_id, att.message_id, att.attachment_id);
+            let att_doc_id =
+                build_attachment_doc_id(thread_id, &att.message_id, &att.filename, att.size);
 
             let mut att_extra = HashMap::new();
             att_extra.insert("parent_thread_id".to_string(), json!(thread_id));

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -1926,7 +1926,14 @@ impl SyncManager {
 
         // Extract attachments and store their content first, so the thread
         // document can carry pointers to its attachments in metadata.extra.
+        //
+        // Within a thread, dedup by (filename, size): the same file forwarded
+        // across multiple replies would otherwise produce one document per
+        // occurrence (different message_id → different composite), flooding
+        // the BM25 index with copies of identical content. First occurrence
+        // wins; the kept message_id is the one fetch_file will use.
         let mut stored_attachments: Vec<(ExtractedAttachment, String)> = Vec::new();
+        let mut seen: HashSet<(String, u64)> = HashSet::new();
         for message in &gmail_thread.messages {
             let attachments = self
                 .gmail_client
@@ -1941,6 +1948,14 @@ impl SyncManager {
 
             for att in attachments {
                 if att.extracted_text.trim().is_empty() {
+                    continue;
+                }
+
+                if !seen.insert((att.filename.clone(), att.size)) {
+                    debug!(
+                        "Skipping duplicate attachment {} (size {}) in thread {}",
+                        att.filename, att.size, thread_id
+                    );
                     continue;
                 }
 

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -1929,12 +1929,36 @@ impl SyncManager {
         //
         // Within a thread, dedup by (filename, size): the same file forwarded
         // across multiple replies would otherwise produce one document per
-        // occurrence (different message_id → different composite), flooding
-        // the BM25 index with copies of identical content. First occurrence
-        // wins; the kept message_id is the one fetch_file will use.
-        let mut stored_attachments: Vec<(ExtractedAttachment, String)> = Vec::new();
+        // occurrence, flooding the BM25 index with copies of identical content.
+        //
+        // We persist the canonical RFC 822 Message-ID (not Gmail's per-mailbox
+        // messageId) so the attachment can be fetched from any participating
+        // user's mailbox via `messages.list?q=rfc822msgid:<id>`.
+        let mut stored_attachments: Vec<(ExtractedAttachment, String, String)> = Vec::new();
         let mut seen: HashSet<(String, u64)> = HashSet::new();
         for message in &gmail_thread.messages {
+            let rfc822_msgid = match self
+                .gmail_client
+                .get_header_value(message, "Message-ID")
+                .map(|raw| {
+                    raw.trim()
+                        .trim_start_matches('<')
+                        .trim_end_matches('>')
+                        .to_string()
+                })
+                .filter(|s| !s.is_empty())
+            {
+                Some(id) => id,
+                None => {
+                    warn!(
+                        "Gmail message {} in thread {} has no Message-ID header; \
+                         skipping its attachments (cannot be fetched without canonical id)",
+                        message.id, thread_id
+                    );
+                    continue;
+                }
+            };
+
             let attachments = self
                 .gmail_client
                 .extract_attachments(
@@ -1970,14 +1994,14 @@ impl SyncManager {
                     }
                 };
 
-                stored_attachments.push((att, att_content_id));
+                stored_attachments.push((att, att_content_id, rfc822_msgid.clone()));
             }
         }
 
         let attachment_pointers: Vec<AttachmentPointer> = stored_attachments
             .iter()
-            .map(|(att, _)| AttachmentPointer {
-                id: build_attachment_doc_id(thread_id, &att.message_id, &att.filename, att.size),
+            .map(|(att, _, rfc822_msgid)| AttachmentPointer {
+                id: build_attachment_doc_id(rfc822_msgid, &att.filename, att.size),
                 filename: att.filename.clone(),
                 mime_type: att.mime_type.clone(),
                 size: att.size,
@@ -2035,9 +2059,8 @@ impl SyncManager {
             groups: att_groups,
         };
 
-        for (att, att_content_id) in stored_attachments {
-            let att_doc_id =
-                build_attachment_doc_id(thread_id, &att.message_id, &att.filename, att.size);
+        for (att, att_content_id, rfc822_msgid) in stored_attachments {
+            let att_doc_id = build_attachment_doc_id(&rfc822_msgid, &att.filename, att.size);
 
             let mut att_extra = HashMap::new();
             att_extra.insert("parent_thread_id".to_string(), json!(thread_id));

--- a/services/ai/db/documents.py
+++ b/services/ai/db/documents.py
@@ -91,6 +91,40 @@ class DocumentsRepository:
             )
         return None
 
+    async def get_by_external_id(
+        self, external_id: str, user_email: str | None = None
+    ) -> Optional[Document]:
+        """Get a document by its connector-native external_id.
+
+        Mirrors get_by_id's permission filter. If multiple documents share the
+        external_id (cross-source duplicates), returns the first match —
+        acceptable for composite ids like Gmail's `{thread}:att:{msg}:{att}`
+        which are practically unique.
+        """
+        pool = await self._get_pool()
+
+        if user_email:
+            perm_filter = _permission_filter(user_email.lower())
+            query = (
+                f"SELECT {_COLUMNS} FROM documents "
+                f"WHERE external_id = $1 {perm_filter} LIMIT 1"
+            )
+        else:
+            query = f"SELECT {_COLUMNS} FROM documents WHERE external_id = $1 LIMIT 1"
+        row = await pool.fetchrow(query, external_id)
+
+        if row:
+            return Document(
+                id=row["id"],
+                content_id=row["content_id"],
+                source_id=row["source_id"],
+                external_id=row["external_id"],
+                title=row["title"],
+                content_type=row["content_type"],
+                embedding_status=row["embedding_status"],
+            )
+        return None
+
     async def find_embedded_duplicate(
         self, external_id: str, exclude_document_id: str
     ) -> Optional[str]:

--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -34,6 +34,7 @@ Connected apps: {connected_apps}
 - When asked about a person's work, use by: or from: operators: "from:sarah last week".
 - Use multiple targeted searches rather than one broad search. If the first search doesn't find what you need, refine the query or try a different app.
 - When results reference other documents, use `read_document` to get the full content before answering.
+- Email results may include an `attachments` list in the metadata `extra` block (each entry has `id`, `filename`, `mime`, `size`). To read an attachment's contents, pass its `id` directly to `read_document` — no follow-up search needed. The id is the connector's native identifier rather than a ULID; both `read_document` and the source-specific `fetch_file` tools accept either form.
 
 # Taking actions
 - Before executing a write action, state exactly what you will do and why in one sentence. The user will be prompted to approve or deny.
@@ -45,7 +46,8 @@ Connected apps: {connected_apps}
 # Sandbox (code execution)
 - Use sandbox tools (`run_python`, `run_bash`, `write_file`, `read_file`) when the user needs data processing, analysis, or transformation that cannot be done with search alone.
 - Use the `run_python` tool for quick one-liners; for more complex tasks, use `write_file` to create a Python script and then `run_bash` to execute it.
-- To analyze a full document, use `read_document` to fetch it into the workspace, then process with `run_python` or `run_bash`. For large text documents and binary files (spreadsheets, PDFs), `read_document` automatically saves them to the workspace.
+- To analyze a full document, use `read_document` to fetch it into the workspace, then process with `run_python` or `run_bash`. `read_document` returns the indexed extracted text for text-extractable formats (PDFs, Word docs, presentations) — small results inline, large results as a `.txt` in the workspace. For spreadsheets and images it saves the original binary to the workspace so you can load it with pandas / Pillow.
+- Use a connector's `fetch_file` tool only when you specifically need the original binary (e.g., a spreadsheet for pandas). If you already pulled a PDF or document binary into the workspace via `fetch_file` and only need its text, switch to `read_document` instead of writing a sandbox script to extract text.
 - Always print results to stdout so they appear in the output. Don't just assign to variables silently.
 - If code fails, read the error, fix the issue, and retry. Don't ask the user to debug it.
 

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -99,19 +99,40 @@ async def create_test_document(
     title: str,
     content: str,
     permissions: dict | None = None,
+    content_type: str | None = None,
+    content_id: str | None = None,
+    external_id: str | None = None,
 ) -> str:
-    """Create a test document (for search tests). Returns doc_id."""
+    """Create a test document (for search tests). Returns doc_id.
+
+    Optionally sets content_type and content_id; if content_id is provided,
+    a matching content_blobs row is inserted so the document resolves to
+    text content. external_id defaults to ext-{doc_id} when omitted.
+    """
     doc_id = str(ULID())
     async with db_pool.acquire() as conn:
+        if content_id is not None:
+            content_bytes = content.encode("utf-8")
+            await conn.execute(
+                """INSERT INTO content_blobs (id, content, size_bytes, storage_backend)
+                   VALUES ($1, $2, $3, 'postgres')""",
+                content_id,
+                content_bytes,
+                len(content_bytes),
+            )
         await conn.execute(
-            """INSERT INTO documents (id, source_id, external_id, title, content, permissions)
-               VALUES ($1, $2, $3, $4, $5, $6::jsonb)""",
+            """INSERT INTO documents
+                 (id, source_id, external_id, title, content, permissions,
+                  content_type, content_id)
+               VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)""",
             doc_id,
             source_id,
-            f"ext-{doc_id}",
+            external_id if external_id is not None else f"ext-{doc_id}",
             title,
             content,
             json.dumps(permissions or {}),
+            content_type,
+            content_id,
         )
     return doc_id
 

--- a/services/ai/tests/integration/test_document_handler.py
+++ b/services/ai/tests/integration/test_document_handler.py
@@ -4,7 +4,7 @@ Verifies that read_document gates access based on the document's
 permissions JSONB, using a real ParadeDB instance.
 """
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import pytest
 from ulid import ULID
@@ -137,3 +137,128 @@ class TestDocumentHandlerPermissions:
             _ctx("bob@co.com", skip=True),
         )
         assert "not found" not in result.content[0]["text"].lower()
+
+
+class TestPdfReturnsExtractedText:
+    """`read_document` on a PDF should return the indexed extracted text rather
+    than fetching the binary from the source connector. Guarded by removing
+    "pdf"/"application/pdf" from BINARY_CONTENT_TYPES so the dispatch falls
+    through to _read_text."""
+
+    @pytest.mark.asyncio
+    async def test_pdf_with_content_id_returns_text(self, db_pool, test_user_id):
+        source_id = await create_test_source(db_pool, test_user_id, "gmail")
+        content_id = str(ULID())
+        doc_id = await create_test_document(
+            db_pool,
+            source_id,
+            "report.pdf",
+            "Q3 revenue grew 14% YoY.",
+            permissions={"public": True, "users": [], "groups": []},
+            content_type="pdf",
+            content_id=content_id,
+        )
+
+        # Real content storage is mocked, but we wire in connector-manager and
+        # sandbox URLs that *would* be used if PDF were treated as binary.
+        # If the dispatch ever regresses, the connector-manager mock raises so
+        # the test fails loudly rather than silently fetching a binary.
+        mock_storage = AsyncMock()
+        mock_storage.get_text.return_value = "Q3 revenue grew 14% YoY."
+
+        handler = DocumentToolHandler(
+            content_storage=mock_storage,
+            documents_repo=DocumentsRepository(db_pool),
+            sandbox_url="http://sandbox.invalid",
+            connector_manager_url="http://connector-manager.invalid",
+        )
+
+        with patch("tools.document_handler.httpx.AsyncClient") as mock_client_cls:
+            mock_client_cls.side_effect = AssertionError(
+                "read_document should not have called the connector for a PDF "
+                "with indexed content"
+            )
+
+            result = await handler.execute(
+                "read_document",
+                {"id": doc_id, "name": "report.pdf"},
+                _ctx("anyone@co.com"),
+            )
+
+        assert not result.is_error
+        assert result.content[0]["text"] == "Q3 revenue grew 14% YoY."
+        mock_storage.get_text.assert_awaited_once_with(content_id)
+
+
+class TestReadDocumentByExternalId:
+    """`read_document` accepts either a documents.id (ULID) or a connector-native
+    external_id. This is the path used when the model follows an attachment
+    pointer from an email thread's metadata.extra.attachments — the pointer's
+    `id` is the composite external_id, not the indexer-assigned ULID."""
+
+    @pytest.mark.asyncio
+    async def test_external_id_resolves_to_document(self, db_pool, test_user_id):
+        source_id = await create_test_source(db_pool, test_user_id, "gmail")
+        content_id = str(ULID())
+        composite = "thread1:att:msg1:att1"
+
+        doc_id = await create_test_document(
+            db_pool,
+            source_id,
+            "report.pdf",
+            "Q3 revenue grew 14% YoY.",
+            permissions={"public": True, "users": [], "groups": []},
+            content_type="pdf",
+            content_id=content_id,
+            external_id=composite,
+        )
+
+        mock_storage = AsyncMock()
+        mock_storage.get_text.return_value = "Q3 revenue grew 14% YoY."
+
+        handler = DocumentToolHandler(
+            content_storage=mock_storage,
+            documents_repo=DocumentsRepository(db_pool),
+        )
+
+        result = await handler.execute(
+            "read_document",
+            {"id": composite, "name": "report.pdf"},
+            _ctx("anyone@co.com"),
+        )
+
+        assert not result.is_error
+        assert result.content[0]["text"] == "Q3 revenue grew 14% YoY."
+        mock_storage.get_text.assert_awaited_once_with(content_id)
+        assert doc_id  # sanity: the doc was actually inserted under a real ULID
+
+    @pytest.mark.asyncio
+    async def test_external_id_respects_permissions(self, db_pool, test_user_id):
+        """A user without permission on the document gets the same not-found
+        response whether they query by id or external_id."""
+        source_id = await create_test_source(db_pool, test_user_id, "gmail")
+        composite = "thread2:att:msg2:att2"
+        await create_test_document(
+            db_pool,
+            source_id,
+            "secret.pdf",
+            "secret contents",
+            permissions={"public": False, "users": ["alice@co.com"], "groups": []},
+            content_type="pdf",
+            content_id=str(ULID()),
+            external_id=composite,
+        )
+
+        handler = DocumentToolHandler(
+            content_storage=AsyncMock(),
+            documents_repo=DocumentsRepository(db_pool),
+        )
+
+        result = await handler.execute(
+            "read_document",
+            {"id": composite, "name": "secret.pdf"},
+            _ctx("bob@co.com"),
+        )
+
+        assert result.is_error
+        assert "not found" in result.content[0]["text"].lower()

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -362,10 +362,20 @@ class ConnectorToolHandler:
                     )
 
                 result = response.json()
-        except Exception as e:
-            logger.error(f"Connector action failed: {e.response.text}")
+        except httpx.HTTPStatusError as e:
+            logger.error(
+                f"Connector action HTTP {e.response.status_code}: {e.response.text}"
+            )
             return ToolResult(
                 content=[{"type": "text", "text": f"Action failed: {e.response.text}"}],
+                is_error=True,
+            )
+        except Exception as e:
+            # Transport-level errors (ReadError, ConnectError, TimeoutException, etc.)
+            # don't carry a response. Don't try to access e.response.
+            logger.error(f"Connector action failed: {e}", exc_info=True)
+            return ToolResult(
+                content=[{"type": "text", "text": f"Action failed: {e}"}],
                 is_error=True,
             )
 

--- a/services/ai/tools/document_handler.py
+++ b/services/ai/tools/document_handler.py
@@ -20,17 +20,20 @@ logger = logging.getLogger(__name__)
 # Content types considered binary (not extracted text).
 # The documents.content_type column stores the standardized content_type
 # (e.g. "spreadsheet") when set, falling back to MIME type otherwise.
+#
+# PDFs are deliberately omitted: the indexer extracts their text at sync time
+# and stores it in content_blobs, so read_document can return that text directly
+# instead of forcing the model to download the binary and re-extract in the
+# sandbox.
 BINARY_CONTENT_TYPES = {
     # Standardized content types
     "spreadsheet",
     "document",
     "presentation",
-    "pdf",
     # MIME type fallbacks (for documents without a standardized content_type)
     "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
     "application/vnd.ms-excel",
     "application/vnd.google-apps.spreadsheet",
-    "application/pdf",
     "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
     "application/vnd.google-apps.document",
     "application/vnd.openxmlformats-officedocument.presentationml.presentation",
@@ -126,11 +129,18 @@ class DocumentToolHandler:
             )
 
         try:
-            # Look up document metadata, applying permission filter when appropriate
+            # Look up document metadata, applying permission filter when appropriate.
+            # Accept either a documents.id (ULID) or a connector-native external_id —
+            # the latter is what attachment pointers in email threads carry, since
+            # the indexer-assigned ULID isn't known at the time the thread is emitted.
             user_email = None if context.skip_permission_check else context.user_email
             doc = await self._documents_repo.get_by_id(
                 document_id, user_email=user_email
             )
+            if doc is None:
+                doc = await self._documents_repo.get_by_external_id(
+                    document_id, user_email=user_email
+                )
             if doc is None:
                 return ToolResult(
                     content=[

--- a/services/sandbox/src/lib.rs
+++ b/services/sandbox/src/lib.rs
@@ -5,6 +5,7 @@ pub mod models;
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use axum::extract::DefaultBodyLimit;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json};
 use axum::routing::{get, post};
@@ -76,7 +77,14 @@ pub fn create_app(state: Arc<AppState>) -> Router {
         .route("/execute/bash", post(handlers::execute_bash))
         .route("/execute/python", post(handlers::execute_python))
         .route("/files/write", post(handlers::write_file))
-        .route("/files/write_binary", post(handlers::write_file_binary))
+        // Override axum's 2 MB default body limit — attachments fetched from
+        // connector sources (Gmail, Drive, etc.) can be tens of MB, and the
+        // payload here is base64-encoded JSON so it's ~33% larger than the
+        // raw bytes. Matches the precedent in services/connector-manager.
+        .route(
+            "/files/write_binary",
+            post(handlers::write_file_binary).layer(DefaultBodyLimit::max(400 * 1024 * 1024)),
+        )
         .route("/files/read", post(handlers::read_file))
         .route("/files/stat", post(handlers::file_stat))
         .route("/files/download", get(handlers::download_file))


### PR DESCRIPTION
- Surface attachment pointers on Gmail thread search results
- Stable cross-mailbox message IDs for indexed emails (rfc822 Message-ID)
- 3-hop user-scoped fetch_file, first fetch message ID corresponding to rfc822 ID, then fetch the message, then fetch attachment
- read_document: for PDFs, return text instead of og file
- Fix connector_handler exception path + sandbox body limit
