### PR TITLE
Fix Anthropic search result payloads

### DIFF
--- a/services/ai/providers/anthropic.py
+++ b/services/ai/providers/anthropic.py
@@ -8,31 +8,12 @@ from collections.abc import AsyncIterator, Iterable
 from typing import Any, cast
 
 from anthropic import AsyncAnthropic, AsyncStream, MessageStreamEvent
-from anthropic.types import (
-    ContentBlockParam,
-    MessageParam,
-    SearchResultBlockParam,
-    ToolParam,
-    ToolResultBlockParam,
-)
-from anthropic.types.tool_result_block_param import (
-    Content as ToolResultContentBlockParam,
-)
+from anthropic.types import MessageParam, ToolParam
 
 from . import LLMProvider, LLMProviderStreamError, TokenUsage
+from .anthropic_message_adapter import build_messages_for_anthropic_api
 
 logger = logging.getLogger(__name__)
-
-
-class OmniSearchResultBlockParam(SearchResultBlockParam, total=False):
-    source_type: str
-
-
-type OmniContentBlockParam = ContentBlockParam | OmniSearchResultBlockParam
-type OmniToolResultContentBlockParam = (
-    ToolResultContentBlockParam | OmniSearchResultBlockParam
-)
-type AnthropicMessageContent = str | Iterable[OmniContentBlockParam]
 
 
 class AnthropicProvider(LLMProvider):
@@ -79,81 +60,7 @@ class AnthropicProvider(LLMProvider):
         messages: list[MessageParam],
     ) -> list[MessageParam]:
         """Convert Omni's internal message blocks to Anthropic's request shape."""
