### PR TITLE
fix(ai): parse connector source overview rows

### DIFF
--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -77,7 +77,7 @@ async def _fetch_sources() -> list[Source] | None:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(f"{CONNECTOR_MANAGER_URL.rstrip('/')}/sources")
             resp.raise_for_status()
-            return [Source.from_row(s) for s in resp.json()]
+            return [Source.from_row(s["source"]) for s in resp.json()]
     except Exception as e:
         logger.warning(f"Failed to fetch sources: {e}")
         return None

--- a/services/ai/db/models.py
+++ b/services/ai/db/models.py
@@ -120,13 +120,12 @@ class Source:
 
     @classmethod
     def from_row(cls, row: dict) -> "Source":
-        source = row.get("source") if isinstance(row.get("source"), dict) else row
         return cls(
-            id=source["id"],
-            name=source["name"],
-            source_type=source["source_type"],
-            is_active=source["is_active"],
-            is_deleted=source["is_deleted"],
+            id=row["id"],
+            name=row["name"],
+            source_type=row["source_type"],
+            is_active=row["is_active"],
+            is_deleted=row["is_deleted"],
         )
 
 

--- a/services/ai/db/models.py
+++ b/services/ai/db/models.py
@@ -120,12 +120,13 @@ class Source:
 
     @classmethod
     def from_row(cls, row: dict) -> "Source":
+        source = row.get("source") if isinstance(row.get("source"), dict) else row
         return cls(
-            id=row["id"],
-            name=row["name"],
-            source_type=row["source_type"],
-            is_active=row["is_active"],
-            is_deleted=row["is_deleted"],
+            id=source["id"],
+            name=source["name"],
+            source_type=source["source_type"],
+            is_active=source["is_active"],
+            is_deleted=source["is_deleted"],
         )
 
 

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -204,7 +204,7 @@ async def _fetch_sources_from_connector_manager() -> list[Source] | None:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(f"{CONNECTOR_MANAGER_URL.rstrip('/')}/sources")
             resp.raise_for_status()
-            return [Source.from_row(s) for s in resp.json()]
+            return [Source.from_row(s["source"]) for s in resp.json()]
     except Exception as e:
         logger.warning(f"Failed to fetch sources from connector manager: {e}")
         return None

--- a/services/ai/tests/unit/test_source_model.py
+++ b/services/ai/tests/unit/test_source_model.py
@@ -23,26 +23,3 @@ def test_source_from_row_accepts_flat_row():
     assert source.source_type == "google_drive"
     assert source.is_active is True
     assert source.is_deleted is False
-
-
-def test_source_from_row_accepts_connector_manager_overview():
-    source = Source.from_row(
-        {
-            "source": {
-                "id": "src-2",
-                "name": "Team Slack",
-                "source_type": "slack",
-                "is_active": True,
-                "is_deleted": False,
-                "config": {},
-            },
-            "health": "healthy",
-            "sync_runs": [],
-        }
-    )
-
-    assert source.id == "src-2"
-    assert source.name == "Team Slack"
-    assert source.source_type == "slack"
-    assert source.is_active is True
-    assert source.is_deleted is False

--- a/services/ai/tests/unit/test_source_model.py
+++ b/services/ai/tests/unit/test_source_model.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import pytest
+
+from db.models import Source
+
+pytestmark = pytest.mark.unit
+
+
+def test_source_from_row_accepts_flat_row():
+    source = Source.from_row(
+        {
+            "id": "src-1",
+            "name": "My Drive",
+            "source_type": "google_drive",
+            "is_active": True,
+            "is_deleted": False,
+        }
+    )
+
+    assert source.id == "src-1"
+    assert source.name == "My Drive"
+    assert source.source_type == "google_drive"
+    assert source.is_active is True
+    assert source.is_deleted is False
+
+
+def test_source_from_row_accepts_connector_manager_overview():
+    source = Source.from_row(
+        {
+            "source": {
+                "id": "src-2",
+                "name": "Team Slack",
+                "source_type": "slack",
+                "is_active": True,
+                "is_deleted": False,
+                "config": {},
+            },
+            "health": "healthy",
+            "sync_runs": [],
+        }
+    )
+
+    assert source.id == "src-2"
+    assert source.name == "Team Slack"
+    assert source.source_type == "slack"
+    assert source.is_active is True
+    assert source.is_deleted is False

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -140,7 +140,7 @@ class ConnectorToolHandler:
                         f"{self._connector_manager_url}/sources"
                     )
                     sources_resp.raise_for_status()
-                    sources = [Source.from_row(s) for s in sources_resp.json()]
+                    sources = [Source.from_row(s["source"]) for s in sources_resp.json()]
 
         except Exception as e:
             logger.error(f"Failed to fetch connector info: {e}")


### PR DESCRIPTION
## Summary
- Accept connector-manager `/sources` overview rows in `Source.from_row`.
- Preserve existing flat DB row parsing.
- Add unit coverage for both shapes.

## Why This Change Was Required
- The AI service expected flat source rows (`id`, `name`, `source_type`, ...) but connector-manager `/sources` returns `SourceSyncOverview` objects with a nested `source` payload.
- That mismatch triggered key lookup failures during source parsing, which caused source discovery to fail in chat sessions.
- When source discovery failed, the model was more likely to behave as if no apps were connected, which directly degraded RAG retrieval behavior for email/chat queries.
- Supporting both payload shapes removes this integration fragility and keeps chat source context plus retrieval paths reliable.

## Validation
- Unit tests cover both flat and wrapped source rows.
- Manual runtime verification confirmed wrapped connector-manager rows parse successfully.