### PR TITLE
feat(dev): add dev-stack.sh for isolated worktree development stacks

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -29,9 +29,15 @@
    cp .env.example .env
    ```
 
-2. Start the development environment:
+2. Start the development environment (standard shared stack):
    ```bash
    docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml --env-file .env up -d --build
+   ```
+
+   **Or** use the isolated worktree stack manager (recommended when working across multiple branches):
+   ```bash
+   ./scripts/dev-stack.sh init   # creates .env.<branch>
+   ./scripts/dev-stack.sh start  # starts your isolated stack
    ```
 
 3. Access the web UI at http://localhost:3000
@@ -43,6 +49,7 @@
   ```bash
   docker compose -f docker/docker-compose.yml -f docker/docker-compose.dev.yml --env-file .env up -d --build searcher
   ```
+  (Or `./scripts/dev-stack.sh logs searcher` when using the isolated stack.)
 
 ### Local Development (Optional)
 

--- a/docker/docker-compose.dev.yml
+++ b/docker/docker-compose.dev.yml
@@ -1,5 +1,10 @@
 # Development-specific overrides
 # Usage: docker-compose -f docker-compose.yml -f docker-compose.dev.yml up
+#
+# This file provides worktree isolation via OMNI_WORKTREE.
+# When OMNI_WORKTREE is set (e.g. omni-feature-x), all containers,
+# volumes, networks, and dev images are prefixed accordingly.
+# Default behaviour (unset) preserves the legacy omni-* names.
 
 x-dev-db-config: &dev-db-config
   POSTGRES_DB: omni_dev
@@ -16,6 +21,7 @@ x-dev-database-url: &dev-database-url
 services:
   # Infrastructure only for development
   postgres:
+    container_name: ${OMNI_WORKTREE:-omni}-postgres
     ports:
       - "5432:5432"
     environment:
@@ -24,12 +30,14 @@ services:
       test: ["CMD-SHELL", "pg_isready -U omni_dev -d omni_dev"]
 
   redis:
+    container_name: ${OMNI_WORKTREE:-omni}-redis
     ports:
       - "6379:6379"
 
   # Override for development with hot reload
   web:
-    image: omni-web:dev
+    container_name: ${OMNI_WORKTREE:-omni}-web
+    image: ${OMNI_WORKTREE:-omni}-web:dev
     build:
       context: ../web
       dockerfile: Dockerfile.dev
@@ -46,7 +54,8 @@ services:
   # Update database URLs for all services in dev
 
   migrator:
-    image: omni-migrator:dev
+    container_name: ${OMNI_WORKTREE:-omni}-migrator
+    image: ${OMNI_WORKTREE:-omni}-migrator:dev
     build:
       context: ..
       dockerfile: services/migrations/Dockerfile
@@ -54,7 +63,8 @@ services:
       <<: *dev-database-url
 
   searcher:
-    image: omni-searcher:dev
+    container_name: ${OMNI_WORKTREE:-omni}-searcher
+    image: ${OMNI_WORKTREE:-omni}-searcher:dev
     build:
       context: ..
       dockerfile: services/searcher/Dockerfile
@@ -65,7 +75,8 @@ services:
       RUST_BACKTRACE: full
 
   indexer:
-    image: omni-indexer:dev
+    container_name: ${OMNI_WORKTREE:-omni}-indexer
+    image: ${OMNI_WORKTREE:-omni}-indexer:dev
     build:
       context: ..
       dockerfile: services/indexer/Dockerfile
@@ -76,7 +87,8 @@ services:
       RUST_BACKTRACE: full
 
   ai:
-    image: omni-ai:dev
+    container_name: ${OMNI_WORKTREE:-omni}-ai
+    image: ${OMNI_WORKTREE:-omni}-ai:dev
     build:
       context: ../services/ai
       dockerfile: Dockerfile
@@ -91,7 +103,8 @@ services:
     command: python -m uvicorn main:app --host 0.0.0.0 --port ${AI_SERVICE_PORT} --reload
 
   sandbox:
-    image: omni-sandbox:dev
+    container_name: ${OMNI_WORKTREE:-omni}-sandbox
+    image: ${OMNI_WORKTREE:-omni}-sandbox:dev
     build:
       context: ..
       dockerfile: services/sandbox/Dockerfile
@@ -99,7 +112,8 @@ services:
       - "${SANDBOX_PORT}:${SANDBOX_PORT}"
 
   connector-manager:
-    image: omni-connector-manager:dev
+    container_name: ${OMNI_WORKTREE:-omni}-connector-manager
+    image: ${OMNI_WORKTREE:-omni}-connector-manager:dev
     build:
       context: ..
       dockerfile: services/connector-manager/Dockerfile
@@ -110,7 +124,8 @@ services:
       RUST_BACKTRACE: full
 
   google-connector:
-    image: omni-google-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-google-connector
+    image: ${OMNI_WORKTREE:-omni}-google-connector:dev
     build:
       context: ..
       dockerfile: connectors/google/Dockerfile
@@ -120,7 +135,8 @@ services:
       RUST_BACKTRACE: full
 
   slack-connector:
-    image: omni-slack-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-slack-connector
+    image: ${OMNI_WORKTREE:-omni}-slack-connector:dev
     build:
       context: ..
       dockerfile: connectors/slack/Dockerfile
@@ -128,7 +144,8 @@ services:
       RUST_BACKTRACE: full
 
   atlassian-connector:
-    image: omni-atlassian-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-atlassian-connector
+    image: ${OMNI_WORKTREE:-omni}-atlassian-connector:dev
     build:
       context: ..
       dockerfile: connectors/atlassian/Dockerfile
@@ -136,7 +153,8 @@ services:
       RUST_BACKTRACE: full
 
   web-connector:
-    image: omni-web-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-web-connector
+    image: ${OMNI_WORKTREE:-omni}-web-connector:dev
     build:
       context: ..
       dockerfile: connectors/web/Dockerfile
@@ -146,25 +164,29 @@ services:
       RUST_BACKTRACE: full
 
   github-connector:
-    image: omni-github-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-github-connector
+    image: ${OMNI_WORKTREE:-omni}-github-connector:dev
     build:
       context: ..
       dockerfile: connectors/github/Dockerfile
 
   notion-connector:
-    image: omni-notion-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-notion-connector
+    image: ${OMNI_WORKTREE:-omni}-notion-connector:dev
     build:
       context: ..
       dockerfile: connectors/notion/Dockerfile
 
   hubspot-connector:
-    image: omni-hubspot-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-hubspot-connector
+    image: ${OMNI_WORKTREE:-omni}-hubspot-connector:dev
     build:
       context: ..
       dockerfile: connectors/hubspot/Dockerfile
 
   fireflies-connector:
-    image: omni-fireflies-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-fireflies-connector
+    image: ${OMNI_WORKTREE:-omni}-fireflies-connector:dev
     build:
       context: ..
       dockerfile: connectors/fireflies/Dockerfile
@@ -172,7 +194,8 @@ services:
       RUST_LOG: debug
 
   imap-connector:
-    image: omni-imap-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-imap-connector
+    image: ${OMNI_WORKTREE:-omni}-imap-connector:dev
     build:
       context: ..
       dockerfile: connectors/imap/Dockerfile
@@ -180,7 +203,8 @@ services:
       RUST_LOG: debug
 
   nextcloud-connector:
-    image: omni-nextcloud-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-nextcloud-connector
+    image: ${OMNI_WORKTREE:-omni}-nextcloud-connector:dev
     build:
       context: ..
       dockerfile: connectors/nextcloud/Dockerfile
@@ -188,25 +212,29 @@ services:
       RUST_LOG: debug
 
   clickup-connector:
-    image: omni-clickup-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-clickup-connector
+    image: ${OMNI_WORKTREE:-omni}-clickup-connector:dev
     build:
       context: ..
       dockerfile: connectors/clickup/Dockerfile
 
   linear-connector:
-    image: omni-linear-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-linear-connector
+    image: ${OMNI_WORKTREE:-omni}-linear-connector:dev
     build:
       context: ..
       dockerfile: connectors/linear/Dockerfile
 
   microsoft-connector:
-    image: omni-microsoft-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-microsoft-connector
+    image: ${OMNI_WORKTREE:-omni}-microsoft-connector:dev
     build:
       context: ..
       dockerfile: connectors/microsoft/Dockerfile
 
   filesystem-connector:
-    image: omni-filesystem-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-filesystem-connector
+    image: ${OMNI_WORKTREE:-omni}-filesystem-connector:dev
     build:
       context: ..
       dockerfile: connectors/filesystem/Dockerfile
@@ -215,13 +243,15 @@ services:
       RUST_BACKTRACE: full
 
   paperless-connector:
-    image: omni-paperless-connector:dev
+    container_name: ${OMNI_WORKTREE:-omni}-paperless-connector
+    image: ${OMNI_WORKTREE:-omni}-paperless-connector:dev
     build:
       context: ..
       dockerfile: connectors/paperless/Dockerfile
 
   docling:
-    image: omni-docling:dev
+    container_name: ${OMNI_WORKTREE:-omni}-docling
+    image: ${OMNI_WORKTREE:-omni}-docling:dev
     build:
       context: ../services/docling
       dockerfile: Dockerfile
@@ -229,10 +259,35 @@ services:
         DEVICE: ${DOCLING_DEVICE:-cpu}
 
   embeddings:
+    container_name: ${OMNI_WORKTREE:-omni}-embeddings
     ports:
       - "${LOCAL_EMBEDDINGS_PORT}:${LOCAL_EMBEDDINGS_PORT}"
 
   caddy:
+    container_name: ${OMNI_WORKTREE:-omni}-caddy
     profiles:
       - production
 
+volumes:
+  postgres_data:
+    name: ${OMNI_WORKTREE:-omni}-postgres-data
+  redis_data:
+    name: ${OMNI_WORKTREE:-omni}-redis-data
+  ai_models:
+    name: ${OMNI_WORKTREE:-omni}-ai-models
+  tei_models:
+    name: ${OMNI_WORKTREE:-omni}-tei-models
+  docling_models:
+    name: ${OMNI_WORKTREE:-omni}-docling-models
+  caddy_data:
+    name: ${OMNI_WORKTREE:-omni}-caddy-data
+  caddy_config:
+    name: ${OMNI_WORKTREE:-omni}-caddy-config
+  sandbox_data:
+    name: ${OMNI_WORKTREE:-omni}-sandbox-data
+
+networks:
+  omni-network:
+    name: ${OMNI_WORKTREE:-omni}-network
+  sandbox-net:
+    name: ${OMNI_WORKTREE:-omni}-sandbox-net

--- a/scripts/dev-stack.sh
+++ b/scripts/dev-stack.sh
@@ -1,0 +1,255 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Dev Stack Manager
+# Provides temporal isolation for local omni development across git worktrees.
+# Only one stack may be active at a time to conserve RAM.
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+LOCK_DIR="${HOME}/.omni"
+LOCK_FILE="${LOCK_DIR}/dev-stack.lock"
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") <command>
+
+Commands:
+  init              Create .env.<branch> from .env.example for this worktree
+  start             Start this worktree's stack (enforces single active stack)
+  stop              Stop this worktree's stack and release the lock
+  status            Show active stack owner and running containers
+  logs [service]    Tail logs for the given service (or all if omitted)
+
+Environment:
+  OMNI_WORKTREE is derived from the current git branch.
+EOF
+    exit 1
+}
+
+get_branch() {
+    git -C "${REPO_ROOT}" rev-parse --abbrev-ref HEAD 2>/dev/null || true
+}
+
+sanitize_name() {
+    local raw="$1"
+    # Replace non-alphanumeric with dashes, collapse multiple dashes, trim ends
+    echo "${raw}" | sed -E 's/[^a-zA-Z0-9]+/-/g; s/^-+//; s/-+$//'
+}
+
+get_env_file() {
+    local branch
+    branch="$(get_branch)"
+    if [[ -z "${branch}" ]]; then
+        echo ".env"
+    else
+        echo ".env.${branch}"
+    fi
+}
+
+get_project_name() {
+    local branch
+    branch="$(get_branch)"
+    if [[ -z "${branch}" ]]; then
+        echo "omni"
+    else
+        echo "omni-$(sanitize_name "${branch}")"
+    fi
+}
+
+compose_cmd() {
+    local env_file
+    env_file="$(get_env_file)"
+    docker compose \
+        -f "${REPO_ROOT}/docker/docker-compose.yml" \
+        -f "${REPO_ROOT}/docker/docker-compose.dev.yml" \
+        --env-file "${REPO_ROOT}/${env_file}" \
+        "$@"
+}
+
+# ---------------------------------------------------------------------------
+# Lockfile operations
+# ---------------------------------------------------------------------------
+
+acquire_lock() {
+    mkdir -p "${LOCK_DIR}"
+    local worktree_path branch
+    worktree_path="$(cd "${REPO_ROOT}" && pwd)"
+    branch="$(get_branch)"
+
+    if [[ -f "${LOCK_FILE}" ]]; then
+        local locked_path locked_branch
+        locked_path="$(head -n1 "${LOCK_FILE}" 2>/dev/null || true)"
+        locked_branch="$(sed -n '2p' "${LOCK_FILE}" 2>/dev/null || true)"
+
+        if [[ "${locked_path}" != "${worktree_path}" ]]; then
+            echo "ERROR: Another dev stack is already active." >&2
+            echo "  Worktree: ${locked_path}" >&2
+            echo "  Branch:   ${locked_branch}" >&2
+            echo "Run 'dev-stack.sh stop' in that worktree first." >&2
+            exit 1
+        fi
+    fi
+
+    printf '%s\n%s\n%d\n' "${worktree_path}" "${branch}" "$(date +%s)" > "${LOCK_FILE}"
+}
+
+release_lock() {
+    local worktree_path
+    worktree_path="$(cd "${REPO_ROOT}" && pwd)"
+
+    if [[ -f "${LOCK_FILE}" ]]; then
+        local locked_path
+        locked_path="$(head -n1 "${LOCK_FILE}" 2>/dev/null || true)"
+        if [[ "${locked_path}" == "${worktree_path}" ]]; then
+            rm -f "${LOCK_FILE}"
+        else
+            echo "WARNING: Lock is owned by another worktree (${locked_path}). Not releasing." >&2
+        fi
+    fi
+}
+
+read_lock() {
+    if [[ -f "${LOCK_FILE}" ]]; then
+        local locked_path locked_branch locked_at
+        locked_path="$(head -n1 "${LOCK_FILE}" 2>/dev/null || true)"
+        locked_branch="$(sed -n '2p' "${LOCK_FILE}" 2>/dev/null || true)"
+        locked_at="$(sed -n '3p' "${LOCK_FILE}" 2>/dev/null || true)"
+        echo "${locked_path}"$'\t'"${locked_branch}"$'\t'"${locked_at}"
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Commands
+# ---------------------------------------------------------------------------
+
+cmd_init() {
+    local branch env_file project_name example_env
+    branch="$(get_branch)"
+    if [[ -z "${branch}" ]]; then
+        echo "ERROR: Not in a git repository or detached HEAD." >&2
+        exit 1
+    fi
+
+    env_file="$(get_env_file)"
+    project_name="$(get_project_name)"
+    example_env="${REPO_ROOT}/.env.example"
+
+    if [[ ! -f "${example_env}" ]]; then
+        echo "ERROR: .env.example not found at ${example_env}" >&2
+        exit 1
+    fi
+
+    if [[ -f "${REPO_ROOT}/${env_file}" ]]; then
+        echo "Env file already exists: ${env_file}"
+        read -r -p "Overwrite? [y/N] " reply
+        if [[ "${reply}" != "y" && "${reply}" != "Y" ]]; then
+            echo "Aborted."
+            exit 0
+        fi
+    fi
+
+    cp "${example_env}" "${REPO_ROOT}/${env_file}"
+    # Prepend OMNI_WORKTREE if not already present
+    if ! grep -q '^OMNI_WORKTREE=' "${REPO_ROOT}/${env_file}"; then
+        {
+            echo ""
+            echo "# Worktree isolation — managed by dev-stack.sh"
+            echo "OMNI_WORKTREE=${project_name}"
+        } >> "${REPO_ROOT}/${env_file}"
+    fi
+
+    echo "Created ${env_file} with OMNI_WORKTREE=${project_name}"
+}
+
+cmd_start() {
+    local env_file
+    env_file="$(get_env_file)"
+
+    if [[ ! -f "${REPO_ROOT}/${env_file}" ]]; then
+        echo "ERROR: Env file not found: ${REPO_ROOT}/${env_file}" >&2
+        echo "Run '$(basename "$0") init' first." >&2
+        exit 1
+    fi
+
+    acquire_lock
+
+    echo "Starting dev stack: $(get_project_name)"
+    compose_cmd up -d --build
+
+    echo ""
+    echo "Stack started. Running database seed..."
+    "${SCRIPT_DIR}/seed-db.sh" "$(get_project_name)"
+
+    echo ""
+    echo "Done. Access the app at http://localhost:${WEB_PORT:-3000}"
+}
+
+cmd_stop() {
+    local env_file
+    env_file="$(get_env_file)"
+
+    if [[ ! -f "${REPO_ROOT}/${env_file}" ]]; then
+        echo "WARNING: Env file not found: ${env_file}. Stopping via project name fallback." >&2
+    fi
+
+    echo "Stopping dev stack: $(get_project_name)"
+    compose_cmd down --remove-orphans || true
+    release_lock
+    echo "Stopped."
+}
+
+cmd_status() {
+    local lock_info
+    lock_info="$(read_lock)"
+
+    echo "=== Dev Stack Lock ==="
+    if [[ -n "${lock_info}" ]]; then
+        local locked_path locked_branch locked_at
+        locked_path="$(echo "${lock_info}" | cut -f1)"
+        locked_branch="$(echo "${lock_info}" | cut -f2)"
+        locked_at="$(echo "${lock_info}" | cut -f3)"
+        locked_at_human="$(date -d "@${locked_at}" 2>/dev/null || date -r "${locked_at}" 2>/dev/null || echo "${locked_at}")"
+        echo "Active:  YES"
+        echo "Path:    ${locked_path}"
+        echo "Branch:  ${locked_branch}"
+        echo "Since:   ${locked_at_human}"
+    else
+        echo "Active:  NO"
+    fi
+
+    echo ""
+    echo "=== Running omni containers ==="
+    docker ps --filter "name=^/$(get_project_name)" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}" 2>/dev/null || true
+}
+
+cmd_logs() {
+    local service="${1:-}"
+    if [[ -n "${service}" ]]; then
+        compose_cmd logs -f "${service}"
+    else
+        compose_cmd logs -f
+    fi
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+[[ $# -eq 0 ]] && usage
+
+COMMAND="$1"
+shift || true
+
+case "${COMMAND}" in
+    init)   cmd_init ;;
+    start)  cmd_start ;;
+    stop)   cmd_stop ;;
+    status) cmd_status ;;
+    logs)   cmd_logs "$@" ;;
+    *)      usage ;;
+esac

--- a/scripts/seed-db.sh
+++ b/scripts/seed-db.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# Seed a fresh dev database after stack startup.
+# Inserts an admin user, approves the domain, and marks the system as initialized.
+
+PROJECT_NAME="${1:-omni}"
+POSTGRES_CONTAINER="${PROJECT_NAME}-postgres"
+REDIS_CONTAINER="${PROJECT_NAME}-redis"
+MIGRATOR_CONTAINER="${PROJECT_NAME}-migrator"
+MAX_WAIT_SECS=120
+
+ADMIN_EMAIL="admin@omni.local"
+ADMIN_PASSWORD_HASH='$argon2id$v=19$m=65536,t=3,p=1$C7DiqGmKyt3oSKz/RdKC9w$lyb48nV0cPdfRz2wbPPwV+GBIvbfyL+6JNUDzn0HxrA'
+ADMIN_ID='01KRFT782W41QB8Q40XTAP9C3B'
+DOMAIN_ID='01KRFT782W41QB8Q40XTAP9C3C'
+
+wait_for_postgres() {
+    local elapsed=0
+    echo -n "Waiting for ${POSTGRES_CONTAINER}..."
+    while ! docker exec "${POSTGRES_CONTAINER}" pg_isready -U omni_dev -d omni_dev >/dev/null 2>&1; do
+        if (( elapsed >= MAX_WAIT_SECS )); then
+            echo " timeout"
+            echo "ERROR: Postgres did not become ready within ${MAX_WAIT_SECS}s" >&2
+            exit 1
+        fi
+        sleep 1
+        ((elapsed++))
+        echo -n "."
+    done
+    echo " ready"
+}
+
+wait_for_migrator() {
+    local elapsed=0
+    echo -n "Waiting for ${MIGRATOR_CONTAINER}..."
+    while true; do
+        local status
+        status="$(docker inspect -f '{{.State.Status}}' "${MIGRATOR_CONTAINER}" 2>/dev/null || echo 'unknown')"
+        if [[ "${status}" == "exited" ]]; then
+            local exit_code
+            exit_code="$(docker inspect -f '{{.State.ExitCode}}' "${MIGRATOR_CONTAINER}" 2>/dev/null || echo 1)"
+            if [[ "${exit_code}" == "0" ]]; then
+                echo " completed"
+                return 0
+            else
+                echo " failed"
+                echo "ERROR: Migrator exited with code ${exit_code}" >&2
+                docker logs "${MIGRATOR_CONTAINER}" >&2 || true
+                exit 1
+            fi
+        fi
+        if (( elapsed >= MAX_WAIT_SECS )); then
+            echo " timeout"
+            echo "ERROR: Migrator did not complete within ${MAX_WAIT_SECS}s" >&2
+            exit 1
+        fi
+        sleep 1
+        ((elapsed++))
+        echo -n "."
+    done
+}
+
+seed_user() {
+    echo "Seeding admin user..."
+
+    local existing
+    existing="$(docker exec "${POSTGRES_CONTAINER}" psql -U omni_dev -d omni_dev -Atc "SELECT COUNT(*) FROM users WHERE email = '${ADMIN_EMAIL}';" 2>/dev/null || echo '0')"
+
+    if [[ "${existing}" != "0" ]]; then
+        echo "  Admin user already exists, skipping."
+        return 0
+    fi
+
+    docker exec "${POSTGRES_CONTAINER}" psql -U omni_dev -d omni_dev -q -c "
+        INSERT INTO users (id, email, password_hash, full_name, role, is_active, auth_method, domain, created_at, updated_at)
+        VALUES ('${ADMIN_ID}', '${ADMIN_EMAIL}', '${ADMIN_PASSWORD_HASH}', 'Admin User', 'admin', true, 'password', 'omni.local', NOW(), NOW());
+    "
+
+    docker exec "${POSTGRES_CONTAINER}" psql -U omni_dev -d omni_dev -q -c "
+        INSERT INTO approved_domains (id, domain, approved_by, created_at, updated_at)
+        VALUES ('${DOMAIN_ID}', 'omni.local', '${ADMIN_ID}', NOW(), NOW());
+    "
+
+    echo "  Admin user created: ${ADMIN_EMAIL}"
+}
+
+seed_redis() {
+    echo "Marking system as initialized in Redis..."
+    docker exec "${REDIS_CONTAINER}" redis-cli HSET system:flags initialized true >/dev/null 2>&1 || true
+}
+
+echo "=== Database seed for ${PROJECT_NAME} ==="
+wait_for_postgres
+wait_for_migrator
+seed_user
+seed_redis
+
+echo ""
+echo "Done. Log in at http://localhost:3000/login"
+echo "  Email:    ${ADMIN_EMAIL}"
+echo "  Password: omni-dev"
+echo ""


### PR DESCRIPTION
- Prefix containers, volumes, networks, and images with OMNI_PROJECT_NAME in docker-compose.dev.yml
- Add scripts/dev-stack.sh with init/start/stop/status/logs and strict lockfile coordination
- Add scripts/seed-db.sh to insert admin user, approve domain, and mark system initialized
- Update CONTRIBUTING.md and AGENTS.md with isolated stack workflow documentation