### PR TITLE
fix(ai): fix OpenAI provider for reasoning models (gpt-5.x)

### DIFF
--- a/services/ai/providers/openai.py
+++ b/services/ai/providers/openai.py
@@ -32,6 +32,39 @@ from . import LLMProvider, LLMProviderStreamError, TokenUsage
 
 logger = logging.getLogger(__name__)
 
+MIN_REASONING_OUTPUT_TOKENS = 1024
+
+
+def _is_reasoning_model(model: str) -> bool:
+    normalized = model.lower()
+    return normalized.startswith(("gpt-5", "o1", "o3", "o4"))
+
+
+def _supports_sampling_params(model: str) -> bool:
+    """Whether the model accepts temperature/top_p on the Responses API."""
+    return not _is_reasoning_model(model)
+
+
+def _effective_max_output_tokens(model: str, max_tokens: int | None) -> int:
+    tokens = max_tokens or 4096
+    if _is_reasoning_model(model):
+        return max(tokens, MIN_REASONING_OUTPUT_TOKENS)
+    return tokens
+
+
+def _add_sampling_params(
+    params: dict[str, Any],
+    model: str,
+    temperature: float | None,
+    top_p: float | None,
+) -> None:
+    if not _supports_sampling_params(model):
+        return
+    if temperature is not None:
+        params["temperature"] = temperature
+    if top_p is not None:
+        params["top_p"] = top_p
+
 
 def _convert_tools_to_openai(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
     """Convert Anthropic tool schema to OpenAI Responses API function-calling format (flat)."""
@@ -73,17 +106,16 @@ class OpenAIProvider(LLMProvider):
             request_params: dict[str, Any] = {
                 "model": self.model,
                 "input": input_items,
-                "max_output_tokens": max_tokens or 4096,
+                "max_output_tokens": _effective_max_output_tokens(
+                    self.model, max_tokens
+                ),
                 "stream": True,
             }
 
             if system_prompt:
                 request_params["instructions"] = system_prompt
 
-            if temperature is not None:
-                request_params["temperature"] = temperature
-            if top_p is not None:
-                request_params["top_p"] = top_p
+            _add_sampling_params(request_params, self.model, temperature, top_p)
 
             if tools:
                 request_params["tools"] = _convert_tools_to_openai(tools)
@@ -354,21 +386,20 @@ class OpenAIProvider(LLMProvider):
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from OpenAI Responses API."""
         try:
-            # Reasoning models (gpt-5.x, o-series) consume their internal reasoning
-            # chain against max_output_tokens before producing any visible text.
-            # Enforce a minimum so small caller-supplied limits do not exhaust the
-            # budget before any output is written.
-            effective_max_tokens = max(max_tokens or 4096, 1024)
+            # Reasoning models consume their internal reasoning chain against
+            # max_output_tokens before producing any visible text. Enforce a
+            # minimum so short utility calls, like title generation, still have
+            # room to write an answer.
+            effective_max_tokens = _effective_max_output_tokens(
+                self.model, max_tokens
+            )
             params: dict[str, Any] = {
                 "model": self.model,
                 "input": prompt,
                 "max_output_tokens": effective_max_tokens,
                 "stream": False,
             }
-            if temperature is not None:
-                params["temperature"] = temperature
-            if top_p is not None:
-                params["top_p"] = top_p
+            _add_sampling_params(params, self.model, temperature, top_p)
 
             response = await self.client.responses.create(**params)
 
@@ -413,7 +444,7 @@ class OpenAIProvider(LLMProvider):
             await self.client.responses.create(
                 model=self.model,
                 input="Hello",
-                max_output_tokens=1,
+                max_output_tokens=_effective_max_output_tokens(self.model, 16),
                 stream=False,
             )
             return True

--- a/services/ai/providers/openai.py
+++ b/services/ai/providers/openai.py
@@ -80,6 +80,8 @@ class OpenAIProvider(LLMProvider):
             if system_prompt:
                 request_params["instructions"] = system_prompt
 
+            if temperature is not None:
+                request_params["temperature"] = temperature
             if top_p is not None:
                 request_params["top_p"] = top_p
 
@@ -97,7 +99,7 @@ class OpenAIProvider(LLMProvider):
 
             text_started = False
             current_text_index = 0
-            tool_call_indices: dict[str, int] = {}  # call_id -> content block index
+            tool_call_indices: dict[str, int] = {}  # item_id -> content block index
             next_block_index = 0
 
             async for event in stream:
@@ -144,19 +146,24 @@ class OpenAIProvider(LLMProvider):
                 elif event_type == "response.output_item.added":
                     item = event.item
                     if item.type == "function_call":
-                        block_index = next_block_index
-                        next_block_index += 1
-                        tool_call_indices[item.id] = block_index
-                        yield RawContentBlockStartEvent(
-                            type="content_block_start",
-                            index=block_index,
-                            content_block=ToolUseBlock(
-                                type="tool_use",
-                                id=item.call_id,
-                                name=item.name,
-                                input={},
-                            ),
-                        )
+                        if item.id is None:
+                            logger.warning(
+                                f"Received function_call item with no id (call_id={item.call_id}); skipping tool block"
+                            )
+                        else:
+                            block_index = next_block_index
+                            next_block_index += 1
+                            tool_call_indices[item.id] = block_index
+                            yield RawContentBlockStartEvent(
+                                type="content_block_start",
+                                index=block_index,
+                                content_block=ToolUseBlock(
+                                    type="tool_use",
+                                    id=item.call_id,
+                                    name=item.name,
+                                    input={},
+                                ),
+                            )
 
                 # Handle tool call argument deltas
                 elif event_type == "response.function_call_arguments.delta":
@@ -211,6 +218,40 @@ class OpenAIProvider(LLMProvider):
                             ),
                         )
                     break
+
+                # Handle incomplete response (max_output_tokens exhausted mid-stream)
+                elif event_type == "response.incomplete":
+                    resp_usage = getattr(event.response, "usage", None)
+                    if resp_usage:
+                        input_tokens = getattr(resp_usage, "input_tokens", 0) or 0
+                        output_tokens = getattr(resp_usage, "output_tokens", 0) or 0
+                        details = getattr(resp_usage, "input_tokens_details", None)
+                        cached_tokens = (
+                            (getattr(details, "cached_tokens", 0) or 0)
+                            if details
+                            else 0
+                        )
+                        yield RawMessageDeltaEvent(
+                            type="message_delta",
+                            delta=Delta(stop_reason="max_tokens"),
+                            usage=MessageDeltaUsage(
+                                input_tokens=input_tokens,
+                                output_tokens=output_tokens,
+                                cache_read_input_tokens=cached_tokens,
+                            ),
+                        )
+                    break
+
+                # Handle explicit failure events
+                elif event_type == "response.failed":
+                    error = getattr(event.response, "error", None)
+                    msg = getattr(error, "message", None) or "Response failed"
+                    raise LLMProviderStreamError(msg)
+
+                elif event_type == "error":
+                    raise LLMProviderStreamError(
+                        getattr(event, "message", "Unknown stream error")
+                    )
 
             yield RawMessageStopEvent(type="message_stop")
 
@@ -294,6 +335,8 @@ class OpenAIProvider(LLMProvider):
                 for tc in tool_calls:
                     input_items.append(tc)
             elif role == "user" and tool_results:
+                if text_parts:
+                    input_items.append({"role": role, "content": "\n".join(text_parts)})
                 for tr in tool_results:
                     input_items.append(tr)
             else:
@@ -311,12 +354,22 @@ class OpenAIProvider(LLMProvider):
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from OpenAI Responses API."""
         try:
+            # Reasoning models (gpt-5.x, o-series) consume their internal reasoning
+            # chain against max_output_tokens before producing any visible text.
+            # Enforce a minimum so small caller-supplied limits do not exhaust the
+            # budget before any output is written.
+            effective_max_tokens = max(max_tokens or 4096, 1024)
             params: dict[str, Any] = {
                 "model": self.model,
                 "input": prompt,
-                "max_output_tokens": max_tokens or 4096,
+                "max_output_tokens": effective_max_tokens,
                 "stream": False,
             }
+            if temperature is not None:
+                params["temperature"] = temperature
+            if top_p is not None:
+                params["top_p"] = top_p
+
             response = await self.client.responses.create(**params)
 
             usage = TokenUsage()
@@ -332,6 +385,18 @@ class OpenAIProvider(LLMProvider):
                     cache_read_tokens=cached_tokens,
                 )
 
