### PR TITLE
fix(imap): detect message deletions during full sync

### DIFF
--- a/connectors/imap/src/sync.rs
+++ b/connectors/imap/src/sync.rs
@@ -43,11 +43,22 @@ impl SyncManager {
         }
 
         let mut connector_state = if ctx.sync_mode() == SyncType::Full {
+            // On a full sync we want to re-fetch all messages from scratch, but
+            // deletion detection requires the previous state:
+            // - indexed_uids: so deleted_uids = old_indexed_uids − server_uids can be computed
+            // - messages: so the deletion loop can find thread snapshots to emit DocumentDeleted
+            // indexed_uids is cleared immediately after deleted_uids is computed in
+            // sync_folder, before new messages are pushed, to avoid duplicates.
+            // Clear skipped_uids so oversized messages are retried on a full sync.
             info!(
-                "Full sync requested, resetting connector state for source {}",
+                "Full sync requested, preserving state for deletion detection for source {}",
                 source_id
             );
-            ImapConnectorState::default()
+            let mut old_state = state.unwrap_or_default();
+            for folder_state in old_state.folders.values_mut() {
+                folder_state.skipped_uids.clear();
+            }
+            old_state
         } else {
             state.unwrap_or_default()
         };
@@ -242,20 +253,32 @@ impl SyncManager {
             .filter(|uid| !server_uid_set.contains(uid))
             .collect();
 
+        // On a full sync, clear indexed_uids now that the deletion list has
+        // been captured.  Every surviving UID will be re-pushed in the
+        // new-message pass below, keeping the set clean with no duplicates.
+        if ctx.sync_mode() == SyncType::Full {
+            folder_state.indexed_uids.clear();
+        }
+
         // --- New-message detection --------------------------------------------
-        // Compute new_uids = server_uids − indexed_uids_set.
-        //
-        // Using set subtraction (rather than a `last_uid` high-water-mark)
-        // guarantees that messages skipped in a previous sync due to parse
-        // errors, store failures, or size limits are retried on every
-        // subsequent sync instead of being permanently lost.
-        let indexed_uid_set: HashSet<u32> = folder_state.indexed_uids.iter().copied().collect();
-        let mut new_uids: Vec<u32> = server_uids
-            .into_iter()
-            .filter(|uid| {
-                !indexed_uid_set.contains(uid) && !folder_state.skipped_uids.contains(uid)
-            })
-            .collect();
+        // On incremental syncs: new_uids = server_uids − indexed_uids_set, so
+        // messages already indexed are not re-fetched.
+        // On full syncs: new_uids = all server_uids, so every message body is
+        // re-downloaded regardless of indexed_uids.  deleted_uids was already
+        // captured from indexed_uids above before it was cleared, so deletion
+        // detection still fires for messages removed from the server.
+        let mut new_uids: Vec<u32> = if ctx.sync_mode() == SyncType::Full {
+            server_uids
+        } else {
+            let indexed_uid_set: HashSet<u32> =
+                folder_state.indexed_uids.iter().copied().collect();
+            server_uids
+                .into_iter()
+                .filter(|uid| {
+                    !indexed_uid_set.contains(uid) && !folder_state.skipped_uids.contains(uid)
+                })
+                .collect()
+        };
         new_uids.sort_unstable();
 
         let count_new = new_uids.len();
@@ -461,7 +484,8 @@ impl SyncManager {
                     by_message_id.insert(mid.clone(), raw.uid);
                 }
                 thread_root_map.insert(raw.uid, thread_root.clone());
-                // Guaranteed not in indexed_uids (new_uids = server_uids − indexed_uid_set − skipped_uids).
+                // Incremental: UID was not in indexed_uids (new_uids = server_uids − indexed_uid_set − skipped_uids).
+                // Full sync: indexed_uids was cleared before this pass; no duplicate can exist.
                 folder_state.indexed_uids.push(raw.uid);
                 folder_state.messages.insert(raw.uid, email);
                 processed += 1;


### PR DESCRIPTION
## Problem

Full sync reset `connector_state` to `ImapConnectorState::default()`, which zeroed out `indexed_uids`.  With `indexed_uids = []`, the deletion diff (`indexed_uids − server_uids`) always produced an empty set — messages deleted from the server were silently orphaned in the Omni index and never cleaned up.

This affected anyone who triggered a full sync (e.g. via the UI "Force resync" button) after deleting messages.  The deleted messages would remain searchable in Omni indefinitely.

## Root cause

`connectors/imap/src/sync.rs`, `run_sync()`:

```rust
// BEFORE — full sync reset everything, preventing deletion detection
let mut connector_state = if ctx.sync_mode() == SyncType::Full {
    ImapConnectorState::default()   // ← indexed_uids = [] here
} else {
    state.unwrap_or_default()
};
```

## Fix

On a full sync, load the previous state and:

1. Capture `deleted_uids = indexed_uids − server_uids` (deletion diff, same as incremental)
2. **Clear `indexed_uids`** after capturing deletions — clean slate so the re-index pass has no duplicates
3. **Keep `messages` snapshots** — the deletion loop needs them to reconstruct thread document IDs for `DocumentDeleted` / `DocumentUpdated` events
4. **Clear `skipped_uids`** — full sync intent is to retry everything, including previously oversized messages
5. Set `new_uids = all server_uids` so every message body is re-downloaded

## Invariants preserved

| Property | Incremental | Full sync (before) | Full sync (after) |
|---|---|---|---|
| Deletions detected | ✅ | ❌ | ✅ |
| All messages re-fetched | ❌ | ✅ | ✅ |
| No duplicate indexed_uids | ✅ | ✅ | ✅ |
| Thread updates on partial delete | ✅ | ❌ | ✅ |

## Changes

- `connectors/imap/src/sync.rs`: fix `run_sync()` and `sync_folder()` as described above