### PR TITLE
fix(compose): set default project name in run script

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+PROJECT_NAME="${COMPOSE_PROJECT_NAME:-omni}"
+
+docker compose -p "$PROJECT_NAME" -f docker/docker-compose.yml --env-file .env build
+docker compose -p "$PROJECT_NAME" -f docker/docker-compose.yml --env-file .env up -d --no-build
+docker compose -p "$PROJECT_NAME" -f docker/docker-compose.yml --env-file .env logs -f


### PR DESCRIPTION
## Summary
- Add `run.sh` with a default Compose project name of `omni`.
- Allow overrides through `COMPOSE_PROJECT_NAME`.
- Apply the same project name to build, up, and logs commands.

## Validation
- `sh -n run.sh`
- `docker compose -p omni -f docker/docker-compose.yml --env-file .env.example config --quiet`
- `git diff --check`