### PR TITLE
feat(nextcloud): implement fetch_file action for binary document access

### DIFF
--- a/connectors/nextcloud/src/client.rs
+++ b/connectors/nextcloud/src/client.rs
@@ -170,6 +170,51 @@ impl NextcloudClient {
         Ok(bytes.to_vec())
     }
 
+    /// Resolve a Nextcloud file ID (oc:fileid) to its WebDAV href via the meta
+    /// endpoint (`/remote.php/dav/meta/{fileId}/`). Returns the path component
+    /// that can be appended to server_url for a direct download.
+    pub async fn get_href_by_file_id(&self, server_url: &str, file_id: &str) -> Result<String> {
+        let meta_url = format!(
+            "{}/remote.php/dav/meta/{}/",
+            server_url.trim_end_matches('/'),
+            file_id
+        );
+        let response = self
+            .client
+            .request(reqwest::Method::from_bytes(b"PROPFIND").unwrap(), &meta_url)
+            .basic_auth(&self.username, Some(&self.password))
+            .header("Depth", "0")
+            .header("Content-Type", "application/xml")
+            .body(PROPFIND_BODY)
+            .send()
+            .await
+            .context("PROPFIND meta request failed")?;
+
+        if !response.status().is_success() {
+            let status = response.status();
+            let body = response.text().await.unwrap_or_default();
+            anyhow::bail!("PROPFIND meta failed with status {}: {}", status, body);
+        }
+
+        let xml = response
+            .text()
+            .await
+            .context("Failed to read PROPFIND meta response")?;
+
+        let entries = parse_multistatus(&xml)?;
+        entries
+            .into_iter()
+            .next()
+            .map(|e| e.href)
+            .filter(|h| !h.is_empty())
+            .ok_or_else(|| {
+                anyhow::anyhow!(
+                    "No href found in PROPFIND meta response for file_id {}",
+                    file_id
+                )
+            })
+    }
+
     /// Validate credentials by issuing a PROPFIND Depth:0 on the user's root.
     pub async fn validate_credentials(&self, base_url: &str) -> Result<bool> {
         let response = self

--- a/connectors/nextcloud/src/connector.rs
+++ b/connectors/nextcloud/src/connector.rs
@@ -8,10 +8,50 @@ use omni_connector_sdk::{
 use serde::Deserialize;
 use serde_json::{json, Value as JsonValue};
 
+fn guess_mime_type(filename: &str) -> &'static str {
+    match filename.rsplit('.').next().unwrap_or("").to_lowercase().as_str() {
+        // Office Open XML
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "pptx" => "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        // Legacy MS Office
+        "doc" => "application/msword",
+        "xls" => "application/vnd.ms-excel",
+        "ppt" => "application/vnd.ms-powerpoint",
+        // OpenDocument (common on Nextcloud)
+        "odt" => "application/vnd.oasis.opendocument.text",
+        "ods" => "application/vnd.oasis.opendocument.spreadsheet",
+        "odp" => "application/vnd.oasis.opendocument.presentation",
+        "odg" => "application/vnd.oasis.opendocument.graphics",
+        // PDF
+        "pdf" => "application/pdf",
+        // Markup / text
+        "md" | "markdown" => "text/markdown",
+        "html" | "htm" => "text/html",
+        "xml" => "application/xml",
+        "csv" => "text/csv",
+        "txt" => "text/plain",
+        "json" => "application/json",
+        // Calendar / email
+        "ics" => "text/calendar",
+        "eml" => "message/rfc822",
+        "msg" => "application/vnd.ms-outlook",
+        // Images
+        "png" => "image/png",
+        "jpg" | "jpeg" => "image/jpeg",
+        "gif" => "image/gif",
+        "webp" => "image/webp",
+        "svg" => "image/svg+xml",
+        // Archives
+        "zip" => "application/zip",
+        _ => "application/octet-stream",
+    }
+}
+
 use crate::client::NextcloudClient;
 use crate::config::NextcloudConfig;
 use crate::models::NextcloudConnectorState;
-use crate::sync::run_sync;
+use crate::sync::{build_download_url, run_sync};
 
 #[derive(Debug, Deserialize)]
 pub struct NextcloudCredentials {
@@ -68,14 +108,33 @@ impl Connector for NextcloudConnector {
     }
 
     fn actions(&self) -> Vec<ActionDefinition> {
-        vec![ActionDefinition {
-            name: "validate_credentials".into(),
-            description: "Verify that the provided Nextcloud credentials are valid".into(),
-            input_schema: json!({}),
-            mode: omni_connector_sdk::ActionMode::Read,
-            source_types: Vec::new(),
-            admin_only: false,
-        }]
+        vec![
+            ActionDefinition {
+                name: "validate_credentials".into(),
+                description: "Verify that the provided Nextcloud credentials are valid".into(),
+                input_schema: json!({}),
+                mode: omni_connector_sdk::ActionMode::Read,
+                source_types: Vec::new(),
+                admin_only: false,
+            },
+            ActionDefinition {
+                name: "fetch_file".into(),
+                description: "Download a file from Nextcloud by its document ID".into(),
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "file_id": {
+                            "type": "string",
+                            "description": "External file ID (nextcloud:{source_id}:{key})"
+                        }
+                    },
+                    "required": ["file_id"]
+                }),
+                mode: omni_connector_sdk::ActionMode::Read,
+                source_types: Vec::new(),
+                admin_only: false,
+            },
+        ]
     }
 
     async fn sync(
@@ -117,6 +176,65 @@ impl Connector for NextcloudConnector {
                     ActionResponse::success(json!({ "authenticated": authenticated }))
                         .into_response(),
                 )
+            }
+            "fetch_file" => {
+                // Source config (server_url etc.) is merged into params by the
+                // connector-manager before dispatch, so from_source_config works here.
+                let config = NextcloudConfig::from_source_config(&params)?;
+                let creds =
+                    credentials.ok_or_else(|| anyhow!("Nextcloud credentials are required"))?;
+                let nextcloud_creds: NextcloudCredentials =
+                    serde_json::from_value(creds.credentials)?;
+                let client =
+                    NextcloudClient::new(&nextcloud_creds.username, &nextcloud_creds.password);
+
+                let file_id = params
+                    .get("file_id")
+                    .and_then(|v| v.as_str())
+                    .ok_or_else(|| anyhow!("Missing required parameter: file_id"))?;
+
+                // external_id format: "nextcloud:{source_id}:{url_encoded_key}"
+                // The key is either a WebDAV href (starts with '/') or a
+                // Nextcloud oc:fileid (numeric/alphanumeric string).
+                let parts: Vec<&str> = file_id.splitn(3, ':').collect();
+                if parts.len() < 3 || parts[0] != "nextcloud" {
+                    anyhow::bail!("Invalid file_id format: {}", file_id);
+                }
+                let key = urlencoding::decode(parts[2])
+                    .map_err(|e| anyhow!("Failed to URL-decode file key: {}", e))?
+                    .into_owned();
+
+                // Resolve key to a canonical WebDAV href.
+                let href = if key.starts_with('/') {
+                    key
+                } else {
+                    // Numeric oc:fileid — resolve to path via PROPFIND meta endpoint.
+                    client
+                        .get_href_by_file_id(&config.server_url, &key)
+                        .await?
+                };
+
+                // build_download_url handles both relative paths and absolute URLs
+                // (some Nextcloud instances return absolute d:href values).
+                let download_url = build_download_url(&config.server_url, &href);
+
+                // Extract and decode the filename from the last path segment.
+                let raw_name = href.rsplit('/').next().unwrap_or("document");
+                let filename = urlencoding::decode(raw_name)
+                    .unwrap_or_else(|_| std::borrow::Cow::Borrowed(raw_name))
+                    .into_owned();
+
+                let bytes = client.download_file(&download_url).await?;
+                let content_type = guess_mime_type(&filename);
+                let encoded_name = urlencoding::encode(&filename).into_owned();
+
+                Response::builder()
+                    .status(200)
+                    .header("Content-Type", content_type)
+                    .header("Content-Length", bytes.len())
+                    .header("X-File-Name", encoded_name)
+                    .body(axum::body::Body::from(bytes))
+                    .map_err(|e| anyhow!("Failed to build response: {}", e))
             }
             other => Err(anyhow!("Action not supported: {}", other)),
         }

