### PR TITLE
Fix and harden Notion connector

### DIFF
--- a/connectors/notion/notion_connector/client.py
+++ b/connectors/notion/notion_connector/client.py
@@ -7,7 +7,7 @@ from typing import Any
 from notion_client import AsyncClient
 from notion_client.errors import APIResponseError
 
-from .config import ITEMS_PER_PAGE, RATE_LIMIT_DELAY
+from .config import ITEMS_PER_PAGE, NOTION_API_VERSION, RATE_LIMIT_DELAY
 
 logger = logging.getLogger(__name__)
 
@@ -20,6 +20,12 @@ class NotionError(Exception):
 
 class AuthenticationError(NotionError):
     """Invalid or expired token (401)."""
+
+    pass
+
+
+class ForbiddenError(NotionError):
+    """Integration is missing the capability required to call this endpoint (403)."""
 
     pass
 
@@ -41,7 +47,10 @@ class NotionClient:
         base_url: str | None = None,
         rate_limit_delay: float = RATE_LIMIT_DELAY,
     ):
-        kwargs: dict[str, Any] = {"auth": token}
+        kwargs: dict[str, Any] = {
+            "auth": token,
+            "notion_version": NOTION_API_VERSION,
+        }
         if base_url:
             kwargs["base_url"] = base_url
         self._client = AsyncClient(**kwargs)
@@ -62,37 +71,48 @@ class NotionClient:
         start_cursor: str | None = None,
         page_size: int = ITEMS_PER_PAGE,
     ) -> dict[str, Any]:
-        """Search for all pages in the workspace."""
+        """Search for all pages in the workspace, newest-edited first."""
         kwargs: dict[str, Any] = {
             "filter": {"value": "page", "property": "object"},
+            "sort": {"timestamp": "last_edited_time", "direction": "descending"},
             "page_size": page_size,
         }
         if start_cursor:
             kwargs["start_cursor"] = start_cursor
         return await self._api_call(self._client.search, **kwargs)
 
