### PR TITLE
fix(chat): open links in new tab; hide invalid email source links

### DIFF
--- a/web/src/lib/components/markdown-message.svelte
+++ b/web/src/lib/components/markdown-message.svelte
@@ -21,9 +21,9 @@
 
             const text = this.parser.parseInline(tokens)
             if (citation) {
-                return `<a href="${href}" class="omni-reflink" title="${citation?.title}" data-snippet="${citation?.cited_text}">${text}</a>`
+                return `<a href="${href}" class="omni-reflink" title="${citation?.title}" data-snippet="${citation?.cited_text}" target="_blank" rel="noopener noreferrer">${text}</a>`
             } else {
-                return `<a href="${href}">${text}</a>`
+                return `<a href="${href}" target="_blank" rel="noopener noreferrer">${text}</a>`
             }
         },
     }

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -376,12 +376,20 @@
                                         <FileText
                                             class="text-muted-foreground h-4 w-4 flex-shrink-0" />
                                     {/if}
-                                    <a
-                                        href={result.source.split('#')[0]}
-                                        target="_blank"
-                                        class="block max-w-screen-sm overflow-hidden font-normal text-ellipsis whitespace-nowrap no-underline hover:underline">
-                                        {result.title}
-                                    </a>
+                                    {#if result.source?.startsWith('http://') || result.source?.startsWith('https://')}
+                                        <a
+                                            href={result.source.split('#')[0]}
+                                            target="_blank"
+                                            rel="noopener noreferrer"
+                                            class="block max-w-screen-sm overflow-hidden font-normal text-ellipsis whitespace-nowrap no-underline hover:underline">
+                                            {result.title}
+                                        </a>
+                                    {:else}
+                                        <span
+                                            class="block max-w-screen-sm overflow-hidden text-ellipsis whitespace-nowrap font-normal">
+                                            {result.title}
+                                        </span>
+                                    {/if}
                                 </div>
                             {/each}
                         </div>


### PR DESCRIPTION
## Problem

Two related link-rendering issues in the chat UI:

**Email source links produce broken URLs.** The search-result accordion in the tool-message panel renders each result's `source` field as an `<a href>`. For sources that have no publicly accessible URL (emails, calendar events, and other items where the connector stores a non-HTTP identifier such as `<unknown>`), this produced navigable-but-broken links like `http://host/chat/%3Cunknown%3E` that go nowhere.

**Markdown links in responses open in the same tab.** The `marked` renderer in `markdown-message.svelte` produced plain `<a href="…">` elements without `target="_blank"`, so clicking any link in an assistant response navigated away from the conversation.

## Changes

**`web/src/lib/components/tool-message.svelte`**
- Only wrap a search result in a hyperlink when `result.source` is an absolute `http://` or `https://` URL. When the source is any other value, the document title is displayed as a non-interactive `<span>` so no broken link is produced.
- Added `rel="noopener noreferrer"` to the existing `target="_blank"` anchor.

**`web/src/lib/components/markdown-message.svelte`**
- Added `target="_blank" rel="noopener noreferrer"` to every `<a>` element produced by the marked renderer, covering both regular markdown links and citation hover-card anchors.