+            status = getattr(response, "status", None)
+            if status == "incomplete":
+                raise Exception(
+                    f"Response was incomplete (max_output_tokens={effective_max_tokens} exhausted)"
+                )
+            if status == "failed":
+                error = getattr(response, "error", None)
+                msg = getattr(error, "message", None) or "Response failed"
+                raise Exception(msg)
+            if status == "cancelled":
+                raise Exception("Response was cancelled")
+
             content = response.output_text
             if not content:
                 raise Exception("Empty response from OpenAI")
@@ -340,7 +405,7 @@ class OpenAIProvider(LLMProvider):
 
         except Exception as e:
             logger.error(f"Failed to generate response: {str(e)}")
-            raise Exception(f"Failed to generate response: {str(e)}")
+            raise Exception(f"Failed to generate response: {str(e)}") from e
 
     async def health_check(self) -> bool:
         """Check if OpenAI API is accessible."""

--- a/services/ai/tests/unit/test_openai_provider.py
+++ b/services/ai/tests/unit/test_openai_provider.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from types import SimpleNamespace
 
 import pytest
 
@@ -49,3 +50,86 @@ def test_convert_messages_does_not_forward_search_result_extras():
     internal_search_result = messages[0]["content"][0]["content"][0]
     assert internal_search_result["source_type"] == "jira"
     assert internal_search_result["internal_extra"] == "must-not-be-sent"
