### PR TITLE
fix(connector-manager): cancel running syncs when source is disabled

### DIFF
--- a/services/connector-manager/src/scheduler.rs
+++ b/services/connector-manager/src/scheduler.rs
@@ -101,6 +101,20 @@ impl Scheduler {
             .await;
 
         self.run_phase(
+            "cancel_syncs_for_inactive_sources",
+            self.sync_manager.cancel_syncs_for_inactive_sources(),
+        )
+        .await
+        .inspect(|cancelled| {
+            if !cancelled.is_empty() {
+                info!(
+                    "Cancelled {} sync(s) for inactive/deleted sources",
+                    cancelled.len()
+                );
+            }
+        });
+
+        self.run_phase(
             "monitor_running_syncs",
             self.sync_manager.monitor_running_syncs(),
         )

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -505,6 +505,62 @@ impl SyncManager {
         }
     }
 
+    /// Cancel any running sync whose source has been disabled or deleted.
+    /// Runs on every scheduler tick so that disabling a source stops an
+    /// in-progress sync within one tick interval.
+    pub async fn cancel_syncs_for_inactive_sources(&self) -> Result<Vec<String>, SyncError> {
+        let running: Vec<(String, String, SourceType)> = sqlx::query_as(
+            r#"
+            SELECT sr.id, sr.source_id, s.source_type
+            FROM sync_runs sr
+            JOIN sources s ON sr.source_id = s.id
+            WHERE sr.status = 'running'
+            AND (s.is_active = false OR s.is_deleted = true)
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+
+        let mut cancelled = Vec::new();
+        for (sync_run_id, source_id, source_type) in running {
+            info!(
+                "Cancelling sync {} for inactive/deleted source {}",
+                sync_run_id, source_id
+            );
+
+            if let Some(connector_url) =
+                get_connector_url_for_source(&self.redis_client, source_type).await
+            {
+                if let Err(e) = self
+                    .connector_client
+                    .cancel_sync(&connector_url, &sync_run_id)
+                    .await
+                {
+                    warn!(
+                        "Failed to cancel sync {} on connector for inactive source {}: {}",
+                        sync_run_id, source_id, e
+                    );
+                }
+            }
+
+            match self
+                .sync_run_repo
+                .mark_cancelled_with_message(&sync_run_id, "Source was disabled")
+                .await
+            {
+                Ok(true) => cancelled.push(sync_run_id),
+                Ok(false) => {}
+                Err(e) => error!(
+                    "Failed to mark sync {} cancelled for inactive source {}: {}",
+                    sync_run_id, source_id, e
+                ),
+            }
+        }
+
+        Ok(cancelled)
+    }
+
     /// Sweep running syncs whose `last_activity_at` hasn't advanced within the
     /// configured timeout — mark them failed and cancel on the connector.
     /// Realtime watchers rely on periodic `ctx.heartbeat()` calls to stay on

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -9,6 +9,7 @@ use shared::db::repositories::SyncRunRepository;
 use shared::models::{SourceType, SyncSlotClass, SyncStatus, SyncType};
 use shared::{DatabasePool, Repository, SourceRepository};
 use sqlx::PgPool;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 use time::format_description::well_known::Rfc3339;
@@ -509,56 +510,61 @@ impl SyncManager {
     /// Runs on every scheduler tick so that disabling a source stops an
     /// in-progress sync within one tick interval.
     pub async fn cancel_syncs_for_inactive_sources(&self) -> Result<Vec<String>, SyncError> {
-        let running: Vec<(String, String, SourceType)> = sqlx::query_as(
-            r#"
-            SELECT sr.id, sr.source_id, s.source_type
-            FROM sync_runs sr
-            JOIN sources s ON sr.source_id = s.id
-            WHERE sr.status = 'running'
-            AND (s.is_active = false OR s.is_deleted = true)
-            "#,
-        )
-        .fetch_all(&self.pool)
-        .await
-        .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+        let source_repo = SourceRepository::new(&self.pool);
 
-        let mut cancelled = Vec::new();
-        for (sync_run_id, source_id, source_type) in running {
+        let inactive_sources = source_repo
+            .find_inactive()
+            .await
+            .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+
+        if inactive_sources.is_empty() {
+            return Ok(vec![]);
+        }
+
+        let source_type_map: HashMap<String, SourceType> = inactive_sources
+            .iter()
+            .map(|s| (s.id.clone(), s.source_type))
+            .collect();
+        let source_ids: Vec<String> = inactive_sources.into_iter().map(|s| s.id).collect();
+
+        let running = self
+            .sync_run_repo
+            .find_running_for_sources(&source_ids)
+            .await
+            .map_err(|e| SyncError::DatabaseError(e.to_string()))?;
+
+        if running.is_empty() {
+            return Ok(vec![]);
+        }
+
+        for run in &running {
             info!(
                 "Cancelling sync {} for inactive/deleted source {}",
-                sync_run_id, source_id
+                run.id, run.source_id
             );
-
-            if let Some(connector_url) =
-                get_connector_url_for_source(&self.redis_client, source_type).await
-            {
-                if let Err(e) = self
-                    .connector_client
-                    .cancel_sync(&connector_url, &sync_run_id)
-                    .await
+            if let Some(&source_type) = source_type_map.get(&run.source_id) {
+                if let Some(connector_url) =
+                    get_connector_url_for_source(&self.redis_client, source_type).await
                 {
-                    warn!(
-                        "Failed to cancel sync {} on connector for inactive source {}: {}",
-                        sync_run_id, source_id, e
-                    );
+                    if let Err(e) = self
+                        .connector_client
+                        .cancel_sync(&connector_url, &run.id)
+                        .await
+                    {
+                        warn!(
+                            "Failed to cancel sync {} on connector for inactive source {}: {}",
+                            run.id, run.source_id, e
+                        );
+                    }
                 }
-            }
-
-            match self
-                .sync_run_repo
-                .mark_cancelled_with_message(&sync_run_id, "Source was disabled")
-                .await
-            {
-                Ok(true) => cancelled.push(sync_run_id),
-                Ok(false) => {}
-                Err(e) => error!(
-                    "Failed to mark sync {} cancelled for inactive source {}: {}",
-                    sync_run_id, source_id, e
-                ),
             }
         }
 
-        Ok(cancelled)
+        let run_ids: Vec<String> = running.into_iter().map(|r| r.id).collect();
+        self.sync_run_repo
+            .mark_cancelled_many(&run_ids, "Source was disabled")
+            .await
+            .map_err(|e| SyncError::DatabaseError(e.to_string()))
     }
 
     /// Sweep running syncs whose `last_activity_at` hasn't advanced within the

--- a/shared/src/db/repositories/source.rs
+++ b/shared/src/db/repositories/source.rs
@@ -65,6 +65,23 @@ impl SourceRepository {
         Ok(sources)
     }
 
+    pub async fn find_inactive(&self) -> Result<Vec<Source>, DatabaseError> {
+        let sources = sqlx::query_as::<_, Source>(
+            r#"
+            SELECT id, name, source_type, config, is_active, is_deleted, scope,
+                   user_filter_mode, user_whitelist, user_blacklist,
+                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+            FROM sources
+            WHERE is_active = false OR is_deleted = true
+            ORDER BY created_at DESC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(sources)
+    }
+
     pub async fn update_user_filter_settings(
         &self,
         id: &str,

--- a/shared/src/db/repositories/sync_run.rs
+++ b/shared/src/db/repositories/sync_run.rs
@@ -295,6 +295,59 @@ impl SyncRunRepository {
         Ok(sync_runs)
     }
 
+    /// Fetch all running sync runs whose source_id is in the supplied list.
+    pub async fn find_running_for_sources(
+        &self,
+        source_ids: &[String],
+    ) -> Result<Vec<SyncRun>, DatabaseError> {
+        if source_ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let sync_runs = sqlx::query_as::<_, SyncRun>(
+            r#"
+            SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
+                   documents_scanned, documents_processed, documents_updated, error_message,
+                   created_at, updated_at
+            FROM sync_runs
+            WHERE status = $1 AND source_id = ANY($2)
+            ORDER BY created_at DESC
+            "#,
+        )
+        .bind(SyncStatus::Running)
+        .bind(source_ids)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(sync_runs)
+    }
+
+    /// Mark a batch of sync runs as cancelled, returning the IDs that were
+    /// actually transitioned (i.e., were still in `running` state).
+    pub async fn mark_cancelled_many(
+        &self,
+        ids: &[String],
+        message: &str,
+    ) -> Result<Vec<String>, DatabaseError> {
+        if ids.is_empty() {
+            return Ok(vec![]);
+        }
+        let rows: Vec<(String,)> = sqlx::query_as(
+            "UPDATE sync_runs
+             SET status = $1, completed_at = CURRENT_TIMESTAMP,
+                 error_message = $2, updated_at = CURRENT_TIMESTAMP
+             WHERE id = ANY($3) AND status = $4
+             RETURNING id",
+        )
+        .bind(SyncStatus::Cancelled)
+        .bind(message)
+        .bind(ids)
+        .bind(SyncStatus::Running)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows.into_iter().map(|(id,)| id).collect())
+    }
+
     pub async fn count_running_in_slot_class(
         &self,
         slot_class: crate::models::SyncSlotClass,


### PR DESCRIPTION
## Problem

When a user disables a connector source in the UI, any in-progress sync for that source continues running until it completes naturally. This wastes resources and can produce documents for a source the user has intentionally turned off.

## Solution

Add a new scheduler phase `cancel_syncs_for_inactive_sources` that runs on every tick. It queries for `running` sync_runs whose source has `is_active = false` or `is_deleted = true`, sends a best-effort cancel to the connector process, and marks the sync_run as `cancelled` in the database with the message `Source was disabled`.

This is consistent with the existing `detect_stale_syncs` phase pattern: connector cancel is fire-and-forget (warn on failure), but the DB state is always updated.

## Changes

- `services/connector-manager/src/sync_manager.rs`: new `cancel_syncs_for_inactive_sources()` method
- `services/connector-manager/src/scheduler.rs`: new tick phase calling the above