### PR TITLE
fix(content-extractor): guard docx-rs extraction against panics

### DIFF
--- a/shared/src/content_extractor.rs
+++ b/shared/src/content_extractor.rs
@@ -161,23 +161,35 @@ fn extract_pdf_text(data: &[u8]) -> Result<String> {
 }
 
 fn extract_docx_text(data: &[u8]) -> Result<String> {
-    let docx = read_docx(data).context("Failed to read DOCX")?;
-    let mut text = String::new();
+    let data_owned = data.to_vec();
+    let result = std::panic::catch_unwind(move || {
+        let docx = read_docx(&data_owned).context("Failed to read DOCX")?;
+        let mut text = String::new();
 
-    for child in &docx.document.children {
-        match child {
-            docx_rs::DocumentChild::Paragraph(paragraph) => {
-                extract_paragraph_text(paragraph, &mut text);
-                text.push('\n');
+        for child in &docx.document.children {
+            match child {
+                docx_rs::DocumentChild::Paragraph(paragraph) => {
+                    extract_paragraph_text(paragraph, &mut text);
+                    text.push('\n');
+                }
+                docx_rs::DocumentChild::Table(table) => {
+                    extract_table_text(table, &mut text);
+                }
+                _ => {}
             }
-            docx_rs::DocumentChild::Table(table) => {
-                extract_table_text(table, &mut text);
-            }
-            _ => {}
+        }
+
+        Ok(text.trim().to_string())
+    });
+
+    match result {
+        Ok(Ok(text)) => Ok(text),
+        Ok(Err(e)) => Err(e),
+        Err(_) => {
+            warn!("DOCX extraction panicked — likely a malformed or unsupported document");
+            Err(anyhow!("DOCX extraction panicked due to malformed content"))
         }
     }
-
-    Ok(text.trim().to_string())
 }
 
 fn extract_paragraph_text(paragraph: &docx_rs::Paragraph, text: &mut String) {


### PR DESCRIPTION
## Problem

The `docx-rs` library (v0.4.20) can panic with an index-out-of-bounds error when parsing certain malformed or edge-case DOCX documents. Because the DOCX extraction runs synchronously inside the connector-manager's async runtime, a panic propagates through the tokio worker thread and terminates the in-progress SDK request abruptly. The caller receives a connection error instead of a structured error response, and the surrounding request context (including any partial work) is lost.

In practice this means that any connector that sends a DOCX file to `/sdk/extract-text` or `/sdk/extract-content` when the file triggers the upstream panic will see its request fail with a network error rather than receiving a graceful error it can handle.

## Root cause

The `extract_docx_text` function called `read_docx` and traversed the resulting document tree with no panic boundary. The existing PDF extractor (`extract_pdf_text`) already uses `std::panic::catch_unwind` to handle exactly this kind of upstream library panic, but the same treatment was not applied to the DOCX extractor.

## Fix

Wrap the `docx-rs` parse and document walk inside `std::panic::catch_unwind`, mapping a panic to an `Err` with a WARN-level log message. This mirrors the existing pattern in `extract_pdf_text` and ensures that a malformed DOCX file produces a logged warning and an empty extraction result rather than a panic that disrupts the entire request.

This is a workaround for an upstream `docx-rs` bug; the guard can be revisited when a fixed version of the library is available.