-    async def search_databases(
+    async def search_data_sources(
         self,
         start_cursor: str | None = None,
         page_size: int = ITEMS_PER_PAGE,
     ) -> dict[str, Any]:
-        """Search for all databases in the workspace."""
+        """Search for all data sources in the workspace, newest-edited first.
+
+        Under Notion-Version 2025-09-03+, the search endpoint returns data
+        sources (not databases). A database can contain multiple data sources;
+        each data source is what holds rows and a property schema.
+        """
         kwargs: dict[str, Any] = {
             "filter": {"value": "data_source", "property": "object"},
+            "sort": {"timestamp": "last_edited_time", "direction": "descending"},
             "page_size": page_size,
         }
         if start_cursor:
             kwargs["start_cursor"] = start_cursor
         return await self._api_call(self._client.search, **kwargs)
 
-    async def query_database(
+    async def query_data_source(
         self,
-        database_id: str,
+        data_source_id: str,
         start_cursor: str | None = None,
         filter: dict[str, Any] | None = None,
         page_size: int = ITEMS_PER_PAGE,
     ) -> dict[str, Any]:
-        """Query pages within a database."""
+        """Query pages within a data source.
+
+        Under Notion-Version 2025-09-03+, the legacy databases/{id}/query
+        endpoint is deprecated in favor of data_sources/{id}/query.
+        """
         body: dict[str, Any] = {"page_size": page_size}
         if start_cursor:
             body["start_cursor"] = start_cursor
@@ -101,16 +121,12 @@ class NotionClient:
 
         async def _do_query() -> Any:
             return await self._client.request(
-                path=f"databases/{database_id}/query",
+                path=f"data_sources/{data_source_id}/query",
                 method="POST",
                 body=body,
             )
 
         return await self._api_call(_do_query)
-
-    async def get_page(self, page_id: str) -> dict[str, Any]:
-        """Retrieve a page's metadata and properties."""
-        return await self._api_call(self._client.pages.retrieve, page_id=page_id)
 
     async def get_block_children(
         self,
@@ -144,12 +160,6 @@ class NotionClient:
 
         return blocks
 
-    async def get_database(self, database_id: str) -> dict[str, Any]:
-        """Get database metadata."""
-        return await self._api_call(
-            self._client.databases.retrieve, database_id=database_id
-        )
-
     async def list_users(self) -> list[dict[str, Any]]:
         """List all users in the workspace."""
         users: list[dict[str, Any]] = []
@@ -167,16 +177,21 @@ class NotionClient:
 
         return users
 
-    async def _api_call(self, method: Any, **kwargs: Any) -> Any:
+    async def _api_call(self, method: Any, **kwargs: Any) -> dict[str, Any]:
         """Execute an API call with retry logic for rate limits."""
         max_retries = 3
         for attempt in range(max_retries + 1):
             try:
                 await asyncio.sleep(self._rate_limit_delay)
-                return await method(**kwargs)
+                result: dict[str, Any] = await method(**kwargs)
+                return result
             except APIResponseError as e:
                 if e.status == 401:
                     raise AuthenticationError("Invalid or expired token") from e
+                if e.status == 403:
+                    raise ForbiddenError(
+                        f"Integration lacks required capability ({e})"
+                    ) from e
                 if e.status == 429:
                     retry_after = (
                         float(e.headers.get("Retry-After", "1.0"))
@@ -196,6 +211,8 @@ class NotionClient:
                         f"Rate limited after {max_retries} retries", retry_after
                     ) from e
                 raise NotionError(f"Notion API error ({e.status}): {e}") from e
+            except asyncio.CancelledError:
+                raise
             except Exception as e:
                 raise NotionError(f"Notion API call failed: {e}") from e
         raise NotionError("Unexpected retry loop exit")

--- a/connectors/notion/notion_connector/config.py
+++ b/connectors/notion/notion_connector/config.py
@@ -4,3 +4,8 @@ ITEMS_PER_PAGE = 100
 MAX_CONTENT_LENGTH = 100_000
 CHECKPOINT_INTERVAL = 50
 RATE_LIMIT_DELAY = 0.35
+
+# Pin the Notion-Version header so behavior is stable when notion-client bumps
+# its default. 2025-09-03 introduced data sources and is what this connector
+# is written against.
+NOTION_API_VERSION = "2025-09-03"

--- a/connectors/notion/notion_connector/connector.py
+++ b/connectors/notion/notion_connector/connector.py
@@ -1,17 +1,17 @@
 """Main NotionConnector class."""
 
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 from omni_connector import Connector, SyncContext
 
-from .client import AuthenticationError, NotionClient, NotionError
+from .client import AuthenticationError, ForbiddenError, NotionClient, NotionError
 from .config import CHECKPOINT_INTERVAL, RATE_LIMIT_DELAY
 from .mappers import (
-    generate_database_content,
+    generate_data_source_content,
     generate_page_content,
-    map_database_to_document,
+    map_data_source_to_document,
     map_page_to_document,
 )
 
@@ -26,6 +26,10 @@ class NotionConnector(Connector):
         return "notion"
 
     @property
+    def display_name(self) -> str:
+        return "Notion"
+
+    @property
     def version(self) -> str:
         return "1.0.0"
 
@@ -35,7 +39,7 @@ class NotionConnector(Connector):
 
     @property
     def description(self) -> str:
-        return "Connect to Notion pages and databases"
+        return "Index pages and databases from a Notion workspace"
 
     @property
     def sync_modes(self) -> list[str]:
@@ -69,11 +73,13 @@ class NotionConnector(Connector):
             await ctx.fail(f"Connection test failed: {e}")
             return
 
-        bot_name = bot_user.get("name", "Unknown")
+        bot_name = bot_user.get("name") or "Unknown"
         logger.info("Starting Notion sync as bot '%s'", bot_name)
 
-        workspace_name = bot_user.get("bot", {}).get(
-            "workspace_name", "Notion Workspace"
+        # Notion can return workspace_name as an explicit null, so dict.get's
+        # default doesn't fire — normalize via `or`.
+        workspace_name = (
+            bot_user.get("bot", {}).get("workspace_name") or "Notion Workspace"
         )
         permission_group = f"notion:workspace:{ctx.source_id}"
 
@@ -103,46 +109,45 @@ class NotionConnector(Connector):
         permission_group: str,
         ctx: SyncContext,
     ) -> None:
-        """Full sync: index all accessible databases and pages."""
+        """Full sync: index all accessible data sources and pages."""
         docs_emitted = 0
-        database_page_ids: set[str] = set()
+        data_source_entry_ids: set[str] = set()
 
-        # Phase 1: discover and index all databases + their entries
+        # Phase 1: discover and index all data sources + their entries
         cursor: str | None = None
         while True:
             if ctx.is_cancelled():
                 await ctx.fail("Cancelled by user")
                 return
 
-            response = await client.search_databases(start_cursor=cursor)
-            databases = response.get("results", [])
+            response = await client.search_data_sources(start_cursor=cursor)
+            data_sources = response.get("results", [])
 
-            for db in databases:
+            for ds in data_sources:
                 if ctx.is_cancelled():
                     await ctx.fail("Cancelled by user")
                     return
 
                 await ctx.increment_scanned()
-                db_id = db["id"]
+                ds_id = ds["id"]
 
                 try:
-                    docs_emitted = await self._sync_database(
-                        client, db, permission_group, ctx, docs_emitted
+                    docs_emitted = await self._sync_data_source(
+                        client, ds, permission_group, ctx, docs_emitted
                     )
-                    entry_ids = await self._sync_database_entries(
-                        client, db_id, permission_group, ctx, docs_emitted
+                    entries, docs_emitted = await self._sync_data_source_entries(
+                        client, ds_id, permission_group, ctx, docs_emitted
                     )
-                    database_page_ids.update(entry_ids[0])
-                    docs_emitted = entry_ids[1]
+                    data_source_entry_ids.update(entries)
                 except NotionError as e:
-                    logger.error("Error syncing database %s: %s", db_id, e)
-                    await ctx.emit_error(f"notion:database:{db_id}", str(e))
+                    logger.error("Error syncing data source %s: %s", ds_id, e)
+                    await ctx.emit_error(f"notion:data_source:{ds_id}", str(e))
 
             if not response.get("has_more"):
                 break
             cursor = response.get("next_cursor")
 
-        # Phase 2: index standalone pages (not in any database)
+        # Phase 2: index standalone pages (not part of any data source)
         cursor = None
         while True:
             if ctx.is_cancelled():
@@ -158,7 +163,7 @@ class NotionConnector(Connector):
                     return
 
                 page_id = page["id"]
-                if page_id in database_page_ids:
+                if page_id in data_source_entry_ids:
                     continue
 
                 await ctx.increment_scanned()
@@ -169,7 +174,7 @@ class NotionConnector(Connector):
                         permission_group,
                         ctx,
                         docs_emitted,
-                        is_database_entry=False,
+                        is_data_source_entry=False,
                     )
                 except Exception as e:
                     eid = f"notion:page:{page_id}"
@@ -184,8 +189,10 @@ class NotionConnector(Connector):
                 break
             cursor = response.get("next_cursor")
 
-        now = datetime.now(timezone.utc).isoformat()
-        await ctx.complete(new_state={"last_sync_at": now})
+        now = datetime.now(UTC).isoformat()
+        # save_state actually persists; complete()'s new_state is dropped by CM.
+        await ctx.save_state({"last_sync_at": now})
+        await ctx.complete()
         logger.info(
             "Full sync completed: %d scanned, %d emitted",
             ctx.documents_scanned,
@@ -199,11 +206,12 @@ class NotionConnector(Connector):
         permission_group: str,
         ctx: SyncContext,
     ) -> None:
-        """Incremental sync: re-index pages/databases modified since last sync."""
+        """Incremental sync: re-index pages/data sources modified since last sync."""
         last_sync_at = state["last_sync_at"]
         docs_emitted = 0
 
-        # Search pages sorted by last_edited_time (most recent first)
+        # Pages: search returns most-recently-edited first; stop once we cross
+        # the cutoff. Database entries are also pages and surface here too.
         cursor: str | None = None
         while True:
             if ctx.is_cancelled():
@@ -226,7 +234,8 @@ class NotionConnector(Connector):
 
                 await ctx.increment_scanned()
                 page_id = page["id"]
-                is_db_entry = page.get("parent", {}).get("type") == "database_id"
+                parent_type = page.get("parent", {}).get("type")
+                is_ds_entry = parent_type in ("data_source_id", "database_id")
 
                 try:
                     docs_emitted = await self._sync_page(
@@ -235,7 +244,7 @@ class NotionConnector(Connector):
                         permission_group,
                         ctx,
                         docs_emitted,
-                        is_database_entry=is_db_entry,
+                        is_data_source_entry=is_ds_entry,
                     )
                 except Exception as e:
                     eid = f"notion:page:{page_id}"
@@ -250,39 +259,40 @@ class NotionConnector(Connector):
                 break
             cursor = response.get("next_cursor")
 
-        # Also check for modified databases
+        # Data sources: same early-break logic, sorted desc.
         cursor = None
         while True:
             if ctx.is_cancelled():
                 await ctx.fail("Cancelled by user")
                 return
 
-            response = await client.search_databases(start_cursor=cursor)
-            databases = response.get("results", [])
+            response = await client.search_data_sources(start_cursor=cursor)
+            data_sources = response.get("results", [])
 
             found_old = False
-            for db in databases:
-                edited_time = db.get("last_edited_time", "")
+            for ds in data_sources:
+                edited_time = ds.get("last_edited_time", "")
                 if edited_time and edited_time < last_sync_at:
                     found_old = True
                     break
 
                 await ctx.increment_scanned()
                 try:
-                    docs_emitted = await self._sync_database(
-                        client, db, permission_group, ctx, docs_emitted
+                    docs_emitted = await self._sync_data_source(
+                        client, ds, permission_group, ctx, docs_emitted
                     )
                 except Exception as e:
-                    db_id = db["id"]
-                    logger.warning("Error processing database %s: %s", db_id, e)
-                    await ctx.emit_error(f"notion:database:{db_id}", str(e))
+                    ds_id = ds["id"]
+                    logger.warning("Error processing data source %s: %s", ds_id, e)
+                    await ctx.emit_error(f"notion:data_source:{ds_id}", str(e))
 
             if found_old or not response.get("has_more"):
                 break
             cursor = response.get("next_cursor")
 
-        now = datetime.now(timezone.utc).isoformat()
-        await ctx.complete(new_state={"last_sync_at": now})
+        now = datetime.now(UTC).isoformat()
+        await ctx.save_state({"last_sync_at": now})
+        await ctx.complete()
         logger.info(
             "Incremental sync completed: %d scanned, %d emitted",
             ctx.documents_scanned,
@@ -296,8 +306,26 @@ class NotionConnector(Connector):
         workspace_name: str,
         ctx: SyncContext,
     ) -> None:
-        """Emit a workspace-level group membership event with all workspace members."""
-        users = await client.list_users()
+        """Emit a workspace-level group membership event with all workspace members.
+
+        If the integration is missing the "Read user information" capability,
+        Notion returns 403 from /v1/users. We log a warning and skip emitting
+        memberships rather than failing the entire sync — documents can still
+        be indexed without group resolution, and the admin can grant the
+        capability and re-sync later.
+        """
+        try:
+            users = await client.list_users()
+        except ForbiddenError as e:
+            logger.warning(
+                "Skipping workspace membership sync: %s. "
+                "Under the integration's User capabilities, select "
+                "'User information with email addresses' and re-sync to "
+                "populate the workspace group.",
+                e,
+            )
+            return
+
         member_emails: list[str] = []
 
         for user in users:
@@ -323,31 +351,31 @@ class NotionConnector(Connector):
 
         logger.info("Emitted workspace group with %d members", len(member_emails))
 
-    async def _sync_database(
+    async def _sync_data_source(
         self,
         client: NotionClient,
-        database: dict[str, Any],
+        data_source: dict[str, Any],
         permission_group: str,
         ctx: SyncContext,
         docs_emitted: int,
     ) -> int:
-        """Emit a document for the database itself. Returns updated docs_emitted."""
-        content = generate_database_content(database)
+        """Emit a document for the data source itself. Returns updated docs_emitted."""
+        content = generate_data_source_content(data_source)
         content_id = await ctx.content_storage.save(content, "text/plain")
-        doc = map_database_to_document(database, content_id, permission_group)
+        doc = map_data_source_to_document(data_source, content_id, permission_group)
         await ctx.emit(doc)
         docs_emitted += 1
         return docs_emitted
 
-    async def _sync_database_entries(
+    async def _sync_data_source_entries(
         self,
         client: NotionClient,
-        database_id: str,
+        data_source_id: str,
         permission_group: str,
         ctx: SyncContext,
         docs_emitted: int,
     ) -> tuple[set[str], int]:
-        """Sync all pages within a database. Returns (page_ids, docs_emitted)."""
+        """Sync all pages within a data source. Returns (page_ids, docs_emitted)."""
         page_ids: set[str] = set()
         cursor: str | None = None
 
@@ -355,7 +383,9 @@ class NotionConnector(Connector):
             if ctx.is_cancelled():
                 break
 
-            response = await client.query_database(database_id, start_cursor=cursor)
+            response = await client.query_data_source(
+                data_source_id, start_cursor=cursor
+            )
             pages = response.get("results", [])
 
             for page in pages:
@@ -373,7 +403,7 @@ class NotionConnector(Connector):
                         permission_group,
                         ctx,
                         docs_emitted,
-                        is_database_entry=True,
+                        is_data_source_entry=True,
                     )
                 except Exception as e:
                     eid = f"notion:page:{page_id}"
@@ -397,19 +427,19 @@ class NotionConnector(Connector):
         permission_group: str,
         ctx: SyncContext,
         docs_emitted: int,
-        is_database_entry: bool,
+        is_data_source_entry: bool,
     ) -> int:
         """Fetch blocks for a page, generate content, and emit document."""
         page_id = page["id"]
         blocks = await client.get_all_blocks(page_id)
-        properties = page.get("properties") if is_database_entry else None
+        properties = page.get("properties") if is_data_source_entry else None
         content = generate_page_content(page, blocks, properties)
         content_id = await ctx.content_storage.save(content, "text/plain")
         doc = map_page_to_document(
             page,
             content_id,
             permission_group,
-            is_database_entry=is_database_entry,
+            is_data_source_entry=is_data_source_entry,
         )
         await ctx.emit(doc)
         docs_emitted += 1

--- a/connectors/notion/notion_connector/mappers.py
+++ b/connectors/notion/notion_connector/mappers.py
@@ -12,7 +12,7 @@ def map_page_to_document(
     page: dict[str, Any],
     content_id: str,
     permission_group: str,
-    is_database_entry: bool = False,
+    is_data_source_entry: bool = False,
 ) -> Document:
     """Map a Notion page to an Omni Document."""
     page_id = page["id"]
@@ -20,13 +20,17 @@ def map_page_to_document(
     created_by = page.get("created_by", {})
     parent = page.get("parent", {})
 
-    content_type_value = "database_entry" if is_database_entry else "page"
+    content_type_value = "data_source_entry" if is_data_source_entry else "page"
 
     attributes: dict[str, Any] = {
         "source_type": "notion",
     }
-    if is_database_entry and parent.get("type") == "database_id":
-        attributes["parent_database"] = parent["database_id"]
+    if is_data_source_entry:
+        parent_type = parent.get("type")
+        if parent_type == "data_source_id":
+            attributes["parent_data_source"] = parent["data_source_id"]
+        elif parent_type == "database_id":
+            attributes["parent_database"] = parent["database_id"]
 
     is_public = bool(page.get("public_url"))
 
@@ -50,28 +54,28 @@ def map_page_to_document(
     )
 
 
-def map_database_to_document(
-    database: dict[str, Any],
+def map_data_source_to_document(
+    data_source: dict[str, Any],
     content_id: str,
     permission_group: str,
 ) -> Document:
-    """Map a Notion database to an Omni Document."""
-    db_id = database["id"]
-    title = _extract_rich_text(database.get("title", []))
-    created_by = database.get("created_by", {})
+    """Map a Notion data source to an Omni Document."""
+    ds_id = data_source["id"]
+    title = _extract_rich_text(data_source.get("title", []))
+    created_by = data_source.get("created_by", {})
 
-    is_public = bool(database.get("public_url"))
+    is_public = bool(data_source.get("public_url"))
 
     return Document(
-        external_id=f"notion:database:{db_id}",
-        title=title or "Untitled Database",
+        external_id=f"notion:data_source:{ds_id}",
+        title=title or "Untitled",
         content_id=content_id,
         metadata=DocumentMetadata(
             author=created_by.get("id"),
-            created_at=_parse_iso(database.get("created_time")),
-            updated_at=_parse_iso(database.get("last_edited_time")),
-            url=database.get("url"),
-            content_type="database",
+            created_at=_parse_iso(data_source.get("created_time")),
+            updated_at=_parse_iso(data_source.get("last_edited_time")),
+            url=data_source.get("url"),
+            content_type="data_source",
             mime_type="text/plain",
         ),
         permissions=DocumentPermissions(
@@ -108,17 +112,17 @@ def generate_page_content(
     return _truncate("\n".join(lines))
 
 
-def generate_database_content(database: dict[str, Any]) -> str:
-    """Generate searchable text for a database."""
+def generate_data_source_content(data_source: dict[str, Any]) -> str:
+    """Generate searchable text for a data source."""
     lines: list[str] = []
-    title = _extract_rich_text(database.get("title", []))
-    lines.append(f"Database: {title or 'Untitled'}")
+    title = _extract_rich_text(data_source.get("title", []))
+    lines.append(f"Data source: {title or 'Untitled'}")
 
-    description = _extract_rich_text(database.get("description", []))
+    description = _extract_rich_text(data_source.get("description", []))
     if description:
         lines.append(f"Description: {description}")
 
-    props = database.get("properties", {})
+    props = data_source.get("properties", {})
     if props:
         lines.append("")
         lines.append("Properties:")
@@ -224,7 +228,7 @@ def _render_table(block: dict[str, Any]) -> str:
 
 
 def render_page_properties(properties: dict[str, Any]) -> str:
-    """Convert database entry properties to text."""
+    """Convert data source entry properties to text."""
     lines: list[str] = []
     for name, prop in properties.items():
         value = _extract_property_value(prop)
@@ -233,73 +237,83 @@ def render_page_properties(properties: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def _extract_property_value(prop: dict[str, Any]) -> str:
-    """Extract a displayable string from a Notion property value."""
-    prop_type = prop.get("type", "")
+def _extract_property_value(prop: dict[str, Any]) -> str | None:
+    """Extract a displayable string from a Notion property value, or None if empty."""
+    prop_type = prop.get("type")
 
     if prop_type == "title":
-        return _extract_rich_text(prop.get("title", []))
+        return _extract_rich_text(prop.get("title", [])) or None
     elif prop_type == "rich_text":
-        return _extract_rich_text(prop.get("rich_text", []))
+        return _extract_rich_text(prop.get("rich_text", [])) or None
     elif prop_type == "number":
         val = prop.get("number")
-        return str(val) if val is not None else ""
+        return str(val) if val is not None else None
     elif prop_type == "select":
         sel = prop.get("select")
-        return sel["name"] if sel else ""
+        return sel["name"] if sel else None
     elif prop_type == "multi_select":
         items = prop.get("multi_select", [])
-        return ", ".join(item["name"] for item in items)
+        return ", ".join(item["name"] for item in items) or None
     elif prop_type == "date":
         date = prop.get("date")
         if not date:
-            return ""
-        start = date.get("start", "")
+            return None
+        start = date.get("start")
         end = date.get("end")
+        if not start:
+            return None
         return f"{start} → {end}" if end else start
     elif prop_type == "checkbox":
         return "Yes" if prop.get("checkbox") else "No"
     elif prop_type == "url":
-        return prop.get("url", "") or ""
+        return prop.get("url") or None
     elif prop_type == "email":
-        return prop.get("email", "") or ""
+        return prop.get("email") or None
     elif prop_type == "phone_number":
-        return prop.get("phone_number", "") or ""
+        return prop.get("phone_number") or None
     elif prop_type == "people":
         people = prop.get("people", [])
-        return ", ".join(p.get("name", p.get("id", "")) for p in people)
+        names = [p.get("name") or p.get("id") for p in people]
+        return ", ".join(n for n in names if n) or None
     elif prop_type == "relation":
         relations = prop.get("relation", [])
-        return ", ".join(r.get("id", "") for r in relations)
+        ids = [r.get("id") for r in relations]
+        return ", ".join(i for i in ids if i) or None
     elif prop_type == "formula":
         formula = prop.get("formula", {})
-        f_type = formula.get("type", "")
-        return str(formula.get(f_type, "")) if f_type else ""
+        f_type = formula.get("type")
+        if not f_type:
+            return None
+        val = formula.get(f_type)
+        return str(val) if val is not None else None
     elif prop_type == "status":
         status = prop.get("status")
-        return status["name"] if status else ""
+        return status["name"] if status else None
     elif prop_type == "rollup":
         rollup = prop.get("rollup", {})
-        r_type = rollup.get("type", "")
+        r_type = rollup.get("type")
         if r_type == "number":
             val = rollup.get("number")
-            return str(val) if val is not None else ""
+            return str(val) if val is not None else None
         elif r_type == "array":
             items = rollup.get("array", [])
-            return ", ".join(_extract_property_value(item) for item in items if item)
-        return ""
+            rendered = [
+                v for v in (_extract_property_value(item) for item in items) if v
+            ]
+            return ", ".join(rendered) or None
+        return None
     elif prop_type == "created_time":
-        return prop.get("created_time", "")
+        return prop.get("created_time") or None
     elif prop_type == "last_edited_time":
-        return prop.get("last_edited_time", "")
+        return prop.get("last_edited_time") or None
     elif prop_type == "created_by":
         user = prop.get("created_by", {})
-        return user.get("name", user.get("id", ""))
+        return user.get("name") or user.get("id") or None
     elif prop_type == "last_edited_by":
         user = prop.get("last_edited_by", {})
-        return user.get("name", user.get("id", ""))
+        return user.get("name") or user.get("id") or None
 
-    return ""
+    return None
 
 
 def _extract_page_title(page: dict[str, Any]) -> str:

--- a/connectors/notion/pyproject.toml
+++ b/connectors/notion/pyproject.toml
@@ -13,7 +13,7 @@ authors = [
 ]
 dependencies = [
     "omni-connector[mcp]",
-    "notion-client>=2.0.0",
+    "notion-client>=3.0.0",
 ]
 
 [tool.uv.sources]

--- a/connectors/notion/tests/conftest.py
+++ b/connectors/notion/tests/conftest.py
@@ -16,12 +16,11 @@ import httpx
 import pytest
 import pytest_asyncio
 import uvicorn
+from omni_connector.testing import OmniTestHarness, SeedHelper
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import JSONResponse
 from starlette.routing import Route
-
-from omni_connector.testing import OmniTestHarness, SeedHelper
 
 logger = logging.getLogger(__name__)
 
@@ -40,6 +39,7 @@ def _page_payload(
     title: str,
     parent: dict[str, Any] | None = None,
     properties: dict[str, Any] | None = None,
+    last_edited_time: str = "2024-06-01T12:00:00.000Z",
 ) -> dict[str, Any]:
     if parent is None:
         parent = {"type": "workspace", "workspace": True}
@@ -54,7 +54,7 @@ def _page_payload(
         "object": "page",
         "id": page_id,
         "created_time": "2024-01-15T10:00:00.000Z",
-        "last_edited_time": "2024-06-01T12:00:00.000Z",
+        "last_edited_time": last_edited_time,
         "created_by": {"object": "user", "id": "user-001"},
         "last_edited_by": {"object": "user", "id": "user-001"},
         "cover": None,
@@ -67,17 +67,19 @@ def _page_payload(
     }
 
 
-def _database_payload(
-    db_id: str,
+def _data_source_payload(
+    ds_id: str,
     title: str,
     properties_schema: dict[str, Any],
     description: str = "",
+    last_edited_time: str = "2024-06-01T12:00:00.000Z",
 ) -> dict[str, Any]:
+    """Payload shape returned by /v1/search for a data source under 2025-09-03+."""
     return {
-        "object": "database",
-        "id": db_id,
+        "object": "data_source",
+        "id": ds_id,
         "created_time": "2024-01-10T08:00:00.000Z",
-        "last_edited_time": "2024-06-01T12:00:00.000Z",
+        "last_edited_time": last_edited_time,
         "created_by": {"object": "user", "id": "user-001"},
         "last_edited_by": {"object": "user", "id": "user-001"},
         "title": _rich_text(title),
@@ -85,8 +87,8 @@ def _database_payload(
         "icon": None,
         "cover": None,
         "properties": properties_schema,
-        "parent": {"type": "workspace", "workspace": True},
-        "url": f"https://www.notion.so/{db_id.replace('-', '')}",
+        "parent": {"type": "database_id", "database_id": f"db-{ds_id}"},
+        "url": f"https://www.notion.so/{ds_id.replace('-', '')}",
         "archived": False,
         "in_trash": False,
         "is_inline": False,
@@ -122,23 +124,27 @@ def _block_payload(
 
 
 class MockNotionAPI:
-    """Controllable mock of the Notion API v1 endpoints."""
+    """Controllable mock of the Notion API v1 endpoints (Notion-Version 2025-09-03)."""
 
     def __init__(self) -> None:
         self.pages: dict[str, dict[str, Any]] = {}
-        self.databases: dict[str, dict[str, Any]] = {}
-        self.database_pages: dict[str, list[dict[str, Any]]] = {}
+        self.data_sources: dict[str, dict[str, Any]] = {}
+        self.data_source_pages: dict[str, list[dict[str, Any]]] = {}
         self.blocks: dict[str, list[dict[str, Any]]] = {}
         self.users: list[dict[str, Any]] = []
         self.should_fail_auth: bool = False
+        self.should_forbid_users: bool = False
+        self.workspace_name: str | None = "Test Workspace"
 
     def reset(self) -> None:
         self.pages.clear()
-        self.databases.clear()
-        self.database_pages.clear()
+        self.data_sources.clear()
+        self.data_source_pages.clear()
         self.blocks.clear()
         self.users.clear()
         self.should_fail_auth = False
+        self.should_forbid_users = False
+        self.workspace_name = "Test Workspace"
 
     def add_page(
         self,
@@ -146,19 +152,23 @@ class MockNotionAPI:
         title: str,
         blocks: list[dict[str, Any]],
         parent: dict[str, Any] | None = None,
+        last_edited_time: str = "2024-06-01T12:00:00.000Z",
     ) -> None:
-        self.pages[page_id] = _page_payload(page_id, title, parent=parent)
+        self.pages[page_id] = _page_payload(
+            page_id, title, parent=parent, last_edited_time=last_edited_time
+        )
         self.blocks[page_id] = blocks
 
-    def add_database(
+    def add_data_source(
         self,
-        db_id: str,
+        ds_id: str,
         title: str,
         properties_schema: dict[str, Any],
         description: str = "",
+        last_edited_time: str = "2024-06-01T12:00:00.000Z",
     ) -> None:
-        self.databases[db_id] = _database_payload(
-            db_id, title, properties_schema, description
+        self.data_sources[ds_id] = _data_source_payload(
+            ds_id, title, properties_schema, description, last_edited_time
         )
 
     def add_user(
@@ -180,56 +190,77 @@ class MockNotionAPI:
             user["bot"] = {}
         self.users.append(user)
 
-    def add_database_entry(
+    def add_data_source_entry(
         self,
-        db_id: str,
+        ds_id: str,
         page_id: str,
         title: str,
         properties: dict[str, Any],
         blocks: list[dict[str, Any]],
+        last_edited_time: str = "2024-06-01T12:00:00.000Z",
     ) -> None:
-        parent = {"type": "database_id", "database_id": db_id}
-        page = _page_payload(page_id, title, parent=parent, properties=properties)
-        self.database_pages.setdefault(db_id, []).append(page)
+        parent = {"type": "data_source_id", "data_source_id": ds_id}
+        page = _page_payload(
+            page_id,
+            title,
+            parent=parent,
+            properties=properties,
+            last_edited_time=last_edited_time,
+        )
+        self.data_source_pages.setdefault(ds_id, []).append(page)
         self.blocks[page_id] = blocks
 
     def create_app(self) -> Starlette:
         mock = self
 
+        def _unauth() -> JSONResponse:
+            return JSONResponse(
+                {
+                    "object": "error",
+                    "status": 401,
+                    "code": "unauthorized",
+                    "message": "API token is invalid.",
+                },
+                status_code=401,
+            )
+
+        def _sort_desc(items: list[dict[str, Any]]) -> list[dict[str, Any]]:
+            return sorted(
+                items, key=lambda x: x.get("last_edited_time", ""), reverse=True
+            )
+
         async def users_me(request: Request) -> JSONResponse:
             if mock.should_fail_auth:
-                return JSONResponse(
-                    {
-                        "object": "error",
-                        "status": 401,
-                        "code": "unauthorized",
-                        "message": "API token is invalid.",
-                    },
-                    status_code=401,
-                )
+                return _unauth()
+            bot_payload: dict[str, Any] = {
+                "owner": {"type": "workspace", "workspace": True},
+                "workspace_name": mock.workspace_name,
+            }
             return JSONResponse(
                 {
                     "object": "user",
                     "id": "bot-001",
                     "type": "bot",
                     "name": "Test Integration",
-                    "bot": {
-                        "owner": {"type": "workspace", "workspace": True},
-                        "workspace_name": "Test Workspace",
-                    },
+                    "bot": bot_payload,
                 }
             )
 
         async def list_users(request: Request) -> JSONResponse:
             if mock.should_fail_auth:
+                return _unauth()
+            if mock.should_forbid_users:
                 return JSONResponse(
                     {
                         "object": "error",
-                        "status": 401,
-                        "code": "unauthorized",
-                        "message": "API token is invalid.",
+                        "status": 403,
+                        "code": "restricted_resource",
+                        "message": (
+                            "Insufficient permissions for this endpoint. "
+                            "Enable 'Read user information' on the integration."
+                        ),
                     },
-                    status_code=401,
+                    status_code=403,
                 )
             return JSONResponse(
                 {
@@ -243,24 +274,30 @@ class MockNotionAPI:
 
         async def search(request: Request) -> JSONResponse:
             if mock.should_fail_auth:
+                return _unauth()
+            body = await request.json()
+            filter_obj = body.get("filter", {}) or {}
+            filter_value = filter_obj.get("value")
+
+            if filter_value == "page":
+                results = _sort_desc(list(mock.pages.values()))
+            elif filter_value == "data_source":
+                results = _sort_desc(list(mock.data_sources.values()))
+            else:
+                # Tighten the contract: reject anything else so connector regressions
+                # surface immediately instead of falling through to a mixed result set.
                 return JSONResponse(
                     {
                         "object": "error",
-                        "status": 401,
-                        "code": "unauthorized",
-                        "message": "API token is invalid.",
+                        "status": 400,
+                        "code": "validation_error",
+                        "message": (
+                            "filter.value must be 'page' or 'data_source' "
+                            f"(got {filter_value!r})"
+                        ),
                     },
-                    status_code=401,
+                    status_code=400,
                 )
-            body = await request.json()
-            filter_value = body.get("filter", {}).get("value")
-
-            if filter_value == "page":
-                results = list(mock.pages.values())
-            elif filter_value == "database":
-                results = list(mock.databases.values())
-            else:
-                results = list(mock.pages.values()) + list(mock.databases.values())
 
             return JSONResponse(
                 {
@@ -268,44 +305,28 @@ class MockNotionAPI:
                     "results": results,
                     "has_more": False,
                     "next_cursor": None,
-                    "type": "page_or_database",
+                    "type": "page_or_data_source",
                 }
             )
 
-        async def query_database(request: Request) -> JSONResponse:
+        async def query_data_source(request: Request) -> JSONResponse:
             if mock.should_fail_auth:
-                return JSONResponse(
-                    {
-                        "object": "error",
-                        "status": 401,
-                        "code": "unauthorized",
-                        "message": "API token is invalid.",
-                    },
-                    status_code=401,
-                )
-            db_id = request.path_params["database_id"]
-            pages = mock.database_pages.get(db_id, [])
+                return _unauth()
+            ds_id = request.path_params["data_source_id"]
+            pages = mock.data_source_pages.get(ds_id, [])
             return JSONResponse(
                 {
                     "object": "list",
                     "results": pages,
                     "has_more": False,
                     "next_cursor": None,
-                    "type": "page_or_database",
+                    "type": "page_or_data_source",
                 }
             )
 
         async def get_block_children(request: Request) -> JSONResponse:
             if mock.should_fail_auth:
-                return JSONResponse(
-                    {
-                        "object": "error",
-                        "status": 401,
-                        "code": "unauthorized",
-                        "message": "API token is invalid.",
-                    },
-                    status_code=401,
-                )
+                return _unauth()
             block_id = request.path_params["block_id"]
             children = mock.blocks.get(block_id, [])
             return JSONResponse(
@@ -323,7 +344,9 @@ class MockNotionAPI:
             Route("/v1/users", list_users),
             Route("/v1/search", search, methods=["POST"]),
             Route(
-                "/v1/databases/{database_id}/query", query_database, methods=["POST"]
+                "/v1/data_sources/{data_source_id}/query",
+                query_data_source,
+                methods=["POST"],
             ),
             Route("/v1/blocks/{block_id}/children", get_block_children),
         ]
@@ -382,15 +405,66 @@ def connector_port() -> int:
     return _free_port()
 
 
+@pytest_asyncio.fixture(scope="session")
+async def harness() -> OmniTestHarness:
+    """Session-scoped OmniTestHarness with infra + connector-manager started.
+
+    Starts before `connector_server` so the connector can register itself
+    against the real CM URL on startup (SDK reads CONNECTOR_MANAGER_URL once
+    at create_app and caches it).
+    """
+    h = OmniTestHarness()
+    await h.start_infra()
+    await h.start_connector_manager()
+
+    yield h
+    await h.teardown()
+
+
+def _wait_for_registration(cm_url: str, source_type: str, timeout: float = 15) -> None:
+    """Poll CM until the connector has registered itself."""
+    deadline = time.monotonic() + timeout
+    last_err: Exception | None = None
+    while time.monotonic() < deadline:
+        try:
+            with httpx.Client(timeout=2) as client:
+                resp = client.get(f"{cm_url}/connectors")
+                if resp.status_code == 200:
+                    payload = resp.json()
+                    for c in payload:
+                        if source_type in (c.get("manifest") or {}).get(
+                            "source_types", []
+                        ):
+                            return
+        except Exception as e:
+            last_err = e
+        time.sleep(0.2)
+    raise TimeoutError(
+        f"Connector for source_type={source_type} did not register within "
+        f"{timeout}s (last err: {last_err})"
+    )
+
+
 @pytest.fixture(scope="session")
-def connector_server(connector_port: int) -> str:
-    """Start the Notion connector as a uvicorn server in a daemon thread. Returns base URL."""
+def connector_server(connector_port: int, harness: OmniTestHarness) -> str:
+    """Start the Notion connector as a uvicorn server in a daemon thread.
+
+    Depends on `harness` so we can point CONNECTOR_MANAGER_URL at the real CM
+    URL before `create_app` runs (SdkClient reads the env var once at
+    construction and caches it).
+    """
     import os
 
-    os.environ.setdefault("CONNECTOR_MANAGER_URL", "http://localhost:0")
+    os.environ["CONNECTOR_MANAGER_URL"] = harness.connector_manager_url
+    # Connector advertises this hostname in its registration manifest. CM
+    # health-checks the URL from inside its container, so localhost would
+    # resolve to the container itself — use host.docker.internal instead.
+    os.environ["CONNECTOR_HOST_NAME"] = "host.docker.internal"
+    os.environ.setdefault("PORT", str(connector_port))
+
+    from omni_connector.server import create_app
 
     from notion_connector import NotionConnector
-    from omni_connector.server import create_app
 
     app = create_app(NotionConnector())
     config = uvicorn.Config(
@@ -402,29 +476,8 @@ def connector_server(connector_port: int) -> str:
     thread.start()
 
     _wait_for_port(connector_port)
+    _wait_for_registration(harness.connector_manager_url, "notion")
     return f"http://localhost:{connector_port}"
-
-
-@pytest_asyncio.fixture(scope="session")
-async def harness(
-    connector_server: str,
-    connector_port: int,
-) -> OmniTestHarness:
-    """Session-scoped OmniTestHarness with all infrastructure started."""
-    import os
-
-    h = OmniTestHarness()
-    await h.start_infra()
-    await h.start_connector_manager(
-        {
-            "NOTION_CONNECTOR_URL": f"http://host.docker.internal:{connector_port}",
-        }
-    )
-
-    os.environ["CONNECTOR_MANAGER_URL"] = h.connector_manager_url
-
-    yield h
-    await h.teardown()
 
 
 # ---------------------------------------------------------------------------
@@ -439,6 +492,7 @@ async def seed(harness: OmniTestHarness) -> SeedHelper:
 
 @pytest_asyncio.fixture
 async def source_id(
+    connector_server: str,
     seed: SeedHelper,
     mock_notion_server: str,
     mock_notion_api: MockNotionAPI,

--- a/connectors/notion/tests/test_full_sync.py
+++ b/connectors/notion/tests/test_full_sync.py
@@ -1,20 +1,19 @@
-"""Integration tests: full sync indexes pages and databases."""
+"""Integration tests: full sync indexes pages and data sources."""
 
-import pytest
 import httpx
-
+import pytest
 from omni_connector.testing import count_events, get_events, wait_for_sync
 
 from .conftest import _block_payload
 
 pytestmark = pytest.mark.integration
 
-DB_ID = "db-00000000-0000-0000-0000-000000000001"
+DS_ID = "ds-00000000-0000-0000-0000-000000000001"
 ENTRY_PAGE_ID = "pg-00000000-0000-0000-0000-000000000001"
 STANDALONE_PAGE_ID = "pg-00000000-0000-0000-0000-000000000002"
 
 
-async def test_full_sync_indexes_pages_and_databases(
+async def test_full_sync_indexes_pages_and_data_sources(
     harness, seed, source_id, mock_notion_api, cm_client: httpx.AsyncClient
 ):
     properties_schema = {
@@ -44,8 +43,8 @@ async def test_full_sync_indexes_pages_and_databases(
             },
         },
     }
-    mock_notion_api.add_database(
-        DB_ID, "Project Tasks", properties_schema, description="Team task tracker"
+    mock_notion_api.add_data_source(
+        DS_ID, "Project Tasks", properties_schema, description="Team task tracker"
     )
 
     entry_properties = {
@@ -77,8 +76,8 @@ async def test_full_sync_indexes_pages_and_databases(
         ),
         _block_payload("blk-002", "heading_2", "Steps to Reproduce"),
     ]
-    mock_notion_api.add_database_entry(
-        DB_ID, ENTRY_PAGE_ID, "Fix login bug", entry_properties, entry_blocks
+    mock_notion_api.add_data_source_entry(
+        DS_ID, ENTRY_PAGE_ID, "Fix login bug", entry_properties, entry_blocks
     )
 
     standalone_blocks = [
@@ -108,14 +107,21 @@ async def test_full_sync_indexes_pages_and_databases(
     assert n_events == 3, f"Expected 3 document_created events, got {n_events}"
 
     events = await get_events(harness.db_pool, source_id)
-    doc_ids = {
-        e["payload"]["document_id"]
-        for e in events
-        if e["event_type"] == "document_created"
-    }
-    assert f"notion:database:{DB_ID}" in doc_ids
+    doc_events = [e for e in events if e["event_type"] == "document_created"]
+    doc_ids = {e["payload"]["document_id"] for e in doc_events}
+    assert f"notion:data_source:{DS_ID}" in doc_ids
     assert f"notion:page:{ENTRY_PAGE_ID}" in doc_ids
     assert f"notion:page:{STANDALONE_PAGE_ID}" in doc_ids
+
+    # Every emitted doc must carry the workspace permission group, with
+    # public=False (these test fixtures don't set public_url).
+    expected_group = f"notion:workspace:{source_id}"
+    for event in doc_events:
+        perms = event["payload"]["permissions"]
+        assert (
+            expected_group in perms["groups"]
+        ), f"document {event['payload']['document_id']} missing workspace group"
+        assert perms["public"] is False
 
     state = await seed.get_connector_state(source_id)
     assert state is not None, "connector_state should be saved after sync"

--- a/connectors/notion/tests/test_incremental_sync.py
+++ b/connectors/notion/tests/test_incremental_sync.py
@@ -1,0 +1,85 @@
+"""Integration tests: incremental sync only re-emits items modified after the cutoff."""
+
+import httpx
+import pytest
+from omni_connector.testing import count_events, get_events, wait_for_sync
+
+from .conftest import _block_payload
+
+pytestmark = pytest.mark.integration
+
+OLD_PAGE_ID = "pg-00000000-0000-0000-0000-000000000aaa"
+NEW_PAGE_ID = "pg-00000000-0000-0000-0000-000000000bbb"
+NEWER_PAGE_ID = "pg-00000000-0000-0000-0000-000000000ccc"
+
+
+async def test_incremental_sync_only_emits_modified_items(
+    harness, seed, source_id, mock_notion_api, cm_client: httpx.AsyncClient
+):
+    """Pages older than last_sync_at are skipped; newer ones are re-emitted.
+
+    Pages are returned by /v1/search in arbitrary order from the mock's dict —
+    we explicitly sort the response server-side. The connector relies on a
+    desc-by-last_edited_time sort param; this test asserts the early-break
+    logic stops after seeing the cutoff.
+    """
+    # Page edited well before the cutoff — should not be emitted.
+    mock_notion_api.add_page(
+        OLD_PAGE_ID,
+        "Stale Page",
+        [_block_payload("blk-old", "paragraph", "old content")],
+        last_edited_time="2024-01-01T00:00:00.000Z",
+    )
+
+    # Two pages edited after the cutoff — both should be emitted.
+    mock_notion_api.add_page(
+        NEW_PAGE_ID,
+        "Recently Edited",
+        [_block_payload("blk-new", "paragraph", "new content")],
+        last_edited_time="2024-07-01T12:00:00.000Z",
+    )
+    mock_notion_api.add_page(
+        NEWER_PAGE_ID,
+        "Most Recently Edited",
+        [_block_payload("blk-newer", "paragraph", "newer content")],
+        last_edited_time="2024-08-01T12:00:00.000Z",
+    )
+
+    # Seed connector_state to simulate a prior successful sync. The cutoff
+    # falls between the stale page and the two recent ones.
+    cutoff = "2024-06-01T00:00:00.000Z"
+    await seed.set_connector_state(source_id, {"last_sync_at": cutoff})
+
+    resp = await cm_client.post(
+        "/sync",
+        json={"source_id": source_id, "sync_type": "incremental"},
+    )
+    assert resp.status_code == 200, resp.text
+    sync_run_id = resp.json()["sync_run_id"]
+
+    row = await wait_for_sync(harness.db_pool, sync_run_id, timeout=30)
+    assert (
+        row["status"] == "completed"
+    ), f"status={row['status']}, error={row.get('error_message')}"
+
+    n_events = await count_events(harness.db_pool, source_id, "document_created")
+    assert n_events == 2, (
+        f"Expected exactly 2 document_created events (the two post-cutoff pages); "
+        f"got {n_events}. The stale page should be filtered out by the early-break."
+    )
+
+    events = await get_events(harness.db_pool, source_id)
+    doc_ids = {
+        e["payload"]["document_id"]
+        for e in events
+        if e["event_type"] == "document_created"
+    }
+    assert f"notion:page:{NEW_PAGE_ID}" in doc_ids
+    assert f"notion:page:{NEWER_PAGE_ID}" in doc_ids
+    assert f"notion:page:{OLD_PAGE_ID}" not in doc_ids
+
+    state = await seed.get_connector_state(source_id)
+    assert state is not None
+    assert (
+        state["last_sync_at"] > cutoff
+    ), "last_sync_at should advance to the new run's timestamp"

--- a/connectors/notion/tests/test_permissions.py
+++ b/connectors/notion/tests/test_permissions.py
@@ -1,8 +1,7 @@
 """Integration tests: workspace-level permission group and group membership sync."""
 
-import pytest
 import httpx
-
+import pytest
 from omni_connector.testing import count_events, get_events, wait_for_sync
 
 from .conftest import _block_payload
@@ -10,8 +9,6 @@ from .conftest import _block_payload
 pytestmark = pytest.mark.integration
 
 PAGE_ID = "pg-00000000-0000-0000-0000-000000000010"
-DB_ID = "db-00000000-0000-0000-0000-000000000010"
-ENTRY_PAGE_ID = "pg-00000000-0000-0000-0000-000000000011"
 
 
 async def test_workspace_group_membership_emitted(
@@ -51,64 +48,6 @@ async def test_workspace_group_membership_emitted(
     assert sorted(payload["member_emails"]) == ["alice@example.com", "bob@example.com"]
 
 
-async def test_documents_have_workspace_permission_group(
-    harness, seed, source_id, mock_notion_api, cm_client: httpx.AsyncClient
-):
-    """All emitted documents carry the workspace permission group."""
-    mock_notion_api.add_user("user-001", "Alice", email="alice@example.com")
-
-    mock_notion_api.add_page(
-        PAGE_ID,
-        "Standalone Page",
-        [_block_payload("blk-101", "paragraph", "Content")],
-    )
-
-    db_schema = {
-        "Name": {"id": "title", "name": "Name", "type": "title", "title": {}},
-    }
-    mock_notion_api.add_database(DB_ID, "My Database", db_schema)
-    mock_notion_api.add_database_entry(
-        DB_ID,
-        ENTRY_PAGE_ID,
-        "Entry One",
-        {
-            "Name": {
-                "id": "title",
-                "type": "title",
-                "title": [
-                    {
-                        "type": "text",
-                        "text": {"content": "Entry One"},
-                        "plain_text": "Entry One",
-                    }
-                ],
-            }
-        },
-        [_block_payload("blk-102", "paragraph", "Entry content")],
-    )
-
-    resp = await cm_client.post(
-        "/sync", json={"source_id": source_id, "sync_type": "full"}
-    )
-    assert resp.status_code == 200, resp.text
-    sync_run_id = resp.json()["sync_run_id"]
-
-    row = await wait_for_sync(harness.db_pool, sync_run_id, timeout=30)
-    assert row["status"] == "completed"
-
-    events = await get_events(harness.db_pool, source_id)
-    doc_events = [e for e in events if e["event_type"] == "document_created"]
-    assert len(doc_events) == 3
-
-    expected_group = f"notion:workspace:{source_id}"
-    for event in doc_events:
-        perms = event["payload"]["permissions"]
-        assert (
-            expected_group in perms["groups"]
-        ), f"Document {event['payload']['document_id']} missing workspace group"
-        assert perms["public"] is False
-
-
 async def test_member_without_email_skipped(
     harness, seed, source_id, mock_notion_api, cm_client: httpx.AsyncClient
 ):
@@ -137,3 +76,39 @@ async def test_member_without_email_skipped(
 
     payload = group_events[0]["payload"]
     assert payload["member_emails"] == ["alice@example.com"]
+
+
+async def test_sync_completes_when_users_capability_is_missing(
+    harness, seed, source_id, mock_notion_api, cm_client: httpx.AsyncClient
+):
+    """If /v1/users 403s (integration lacks user-info capability), the sync still
+    completes and emits documents — it just skips group membership.
+    """
+    mock_notion_api.should_forbid_users = True
+    try:
+        mock_notion_api.add_page(
+            PAGE_ID,
+            "Test Page",
+            [_block_payload("blk-104", "paragraph", "Hello")],
+        )
+
+        resp = await cm_client.post(
+            "/sync", json={"source_id": source_id, "sync_type": "full"}
+        )
+        assert resp.status_code == 200, resp.text
+        sync_run_id = resp.json()["sync_run_id"]
+
+        row = await wait_for_sync(harness.db_pool, sync_run_id, timeout=30)
+        assert row["status"] == "completed", (
+            f"sync should complete despite 403 on /users; "
+            f"got status={row['status']} error={row.get('error_message')}"
+        )
+
+        events = await get_events(harness.db_pool, source_id)
+        group_events = [e for e in events if e["event_type"] == "group_membership_sync"]
+        assert len(group_events) == 0, "no group membership when /users is 403"
+
+        n_docs = await count_events(harness.db_pool, source_id, "document_created")
+        assert n_docs >= 1, "documents should still be emitted"
+    finally:
+        mock_notion_api.should_forbid_users = False

--- a/connectors/notion/uv.lock
+++ b/connectors/notion/uv.lock
@@ -809,7 +809,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "notion-client", specifier = ">=2.0.0" },
+    { name = "notion-client", specifier = ">=3.0.0" },
     { name = "omni-connector", extras = ["mcp"], directory = "../../sdk/python" },
 ]
 

--- a/sdk/python/omni_connector/testing/seed.py
+++ b/sdk/python/omni_connector/testing/seed.py
@@ -47,6 +47,7 @@ class SeedHelper:
         user_filter_mode: str = "all",
         user_whitelist: list[str] | None = None,
         user_blacklist: list[str] | None = None,
+        scope: str = "org",
     ) -> str:
         source_id = source_id or _new_ulid()
         name = name or f"Test {source_type} source"
@@ -60,12 +61,12 @@ class SeedHelper:
             INSERT INTO sources (
                 id, name, source_type, config, created_by,
                 user_filter_mode, user_whitelist, user_blacklist,
-                created_at, updated_at
+                scope, created_at, updated_at
             )
             VALUES (
                 $1::char(26), $2, $3, $4::jsonb, $5::char(26),
                 $6, $7::jsonb, $8::jsonb,
-                NOW(), NOW()
+                $9, NOW(), NOW()
             )
             ON CONFLICT (id) DO NOTHING
             """,
@@ -77,6 +78,7 @@ class SeedHelper:
             user_filter_mode,
             whitelist_json,
             blacklist_json,
+            scope,
         )
         return source_id
 
@@ -123,6 +125,14 @@ class SeedHelper:
         if row and row["connector_state"]:
             return json.loads(row["connector_state"])
         return None
+
+    async def set_connector_state(self, source_id: str, state: dict[str, Any]) -> None:
+        """Seed a source's connector_state, e.g. to simulate a prior sync run."""
+        await self._pool.execute(
+            "UPDATE sources SET connector_state = $1::jsonb WHERE id = $2::char(26)",
+            json.dumps(state),
+            source_id,
+        )
 
     async def get_sync_run(self, sync_run_id: str) -> asyncpg.Record | None:
         return await self._pool.fetchrow(

--- a/web/src/lib/components/notion-connector-setup.svelte
+++ b/web/src/lib/components/notion-connector-setup.svelte
@@ -106,6 +106,28 @@
                     and paste the token here.
                 </p>
             </div>
+
+            <div
+                class="rounded-md border border-amber-200 bg-amber-50 p-3 text-sm dark:border-amber-900/50 dark:bg-amber-950/30">
+                <p class="font-medium">Before you connect</p>
+                <ul class="text-muted-foreground mt-1 list-disc space-y-1 pl-5">
+                    <li>
+                        Notion integrations only see pages you explicitly share with them. After
+                        creating the integration, open each top-level page or teamspace you want
+                        indexed and add the integration via
+                        <span class="font-medium">… → Add connections</span>. Sharing inherits to
+                        child pages.
+                    </li>
+                    <li>
+                        On the integration's capabilities page, enable
+                        <span class="font-medium">Read content</span>, and under
+                        <span class="font-medium">User capabilities</span> select
+                        <span class="font-medium">User information with email addresses</span>.
+                        Without it, listing workspace members returns 403 and group membership stays
+                        empty.
+                    </li>
+                </ul>
+            </div>
         </div>
 
         <Dialog.Footer>

--- a/web/src/routes/(admin)/admin/settings/integrations/notion/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/notion/[sourceId]/+page.svelte
@@ -113,11 +113,27 @@
                     </div>
                 </Card.Header>
 
-                <Card.Content>
+                <Card.Content class="space-y-3">
                     <p class="text-muted-foreground text-sm">
-                        Share pages and databases with your Notion integration to make them
-                        searchable in Omni.
+                        Only pages and databases that have been explicitly shared with your Notion
+                        integration are indexed.
                     </p>
+                    <ul class="text-muted-foreground list-disc space-y-1 pl-5 text-sm">
+                        <li>
+                            Open each Notion page or teamspace to index, click
+                            <span class="font-medium">… → Add connections</span>, and add this
+                            integration. Sharing inherits to child pages.
+                        </li>
+                        <li>
+                            On the integration's capabilities page, enable
+                            <span class="font-medium">Read content</span>, and under
+                            <span class="font-medium">User capabilities</span> select
+                            <span class="font-medium">
+                                User information with email addresses
+                            </span>. Without it, listing workspace members returns 403 and group
+                            membership stays empty.
+                        </li>
+                    </ul>
                 </Card.Content>
                 <Card.Footer class="flex justify-end">
                     <Button


### PR DESCRIPTION
- Migrate to Notion-Version 2025-09-03 data sources query API
- Add sort to /v1/search so incremental sync's early-break is correct
- Override display_name so admin UI shows "Notion" not "notion"
- Catch 403 on /v1/users (missing capability) instead of failing sync
- Save state via save_state before complete (CM ignores complete payload)
- Setup/configure UI now explains page-sharing + capability requirements
- Sync test mock with new API contract; add incremental + 403 tests