### PR TITLE
fix(imap): fall back to per-UID fetch when a batch fetch fails

### DIFF
--- a/connectors/imap/src/sync.rs
+++ b/connectors/imap/src/sync.rs
@@ -296,7 +296,22 @@ impl SyncManager {
                 Ok(msgs) => msgs,
                 Err(e) => {
                     warn!("Failed to fetch batch in folder '{}': {}", folder, e);
-                    continue;
+                    // Attempt to retrieve each message individually so a single
+                    // oversized, malformed, or server-rejected message does not
+                    // cause the entire batch to be silently skipped.
+                    let mut recovered = Vec::new();
+                    for &uid in chunk {
+                        match session.fetch_messages(&[uid]).await {
+                            Ok(msgs) => recovered.extend(msgs),
+                            Err(single_err) => {
+                                warn!(
+                                    "Skipping UID {} in '{}': {}",
+                                    uid, folder, single_err
+                                );
+                            }
+                        }
+                    }
+                    recovered
                 }
             };
 


### PR DESCRIPTION
## Problem

The IMAP connector fetches new messages in batches of 50 UIDs per round trip. When the server rejects or drops the connection on a batch request — for example due to an oversized message in the batch, a server-side timeout on a large mailbox, or a connection that was already broken — the entire batch is silently discarded with a single warning log and the sync loop moves on.

This means up to 50 messages per failed batch are never indexed in that sync run. Because the UIDs were not added to `indexed_uids` they should appear as candidates on the next sync, but if the same batch fails again consistently (e.g. because one message always triggers a server error) some messages can end up effectively never indexed.

## Root cause

The error path for `fetch_messages` called `continue`, discarding the entire chunk with no further attempt to retrieve individual messages. There was no fallback mechanism for partial batch failures.

## Fix

When `fetch_messages` returns an error for a batch, retry each UID in the batch individually. Messages that the server can deliver are indexed normally; only the specific UIDs that fail individually are skipped and logged at WARN level. This allows a single problematic message to be isolated without causing the surrounding messages to be lost.

This change complements the session-reconnect fix: reconnection handles recovery between folders while per-UID fallback maximises message recovery within a folder.