--- a/connectors/nextcloud/src/sync.rs
+++ b/connectors/nextcloud/src/sync.rs
@@ -328,7 +328,7 @@ fn parse_datetime(s: &str) -> Option<time::OffsetDateTime> {
 }
 
 /// Build an absolute download URL from server_url and the entry href.
-fn build_download_url(server_url: &str, href: &str) -> String {
+pub(crate) fn build_download_url(server_url: &str, href: &str) -> String {
     if href.starts_with("http://") || href.starts_with("https://") {
         return href.to_string();
     }

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -449,6 +449,21 @@ pub async fn execute_action(
         // If not found, assume the ID is already a source-native ID and pass through
     }
 
+    // Merge source config into params so connectors can access source-level
+    // settings during action execution (e.g., server_url for Nextcloud
+    // fetch_file). Caller-provided param values always take precedence.
+    // Null/missing params is promoted to an empty object so the merge runs.
+    if params.is_null() {
+        params = serde_json::Value::Object(serde_json::Map::new());
+    }
+    if let (Some(src_obj), Some(params_obj)) =
+        (source.config.as_object(), params.as_object_mut())
+    {
+        for (k, v) in src_obj {
+            params_obj.entry(k.clone()).or_insert_with(|| v.clone());
+        }
+    }
+
     info!(
         "Dispatching action '{}' to connector {} with credential {} (provider={:?}, auth_type={:?}, principal={:?})",
         request.action,

--- a/services/connector-manager/src/models.rs
+++ b/services/connector-manager/src/models.rs
@@ -120,6 +120,7 @@ pub struct ExecuteActionRequest {
     #[serde(default)]
     pub user_id: Option<String>,
     pub action: String,
+    #[serde(default)]
     pub params: JsonValue,
 }
 


### PR DESCRIPTION
## Problem

When the AI agent tries to open a DOCX (or other Office/binary) file stored in Nextcloud, it calls \`read_document\`. The document handler classifies files with content types such as \`application/vnd.openxmlformats-officedocument.wordprocessingml.document\` as binary and routes them through the connector-manager's \`/action\` endpoint with \`action=fetch_file\`. The Nextcloud connector did not implement this action, so every such request was rejected with \`400 Bad Request\`, making it impossible for the AI to read the contents of any binary Nextcloud document.

The connector-manager also had two related gaps: it did not pass source-level configuration (e.g. \`server_url\`) to connectors during action dispatch, and it did not guard against a \`null\` params value that would silently bypass the dispatch.

## Changes

**\`services/connector-manager/src/handlers.rs\`**
- Merge \`source.config\` into action params before dispatching to the connector, giving connectors access to source-level settings (e.g. \`server_url\`) without requiring a separate API call.
- Promote a null or missing \`params\` value to an empty JSON object so the merge always runs and connectors never receive a raw \`null\` as their params argument.

**\`services/connector-manager/src/models.rs\`**
- Add \`#[serde(default)]\` to \`ExecuteActionRequest.params\` so callers can omit the field without causing a deserialization error.

**\`connectors/nextcloud/src/sync.rs\`**
- Expose \`build_download_url\` as \`pub(crate)\` so the connector action handler can reuse it, including its guard for absolute URLs that some Nextcloud instances return in WebDAV \`d:href\` elements.

**\`connectors/nextcloud/src/client.rs\`**
- Add \`get_href_by_file_id\`: resolves a Nextcloud \`oc:fileid\` to its canonical WebDAV path via \`PROPFIND /remote.php/dav/meta/{id}/\`.

**\`connectors/nextcloud/src/connector.rs\`**
- Register \`fetch_file\` in \`actions()\` so the connector-manager recognises and dispatches it correctly.
- Implement \`fetch_file\`: decode the \`external_id\` (\`nextcloud:{source_id}:{encoded_key}\`), resolve numeric \`oc:fileid\` values to WebDAV paths via the meta endpoint, construct the download URL through \`build_download_url\` (which handles absolute hrefs returned by some Nextcloud versions), download the file with basic-auth credentials, and return the raw binary with correct \`Content-Type\` and \`X-File-Name\` headers.
- Expand \`guess_mime_type\` to cover OpenDocument formats (\`odt\`, \`ods\`, \`odp\`, \`odg\`), Markdown (\`md\`), HTML, XML, CSV, JSON, calendar (\`ics\`), email (\`eml\`, \`msg\`), WebP, SVG, and ZIP in addition to the existing Office and image types.