-        return [
-            MessageParam(
-                role=msg["role"],
-                content=self._build_content_for_api(msg["content"]),
-            )
-            for msg in messages
-        ]
-
-    def _build_content_for_api(
-        self, content: AnthropicMessageContent
-    ) -> str | list[ContentBlockParam]:
-        if isinstance(content, str):
-            return content
-        return [self._build_block_for_api(block) for block in content]
-
-    def _build_block_for_api(self, block: OmniContentBlockParam) -> ContentBlockParam:
-        if block["type"] == "tool_result":
-            return self._build_tool_result_block_for_api(
-                cast(ToolResultBlockParam, block)
-            )
-        if block["type"] == "search_result":
-            return self._build_search_result_block_for_api(
-                cast(OmniSearchResultBlockParam, block)
-            )
-        return block
-
-    def _build_tool_result_block_for_api(
-        self, block: ToolResultBlockParam
-    ) -> ToolResultBlockParam:
-        result = ToolResultBlockParam(
-            type="tool_result",
-            tool_use_id=block["tool_use_id"],
-        )
-        if "content" in block:
-            result["content"] = self._build_tool_result_content_for_api(
-                block["content"]
-            )
-        if "is_error" in block:
-            result["is_error"] = block["is_error"]
-        if "cache_control" in block:
-            result["cache_control"] = block["cache_control"]
-        return result
-
-    def _build_tool_result_content_for_api(
-        self, content: str | Iterable[OmniToolResultContentBlockParam]
-    ) -> str | list[ToolResultContentBlockParam]:
-        if isinstance(content, str):
-            return content
-        return [
-            self._build_tool_result_content_block_for_api(block) for block in content
-        ]
-
-    def _build_tool_result_content_block_for_api(
-        self, block: OmniToolResultContentBlockParam
-    ) -> ToolResultContentBlockParam:
-        if block["type"] == "search_result":
-            return self._build_search_result_block_for_api(
-                cast(OmniSearchResultBlockParam, block)
-            )
-        return block
-
-    def _build_search_result_block_for_api(
-        self, block: OmniSearchResultBlockParam
-    ) -> SearchResultBlockParam:
-        result = SearchResultBlockParam(
-            type="search_result",
-            title=block["title"],
-            source=block["source"],
-            content=block["content"],
-        )
-        if "citations" in block:
-            result["citations"] = block["citations"]
-        if "cache_control" in block:
-            result["cache_control"] = block["cache_control"]
-        return result
+        return build_messages_for_anthropic_api(messages)
 
     async def stream_response(
         self,

--- a/services/ai/providers/anthropic_message_adapter.py
+++ b/services/ai/providers/anthropic_message_adapter.py
@@ -1,0 +1,110 @@
+"""Adapters for Omni's Anthropic-shaped internal messages.
+
+Omni stores a small number of internal-only fields on Anthropic-compatible blocks
+so the UI and downstream logic can retain source metadata. Anthropic-family APIs
+reject those extras, so providers must pass messages through this adapter before
+sending requests.
+"""
+
+from collections.abc import Iterable
+from typing import cast
+
+from anthropic.types import (
+    ContentBlockParam,
+    MessageParam,
+    SearchResultBlockParam,
+    ToolResultBlockParam,
+)
+from anthropic.types.tool_result_block_param import (
+    Content as ToolResultContentBlockParam,
+)
+
+
+class OmniSearchResultBlockParam(SearchResultBlockParam, total=False):
+    source_type: str
+
+
+type OmniContentBlockParam = ContentBlockParam | OmniSearchResultBlockParam
+type OmniToolResultContentBlockParam = (
+    ToolResultContentBlockParam | OmniSearchResultBlockParam
+)
+type AnthropicMessageContent = str | Iterable[OmniContentBlockParam]
+
+
+def build_messages_for_anthropic_api(
+    messages: list[MessageParam],
+) -> list[MessageParam]:
+    """Convert Omni's internal message blocks to Anthropic's request shape."""
+    return [
+        MessageParam(
+            role=msg["role"],
+            content=_build_content_for_api(cast(AnthropicMessageContent, msg["content"])),
+        )
+        for msg in messages
+    ]
+
+
+def _build_content_for_api(
+    content: AnthropicMessageContent,
+) -> str | list[ContentBlockParam]:
+    if isinstance(content, str):
+        return content
+    return [_build_block_for_api(block) for block in content]
+
+
+def _build_block_for_api(block: OmniContentBlockParam) -> ContentBlockParam:
+    if block["type"] == "tool_result":
+        return _build_tool_result_block_for_api(cast(ToolResultBlockParam, block))
+    if block["type"] == "search_result":
+        return _build_search_result_block_for_api(
+            cast(OmniSearchResultBlockParam, block)
+        )
+    return block
+
+
+def _build_tool_result_block_for_api(
+    block: ToolResultBlockParam,
+) -> ToolResultBlockParam:
+    result = ToolResultBlockParam(
+        type="tool_result",
+        tool_use_id=block["tool_use_id"],
+    )
+    if "content" in block:
+        result["content"] = _build_tool_result_content_for_api(block["content"])
+    if "is_error" in block:
+        result["is_error"] = block["is_error"]
+    if "cache_control" in block:
+        result["cache_control"] = block["cache_control"]
+    return result
+
+
+def _build_tool_result_content_for_api(
+    content: str | Iterable[OmniToolResultContentBlockParam],
+) -> str | list[ToolResultContentBlockParam]:
+    if isinstance(content, str):
+        return content
+    return [_build_tool_result_content_block_for_api(block) for block in content]
+
+
+def _build_tool_result_content_block_for_api(
+    block: OmniToolResultContentBlockParam,
+) -> ToolResultContentBlockParam:
+    if block["type"] == "search_result":
+        return _build_search_result_block_for_api(cast(OmniSearchResultBlockParam, block))
+    return block
+
+
+def _build_search_result_block_for_api(
+    block: OmniSearchResultBlockParam,
+) -> SearchResultBlockParam:
+    result = SearchResultBlockParam(
+        type="search_result",
+        title=block["title"],
+        source=block["source"],
+        content=block["content"],
+    )
+    if "citations" in block:
+        result["citations"] = block["citations"]
+    if "cache_control" in block:
+        result["cache_control"] = block["cache_control"]
+    return result

--- a/services/ai/providers/bedrock.py
+++ b/services/ai/providers/bedrock.py
@@ -2,14 +2,14 @@
 AWS Bedrock Provider for Claude models.
 """
 
-import time
 import json
 import logging
+import time
 from collections.abc import AsyncIterator
 from typing import Any, cast
 
 import boto3
-from botocore.exceptions import ClientError
+from anthropic import AnthropicBedrock
 from anthropic.types import (
     MessageParam,
     Message,
@@ -36,9 +36,10 @@ from anthropic.types import (
 )
 from anthropic.types.message_stream_event import MessageStreamEvent
 from anthropic.types.raw_message_delta_event import Delta
-from anthropic import AnthropicBedrock
+from botocore.exceptions import ClientError
 
 from . import LLMProvider, LLMProviderStreamError, TokenUsage
+from .anthropic_message_adapter import build_messages_for_anthropic_api
 
 logger = logging.getLogger(__name__)
 
@@ -444,7 +445,11 @@ class BedrockProvider(LLMProvider):
         """Stream response from AWS Bedrock models."""
         try:
             if self.model_family == "anthropic":
-                msg_list = messages or [{"role": "user", "content": prompt}]
+                msg_list = (
+                    build_messages_for_anthropic_api(cast(list[MessageParam], messages))
+                    if messages
+                    else [{"role": "user", "content": prompt}]
+                )
 
                 # Prepare the request body for Claude models
                 request_params = {

--- a/services/ai/tests/unit/test_anthropic_provider.py
+++ b/services/ai/tests/unit/test_anthropic_provider.py
@@ -22,6 +22,7 @@ def test_build_messages_for_api_strips_extra_search_result_fields_without_mutati
                             "title": "Issue",
                             "source": "https://jira.example/browse/PROJ-1",
                             "source_type": "jira",
+                            "internal_extra": "must-not-be-sent",
                             "content": [{"type": "text", "text": "body"}],
                             "citations": {"enabled": True},
                         }
@@ -37,7 +38,9 @@ def test_build_messages_for_api_strips_extra_search_result_fields_without_mutati
     internal_search_result = messages[0]["content"][0]["content"][0]
     api_search_result = api_messages[0]["content"][0]["content"][0]
     assert internal_search_result["source_type"] == "jira"
+    assert internal_search_result["internal_extra"] == "must-not-be-sent"
     assert "source_type" not in api_search_result
+    assert "internal_extra" not in api_search_result
     assert api_search_result == {
         "type": "search_result",
         "title": "Issue",

--- a/services/ai/tests/unit/test_bedrock_provider.py
+++ b/services/ai/tests/unit/test_bedrock_provider.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from providers.bedrock import BedrockProvider
+
+pytestmark = pytest.mark.unit
+
+
+def _message_with_search_result_extra_fields():
+    return [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "tool-1",
+                    "content": [
+                        {
+                            "type": "search_result",
+                            "title": "Issue",
+                            "source": "https://example.invalid/issue",
+                            "source_type": "jira",
+                            "internal_extra": "must-not-be-sent",
+                            "content": [{"type": "text", "text": "body"}],
+                            "citations": {"enabled": True},
+                        }
+                    ],
+                    "is_error": False,
+                }
+            ],
+        }
+    ]
+
+
+class _RecordingMessagesClient:
+    def __init__(self) -> None:
+        self.request_params = None
+
+    def create(self, **kwargs):
+        self.request_params = kwargs
+        return []
+
+
+class _RecordingAnthropicBedrockClient:
+    def __init__(self) -> None:
+        self.messages = _RecordingMessagesClient()
+
+
+@pytest.mark.asyncio
+async def test_anthropic_stream_sanitizes_search_result_extras_without_mutating_source():
+    provider = BedrockProvider.__new__(BedrockProvider)
+    provider.model_id = "anthropic.claude-3-5-sonnet-20241022-v2:0"
+    provider.model_family = "anthropic"
+    provider.client = _RecordingAnthropicBedrockClient()
+
+    messages = _message_with_search_result_extra_fields()
+
+    events = [
+        event
+        async for event in provider.stream_response(prompt="ignored", messages=messages)
+    ]
+
+    assert events == []
+    api_search_result = provider.client.messages.request_params["messages"][0]["content"][0][
+        "content"
+    ][0]
+    assert api_search_result == {
+        "type": "search_result",
+        "title": "Issue",
+        "source": "https://example.invalid/issue",
+        "content": [{"type": "text", "text": "body"}],
+        "citations": {"enabled": True},
+    }
+
+    internal_search_result = messages[0]["content"][0]["content"][0]
+    assert internal_search_result["source_type"] == "jira"
+    assert internal_search_result["internal_extra"] == "must-not-be-sent"
+
+
+def test_amazon_message_adapter_does_not_forward_search_result_extras():
+    provider = BedrockProvider.__new__(BedrockProvider)
+    messages = _message_with_search_result_extra_fields()
+
+    adapted = provider._adapt_messages_for_amazon_models(messages)
+
+    encoded = json.dumps(adapted)
+    assert "source_type" not in encoded
+    assert "must-not-be-sent" not in encoded
+    assert "toolResult" in encoded
+    assert "document" in encoded
+
+    internal_search_result = messages[0]["content"][0]["content"][0]
+    assert internal_search_result["source_type"] == "jira"
+    assert internal_search_result["internal_extra"] == "must-not-be-sent"

--- a/services/ai/tests/unit/test_gemini_provider.py
+++ b/services/ai/tests/unit/test_gemini_provider.py
@@ -1,0 +1,46 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from providers.gemini import _convert_messages_to_gemini
+
+pytestmark = pytest.mark.unit
+
+
+def test_convert_messages_does_not_forward_search_result_extras():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-1",
+                    "content": [
+                        {
+                            "type": "search_result",
+                            "title": "Issue",
+                            "source": "https://example.invalid/issue",
+                            "source_type": "jira",
+                            "internal_extra": "must-not-be-sent",
+                            "content": [{"type": "text", "text": "body"}],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    converted = _convert_messages_to_gemini(messages)
+
+    encoded = json.dumps(
+        [content.model_dump(mode="json", exclude_none=True) for content in converted]
+    )
+    assert "source_type" not in encoded
+    assert "must-not-be-sent" not in encoded
+    assert "[Issue](https://example.invalid/issue)\\nbody" in encoded
+
+    internal_search_result = messages[0]["content"][0]["content"][0]
+    assert internal_search_result["source_type"] == "jira"
+    assert internal_search_result["internal_extra"] == "must-not-be-sent"

--- a/services/ai/tests/unit/test_openai_compatible_provider.py
+++ b/services/ai/tests/unit/test_openai_compatible_provider.py
@@ -1,3 +1,7 @@
+from __future__ import annotations
+
+import json
+
 from providers.openai_compatible import (
     REASONING_CONTENT_KEY,
     _convert_messages_to_openai,
@@ -62,6 +66,47 @@ def test_convert_messages_preserves_deepseek_reasoning_content_with_tool_calls()
     assert assistant_message[REASONING_CONTENT_KEY] == "tool reasoning token"
     assert "content" not in assistant_message
     assert assistant_message["tool_calls"][0]["id"] == "call_1"
+
+
+def test_convert_messages_does_not_forward_search_result_extras():
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-1",
+                    "content": [
+                        {
+                            "type": "search_result",
+                            "title": "Issue",
+                            "source": "https://example.invalid/issue",
+                            "source_type": "jira",
+                            "internal_extra": "must-not-be-sent",
+                            "content": [{"type": "text", "text": "body"}],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    converted = _convert_messages_to_openai(messages)
+
+    encoded = json.dumps(converted)
+    assert "source_type" not in encoded
+    assert "must-not-be-sent" not in encoded
+    assert converted == [
+        {
+            "role": "tool",
+            "tool_call_id": "call-1",
+            "content": "[Issue](https://example.invalid/issue)\nbody",
+        }
+    ]
+
+    internal_search_result = messages[0]["content"][0]["content"][0]
+    assert internal_search_result["source_type"] == "jira"
+    assert internal_search_result["internal_extra"] == "must-not-be-sent"
 
 
 def test_get_passthrough_delta_value_reads_pydantic_extra():

--- a/services/ai/tests/unit/test_openai_provider.py
+++ b/services/ai/tests/unit/test_openai_provider.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from providers.openai import OpenAIProvider
+
+pytestmark = pytest.mark.unit
+
+
+def test_convert_messages_does_not_forward_search_result_extras():
+    provider = OpenAIProvider.__new__(OpenAIProvider)
+    messages = [
+        {
+            "role": "user",
+            "content": [
+                {
+                    "type": "tool_result",
+                    "tool_use_id": "call-1",
+                    "content": [
+                        {
+                            "type": "search_result",
+                            "title": "Issue",
+                            "source": "https://example.invalid/issue",
+                            "source_type": "jira",
+                            "internal_extra": "must-not-be-sent",
+                            "content": [{"type": "text", "text": "body"}],
+                        }
+                    ],
+                }
+            ],
+        }
+    ]
+
+    converted = provider._convert_messages(messages)
+
+    encoded = json.dumps(converted)
+    assert "source_type" not in encoded
+    assert "must-not-be-sent" not in encoded
+    assert converted == [
+        {
+            "type": "function_call_output",
+            "call_id": "call-1",
+            "output": "[Issue](https://example.invalid/issue)\nbody",
+        }
+    ]
+
+    internal_search_result = messages[0]["content"][0]["content"][0]
+    assert internal_search_result["source_type"] == "jira"
+    assert internal_search_result["internal_extra"] == "must-not-be-sent"

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -145,12 +145,15 @@
         const chatId = deleteTargetChat.id
         deleteTargetChat = null
 
-        await fetch(`/api/chat/${chatId}`, { method: 'DELETE' })
+        const response = await fetch(`/api/chat/${chatId}`, { method: 'DELETE' })
+        if (!response.ok) return
 
         if (page.params.chatId === chatId) {
-            goto('/')
+            await goto('/', { invalidateAll: true })
+            return
         }
-        invalidate('app:recent_chats')
+
+        await invalidate('app:recent_chats')
     }
 
     async function confirmRename() {


### PR DESCRIPTION
- Sanitize Anthropic-shaped messages before provider API calls
- Reuse the sanitizer for direct Anthropic and Bedrock Claude requests
- Add provider conversion tests to ensure internal search result extras stay local
- Redirect to the home chat screen after deleting the active chat