### PR TITLE
fix(connector-manager): remove 2 MB default body limit on SDK routes

### DIFF
--- a/services/connector-manager/src/lib.rs
+++ b/services/connector-manager/src/lib.rs
@@ -59,14 +59,8 @@ pub fn create_app(state: AppState) -> Router {
         .route("/sdk/events", post(handlers::sdk_emit_event))
         .route("/sdk/events/batch", post(handlers::sdk_emit_batch))
         .route("/sdk/content", post(handlers::sdk_store_content))
-        .route(
-            "/sdk/extract-content",
-            post(handlers::sdk_extract_content).layer(DefaultBodyLimit::max(400 * 1024 * 1024)),
-        ) // 400 MB for binary file extraction
-        .route(
-            "/sdk/extract-text",
-            post(handlers::sdk_extract_text).layer(DefaultBodyLimit::max(400 * 1024 * 1024)),
-        ) // 400 MB for binary file extraction (returns text without storing)
+        .route("/sdk/extract-content", post(handlers::sdk_extract_content))
+        .route("/sdk/extract-text", post(handlers::sdk_extract_text))
         .route("/sdk/sync/:id/heartbeat", post(handlers::sdk_heartbeat))
         .route("/sdk/sync/:id/complete", post(handlers::sdk_complete))
         .route("/sdk/sync/:id/fail", post(handlers::sdk_fail))
@@ -111,6 +105,7 @@ pub fn create_app(state: AppState) -> Router {
             "/sdk/connector-configs/:provider",
             get(handlers::sdk_get_connector_config),
         )
+        .layer(DefaultBodyLimit::disable())
         .layer(
             ServiceBuilder::new()
                 .layer(middleware::from_fn(telemetry::middleware::trace_layer))


### PR DESCRIPTION
## Problem

axum applies a 2 MB default body size limit (`DefaultBodyLimit`) to every route unless explicitly overridden. Several SDK routes in the connector-manager regularly receive payloads that exceed this threshold:

- `POST /sdk/content` — stores raw document content. Email bodies with large inline images or encoded attachments are routinely larger than 2 MB.
- `PUT /sdk/source/:id/connector-state` — persists incremental sync state as JSON. For data sources with many items (large mailboxes, large file trees) this state blob can exceed 2 MB.

When a payload exceeds the limit axum rejects the request with **413 Request Entity Too Large** before the handler is even invoked. Connectors receive the error, log it, and fail the affected operation, causing documents to be silently skipped or sync state to be lost.

The two extraction routes (`/sdk/extract-text`, `/sdk/extract-content`) already had explicit per-route overrides of 400 MB, but the other SDK routes were left at the default 2 MB ceiling.

## Root cause

The per-route overrides on the extraction endpoints created a false impression that the body size issue was fully addressed. The content-store and connector-state routes were not covered.

## Fix

Apply `DefaultBodyLimit::disable()` at the router level. The connector-manager is an internal service that is only reachable by other containers on the Docker network and is never directly exposed to the public internet, so removing the limit does not introduce a meaningful security risk. The now-redundant per-route 400 MB overrides on the extraction endpoints are removed as they are superseded by the router-level setting.