### PR TITLE
Harden sync run lifecycle

### DIFF
--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -569,7 +569,13 @@ impl SdkClient {
         Ok(credentials)
     }
 
-    /// Create a new sync run for a source
+    /// Create a new sync run for a source.
+    ///
+    /// Under normal circumstances, the connector-manager is responsible for
+    /// creating sync runs before calling the connector's `/sync` endpoint. We
+    /// allow connectors to also create sync runs when work is initiated from
+    /// inside the connector itself, such as a realtime/webhook event that
+    /// needs to trigger a short follow-up incremental sync.
     pub async fn create_sync_run(&self, source_id: &str, sync_type: SyncType) -> SdkResult<String> {
         debug!(
             "SDK: Creating sync run for source_id={}, type={:?}",

--- a/sdk/rust/src/context.rs
+++ b/sdk/rust/src/context.rs
@@ -13,6 +13,7 @@ pub struct SyncContext {
     source_type: SourceType,
     sync_mode: SyncType,
     cancelled: Arc<AtomicBool>,
+    terminal_reported: Arc<AtomicBool>,
 }
 
 impl SyncContext {
@@ -31,6 +32,7 @@ impl SyncContext {
             source_type,
             sync_mode,
             cancelled,
+            terminal_reported: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -56,6 +58,10 @@ impl SyncContext {
 
     pub fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::SeqCst)
+    }
+
+    pub fn terminal_reported(&self) -> bool {
+        self.terminal_reported.load(Ordering::SeqCst)
     }
 
     /// Emit a single event. Events are buffered in memory and auto-flushed
@@ -126,6 +132,7 @@ impl SyncContext {
     /// connector state from `save_connector_state`.
     pub async fn complete(&self) -> Result<()> {
         self.sdk_client.complete(&self.sync_run_id).await?;
+        self.terminal_reported.store(true, Ordering::SeqCst);
         Ok(())
     }
 
@@ -140,6 +147,7 @@ impl SyncContext {
             );
         }
         self.sdk_client.fail(&self.sync_run_id, error).await?;
+        self.terminal_reported.store(true, Ordering::SeqCst);
         Ok(())
     }
 
@@ -150,6 +158,7 @@ impl SyncContext {
 
     pub async fn cancel(&self) -> Result<()> {
         self.sdk_client.cancel(&self.sync_run_id).await?;
+        self.terminal_reported.store(true, Ordering::SeqCst);
         Ok(())
     }
 

--- a/sdk/rust/src/context.rs
+++ b/sdk/rust/src/context.rs
@@ -13,7 +13,6 @@ pub struct SyncContext {
     source_type: SourceType,
     sync_mode: SyncType,
     cancelled: Arc<AtomicBool>,
-    terminal_reported: Arc<AtomicBool>,
 }
 
 impl SyncContext {
@@ -32,7 +31,6 @@ impl SyncContext {
             source_type,
             sync_mode,
             cancelled,
-            terminal_reported: Arc::new(AtomicBool::new(false)),
         }
     }
 
@@ -58,10 +56,6 @@ impl SyncContext {
 
     pub fn is_cancelled(&self) -> bool {
         self.cancelled.load(Ordering::SeqCst)
-    }
-
-    pub fn terminal_reported(&self) -> bool {
-        self.terminal_reported.load(Ordering::SeqCst)
     }
 
     /// Emit a single event. Events are buffered in memory and auto-flushed
@@ -132,7 +126,6 @@ impl SyncContext {
     /// connector state from `save_connector_state`.
     pub async fn complete(&self) -> Result<()> {
         self.sdk_client.complete(&self.sync_run_id).await?;
-        self.terminal_reported.store(true, Ordering::SeqCst);
         Ok(())
     }
 
@@ -147,7 +140,6 @@ impl SyncContext {
             );
         }
         self.sdk_client.fail(&self.sync_run_id, error).await?;
-        self.terminal_reported.store(true, Ordering::SeqCst);
         Ok(())
     }
 
@@ -158,7 +150,6 @@ impl SyncContext {
 
     pub async fn cancel(&self) -> Result<()> {
         self.sdk_client.cancel(&self.sync_run_id).await?;
-        self.terminal_reported.store(true, Ordering::SeqCst);
         Ok(())
     }
 

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -18,7 +18,7 @@ use axum::{
 use dashmap::mapref::entry::Entry;
 use dashmap::DashMap;
 use serde::de::DeserializeOwned;
-use shared::models::SyncSlotClass;
+use shared::models::{SyncSlotClass, SyncType};
 use shared::telemetry;
 use std::collections::HashMap;
 use std::sync::atomic::{AtomicBool, Ordering};
@@ -459,11 +459,21 @@ where
             .sync(source, credentials, typed_state, ctx.clone())
             .await;
 
-        if let Err(error) = result {
-            error!("Sync {} failed: {}", sync_run_id, error);
-            if !ctx.is_cancelled() {
-                if let Err(report_error) = ctx.fail(&error.to_string()).await {
-                    error!("Failed to report sync failure: {}", report_error);
+        match result {
+            Ok(()) => {
+                if !ctx.terminal_reported() && ctx.sync_mode() != SyncType::Realtime {
+                    warn!(
+                        "Sync {} returned Ok without reporting completion; call ctx.complete() for successful batch syncs",
+                        sync_run_id
+                    );
+                }
+            }
+            Err(error) => {
+                error!("Sync {} failed: {}", sync_run_id, error);
+                if !ctx.is_cancelled() {
+                    if let Err(report_error) = ctx.fail(&error.to_string()).await {
+                        error!("Failed to report sync failure: {}", report_error);
+                    }
                 }
             }
         }

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -461,11 +461,10 @@ where
 
         match result {
             Ok(()) => {
-                if !ctx.terminal_reported() && ctx.sync_mode() != SyncType::Realtime {
-                    warn!(
-                        "Sync {} returned Ok without reporting completion; call ctx.complete() for successful batch syncs",
-                        sync_run_id
-                    );
+                if ctx.sync_mode() != SyncType::Realtime {
+                    if let Err(error) = ctx.complete().await {
+                        error!("Failed to auto-complete sync {}: {}", sync_run_id, error);
+                    }
                 }
             }
             Err(error) => {

--- a/sdk/rust/tests/common/mod.rs
+++ b/sdk/rust/tests/common/mod.rs
@@ -148,6 +148,7 @@ fn test_source_json(id: &str, config: JsonValue, connector_state: Option<JsonVal
         "config": config,
         "is_active": true,
         "is_deleted": false,
+        "scope": "org",
         "user_filter_mode": "all",
         "user_whitelist": null,
         "user_blacklist": null,
@@ -185,7 +186,6 @@ async fn handle_fail(
 async fn handle_complete(
     State(state): State<SharedState>,
     Path(sync_run_id): Path<String>,
-    Json(_body): Json<JsonValue>,
 ) -> impl IntoResponse {
     state.lock().unwrap().complete_calls.push(sync_run_id);
     StatusCode::NO_CONTENT

--- a/sdk/rust/tests/server_integration_test.rs
+++ b/sdk/rust/tests/server_integration_test.rs
@@ -4,7 +4,7 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
-use axum::{routing, Router};
+use axum::{http::StatusCode, routing, Router};
 use axum_test::{TestServer, TestServerConfig};
 use common::{GetSourceBehavior, MockConnectorManager, SyncBehavior, TestConnector};
 use omni_connector_sdk::{
@@ -58,6 +58,23 @@ async fn wait_for_slot_release(server: &TestServer, sync_run_id: &str, source_id
     panic!("slot never released");
 }
 
+async fn wait_for_complete_call(mock: &MockConnectorManager, sync_run_id: &str) {
+    for _ in 0..40 {
+        if mock
+            .state
+            .lock()
+            .unwrap()
+            .complete_calls
+            .iter()
+            .any(|id| id == sync_run_id)
+        {
+            return;
+        }
+        tokio::time::sleep(Duration::from_millis(25)).await;
+    }
+    panic!("sync was not completed");
+}
+
 #[tokio::test]
 async fn t1_manifest_endpoint_returns_connector_metadata() -> Result<()> {
     let mock = MockConnectorManager::spawn().await;
@@ -69,6 +86,27 @@ async fn t1_manifest_endpoint_returns_connector_metadata() -> Result<()> {
     assert_eq!(body["name"], "test");
     assert_eq!(body["version"], "0.0.0");
     assert_eq!(body["connector_url"], CONNECTOR_URL);
+    Ok(())
+}
+
+#[tokio::test]
+async fn t1_successful_batch_sync_auto_completes() -> Result<()> {
+    let mock = MockConnectorManager::spawn().await;
+    mock.set_source(json!({}));
+    let connector = Arc::new(TestConnector::new(SyncBehavior::Ok));
+    let server = build_server(connector, &mock);
+
+    let resp = server
+        .post("/sync")
+        .json(&json!({
+            "sync_run_id": "run-auto-complete",
+            "source_id": "src-1",
+            "sync_mode": "full",
+        }))
+        .await;
+    assert_eq!(resp.status_code(), 200);
+
+    wait_for_complete_call(&mock, "run-auto-complete").await;
     Ok(())
 }
 

--- a/services/connector-manager/src/connector_client.rs
+++ b/services/connector-manager/src/connector_client.rs
@@ -5,6 +5,7 @@ use crate::models::{
 use reqwest::Client;
 use shared::models::SyncType;
 use shared::{RateLimiter, RetryableError};
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::time::Duration;
 use tracing::{debug, error, warn};
 
@@ -67,8 +68,11 @@ impl ConnectorClient {
     ) -> Result<SyncResponse, ClientError> {
         let url = format!("{}/sync", connector_url);
         debug!(
-            "Triggering sync at {} for source {}",
-            url, request.source_id
+            url,
+            source_id = %request.source_id,
+            sync_run_id = %request.sync_run_id,
+            sync_mode = ?request.sync_mode,
+            "Triggering sync"
         );
 
         let response = self.trigger_sync_with_retry(&url, request).await?;
@@ -98,14 +102,47 @@ impl ConnectorClient {
         url: &str,
         request: &SyncRequest,
     ) -> Result<reqwest::Response, ClientError> {
+        let attempts = AtomicU32::new(0);
         self.sync_trigger_retry
             .execute_with_retry(|| async {
-                self.client
-                    .post(url)
-                    .json(request)
-                    .send()
-                    .await
-                    .map_err(|e| RetryableError::Transient(e.into()))
+                let attempt = attempts.fetch_add(1, Ordering::Relaxed) + 1;
+                debug!(
+                    url,
+                    source_id = %request.source_id,
+                    sync_run_id = %request.sync_run_id,
+                    sync_mode = ?request.sync_mode,
+                    attempt,
+                    "Sending connector sync trigger"
+                );
+
+                let result = self.client.post(url).json(request).send().await;
+
+                match result {
+                    Ok(response) => {
+                        debug!(
+                            url,
+                            source_id = %request.source_id,
+                            sync_run_id = %request.sync_run_id,
+                            sync_mode = ?request.sync_mode,
+                            attempt,
+                            status = response.status().as_u16(),
+                            "Connector sync trigger returned"
+                        );
+                        Ok(response)
+                    }
+                    Err(e) => {
+                        warn!(
+                            url,
+                            source_id = %request.source_id,
+                            sync_run_id = %request.sync_run_id,
+                            sync_mode = ?request.sync_mode,
+                            attempt,
+                            error = %e,
+                            "Connector sync trigger request failed"
+                        );
+                        Err(RetryableError::Transient(e.into()))
+                    }
+                }
             })
             .await
             .map_err(|e| ClientError::RequestFailed(e.to_string()))

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -907,6 +907,7 @@ impl From<SyncError> for ApiError {
             )),
             SyncError::DatabaseError(e) => ApiError::Internal(e),
             SyncError::ConnectorError(e) => ApiError::Internal(e.to_string()),
+            e @ SyncError::ConnectorTriggerTimedOut { .. } => ApiError::Internal(e.to_string()),
         }
     }
 }

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -1887,14 +1887,9 @@ pub async fn sdk_create_sync(
         .create(&request.source_id, request.sync_type, "manual")
         .await
         .map_err(|e| match e {
-            shared::db::error::DatabaseError::ConstraintViolation(name)
-                if name == "idx_sync_runs_one_running_per_source_slot" =>
-            {
-                ApiError::Conflict(format!(
-                    "Sync already running for source: {}",
-                    request.source_id
-                ))
-            }
+            shared::db::error::DatabaseError::RunningSyncSlotConflict => ApiError::Conflict(
+                format!("Sync already running for source: {}", request.source_id),
+            ),
             other => ApiError::Internal(format!("Failed to create sync run: {}", other)),
         })?;
 

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -901,6 +901,10 @@ impl From<SyncError> for ApiError {
                 "{} sync is not available for source: {}",
                 sync_type, source_id
             )),
+            SyncError::ConcurrencyLimitReachedForSlot(slot_class) => ApiError::Conflict(format!(
+                "Concurrency limit reached for {} syncs, try again later",
+                slot_class
+            )),
             SyncError::DatabaseError(e) => ApiError::Internal(e),
             SyncError::ConnectorError(e) => ApiError::Internal(e.to_string()),
         }
@@ -1648,10 +1652,16 @@ pub async fn sdk_complete(
 
     // Status flip only. Counts come from increment_scanned/updated;
     // connector state from save_connector_state.
-    sync_run_repo
+    let updated = sync_run_repo
         .mark_completed(&sync_run_id)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to mark completed: {}", e)))?;
+    if !updated {
+        warn!(
+            "SDK: Ignoring stale complete for non-running sync_run={}",
+            sync_run_id
+        );
+    }
 
     Ok(Json(SdkStatusResponse {
         status: "ok".to_string(),
@@ -1668,10 +1678,16 @@ pub async fn sdk_fail(
     let sync_run_repo = SyncRunRepository::new(state.db_pool.pool());
 
     // Mark sync as failed
-    sync_run_repo
+    let updated = sync_run_repo
         .mark_failed(&sync_run_id, &request.error)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to mark failed: {}", e)))?;
+    if !updated {
+        warn!(
+            "SDK: Ignoring stale fail for non-running sync_run={}",
+            sync_run_id
+        );
+    }
 
     Ok(Json(SdkStatusResponse {
         status: "ok".to_string(),
@@ -1689,10 +1705,16 @@ pub async fn sdk_increment_scanned(
     );
 
     let sync_run_repo = SyncRunRepository::new(state.db_pool.pool());
-    sync_run_repo
+    let updated = sync_run_repo
         .increment_scanned(&sync_run_id, request.count)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to increment scanned: {}", e)))?;
+    if !updated {
+        warn!(
+            "SDK: Ignoring stale scanned increment for non-running sync_run={}",
+            sync_run_id
+        );
+    }
 
     Ok(Json(SdkStatusResponse {
         status: "ok".to_string(),
@@ -1710,10 +1732,16 @@ pub async fn sdk_increment_updated(
     );
 
     let sync_run_repo = SyncRunRepository::new(state.db_pool.pool());
-    sync_run_repo
+    let updated = sync_run_repo
         .increment_updated(&sync_run_id, request.count)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to increment updated: {}", e)))?;
+    if !updated {
+        warn!(
+            "SDK: Ignoring stale updated increment for non-running sync_run={}",
+            sync_run_id
+        );
+    }
 
     Ok(Json(SdkStatusResponse {
         status: "ok".to_string(),
@@ -1813,11 +1841,61 @@ pub async fn sdk_create_sync(
         request.source_id, request.sync_type
     );
 
+    let source_repo = SourceRepository::new(state.db_pool.pool());
+    let source = source_repo
+        .find_by_id(request.source_id.clone())
+        .await
+        .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?
+        .ok_or_else(|| ApiError::NotFound(format!("Source not found: {}", request.source_id)))?;
+    if !source.is_active {
+        return Err(ApiError::BadRequest(format!(
+            "Source is inactive: {}",
+            request.source_id
+        )));
+    }
+    if state
+        .sync_manager
+        .is_sync_class_running(&request.source_id, request.sync_type.slot_class())
+        .await?
+    {
+        return Err(ApiError::Conflict(format!(
+            "Sync already running for source: {}",
+            request.source_id
+        )));
+    }
+    if state.sync_manager.active_sync_count().await? >= state.config.max_concurrent_syncs {
+        return Err(ApiError::Conflict(
+            "Concurrency limit reached, try again later".to_string(),
+        ));
+    }
+    let slot_class = request.sync_type.slot_class();
+    if state
+        .sync_manager
+        .active_sync_count_for_slot_class(slot_class)
+        .await?
+        >= state.config.max_concurrent_syncs_per_type
+    {
+        return Err(ApiError::Conflict(format!(
+            "Concurrency limit reached for {} syncs, try again later",
+            slot_class
+        )));
+    }
+
     let sync_run_repo = SyncRunRepository::new(state.db_pool.pool());
     let sync_run = sync_run_repo
         .create(&request.source_id, request.sync_type, "manual")
         .await
-        .map_err(|e| ApiError::Internal(format!("Failed to create sync run: {}", e)))?;
+        .map_err(|e| match e {
+            shared::db::error::DatabaseError::ConstraintViolation(name)
+                if name == "idx_sync_runs_one_running_per_source_slot" =>
+            {
+                ApiError::Conflict(format!(
+                    "Sync already running for source: {}",
+                    request.source_id
+                ))
+            }
+            other => ApiError::Internal(format!("Failed to create sync run: {}", other)),
+        })?;
 
     Ok(Json(SdkCreateSyncResponse {
         sync_run_id: sync_run.id,
@@ -1831,10 +1909,16 @@ pub async fn sdk_cancel_sync(
     info!("SDK: Cancelling sync_run={}", request.sync_run_id);
 
     let sync_run_repo = SyncRunRepository::new(state.db_pool.pool());
-    sync_run_repo
+    let updated = sync_run_repo
         .mark_cancelled(&request.sync_run_id)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to cancel sync: {}", e)))?;
+    if !updated {
+        warn!(
+            "SDK: Ignoring stale cancel for non-running sync_run={}",
+            request.sync_run_id
+        );
+    }
 
     Ok(Json(SdkCancelSyncResponse { success: true }))
 }

--- a/services/connector-manager/src/lib.rs
+++ b/services/connector-manager/src/lib.rs
@@ -163,16 +163,12 @@ pub async fn run_server() -> AnyhowResult<()> {
         warn!("Startup sync reconciliation failed: {}", e);
     }
 
-    // Start scheduler in background
-    let scheduler = scheduler::Scheduler::new(
+    tokio::spawn(scheduler::Scheduler::run(
         db_pool.pool().clone(),
         redis_client,
         config.clone(),
         sync_manager,
-    );
-    tokio::spawn(async move {
-        scheduler.run().await;
-    });
+    ));
     info!("Scheduler started");
 
     let app = create_app(app_state);

--- a/services/connector-manager/src/scheduler.rs
+++ b/services/connector-manager/src/scheduler.rs
@@ -4,15 +4,23 @@ use crate::models::TriggerType;
 use crate::source_cleanup::SourceCleanup;
 use crate::sync_circuit_breaker::current_unsuccessful_streak;
 use crate::sync_manager::{SyncError, SyncManager};
+use futures::FutureExt;
 use redis::Client as RedisClient;
 use shared::db::repositories::{SourceRepository, SyncRunRepository};
 use shared::models::{Source, SyncRun, SyncSlotClass, SyncStatus, SyncType};
 use sqlx::PgPool;
 use std::collections::HashMap;
+use std::fmt::Display;
+use std::future::Future;
+use std::panic::AssertUnwindSafe;
 use std::sync::{Arc, Mutex};
+use std::time::Instant;
 use time::{Duration as TimeDuration, OffsetDateTime};
-use tokio::time::{interval, Duration};
+use tokio::time::{interval, sleep, timeout, Duration};
 use tracing::{debug, error, info, warn};
+
+const SCHEDULER_PHASE_TIMEOUT: Duration = Duration::from_secs(300);
+const SCHEDULER_RESTART_DELAY: Duration = Duration::from_secs(5);
 
 pub struct Scheduler {
     pool: PgPool,
@@ -23,6 +31,36 @@ pub struct Scheduler {
 }
 
 impl Scheduler {
+    pub async fn run(
+        pool: PgPool,
+        redis_client: RedisClient,
+        config: ConnectorManagerConfig,
+        sync_manager: Arc<SyncManager>,
+    ) {
+        loop {
+            let scheduler = Self::new(
+                pool.clone(),
+                redis_client.clone(),
+                config.clone(),
+                sync_manager.clone(),
+            );
+
+            match AssertUnwindSafe(scheduler.run_internal())
+                .catch_unwind()
+                .await
+            {
+                Ok(()) => {
+                    error!("Scheduler exited unexpectedly; restarting");
+                }
+                Err(_) => {
+                    error!("Scheduler panicked; restarting");
+                }
+            }
+
+            sleep(SCHEDULER_RESTART_DELAY).await;
+        }
+    }
+
     pub fn new(
         pool: PgPool,
         redis_client: RedisClient,
@@ -38,7 +76,7 @@ impl Scheduler {
         }
     }
 
-    pub async fn run(&self) {
+    async fn run_internal(&self) {
         let mut scheduler_interval =
             interval(Duration::from_secs(self.config.scheduler_interval_seconds));
 
@@ -56,37 +94,73 @@ impl Scheduler {
     async fn tick(&self) {
         debug!("Scheduler tick");
 
-        // Ensure realtime watchers are running for sources that declared the
-        // capability. Independent of the scheduled-sync slot, so realtime
-        // never starves Full / Incremental and vice versa.
-        if let Err(e) = self.ensure_realtime_running().await {
-            error!("Error ensuring realtime syncs: {}", e);
-        }
+        self.run_phase("ensure_realtime_running", self.ensure_realtime_running())
+            .await;
 
-        // Check for sources due for scheduled (Full / Incremental) sync.
-        if let Err(e) = self.process_due_sources().await {
-            error!("Error processing due sources: {}", e);
-        }
+        self.run_phase("process_due_sources", self.process_due_sources())
+            .await;
 
-        // Probe in-flight syncs and reconcile any the connector has lost
-        if let Err(e) = self.sync_manager.monitor_running_syncs().await {
-            error!("Error monitoring running syncs: {}", e);
-        }
+        self.run_phase(
+            "monitor_running_syncs",
+            self.sync_manager.monitor_running_syncs(),
+        )
+        .await;
 
-        // Detect and handle stale syncs
-        match self.sync_manager.detect_stale_syncs().await {
-            Ok(stale) => {
-                if !stale.is_empty() {
-                    info!("Marked {} stale syncs as failed", stale.len());
-                }
-            }
-            Err(e) => {
-                error!("Error detecting stale syncs: {}", e);
+        if let Some(stale) = self
+            .run_phase("detect_stale_syncs", self.sync_manager.detect_stale_syncs())
+            .await
+        {
+            if !stale.is_empty() {
+                info!("Marked {} stale syncs as failed", stale.len());
             }
         }
 
-        // Clean up soft-deleted sources
-        SourceCleanup::cleanup_deleted_sources(&self.pool).await;
+        self.run_phase("cleanup_deleted_sources", async {
+            SourceCleanup::cleanup_deleted_sources(&self.pool).await;
+            Ok::<(), SchedulerError>(())
+        })
+        .await;
+    }
+
+    async fn run_phase<T, E, F>(&self, phase: &'static str, future: F) -> Option<T>
+    where
+        E: Display,
+        F: Future<Output = Result<T, E>>,
+    {
+        let started = Instant::now();
+        debug!(
+            phase,
+            timeout_secs = SCHEDULER_PHASE_TIMEOUT.as_secs(),
+            "Scheduler phase started"
+        );
+
+        match timeout(SCHEDULER_PHASE_TIMEOUT, future).await {
+            Ok(Ok(value)) => {
+                debug!(
+                    phase,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    "Scheduler phase completed"
+                );
+                Some(value)
+            }
+            Ok(Err(e)) => {
+                error!(
+                    phase,
+                    elapsed_ms = started.elapsed().as_millis(),
+                    error = %e,
+                    "Scheduler phase failed"
+                );
+                None
+            }
+            Err(_) => {
+                error!(
+                    phase,
+                    timeout_secs = SCHEDULER_PHASE_TIMEOUT.as_secs(),
+                    "Scheduler phase timed out; continuing with next phase"
+                );
+                None
+            }
+        }
     }
 
     /// Ensure each active source whose connector advertised `Realtime` has a
@@ -117,7 +191,14 @@ impl Scheduler {
                 .is_sync_class_running(&source.id, SyncSlotClass::Realtime)
                 .await
             {
-                Ok(true) => continue,
+                Ok(true) => {
+                    debug!(
+                        source_id = %source.id,
+                        source_type = ?source.source_type,
+                        "Realtime sync already running"
+                    );
+                    continue;
+                }
                 Ok(false) => {}
                 Err(e) => {
                     warn!(
@@ -128,6 +209,12 @@ impl Scheduler {
                 }
             }
 
+            debug!(
+                source_id = %source.id,
+                source_type = ?source.source_type,
+                source_name = %source.name,
+                "Starting realtime sync"
+            );
             match self
                 .sync_manager
                 .trigger_sync(&source.id, SyncType::Realtime, TriggerType::Scheduled)

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -123,9 +123,7 @@ impl SyncManager {
             .create(source_id, effective_sync_type, &trigger_type.to_string())
             .await
             .map_err(|e| match e {
-                DatabaseError::ConstraintViolation(name)
-                    if name == "idx_sync_runs_one_running_per_source_slot" =>
-                {
+                DatabaseError::RunningSyncSlotConflict => {
                     SyncError::SyncAlreadyRunning(source_id.to_string())
                 }
                 other => SyncError::DatabaseError(other.to_string()),

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -10,11 +10,14 @@ use shared::models::{SourceType, SyncSlotClass, SyncStatus, SyncType};
 use shared::{DatabasePool, Repository, SourceRepository};
 use sqlx::PgPool;
 use std::sync::Arc;
+use std::time::Duration;
 use time::format_description::well_known::Rfc3339;
 use time::OffsetDateTime;
-use tracing::{error, info, warn};
+use tokio::time::timeout;
+use tracing::{debug, error, info, warn};
 
 const MAX_RESUME_ATTEMPTS: usize = 3;
+const CONNECTOR_TRIGGER_TIMEOUT: Duration = Duration::from_secs(150);
 
 #[derive(Clone)]
 pub struct SyncManager {
@@ -128,6 +131,15 @@ impl SyncManager {
                 other => SyncError::DatabaseError(other.to_string()),
             })?;
 
+        debug!(
+            sync_run_id = %sync_run.id,
+            source_id = %source_id,
+            sync_type = ?effective_sync_type,
+            trigger_type = %trigger_type,
+            connector_url = %connector_url,
+            "Created sync_run; triggering connector"
+        );
+
         let sync_request = SyncRequest {
             sync_run_id: sync_run.id.clone(),
             source_id: source_id.to_string(),
@@ -135,20 +147,22 @@ impl SyncManager {
             last_sync_at,
         };
 
-        // Trigger sync (non-blocking call to connector)
-        match self
-            .connector_client
-            .trigger_sync(&connector_url, &sync_request)
-            .await
-        {
-            Ok(response) => {
+        let trigger_result = timeout(
+            CONNECTOR_TRIGGER_TIMEOUT,
+            self.connector_client
+                .trigger_sync(&connector_url, &sync_request),
+        )
+        .await;
+
+        match trigger_result {
+            Ok(Ok(response)) => {
                 info!(
                     "Sync triggered for source {}: {:?}",
                     source_id, response.status
                 );
                 Ok(sync_run.id)
             }
-            Err(ClientError::ConnectorError { status: 404, .. })
+            Ok(Err(ClientError::ConnectorError { status: 404, .. }))
                 if effective_sync_type == SyncType::Realtime =>
             {
                 self.mark_sync_unavailable(&sync_run.id).await?;
@@ -157,9 +171,20 @@ impl SyncManager {
                     sync_type: effective_sync_type,
                 })
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 self.mark_sync_failed(&sync_run.id, &e.to_string()).await?;
                 Err(SyncError::ConnectorError(e))
+            }
+            Err(_) => {
+                let message = format!(
+                    "Connector trigger timed out after {}s",
+                    CONNECTOR_TRIGGER_TIMEOUT.as_secs()
+                );
+                self.mark_sync_failed(&sync_run.id, &message).await?;
+                Err(SyncError::ConnectorTriggerTimedOut {
+                    sync_run_id: sync_run.id,
+                    timeout_seconds: CONNECTOR_TRIGGER_TIMEOUT.as_secs(),
+                })
             }
         }
     }
@@ -443,12 +468,14 @@ impl SyncManager {
             last_sync_at,
         };
 
-        match self
-            .connector_client
-            .trigger_sync(&connector_url, &sync_request)
-            .await
+        match timeout(
+            CONNECTOR_TRIGGER_TIMEOUT,
+            self.connector_client
+                .trigger_sync(&connector_url, &sync_request),
+        )
+        .await
         {
-            Ok(_) => {
+            Ok(Ok(_)) => {
                 info!(
                     "Auto-resumed sync {} on connector (attempt {}/{})",
                     sync_run_id, attempts, MAX_RESUME_ATTEMPTS
@@ -462,10 +489,19 @@ impl SyncManager {
                     );
                 }
             }
-            Err(e) => {
+            Ok(Err(e)) => {
                 warn!(
                     "Failed to re-trigger sync {} on connector (attempt {}/{}): {}",
                     sync_run_id, attempts, MAX_RESUME_ATTEMPTS, e
+                );
+            }
+            Err(_) => {
+                warn!(
+                    "Timed out re-triggering sync {} on connector after {}s (attempt {}/{})",
+                    sync_run_id,
+                    CONNECTOR_TRIGGER_TIMEOUT.as_secs(),
+                    attempts,
+                    MAX_RESUME_ATTEMPTS
                 );
             }
         }
@@ -592,6 +628,12 @@ pub enum SyncError {
 
     #[error("Concurrency limit reached for {0} syncs")]
     ConcurrencyLimitReachedForSlot(SyncSlotClass),
+
+    #[error("Connector trigger timed out for sync {sync_run_id} after {timeout_seconds}s")]
+    ConnectorTriggerTimedOut {
+        sync_run_id: String,
+        timeout_seconds: u64,
+    },
 
     #[error("Database error: {0}")]
     DatabaseError(String),

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -4,6 +4,7 @@ use crate::handlers::get_connector_url_for_source;
 use crate::models::{SyncRequest, TriggerType};
 use dashmap::DashMap;
 use redis::Client as RedisClient;
+use shared::db::error::DatabaseError;
 use shared::db::repositories::SyncRunRepository;
 use shared::models::{SourceType, SyncSlotClass, SyncStatus, SyncType};
 use shared::{DatabasePool, Repository, SourceRepository};
@@ -61,6 +62,13 @@ impl SyncManager {
             return Err(SyncError::ConcurrencyLimitReached);
         }
 
+        let slot_class = sync_type.slot_class();
+        if self.active_sync_count_for_slot_class(slot_class).await?
+            >= self.config.max_concurrent_syncs_per_type
+        {
+            return Err(SyncError::ConcurrencyLimitReachedForSlot(slot_class));
+        }
+
         // Get source details
         let source_repo = SourceRepository::new(&self.pool);
         let source = source_repo
@@ -111,7 +119,14 @@ impl SyncManager {
             .sync_run_repo
             .create(source_id, effective_sync_type, &trigger_type.to_string())
             .await
-            .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+            .map_err(|e| match e {
+                DatabaseError::ConstraintViolation(name)
+                    if name == "idx_sync_runs_one_running_per_source_slot" =>
+                {
+                    SyncError::SyncAlreadyRunning(source_id.to_string())
+                }
+                other => SyncError::DatabaseError(other.to_string()),
+            })?;
 
         let sync_request = SyncRequest {
             sync_run_id: sync_run.id.clone(),
@@ -181,10 +196,14 @@ impl SyncManager {
             warn!("Failed to send cancel request to connector: {}", e);
         }
 
-        self.sync_run_repo
+        let updated = self
+            .sync_run_repo
             .mark_cancelled(sync_run_id)
             .await
             .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+        if !updated {
+            return Err(SyncError::SyncNotRunning(sync_run_id.to_string()));
+        }
 
         self.resume_attempts.remove(sync_run_id);
         info!("Sync {} cancelled", sync_run_id);
@@ -227,6 +246,17 @@ impl SyncManager {
             .find_all_running()
             .await
             .map(|r| r.len())
+            .map_err(|e| SyncError::DatabaseError(e.to_string()))
+    }
+
+    pub async fn active_sync_count_for_slot_class(
+        &self,
+        slot_class: SyncSlotClass,
+    ) -> Result<usize, SyncError> {
+        self.sync_run_repo
+            .count_running_in_slot_class(slot_class)
+            .await
+            .map(|count| count as usize)
             .map_err(|e| SyncError::DatabaseError(e.to_string()))
     }
 
@@ -504,10 +534,17 @@ impl SyncManager {
     }
 
     async fn mark_sync_failed(&self, sync_run_id: &str, error: &str) -> Result<(), SyncError> {
-        self.sync_run_repo
+        let updated = self
+            .sync_run_repo
             .mark_failed(sync_run_id, error)
             .await
             .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+        if !updated {
+            warn!(
+                "Ignoring stale failure transition for non-running sync {}",
+                sync_run_id
+            );
+        }
 
         self.resume_attempts.remove(sync_run_id);
         Ok(())
@@ -552,6 +589,9 @@ pub enum SyncError {
         source_id: String,
         sync_type: SyncType,
     },
+
+    #[error("Concurrency limit reached for {0} syncs")]
+    ConcurrencyLimitReachedForSlot(SyncSlotClass),
 
     #[error("Database error: {0}")]
     DatabaseError(String),

--- a/services/migrations/093_harden_sync_run_lifecycle.sql
+++ b/services/migrations/093_harden_sync_run_lifecycle.sql
@@ -1,0 +1,29 @@
+-- Enforce one running sync per source per slot class.
+-- Realtime syncs occupy their own slot; full/incremental share the scheduled slot.
+
+WITH duplicate_running AS (
+    SELECT
+        id,
+        ROW_NUMBER() OVER (
+            PARTITION BY source_id,
+                         CASE WHEN sync_type = 'realtime' THEN 'realtime' ELSE 'scheduled' END
+            ORDER BY started_at DESC NULLS LAST, created_at DESC, id DESC
+        ) AS rn
+    FROM sync_runs
+    WHERE status = 'running'
+)
+UPDATE sync_runs sr
+SET status = 'failed',
+    completed_at = COALESCE(sr.completed_at, NOW()),
+    error_message = COALESCE(sr.error_message, 'Marked failed before sync slot uniqueness migration'),
+    updated_at = NOW()
+FROM duplicate_running d
+WHERE sr.id = d.id
+  AND d.rn > 1;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_sync_runs_one_running_per_source_slot
+ON sync_runs (
+    source_id,
+    (CASE WHEN sync_type = 'realtime' THEN 'realtime' ELSE 'scheduled' END)
+)
+WHERE status = 'running';

--- a/services/migrations/Dockerfile
+++ b/services/migrations/Dockerfile
@@ -5,7 +5,7 @@ RUN apt-get update && apt-get install -y \
     libssl-dev \
     && rm -rf /var/lib/apt/lists/*
 
-RUN cargo install sqlx-cli --no-default-features --features native-tls,postgres
+RUN cargo install sqlx-cli --version 0.8.6 --locked --no-default-features --features native-tls,postgres
 
 FROM debian:bookworm-slim
 

--- a/shared/src/db/error.rs
+++ b/shared/src/db/error.rs
@@ -11,6 +11,9 @@ pub enum DatabaseError {
     #[error("Constraint violation: {0}")]
     ConstraintViolation(String),
 
+    #[error("Running sync slot already occupied")]
+    RunningSyncSlotConflict,
+
     #[error("Invalid input: {0}")]
     InvalidInput(String),
 

--- a/shared/src/db/repositories/sync_run.rs
+++ b/shared/src/db/repositories/sync_run.rs
@@ -3,8 +3,19 @@ use crate::{
     models::{SyncRun, SyncStatus, SyncType},
     utils::generate_ulid,
 };
-use sqlx::PgPool;
+use sqlx::{Error as SqlxError, PgPool};
 use time::OffsetDateTime;
+
+const RUNNING_SYNC_SLOT_INDEX: &str = "idx_sync_runs_one_running_per_source_slot";
+
+fn map_sqlx_error(error: SqlxError) -> DatabaseError {
+    if let SqlxError::Database(db_error) = &error {
+        if db_error.constraint() == Some(RUNNING_SYNC_SLOT_INDEX) {
+            return DatabaseError::ConstraintViolation(RUNNING_SYNC_SLOT_INDEX.to_string());
+        }
+    }
+    DatabaseError::Connection(error)
+}
 
 #[derive(Clone)]
 pub struct SyncRunRepository {
@@ -36,7 +47,8 @@ impl SyncRunRepository {
         .bind(trigger_type)
         .bind(now)
         .execute(&self.pool)
-        .await?;
+        .await
+        .map_err(map_sqlx_error)?;
 
         Ok(SyncRun {
             id,
@@ -75,65 +87,71 @@ impl SyncRunRepository {
     /// Flip status to `Completed`. Counters are maintained by
     /// `increment_scanned` / `increment_updated`, so this only touches
     /// status fields.
-    pub async fn mark_completed(&self, id: &str) -> Result<(), DatabaseError> {
-        sqlx::query(
+    pub async fn mark_completed(&self, id: &str) -> Result<bool, DatabaseError> {
+        let result = sqlx::query(
             "UPDATE sync_runs
              SET status = $1, completed_at = CURRENT_TIMESTAMP,
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $2",
+             WHERE id = $2 AND status = $3",
         )
         .bind(SyncStatus::Completed)
         .bind(id)
+        .bind(SyncStatus::Running)
         .execute(&self.pool)
         .await?;
 
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
-    pub async fn mark_failed(&self, id: &str, error: &str) -> Result<(), DatabaseError> {
-        sqlx::query(
+    pub async fn mark_failed(&self, id: &str, error: &str) -> Result<bool, DatabaseError> {
+        let result = sqlx::query(
             "UPDATE sync_runs
              SET status = $1, completed_at = CURRENT_TIMESTAMP,
                  error_message = $2, updated_at = CURRENT_TIMESTAMP
-             WHERE id = $3",
+             WHERE id = $3 AND status = $4",
         )
         .bind(SyncStatus::Failed)
         .bind(error)
         .bind(id)
+        .bind(SyncStatus::Running)
         .execute(&self.pool)
         .await?;
 
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
-    pub async fn increment_scanned(&self, id: &str, count: i32) -> Result<(), DatabaseError> {
-        sqlx::query(
+    pub async fn increment_scanned(&self, id: &str, count: i32) -> Result<bool, DatabaseError> {
+        let result = sqlx::query(
             "UPDATE sync_runs
              SET documents_scanned = documents_scanned + $1,
+                 last_activity_at = CURRENT_TIMESTAMP,
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $2",
+             WHERE id = $2 AND status = $3",
         )
         .bind(count)
         .bind(id)
+        .bind(SyncStatus::Running)
         .execute(&self.pool)
         .await?;
 
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
-    pub async fn increment_updated(&self, id: &str, count: i32) -> Result<(), DatabaseError> {
-        sqlx::query(
+    pub async fn increment_updated(&self, id: &str, count: i32) -> Result<bool, DatabaseError> {
+        let result = sqlx::query(
             "UPDATE sync_runs
              SET documents_updated = documents_updated + $1,
+                 last_activity_at = CURRENT_TIMESTAMP,
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $2",
+             WHERE id = $2 AND status = $3",
         )
         .bind(count)
         .bind(id)
+        .bind(SyncStatus::Running)
         .execute(&self.pool)
         .await?;
 
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn increment_progress(&self, id: &str) -> Result<(), DatabaseError> {
@@ -144,11 +162,13 @@ impl SyncRunRepository {
         sqlx::query(
             "UPDATE sync_runs
              SET documents_processed = documents_processed + $1,
+                 last_activity_at = CURRENT_TIMESTAMP,
                  updated_at = CURRENT_TIMESTAMP
-             WHERE id = $2",
+             WHERE id = $2 AND status = $3",
         )
         .bind(count)
         .bind(id)
+        .bind(SyncStatus::Running)
         .execute(&self.pool)
         .await?;
 
@@ -275,7 +295,27 @@ impl SyncRunRepository {
         Ok(sync_runs)
     }
 
-    pub async fn mark_cancelled(&self, id: &str) -> Result<(), DatabaseError> {
+    pub async fn count_running_in_slot_class(
+        &self,
+        slot_class: crate::models::SyncSlotClass,
+    ) -> Result<i64, DatabaseError> {
+        let sync_types: &[SyncType] = match slot_class {
+            crate::models::SyncSlotClass::Realtime => &[SyncType::Realtime],
+            crate::models::SyncSlotClass::Scheduled => &[SyncType::Full, SyncType::Incremental],
+        };
+        let type_strs: Vec<String> = sync_types.iter().map(|t| t.to_string()).collect();
+        let count = sqlx::query_scalar::<_, i64>(
+            "SELECT COUNT(*) FROM sync_runs WHERE status = $1 AND sync_type::text = ANY($2)",
+        )
+        .bind(SyncStatus::Running)
+        .bind(&type_strs)
+        .fetch_one(&self.pool)
+        .await?;
+
+        Ok(count)
+    }
+
+    pub async fn mark_cancelled(&self, id: &str) -> Result<bool, DatabaseError> {
         self.mark_cancelled_with_message(id, "Cancelled by user")
             .await
     }
@@ -284,33 +324,35 @@ impl SyncRunRepository {
         &self,
         id: &str,
         message: &str,
-    ) -> Result<(), DatabaseError> {
-        sqlx::query(
+    ) -> Result<bool, DatabaseError> {
+        let result = sqlx::query(
             "UPDATE sync_runs
              SET status = $1, completed_at = CURRENT_TIMESTAMP,
                  error_message = $2, updated_at = CURRENT_TIMESTAMP
-             WHERE id = $3",
+             WHERE id = $3 AND status = $4",
         )
         .bind(SyncStatus::Cancelled)
         .bind(message)
         .bind(id)
+        .bind(SyncStatus::Running)
         .execute(&self.pool)
         .await?;
 
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
-    pub async fn update_activity(&self, id: &str) -> Result<(), DatabaseError> {
-        sqlx::query(
+    pub async fn update_activity(&self, id: &str) -> Result<bool, DatabaseError> {
+        let result = sqlx::query(
             "UPDATE sync_runs
              SET last_activity_at = CURRENT_TIMESTAMP, updated_at = CURRENT_TIMESTAMP
-             WHERE id = $1",
+             WHERE id = $1 AND status = $2",
         )
         .bind(id)
+        .bind(SyncStatus::Running)
         .execute(&self.pool)
         .await?;
 
-        Ok(())
+        Ok(result.rows_affected() > 0)
     }
 
     pub async fn find_latest_for_sources(
@@ -381,20 +423,5 @@ impl SyncRunRepository {
         .await?;
 
         Ok(sync_runs)
-    }
-
-    pub async fn increment_scanned_with_activity(&self, id: &str) -> Result<(), DatabaseError> {
-        sqlx::query(
-            "UPDATE sync_runs
-             SET documents_scanned = documents_scanned + 1,
-                 last_activity_at = CURRENT_TIMESTAMP,
-                 updated_at = CURRENT_TIMESTAMP
-             WHERE id = $1",
-        )
-        .bind(id)
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
     }
 }

--- a/shared/src/db/repositories/sync_run.rs
+++ b/shared/src/db/repositories/sync_run.rs
@@ -11,7 +11,7 @@ const RUNNING_SYNC_SLOT_INDEX: &str = "idx_sync_runs_one_running_per_source_slot
 fn map_sqlx_error(error: SqlxError) -> DatabaseError {
     if let SqlxError::Database(db_error) = &error {
         if db_error.constraint() == Some(RUNNING_SYNC_SLOT_INDEX) {
-            return DatabaseError::ConstraintViolation(RUNNING_SYNC_SLOT_INDEX.to_string());
+            return DatabaseError::RunningSyncSlotConflict;
         }
     }
     DatabaseError::Connection(error)


### PR DESCRIPTION
- Enforce one running sync per source slot with a partial unique index
- Guard sync-run terminal transitions and progress updates by running status
- Surface stale SDK lifecycle updates as warnings instead of state changes
- Apply per-slot concurrency checks before creating sync runs