### PR TITLE
Fix Microsoft delta sync resilience

### DIFF
--- a/connectors/microsoft/ms_connector/graph_client.py
+++ b/connectors/microsoft/ms_connector/graph_client.py
@@ -219,6 +219,37 @@ class GraphClient:
             else:
                 next_url = None
 
+    async def get_delta_pages(
+        self,
+        url: str,
+        delta_token: str | None = None,
+        params: dict[str, Any] | None = None,
+    ) -> AsyncIterator[tuple[list[dict[str, Any]], str | None, str | None]]:
+        """Execute a delta query, yielding one page at a time.
+
+        Yields (items, next_link, delta_link) tuples. For intermediate pages,
+        next_link is set and delta_link is None. For the final page, next_link
+        is None and delta_link is the @odata.deltaLink to resume from next run.
+
+        Either next_link or delta_link can be stored as the resume token —
+        both are absolute URLs accepted by `delta_token` on subsequent calls.
+        """
+        if delta_token:
+            next_url: str | None = delta_token
+            next_params = None
+        else:
+            next_url = url
+            next_params = params
+
+        while next_url:
+            data = await self.get(next_url, params=next_params)
+            items: list[dict[str, Any]] = data.get("value", [])
+            next_link = data.get("@odata.nextLink")
+            delta_link = data.get("@odata.deltaLink") if not next_link else None
+            yield items, next_link, delta_link
+            next_url = next_link
+            next_params = None
+
     async def get_delta(
         self,
         url: str,
@@ -231,30 +262,15 @@ class GraphClient:
         for a full snapshot. On subsequent calls, pass the previously returned
         delta_token for incremental changes.
         """
-        if delta_token:
-            # Delta link is an absolute URL — use it directly
-            next_url: str | None = delta_token
-            next_params = None
-        else:
-            next_url = url
-            next_params = params
-
-        items: list[dict[str, Any]] = []
+        all_items: list[dict[str, Any]] = []
         new_delta_token: str | None = None
-
-        while next_url:
-            data = await self.get(next_url, params=next_params)
-            items.extend(data.get("value", []))
-
-            next_link = data.get("@odata.nextLink")
-            if next_link:
-                next_url = next_link
-                next_params = None
-            else:
-                new_delta_token = data.get("@odata.deltaLink")
-                next_url = None
-
-        return items, new_delta_token
+        async for items, _next_link, delta_link in self.get_delta_pages(
+            url, delta_token=delta_token, params=params
+        ):
+            all_items.extend(items)
+            if delta_link:
+                new_delta_token = delta_link
+        return all_items, new_delta_token
 
     async def list_users(self) -> list[dict[str, Any]]:
         """Enumerate all users in the tenant."""

--- a/connectors/microsoft/ms_connector/syncers/base.py
+++ b/connectors/microsoft/ms_connector/syncers/base.py
@@ -30,9 +30,27 @@ class BaseSyncer(abc.ABC):
         delta_token: str | None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
+        delta_tokens: dict[str, str] | None = None,
+        token_key: str | None = None,
     ) -> str | None:
-        """Sync data for a single user. Returns new delta token or None."""
+        """Sync data for a single user. Returns new delta token or None.
+
+        If `delta_tokens` and `token_key` are provided, implementations can call
+        `save_delta_token` with an intermediate resume token after each page so
+        progress is durable across interruptions.
+        """
         ...
+
+    async def save_delta_token(
+        self,
+        ctx: SyncContext,
+        delta_tokens: dict[str, str],
+        token_key: str,
+        token: str,
+    ) -> None:
+        """Persist a delta token while preserving the full token map."""
+        delta_tokens[token_key] = token
+        await ctx.save_state({"delta_tokens": delta_tokens})
 
     async def sync(
         self,
@@ -46,7 +64,8 @@ class BaseSyncer(abc.ABC):
         """Run sync across all users. Returns updated state dict."""
         source_config = source_config or {}
         delta_tokens: dict[str, str] = state.get("delta_tokens", {})
-        new_tokens: dict[str, str] = {}
+        # Seed with existing tokens so users not processed this run retain theirs.
+        new_tokens: dict[str, str] = dict(delta_tokens)
 
         users = await client.list_users()
         logger.info("[%s] Syncing across %d users", self.name, len(users))
@@ -58,25 +77,45 @@ class BaseSyncer(abc.ABC):
         ]
         logger.info("[%s] %d users after filtering", self.name, len(users))
 
+        attempted = 0
+        failed = 0
+
         for user in users:
             if ctx.is_cancelled():
                 logger.info("[%s] Cancelled", self.name)
-                return state
+                return {"delta_tokens": new_tokens}
 
             user_id = user["id"]
             token = delta_tokens.get(user_id)
+            attempted += 1
 
-            new_token = await self.sync_for_user(
-                client,
-                user,
-                ctx,
-                token,
-                user_cache=user_cache,
-                group_cache=group_cache,
-            )
+            try:
+                new_token = await self.sync_for_user(
+                    client,
+                    user,
+                    ctx,
+                    token,
+                    user_cache=user_cache,
+                    group_cache=group_cache,
+                    delta_tokens=new_tokens,
+                    token_key=user_id,
+                )
+            except Exception as e:
+                logger.warning(
+                    "[%s] sync_for_user failed for %s: %s",
+                    self.name,
+                    user.get("displayName", user_id),
+                    e,
+                )
+                failed += 1
+                continue
+
             if new_token:
-                new_tokens[user_id] = new_token
+                await self.save_delta_token(ctx, new_tokens, user_id, new_token)
+            else:
+                await ctx.save_state({"delta_tokens": new_tokens})
 
-            await ctx.save_state({"delta_tokens": new_tokens})
+        if attempted > 0 and failed == attempted:
+            raise RuntimeError(f"[{self.name}] sync failed for all {attempted} users")
 
         return {"delta_tokens": new_tokens}

--- a/connectors/microsoft/ms_connector/syncers/calendar.py
+++ b/connectors/microsoft/ms_connector/syncers/calendar.py
@@ -29,6 +29,8 @@ class CalendarSyncer(BaseSyncer):
         delta_token: str | None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
+        delta_tokens: dict[str, str] | None = None,
+        token_key: str | None = None,
     ) -> str | None:
         user_id = user["id"]
         display_name = user.get("displayName", user_id)

--- a/connectors/microsoft/ms_connector/syncers/mail.py
+++ b/connectors/microsoft/ms_connector/syncers/mail.py
@@ -40,7 +40,7 @@ class MailSyncer(BaseSyncer):
         """Run mail sync across all users and mail folders."""
         source_config = source_config or {}
         delta_tokens: dict[str, str] = state.get("delta_tokens", {})
-        new_tokens: dict[str, str] = {}
+        new_tokens: dict[str, str] = dict(delta_tokens)
 
         users = await client.list_users()
         logger.info("[mail] Syncing across %d users", len(users))
@@ -55,7 +55,7 @@ class MailSyncer(BaseSyncer):
         for user in users:
             if ctx.is_cancelled():
                 logger.info("[mail] Cancelled")
-                return state
+                return {"delta_tokens": new_tokens}
 
             user_id = user["id"]
 
@@ -71,6 +71,7 @@ class MailSyncer(BaseSyncer):
                 )
                 if new_token:
                     new_tokens[token_key] = new_token
+                    await ctx.save_state({"delta_tokens": new_tokens})
 
         return {"delta_tokens": new_tokens}
 
@@ -82,6 +83,8 @@ class MailSyncer(BaseSyncer):
         delta_token: str | None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
+        delta_tokens: dict[str, str] | None = None,
+        token_key: str | None = None,
     ) -> str | None:
         # Not used — sync() is overridden to handle multi-folder logic.
         # Kept to satisfy the abstract base class.
@@ -132,6 +135,9 @@ class MailSyncer(BaseSyncer):
 
             if item.get("deleted") or item.get("@removed"):
                 skipped_deleted += 1
+                message_id = item.get("internetMessageId") or item.get("id")
+                if message_id:
+                    await ctx.emit_deleted(f"mail:{message_id}")
                 continue
 
             await ctx.increment_scanned()

--- a/connectors/microsoft/ms_connector/syncers/onedrive.py
+++ b/connectors/microsoft/ms_connector/syncers/onedrive.py
@@ -52,25 +52,12 @@ class OneDriveSyncer(BaseSyncer):
         delta_token: str | None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
+        delta_tokens: dict[str, str] | None = None,
+        token_key: str | None = None,
     ) -> str | None:
         user_id = user["id"]
         display_name = user.get("displayName", user_id)
         logger.info("[onedrive] Syncing drive for user %s", display_name)
-
-        try:
-            items, new_token = await client.get_delta(
-                f"/users/{user_id}/drive/root/delta",
-                delta_token=delta_token,
-                params={
-                    "$select": "id,name,file,folder,size,webUrl,lastModifiedDateTime,"
-                    "createdDateTime,parentReference,content.downloadUrl"
-                },
-            )
-        except GraphAPIError as e:
-            logger.warning(
-                "[onedrive] Failed to fetch delta for user %s: %s", display_name, e
-            )
-            return delta_token
 
         cutoff = (
             datetime.now(timezone.utc) - timedelta(days=DEFAULT_MAX_AGE_DAYS)
@@ -78,44 +65,102 @@ class OneDriveSyncer(BaseSyncer):
             else None
         )
 
+        total = 0
         skipped_folders = 0
         skipped_cutoff = 0
         skipped_deleted = 0
+        last_resume_token: str | None = delta_token
+        final_token: str | None = None
 
-        for item in items:
-            if ctx.is_cancelled():
-                return delta_token
+        try:
+            pages = client.get_delta_pages(
+                f"/users/{user_id}/drive/root/delta",
+                delta_token=delta_token,
+                params={
+                    "$select": "id,name,file,folder,size,webUrl,lastModifiedDateTime,"
+                    "createdDateTime,parentReference,content.downloadUrl"
+                },
+            )
+            async for items, next_link, delta_link in pages:
+                total += len(items)
+                cancelled = False
 
-            if item.get("deleted"):
-                skipped_deleted += 1
-                drive_id = item.get("parentReference", {}).get("driveId", "unknown")
-                external_id = f"onedrive:{drive_id}:{item['id']}"
-                await ctx.emit_deleted(external_id)
-                continue
+                for item in items:
+                    if ctx.is_cancelled():
+                        cancelled = True
+                        break
 
-            if "folder" in item:
-                skipped_folders += 1
-                continue
+                    if item.get("deleted"):
+                        skipped_deleted += 1
+                        drive_id = item.get("parentReference", {}).get(
+                            "driveId", "unknown"
+                        )
+                        external_id = f"onedrive:{drive_id}:{item['id']}"
+                        await ctx.emit_deleted(external_id)
+                        continue
 
-            if cutoff:
-                modified = _parse_iso(item.get("lastModifiedDateTime"))
-                if modified and modified < cutoff:
-                    skipped_cutoff += 1
-                    continue
+                    if "folder" in item:
+                        skipped_folders += 1
+                        continue
 
-            await ctx.increment_scanned()
+                    if cutoff:
+                        modified = _parse_iso(item.get("lastModifiedDateTime"))
+                        if modified and modified < cutoff:
+                            skipped_cutoff += 1
+                            continue
 
-            try:
-                await self._process_item(
-                    client, user, item, ctx, user_cache, group_cache
+                    await ctx.increment_scanned()
+
+                    try:
+                        await self._process_item(
+                            client, user, item, ctx, user_cache, group_cache
+                        )
+                    except Exception as e:
+                        drive_id = item.get("parentReference", {}).get(
+                            "driveId", "unknown"
+                        )
+                        external_id = f"onedrive:{drive_id}:{item['id']}"
+                        logger.warning(
+                            "[onedrive] Error processing %s: %s", external_id, e
+                        )
+                        await ctx.emit_error(external_id, str(e))
+
+                if cancelled:
+                    return last_resume_token
+
+                # Checkpoint: store nextLink mid-stream, or deltaLink on final page.
+                resume = next_link or delta_link
+                if resume:
+                    last_resume_token = resume
+                    if delta_tokens is not None and token_key is not None:
+                        await self.save_delta_token(
+                            ctx, delta_tokens, token_key, resume
+                        )
+                if delta_link:
+                    final_token = delta_link
+        except GraphAPIError as e:
+            if delta_token is not None and _is_resync_required(e):
+                logger.warning(
+                    "[onedrive] Delta token for user %s requires resync (%s), "
+                    "restarting from scratch",
+                    display_name,
+                    e.diagnostic(),
                 )
-            except Exception as e:
-                drive_id = item.get("parentReference", {}).get("driveId", "unknown")
-                external_id = f"onedrive:{drive_id}:{item['id']}"
-                logger.warning("[onedrive] Error processing %s: %s", external_id, e)
-                await ctx.emit_error(external_id, str(e))
+                return await self.sync_for_user(
+                    client,
+                    user,
+                    ctx,
+                    None,
+                    user_cache=user_cache,
+                    group_cache=group_cache,
+                    delta_tokens=delta_tokens,
+                    token_key=token_key,
+                )
+            logger.warning(
+                "[onedrive] Failed to fetch delta for user %s: %s", display_name, e
+            )
+            return last_resume_token
 
-        total = len(items)
         skipped = skipped_folders + skipped_cutoff + skipped_deleted
         if skipped:
             logger.info(
@@ -129,7 +174,7 @@ class OneDriveSyncer(BaseSyncer):
                 skipped_deleted,
             )
 
-        return new_token
+        return final_token or last_resume_token
 
     async def _process_item(
         self,
@@ -216,3 +261,11 @@ def _is_indexable(mime_type: str, extension: str) -> bool:
     if any(mime_type.startswith(p) for p in INDEXABLE_MIME_PREFIXES):
         return True
     return extension in INDEXABLE_EXTENSIONS
+
+
+def _is_resync_required(err: GraphAPIError) -> bool:
+    if err.status_code == 410:
+        return True
+    code = (err.error_code or "").lower()
+    inner = (err.inner_error_code or "").lower()
+    return "resync" in code or "resync" in inner

--- a/connectors/microsoft/ms_connector/syncers/teams.py
+++ b/connectors/microsoft/ms_connector/syncers/teams.py
@@ -328,9 +328,9 @@ class TeamsSyncer:
         delta_tokens: dict[str, str] = state.get("delta_tokens", {})
         last_sync_ts: dict[str, str] = state.get("last_sync_ts", {})
         chat_last_sync_ts: dict[str, str] = state.get("chat_last_sync_ts", {})
-        new_tokens: dict[str, str] = {}
-        new_sync_ts: dict[str, str] = {}
-        new_chat_sync_ts: dict[str, str] = {}
+        new_tokens: dict[str, str] = dict(delta_tokens)
+        new_sync_ts: dict[str, str] = dict(last_sync_ts)
+        new_chat_sync_ts: dict[str, str] = dict(chat_last_sync_ts)
 
         cutoff = datetime.now(timezone.utc) - timedelta(days=DEFAULT_MAX_AGE_DAYS)
         now_iso = datetime.now(timezone.utc).isoformat()
@@ -343,7 +343,11 @@ class TeamsSyncer:
 
         for team in teams:
             if ctx.is_cancelled():
-                return state
+                return {
+                    "delta_tokens": new_tokens,
+                    "last_sync_ts": new_sync_ts,
+                    "chat_last_sync_ts": new_chat_sync_ts,
+                }
 
             team_id = team["id"]
             team_name = team.get("displayName", team_id)
@@ -360,7 +364,11 @@ class TeamsSyncer:
 
             for channel in channels:
                 if ctx.is_cancelled():
-                    return state
+                    return {
+                        "delta_tokens": new_tokens,
+                        "last_sync_ts": new_sync_ts,
+                        "chat_last_sync_ts": new_chat_sync_ts,
+                    }
 
                 channel_id = channel["id"]
                 channel_name = channel.get("displayName", channel_id)
@@ -842,7 +850,7 @@ class TeamsSyncer:
         channel_state: dict[str, Any] | None = None,
     ) -> dict[str, str]:
         """Iterate users, collect their chats, and sync messages."""
-        new_chat_sync_ts: dict[str, str] = {}
+        new_chat_sync_ts: dict[str, str] = dict(chat_last_sync_ts)
 
         try:
             users = await client.list_users()

--- a/connectors/microsoft/tests/conftest.py
+++ b/connectors/microsoft/tests/conftest.py
@@ -47,6 +47,8 @@ class MockGraphAPI:
         # site_id -> {"status": int, "body": dict} for forcing failures
         self.site_drives_errors: dict[str, dict[str, Any]] = {}
         self.drive_delta_errors: dict[str, list[dict[str, Any]]] = {}
+        self.user_drive_delta_errors: dict[str, list[dict[str, Any]]] = {}
+        self.user_drive_delta_pages: dict[str, list[list[dict[str, Any]]]] = {}
         self.site_diagnostics: dict[str, dict[str, Any]] = {}
         self.file_contents: dict[str, bytes] = {}
         self.groups: list[dict[str, Any]] = []
@@ -72,6 +74,8 @@ class MockGraphAPI:
         self.drive_items_by_drive.clear()
         self.site_drives_errors.clear()
         self.drive_delta_errors.clear()
+        self.user_drive_delta_errors.clear()
+        self.user_drive_delta_pages.clear()
         self.site_diagnostics.clear()
         self.file_contents.clear()
         self.groups.clear()
@@ -88,7 +92,7 @@ class MockGraphAPI:
     def add_user(self, user: dict[str, Any]) -> None:
         self.users.append(user)
 
-    def add_drive_item(self, user_id: str, item: dict[str, Any]) -> None:
+    def add_user_drive_item(self, user_id: str, item: dict[str, Any]) -> None:
         self.drive_items.setdefault(user_id, []).append(item)
 
     def add_mail_message(self, user_id: str, message: dict[str, Any]) -> None:
@@ -136,6 +140,18 @@ class MockGraphAPI:
         self.drive_delta_errors.setdefault(drive_id, []).append(
             {"status": status, "body": body or {}}
         )
+
+    def queue_user_drive_delta_error(
+        self, user_id: str, status: int, body: dict[str, Any] | None = None
+    ) -> None:
+        self.user_drive_delta_errors.setdefault(user_id, []).append(
+            {"status": status, "body": body or {}}
+        )
+
+    def set_user_drive_delta_pages(
+        self, user_id: str, pages: list[list[dict[str, Any]]]
+    ) -> None:
+        self.user_drive_delta_pages[user_id] = pages
 
     def set_site_diagnostic(self, site_id: str, payload: dict[str, Any]) -> None:
         self.site_diagnostics[site_id] = payload
@@ -202,6 +218,29 @@ class MockGraphAPI:
 
         async def user_drive_delta(request: Request) -> JSONResponse:
             uid = request.path_params["uid"]
+            queued = mock.user_drive_delta_errors.get(uid)
+            if queued:
+                err = queued.pop(0)
+                return JSONResponse(err["body"], status_code=err["status"])
+            paged = mock.user_drive_delta_pages.get(uid)
+            if paged:
+                page_idx = int(request.query_params.get("page", "0"))
+                page_items = paged[page_idx] if page_idx < len(paged) else []
+                if page_idx + 1 < len(paged):
+                    next_link = (
+                        f"{base_url}/v1.0/users/{uid}/drive/root/delta"
+                        f"?page={page_idx + 1}"
+                    )
+                    return JSONResponse(
+                        {"value": page_items, "@odata.nextLink": next_link}
+                    )
+                delta_link = (
+                    f"{base_url}/v1.0/users/{uid}/drive/root/delta"
+                    f"?deltatoken=latest"
+                )
+                return JSONResponse(
+                    {"value": page_items, "@odata.deltaLink": delta_link}
+                )
             items = mock.drive_items.get(uid, [])
             delta_link = f"{base_url}/users/{uid}/drive/root/delta?deltatoken=latest"
             return JSONResponse({"value": items, "@odata.deltaLink": delta_link})
@@ -215,6 +254,7 @@ class MockGraphAPI:
 
         async def mail_delta(request: Request) -> JSONResponse:
             uid = request.path_params["uid"]
+            folder = request.path_params.get("folder", "inbox")
             messages = mock.mail_messages.get(uid, [])
             # Respect $filter on receivedDateTime for max-age testing
             filter_param = request.query_params.get("$filter", "")
@@ -224,7 +264,7 @@ class MockGraphAPI:
                     m for m in messages if m.get("receivedDateTime", "") >= cutoff_str
                 ]
             delta_link = (
-                f"{base_url}/users/{uid}/mailFolders/inbox/messages/delta"
+                f"{base_url}/users/{uid}/mailFolders/{folder}/messages/delta"
                 f"?deltatoken=latest"
             )
             return JSONResponse({"value": messages, "@odata.deltaLink": delta_link})
@@ -326,6 +366,16 @@ class MockGraphAPI:
             attachments = mock.message_attachments.get(key, [])
             return JSONResponse({"value": attachments})
 
+        async def mail_attachment_detail(request: Request) -> JSONResponse:
+            uid = request.path_params["uid"]
+            mid = request.path_params["mid"]
+            att_id = request.path_params["att_id"]
+            key = f"{uid}:{mid}"
+            for attachment in mock.message_attachments.get(key, []):
+                if attachment.get("id") == att_id:
+                    return JSONResponse(attachment)
+            return JSONResponse({"error": {"code": "itemNotFound"}}, status_code=404)
+
         async def resolve_share(request: Request) -> JSONResponse:
             token = request.path_params["token"]
             drive_item = mock.share_drive_items.get(token)
@@ -341,13 +391,14 @@ class MockGraphAPI:
             Route("/v1.0/users/{uid}/drive/root/delta", user_drive_delta),
             Route("/v1.0/drives/{did}/items/{iid}/content", drive_item_content),
             Route("/v1.0/drives/{did}/items/{iid}/permissions", item_permissions),
-            Route(
-                "/v1.0/users/{uid}/mailFolders/inbox/messages/delta",
-                mail_delta,
-            ),
+            Route("/v1.0/users/{uid}/mailFolders/{folder}/messages/delta", mail_delta),
             Route(
                 "/v1.0/users/{uid}/messages/{mid}/attachments",
                 mail_attachments,
+            ),
+            Route(
+                "/v1.0/users/{uid}/messages/{mid}/attachments/{att_id}",
+                mail_attachment_detail,
             ),
             Route("/v1.0/users/{uid}/calendarView/delta", calendar_delta),
             Route("/v1.0/groups", list_groups),

--- a/connectors/microsoft/tests/test_full_sync.py
+++ b/connectors/microsoft/tests/test_full_sync.py
@@ -7,6 +7,7 @@ import pytest
 import httpx
 
 from omni_connector.testing import count_events, get_events, wait_for_sync
+from tests.conftest import _create_ms_source
 
 GROUP_ID = "grp-eng-001"
 
@@ -35,7 +36,7 @@ async def test_onedrive_sync(
     harness, seed, onedrive_source_id, mock_graph_api, cm_client: httpx.AsyncClient
 ):
     mock_graph_api.add_user(_make_user())
-    mock_graph_api.add_drive_item(
+    mock_graph_api.add_user_drive_item(
         USER_ID,
         {
             "id": ITEM_ID,
@@ -82,6 +83,60 @@ async def test_onedrive_sync(
 
     state = await seed.get_connector_state(onedrive_source_id)
     assert state is not None, "connector_state should be saved after sync"
+
+
+async def test_onedrive_paged_delta_sync(
+    harness, seed, mock_graph_server, mock_graph_api, cm_client: httpx.AsyncClient
+):
+    source_id = await _create_ms_source(
+        seed, mock_graph_server, mock_graph_api, "one_drive"
+    )
+    mock_graph_api.add_user(_make_user())
+    mock_graph_api.set_user_drive_delta_pages(
+        USER_ID,
+        [
+            [
+                {
+                    "id": "folder-page-1",
+                    "name": "Folder",
+                    "folder": {"childCount": 1},
+                    "parentReference": {"driveId": DRIVE_ID},
+                }
+            ],
+            [
+                {
+                    "id": "paged-file",
+                    "name": "paged.txt",
+                    "file": {"mimeType": "text/plain"},
+                    "size": 100,
+                    "webUrl": "https://contoso.com/paged.txt",
+                    "createdDateTime": "2026-03-01T08:00:00Z",
+                    "lastModifiedDateTime": "2026-03-01T12:00:00Z",
+                    "parentReference": {"driveId": DRIVE_ID, "path": "/drive/root:/"},
+                }
+            ],
+        ],
+    )
+    mock_graph_api.set_file_content(DRIVE_ID, "paged-file", b"paged content")
+
+    resp = await cm_client.post(
+        "/sync", json={"source_id": source_id, "sync_type": "full"}
+    )
+    assert resp.status_code == 200, resp.text
+    row = await wait_for_sync(harness.db_pool, resp.json()["sync_run_id"], timeout=60)
+    assert row["status"] == "completed", row.get("error_message")
+
+    events = await get_events(harness.db_pool, source_id)
+    doc_ids = {
+        e["payload"]["document_id"]
+        for e in events
+        if e["event_type"] == "document_created"
+    }
+    assert f"onedrive:{DRIVE_ID}:paged-file" in doc_ids
+
+    state = await seed.get_connector_state(source_id)
+    token = state.get("delta_tokens", {}).get(USER_ID, "")
+    assert "deltatoken=latest" in token
 
 
 async def test_outlook_sync(
@@ -145,6 +200,59 @@ async def test_outlook_sync(
 
     state = await seed.get_connector_state(outlook_source_id)
     assert state is not None, "connector_state should be saved after sync"
+
+
+async def test_outlook_deleted_delta_emits_document_deleted(
+    harness, seed, mock_graph_server, mock_graph_api, cm_client: httpx.AsyncClient
+):
+    source_id = await _create_ms_source(
+        seed, mock_graph_server, mock_graph_api, "outlook"
+    )
+    mock_graph_api.add_user(_make_user())
+    mock_graph_api.add_mail_message(
+        USER_ID,
+        {
+            "id": "msg-delete",
+            "internetMessageId": "<delete-me@contoso.com>",
+            "subject": "Delete Me",
+            "bodyPreview": "temporary",
+            "body": {"contentType": "text", "content": "temporary"},
+            "from": {"emailAddress": {"address": "bob@contoso.com"}},
+            "toRecipients": [{"emailAddress": {"address": "alice@contoso.com"}}],
+            "ccRecipients": [],
+            "receivedDateTime": "2026-03-15T09:00:00Z",
+            "sentDateTime": "2026-03-15T08:55:00Z",
+            "hasAttachments": False,
+        },
+    )
+
+    resp = await cm_client.post(
+        "/sync", json={"source_id": source_id, "sync_type": "full"}
+    )
+    row = await wait_for_sync(harness.db_pool, resp.json()["sync_run_id"], timeout=60)
+    assert row["status"] == "completed", row.get("error_message")
+
+    mock_graph_api.mail_messages[USER_ID] = [
+        {
+            "id": "msg-delete",
+            "internetMessageId": "<delete-me@contoso.com>",
+            "@removed": {"reason": "deleted"},
+        }
+    ]
+
+    resp = await cm_client.post(
+        "/sync", json={"source_id": source_id, "sync_type": "incremental"}
+    )
+    row = await wait_for_sync(harness.db_pool, resp.json()["sync_run_id"], timeout=60)
+    assert row["status"] == "completed", row.get("error_message")
+
+    events = await get_events(harness.db_pool, source_id)
+    deleted_ids = {
+        e["payload"]["document_id"]
+        for e in events
+        if e["event_type"] == "document_deleted"
+    }
+    assert "mail:<delete-me@contoso.com>" in deleted_ids
 
 
 async def test_outlook_calendar_sync(
@@ -454,7 +562,7 @@ async def test_group_membership_sync(
     )
 
     # Add a drive item so the sync has something to process
-    mock_graph_api.add_drive_item(
+    mock_graph_api.add_user_drive_item(
         USER_ID,
         {
             "id": ITEM_ID,
@@ -1090,7 +1198,7 @@ async def test_onedrive_max_age_filters_old_files(
     )
     mock_graph_api.add_user(_make_user())
     # Recent file — should be indexed
-    mock_graph_api.add_drive_item(
+    mock_graph_api.add_user_drive_item(
         USER_ID,
         {
             "id": "item-recent",
@@ -1105,7 +1213,7 @@ async def test_onedrive_max_age_filters_old_files(
     )
     mock_graph_api.set_file_content(DRIVE_ID, "item-recent", b"recent content")
     # Old file — should be filtered out
-    mock_graph_api.add_drive_item(
+    mock_graph_api.add_user_drive_item(
         USER_ID,
         {
             "id": "item-old",

--- a/connectors/microsoft/tests/test_graph_client.py
+++ b/connectors/microsoft/tests/test_graph_client.py
@@ -7,10 +7,10 @@ import pytest
 import respx
 
 from ms_connector.graph_client import (
+    GRAPH_BASE_URL,
     AuthenticationError,
     GraphAPIError,
     GraphClient,
-    GRAPH_BASE_URL,
 )
 
 
@@ -177,6 +177,40 @@ async def test_delta_query_with_pagination(graph_client, mock_router):
     assert token is not None
 
 
+async def test_delta_pages_yields_resume_links(graph_client, mock_router):
+    page2_url = f"{GRAPH_BASE_URL}/delta?page=2"
+    delta_url = f"{GRAPH_BASE_URL}/delta?token=xyz"
+
+    mock_router.get(url__eq=f"{GRAPH_BASE_URL}/users/u1/drive/root/delta").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "value": [{"id": "item-1"}],
+                "@odata.nextLink": page2_url,
+            },
+        )
+    )
+    mock_router.get(url__eq=page2_url).mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "value": [{"id": "item-2"}],
+                "@odata.deltaLink": delta_url,
+            },
+        )
+    )
+
+    pages = [
+        page
+        async for page in graph_client.get_delta_pages("/users/u1/drive/root/delta")
+    ]
+
+    assert pages == [
+        ([{"id": "item-1"}], page2_url, None),
+        ([{"id": "item-2"}], None, delta_url),
+    ]
+
+
 async def test_list_teams(graph_client, mock_router):
     mock_router.get(url__regex=r".*/groups(\?.*)?$").mock(
         return_value=httpx.Response(
@@ -235,7 +269,9 @@ async def test_channel_messages_delta(graph_client, mock_router):
                         "body": {"contentType": "text", "content": "Hello"},
                     }
                 ],
-                "@odata.deltaLink": f"{GRAPH_BASE_URL}/teams/t1/channels/c1/messages/delta?token=abc",
+                "@odata.deltaLink": (
+                    f"{GRAPH_BASE_URL}/teams/t1/channels/c1/messages/delta?token=abc"
+                ),
             },
         )
     )

--- a/connectors/microsoft/tests/test_syncers.py
+++ b/connectors/microsoft/tests/test_syncers.py
@@ -1,0 +1,183 @@
+"""Focused tests for Microsoft syncer state and delta edge cases."""
+
+import copy
+from typing import Any
+
+import pytest
+
+from ms_connector.graph_client import GraphAPIError
+from ms_connector.syncers.base import BaseSyncer
+from ms_connector.syncers.mail import MailSyncer
+from ms_connector.syncers.onedrive import OneDriveSyncer
+from ms_connector.syncers.teams import TeamsSyncer
+
+
+class FakeContentStorage:
+    async def save(self, content: str, mime_type: str) -> str:
+        return "content-id"
+
+
+class FakeContext:
+    def __init__(self) -> None:
+        self.deleted: list[str] = []
+        self.saved_states: list[dict[str, Any]] = []
+        self.scanned = 0
+        self.content_storage = FakeContentStorage()
+
+    def is_cancelled(self) -> bool:
+        return False
+
+    def should_index_user(self, email: str) -> bool:
+        return True
+
+    async def save_state(self, state: dict[str, Any]) -> None:
+        self.saved_states.append(copy.deepcopy(state))
+
+    async def emit_deleted(self, external_id: str) -> None:
+        self.deleted.append(external_id)
+
+    async def increment_scanned(self) -> None:
+        self.scanned += 1
+
+
+def _user(user_id: str = "u1") -> dict[str, str]:
+    return {
+        "id": user_id,
+        "displayName": "Alice",
+        "mail": "alice@contoso.com",
+        "userPrincipalName": "alice@contoso.com",
+    }
+
+
+def _folder_item(item_id: str, drive_id: str = "drive-1") -> dict[str, Any]:
+    return {
+        "id": item_id,
+        "name": item_id,
+        "folder": {"childCount": 0},
+        "parentReference": {"driveId": drive_id},
+    }
+
+
+async def test_onedrive_checkpoints_each_completed_delta_page() -> None:
+    ctx = FakeContext()
+    delta_tokens: dict[str, str] = {}
+
+    class Client:
+        async def get_delta_pages(self, *args: Any, **kwargs: Any):
+            yield [_folder_item("folder-1")], "next-token", None
+            yield [_folder_item("folder-2")], None, "delta-token"
+
+    token = await OneDriveSyncer().sync_for_user(
+        Client(),
+        _user(),
+        ctx,
+        None,
+        delta_tokens=delta_tokens,
+        token_key="u1",
+    )
+
+    saved_tokens = [state["delta_tokens"]["u1"] for state in ctx.saved_states]
+    assert saved_tokens == ["next-token", "delta-token"]
+    assert token == "delta-token"
+
+
+async def test_onedrive_resyncs_once_when_delta_token_expires() -> None:
+    ctx = FakeContext()
+
+    class Client:
+        def __init__(self) -> None:
+            self.calls: list[str | None] = []
+
+        async def get_delta_pages(self, *args: Any, **kwargs: Any):
+            delta_token = kwargs.get("delta_token")
+            self.calls.append(delta_token)
+            if delta_token == "expired-token":
+                raise GraphAPIError(
+                    "Token expired",
+                    status_code=410,
+                    error_code="resyncRequired",
+                )
+            yield [_folder_item("folder-1")], None, "fresh-delta-token"
+
+    client = Client()
+    token = await OneDriveSyncer().sync_for_user(
+        client,
+        _user(),
+        ctx,
+        "expired-token",
+        delta_tokens={},
+        token_key="u1",
+    )
+
+    assert client.calls == ["expired-token", None]
+    assert token == "fresh-delta-token"
+
+
+async def test_mail_emits_deleted_documents_for_removed_delta_items() -> None:
+    ctx = FakeContext()
+
+    class Client:
+        async def get_delta(self, *args: Any, **kwargs: Any):
+            return ([{"id": "msg-1", "@removed": {"reason": "deleted"}}], "token-1")
+
+    token = await MailSyncer()._sync_folder_for_user(
+        Client(), _user(), ctx, "inbox", None
+    )
+
+    assert token == "token-1"
+    assert ctx.deleted == ["mail:msg-1"]
+
+
+async def test_mail_preserves_existing_tokens_when_folder_has_no_new_token() -> None:
+    ctx = FakeContext()
+
+    class Client:
+        async def list_users(self) -> list[dict[str, str]]:
+            return [_user()]
+
+        async def get_delta(self, *args: Any, **kwargs: Any):
+            return ([], None)
+
+    state = {"delta_tokens": {"u1:inbox": "old-inbox", "u1:archive": "old-archive"}}
+    result = await MailSyncer().sync(Client(), ctx, state)
+
+    assert result["delta_tokens"] == state["delta_tokens"]
+
+
+async def test_teams_preserves_existing_channel_and_chat_state() -> None:
+    ctx = FakeContext()
+
+    class Client:
+        async def list_teams(self) -> list[dict[str, Any]]:
+            return []
+
+        async def list_users(self) -> list[dict[str, Any]]:
+            return []
+
+    state = {
+        "delta_tokens": {"team:channel": "delta-token"},
+        "last_sync_ts": {"team:channel": "2026-01-01T00:00:00+00:00"},
+        "chat_last_sync_ts": {"chat-1": "2026-01-01T00:00:00+00:00"},
+    }
+    result = await TeamsSyncer().sync(Client(), ctx, state)
+
+    assert result == state
+
+
+async def test_base_syncer_fails_when_all_users_fail() -> None:
+    ctx = FakeContext()
+
+    class Client:
+        async def list_users(self) -> list[dict[str, str]]:
+            return [_user("u1"), _user("u2")]
+
+    class FailingSyncer(BaseSyncer):
+        @property
+        def name(self) -> str:
+            return "failing"
+
+        async def sync_for_user(self, *args: Any, **kwargs: Any) -> str | None:
+            raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="sync failed for all 2 users"):
+        await FailingSyncer().sync(Client(), ctx, {})


### PR DESCRIPTION
- Add page-level Graph delta iteration and OneDrive checkpoint/resync handling.
- Preserve sync state across Mail and Teams runs, and emit Mail deletion events.
- Repair Microsoft mock Graph fixtures and add focused syncer/integration coverage.