### PR TITLE
fix(content): quietly skip invalid PDFs

### DIFF
--- a/shared/src/content_extractor.rs
+++ b/shared/src/content_extractor.rs
@@ -153,7 +153,7 @@ fn extract_pdf_text(data: &[u8]) -> Result<String> {
     match result {
         Ok(Ok(text)) => Ok(text.trim().to_string()),
         Ok(Err(e)) => {
-            debug!("Skipping PDF with unextractable text: {}", e);
+            warn!("Skipping PDF with unextractable text: {}", e);
             Ok(String::new())
         }
         Err(_) => {

--- a/shared/src/content_extractor.rs
+++ b/shared/src/content_extractor.rs
@@ -152,7 +152,10 @@ fn extract_pdf_text(data: &[u8]) -> Result<String> {
 
     match result {
         Ok(Ok(text)) => Ok(text.trim().to_string()),
-        Ok(Err(e)) => Err(anyhow!("Failed to extract text from PDF: {}", e)),
+        Ok(Err(e)) => {
+            debug!("Skipping PDF with unextractable text: {}", e);
+            Ok(String::new())
+        }
         Err(_) => {
             warn!("PDF extraction panicked — likely a malformed PDF");
             Err(anyhow!("PDF extraction panicked due to malformed content"))
@@ -360,6 +363,22 @@ mod tests {
         let result = extract_content(data, "text/html", None).unwrap();
         assert!(result.contains("Title"));
         assert!(result.contains("Hello world"));
+    }
+
+    #[test]
+    fn test_invalid_pdf_returns_empty() {
+        let data = concat!(
+            "%PDF-1.4\n",
+            "1 0 obj\n",
+            "<< /Type /Catalog >>\n",
+            "endobj\n",
+            "trailer\n",
+            "<< /Root 1 0 R >>\n",
+            "%%EOF"
+        )
+        .as_bytes();
+        let result = extract_content(data, "application/pdf", Some("bad.pdf")).unwrap();
+        assert!(result.is_empty());
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Treat normal PDF parser failures as an empty extraction result instead of a warning-level extraction failure.
- Preserve panic protection for malformed PDFs that unwind inside the parser.
- Add coverage for a PDF catalog missing `/Pages`, matching the noisy log signature.

## Why
In production invalid PDFs will occur sometimes. The app must threat these cases resiliently.