+
+
+class _FakeStream:
+    def __aiter__(self):
+        return self._events()
+
+    async def _events(self):
+        yield SimpleNamespace(
+            type="response.completed", response=SimpleNamespace(usage=None)
+        )
+
+
+class _FakeResponses:
+    def __init__(self, response=None):
+        self.params = None
+        self.response = response or SimpleNamespace(
+            status="completed", usage=None, output_text="ok"
+        )
+
+    async def create(self, **params):
+        self.params = params
+        return self.response
+
+
+def _provider_with_fake_client(model: str, response=None):
+    responses = _FakeResponses(response=response)
+    provider = OpenAIProvider.__new__(OpenAIProvider)
+    provider.model = model
+    provider.client = SimpleNamespace(responses=responses)
+    return provider, responses
+
+
+@pytest.mark.parametrize(
+    "model",
+    ["gpt-5", "gpt-5.2", "gpt-5.4", "gpt-5.4-mini", "gpt-5.5"],
+)
+@pytest.mark.asyncio
+async def test_generate_response_omits_sampling_params_for_gpt5(model):
+    provider, responses = _provider_with_fake_client(model)
+
+    await provider.generate_response("title", max_tokens=20, temperature=0.7, top_p=0.9)
+
+    assert responses.params["model"] == model
+    assert responses.params["max_output_tokens"] == 1024
+    assert "temperature" not in responses.params
+    assert "top_p" not in responses.params
+
+
+@pytest.mark.parametrize("model", ["gpt-4o", "gpt-4.1", "gpt-4.1-mini"])
+@pytest.mark.asyncio
+async def test_generate_response_forwards_sampling_params_for_supported_models(model):
+    provider, responses = _provider_with_fake_client(model)
+
+    await provider.generate_response("title", max_tokens=20, temperature=0.7, top_p=0.9)
+
+    assert responses.params["max_output_tokens"] == 20
+    assert responses.params["temperature"] == 0.7
+    assert responses.params["top_p"] == 0.9
+
+
+@pytest.mark.asyncio
+async def test_stream_response_omits_sampling_params_for_gpt5():
+    provider, responses = _provider_with_fake_client("gpt-5.2", response=_FakeStream())
+
+    events = [
+        event
+        async for event in provider.stream_response(
+            "hello", max_tokens=20, temperature=0.7, top_p=0.9
+        )
+    ]
+
+    assert responses.params["max_output_tokens"] == 1024
+    assert "temperature" not in responses.params
+    assert "top_p" not in responses.params
+    assert events[-1].type == "message_stop"
+
+
+@pytest.mark.asyncio
+async def test_health_check_uses_reasoning_model_token_floor():
+    provider, responses = _provider_with_fake_client("gpt-5.2")
+
+    assert await provider.health_check() is True
+    assert responses.params["max_output_tokens"] == 1024


### PR DESCRIPTION
## Problem

OpenAI reasoning models such as `gpt-5.2` reject sampling parameters like `temperature`, and small utility calls such as title generation can also exhaust `max_output_tokens` before visible text is produced. The result is failed title generation and opaque empty-response errors.

## Changes

- Detect OpenAI reasoning models (`gpt-5`, `o1`, `o3`, `o4`) and omit unsupported `temperature` / `top_p` parameters for them.
- Preserve sampling parameters for non-reasoning OpenAI models.
- Enforce a 1024-token floor for reasoning-model output budgets so small calls have room for visible output.
- Handle incomplete, failed, and cancelled Responses API statuses/events explicitly.
- Preserve user text when a message also contains tool results, and guard missing function-call item IDs.
- Add unit coverage for reasoning-model sampling omission and token floor behavior.
