### PR TITLE
fix(caddy): avoid health checks for optional connectors

### DIFF
--- a/Caddyfile
+++ b/Caddyfile
@@ -33,11 +33,6 @@
         rewrite /google-webhook /webhook
 
         reverse_proxy google-connector:{$GOOGLE_CONNECTOR_PORT} {
-            # Health check for the connector
-            health_uri /health
-            health_interval 30s
-            health_timeout 5s
-
             # Headers for webhook notifications
             header_up X-Real-IP {remote_host}
             header_up X-Forwarded-Proto {scheme}
@@ -51,10 +46,6 @@
     # Handle Google API endpoints (sync, webhook management)
     handle /google/* {
         reverse_proxy google-connector:{$GOOGLE_CONNECTOR_PORT} {
-            health_uri /health
-            health_interval 30s
-            health_timeout 5s
-
             header_up X-Real-IP {remote_host}
             header_up X-Forwarded-Proto {scheme}
         }
@@ -64,10 +55,6 @@
     handle /webhook/atlassian {
         rewrite /webhook/atlassian /webhook
         reverse_proxy atlassian-connector:{$ATLASSIAN_CONNECTOR_PORT} {
-            health_uri /health
-            health_interval 30s
-            health_timeout 5s
-
             header_up X-Real-IP {remote_host}
             header_up X-Forwarded-Proto {scheme}
             header_up X-Forwarded-Host {host}


### PR DESCRIPTION
## Summary
- Remove active health checks from Google and Atlassian reverse proxy routes.
- Keep the routes available when those optional connector profiles are enabled.
- Stop Caddy from repeatedly resolving disabled connector services.
