### PR TITLE
Fix inferred file extension indexing

### DIFF
--- a/services/indexer/src/queue_processor.rs
+++ b/services/indexer/src/queue_processor.rs
@@ -36,6 +36,7 @@ const DEFAULT_INCREMENTAL_BATCH_MAX_AGE_SECS: i64 = 60;
 const DEFAULT_REALTIME_BATCH_SIZE: i64 = 1;
 const DEFAULT_REALTIME_BATCH_MAX_AGE_SECS: i64 = 0;
 const DEFAULT_GLOBAL_BATCH_MAX_AGE_SECS: i64 = 300;
+const MAX_FILE_EXTENSION_CHARS: usize = 50;
 
 #[derive(Clone)]
 struct BatchingConfig {
@@ -180,6 +181,18 @@ fn env_or<T: std::str::FromStr>(key: &str, default: T) -> T {
         .ok()
         .and_then(|v| v.parse().ok())
         .unwrap_or(default)
+}
+
+fn infer_file_extension(url: &str) -> Option<String> {
+    url.split('.')
+        .last()
+        .filter(|ext| !ext.contains('/') && !ext.contains('?'))
+        .map(|ext| {
+            ext.to_lowercase()
+                .chars()
+                .take(MAX_FILE_EXTENSION_CHARS)
+                .collect()
+        })
 }
 
 // Batch processing types
@@ -1002,13 +1015,7 @@ impl QueueProcessor {
             .transpose()?
             .unwrap_or(serde_json::json!({}));
 
-        // Extract file extension from URL or mime type
-        let file_extension = metadata.url.as_ref().and_then(|url| {
-            url.split('.')
-                .last()
-                .filter(|ext| !ext.contains('/') && !ext.contains('?'))
-                .map(|ext| ext.to_lowercase())
-        });
+        let file_extension = metadata.url.as_deref().and_then(infer_file_extension);
 
         // Parse file size from string to i64
         let file_size = metadata

--- a/services/indexer/tests/integration_tests.rs
+++ b/services/indexer/tests/integration_tests.rs
@@ -217,6 +217,97 @@ async fn test_event_driven_document_lifecycle() {
 }
 
 #[tokio::test]
+async fn test_url_inferred_file_extension_is_capped() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let event_queue = EventQueue::new(fixture.state.db_pool.pool().clone());
+    let repo = DocumentRepository::new(fixture.state.db_pool.pool());
+
+    let processor =
+        QueueProcessor::new(fixture.state.clone()).with_poll_interval(Duration::from_millis(200));
+    let processor_handle = tokio::spawn(async move {
+        let _ = processor.start().await;
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let long_suffix = "a".repeat(64);
+    let gmail_like_url = format!(
+        "https://mail.google.com/mail/u/0/#inbox/rfc822msgid%3A1577287121.{}",
+        long_suffix
+    );
+
+    for (document_id, url) in [
+        ("gmail_long_extension_doc", gmail_like_url.clone()),
+        (
+            "normal_pdf_doc",
+            "https://example.com/docs/report.pdf".to_string(),
+        ),
+    ] {
+        let content_id = fixture
+            .state
+            .content_storage
+            .store_content(format!("content for {document_id}").as_bytes(), None)
+            .await
+            .unwrap();
+
+        let event = ConnectorEvent::DocumentCreated {
+            sync_run_id: "sync_file_extension_cap".to_string(),
+            source_id: TEST_SOURCE_ID.to_string(),
+            document_id: document_id.to_string(),
+            content_id,
+            metadata: DocumentMetadata {
+                title: Some(document_id.to_string()),
+                author: None,
+                created_at: None,
+                updated_at: None,
+                content_type: None,
+                mime_type: Some("message/rfc822".to_string()),
+                size: Some("100".to_string()),
+                url: Some(url),
+                path: None,
+                extra: None,
+            },
+            permissions: DocumentPermissions {
+                public: false,
+                users: vec!["user1".to_string()],
+                groups: vec![],
+            },
+            attributes: None,
+        };
+
+        event_queue.enqueue(TEST_SOURCE_ID, &event).await.unwrap();
+    }
+
+    let completed =
+        common::wait_for_completed(fixture.state.db_pool.pool(), 2, Duration::from_secs(5)).await;
+    assert_eq!(completed, 2);
+
+    let gmail_doc = common::wait_for_document_exists(
+        &repo,
+        TEST_SOURCE_ID,
+        "gmail_long_extension_doc",
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("Gmail-like document should be indexed");
+    let gmail_extension = gmail_doc.file_extension.unwrap();
+    assert_eq!(gmail_extension.chars().count(), 50);
+    assert_eq!(gmail_extension, "a".repeat(50));
+    assert_eq!(gmail_doc.url, Some(gmail_like_url));
+
+    let pdf_doc = common::wait_for_document_exists(
+        &repo,
+        TEST_SOURCE_ID,
+        "normal_pdf_doc",
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("Normal PDF document should be indexed");
+    assert_eq!(pdf_doc.file_extension, Some("pdf".to_string()));
+
+    processor_handle.abort();
+}
+
+#[tokio::test]
 async fn test_batch_processing_and_deduplication() {
     let fixture = common::setup_test_fixture().await.unwrap();
     let event_queue = EventQueue::new(fixture.state.db_pool.pool().clone());

--- a/shared/src/queue.rs
+++ b/shared/src/queue.rs
@@ -1,5 +1,3 @@
-use std::collections::HashMap;
-
 use anyhow::Result;
 use sqlx::{PgPool, Row};
 use ulid::Ulid;
@@ -555,7 +553,7 @@ impl EventQueue {
             r#"
             UPDATE connector_events_queue
             SET status = CASE 
-                    WHEN retry_count >= max_retries THEN 'dead_letter'
+                    WHEN retry_count + 1 >= max_retries THEN 'dead_letter'
                     ELSE 'failed'
                 END,
                 retry_count = retry_count + 1,

--- a/shared/tests/event_queue_test.rs
+++ b/shared/tests/event_queue_test.rs
@@ -43,7 +43,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_dequeue_batches_by_single_sync_run() {
+    async fn test_dequeue_batch_drains_oldest_pending_events() {
         let env = TestEnvironment::new().await.unwrap();
         let queue = EventQueue::new(env.db_pool.pool().clone());
 
@@ -58,12 +58,24 @@ mod tests {
         let event_b = make_event(&run_b, "doc-b1");
         queue.enqueue(TEST_SOURCE_ID, &event_b).await.unwrap();
 
-        // Dequeue should pick run_a (most pending events)
+        // Dequeue drains the oldest pending events across sync runs. The
+        // indexer groups them by sync_run_id after dequeueing.
         let batch = queue.dequeue_batch(10).await.unwrap();
-        assert_eq!(batch.len(), 3);
-        for item in &batch {
-            assert_eq!(item.sync_run_id, run_a);
-        }
+        assert_eq!(batch.len(), 4);
+        assert_eq!(
+            batch
+                .iter()
+                .filter(|item| item.sync_run_id == run_a)
+                .count(),
+            3
+        );
+        assert_eq!(
+            batch
+                .iter()
+                .filter(|item| item.sync_run_id == run_b)
+                .count(),
+            1
+        );
     }
 
     #[tokio::test]
@@ -212,6 +224,64 @@ mod tests {
 
         let stats = queue.get_queue_stats().await.unwrap();
         assert_eq!(stats.failed, 2);
+    }
+
+    #[tokio::test]
+    async fn test_batch_dead_letter_uses_incremented_retry_count() {
+        let env = TestEnvironment::new().await.unwrap();
+        let pool = env.db_pool.pool().clone();
+        let queue = EventQueue::new(pool.clone());
+
+        let near_limit_event = make_event("run-1", "doc-near-limit");
+        let below_limit_event = make_event("run-1", "doc-below-limit");
+        let near_limit_id = queue
+            .enqueue(TEST_SOURCE_ID, &near_limit_event)
+            .await
+            .unwrap();
+        let below_limit_id = queue
+            .enqueue(TEST_SOURCE_ID, &below_limit_event)
+            .await
+            .unwrap();
+
+        queue.dequeue_batch(10).await.unwrap();
+
+        sqlx::query("UPDATE connector_events_queue SET retry_count = $1 WHERE id = $2")
+            .bind(2)
+            .bind(&near_limit_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+        sqlx::query("UPDATE connector_events_queue SET retry_count = $1 WHERE id = $2")
+            .bind(1)
+            .bind(&below_limit_id)
+            .execute(&pool)
+            .await
+            .unwrap();
+
+        let updated = queue
+            .mark_events_dead_letter_batch(vec![
+                (near_limit_id.clone(), "near limit".to_string()),
+                (below_limit_id.clone(), "below limit".to_string()),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(updated, 2);
+
+        let near_limit_row: (String, i32) =
+            sqlx::query_as("SELECT status, retry_count FROM connector_events_queue WHERE id = $1")
+                .bind(&near_limit_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(near_limit_row, ("dead_letter".to_string(), 3));
+
+        let below_limit_row: (String, i32) =
+            sqlx::query_as("SELECT status, retry_count FROM connector_events_queue WHERE id = $1")
+                .bind(&below_limit_id)
+                .fetch_one(&pool)
+                .await
+                .unwrap();
+        assert_eq!(below_limit_row, ("failed".to_string(), 2));
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Cap URL-inferred file extensions to the documents column limit
- Preserve existing final-dot URL inference behavior
- Align batch dead-letter status with incremented retry counts
- Add indexer and queue regression coverage