### PR TITLE
fix(chat): clean up stream state on stop and on conversation switch

### DIFF
--- a/web/e2e/chat-stream.spec.ts
+++ b/web/e2e/chat-stream.spec.ts
@@ -583,3 +583,109 @@ test('chat renders a captured stream from a seeded chat fixture', async ({ page 
         await cleanupChat(seeded)
     }
 })
+
+test('stop button during streaming resets state so the input is ready for a new message', async ({
+    page,
+}) => {
+    let seeded: SeededChat | null = null
+    try {
+        seeded = await seedChat()
+        await authenticate(page, seeded)
+
+        await page.route(`**/api/chat/${seeded.chatId}/messages`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ messageId: ulid() }),
+            })
+        })
+
+        let resolveStream!: () => void
+        const streamUnblocked = new Promise<void>((resolve) => {
+            resolveStream = resolve
+        })
+        await page.route(`**/api/chat/${seeded.chatId}/stream`, async (route) => {
+            await streamUnblocked
+            await route.fulfill({
+                status: 200,
+                headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+                body: '',
+            })
+        })
+
+        await page.goto(`/chat/${seeded.chatId}`)
+        await page.getByRole('main').getByRole('textbox').fill('What tools can you use?')
+        await page.keyboard.press('Enter')
+
+        // Stop button (rounded-full) appears while the stream is pending
+        const stopButton = page.locator('.omni-composer-send.rounded-full')
+        await expect(stopButton).toBeVisible()
+        await stopButton.click()
+        resolveStream()
+
+        // After stopping, the stop button is gone and the input accepts a new message
+        await expect(stopButton).not.toBeVisible()
+        const textbox = page.getByRole('main').getByRole('textbox')
+        await textbox.fill('Follow-up question')
+        await expect(page.locator('.omni-composer-send')).not.toBeDisabled()
+    } finally {
+        await cleanupChat(seeded)
+    }
+})
+
+test('navigating to a different chat while streaming cleans up the stream state', async ({
+    page,
+}) => {
+    let seeded: SeededChat | null = null
+    let chat2Id: string | null = null
+    const sql = postgres(dbConfig)
+    try {
+        seeded = await seedChat()
+        chat2Id = ulid()
+        await sql`
+            INSERT INTO chats (id, user_id, title, is_starred, is_deleted)
+            VALUES (${chat2Id}, ${seeded.userId}, 'Playwright second chat', false, false)
+        `
+        await authenticate(page, seeded)
+
+        await page.route(`**/api/chat/${seeded.chatId}/messages`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ messageId: ulid() }),
+            })
+        })
+
+        let resolveStream!: () => void
+        const streamUnblocked = new Promise<void>((resolve) => {
+            resolveStream = resolve
+        })
+        await page.route(`**/api/chat/${seeded.chatId}/stream`, async (route) => {
+            await streamUnblocked
+            await route.fulfill({
+                status: 200,
+                headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
+                body: '',
+            })
+        })
+
+        await page.goto(`/chat/${seeded.chatId}`)
+        await page.getByRole('main').getByRole('textbox').fill('What tools can you use?')
+        await page.keyboard.press('Enter')
+
+        // Streaming is active on chat 1
+        await expect(page.locator('.omni-composer-send.rounded-full')).toBeVisible()
+
+        // Navigate to chat 2 while streaming is in progress
+        await page.goto(`/chat/${chat2Id}`)
+        resolveStream()
+
+        // Chat 2 must not inherit the streaming state from chat 1
+        await expect(page.locator('.omni-composer-send.rounded-full')).not.toBeVisible()
+        await expect(page.getByRole('main').getByRole('textbox')).toBeEditable()
+    } finally {
+        await sql`DELETE FROM chats WHERE id = ${chat2Id}`.catch(() => {})
+        await sql.end()
+        await cleanupChat(seeded)
+    }
+})

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -82,6 +82,14 @@
     })
 
     afterNavigate(() => {
+        // Tear down any active stream from the previous chat before loading the new one.
+        if (eventSource) {
+            eventSource.close()
+            eventSource = null
+        }
+        isStreaming = false
+        error = null
+        stopThinkingText()
         chatMessages = [...data.messages]
         branchSelections = {}
         activeStreamingMessageId = null
@@ -381,7 +389,12 @@
             eventSource.close()
             eventSource = null
         }
+        // Reset all stream state so the input is immediately ready for a new message.
         isStreaming = false
+        error = null
+        activeStreamingMessageId = null
+        stopThinkingText()
+        refreshProcessedMessages()
         requestAnimationFrame(() => recalcBottomPadding())
         userInputRef?.focus()
     }
@@ -1470,7 +1483,10 @@
         }
 
         const handleConnectionError = () => {
-            if (streamCompleted) return
+            // Guard against treating an intentional stop() as a connection error.
+            // handleStop() sets isStreaming = false before the EventSource fires its
+            // error event, so we can use that as a signal to skip cleanup here.
+            if (streamCompleted || !isStreaming) return
             error =
                 messageEventsReceived > 0
                     ? 'Response stream disconnected before it finished. Please try again.'


### PR DESCRIPTION
## Problem

Two related bugs in the chat EventSource lifecycle caused the input to become unresponsive.

**Stop button leaves input unusable.** `handleStop()` closed the EventSource but did not stop the thinking-text rotation interval, reset `activeStreamingMessageId`, or call `refreshProcessedMessages()`, leaving the UI in a half-stopped state. Additionally, some browsers fire the EventSource `error` event asynchronously after a manual `close()` call. `handleConnectionError` treated this as a genuine connection failure, set an error message, and performed redundant cleanup — even though the stop was intentional. As a result, the input box appeared stuck even though `isStreaming` was false.

**Switching between conversations leaves the old stream running.** `afterNavigate()` reloaded the message list and reset branch/edit state, but did not close the active EventSource from the previous chat. The old stream continued firing event handlers that mutated `chatMessages` for the wrong chat, making the newly loaded conversation appear blank or unresponsive.

## Changes

**`web/src/routes/(app)/chat/[chatId]/+page.svelte`**

`handleStop()`:
- Now calls `stopThinkingText()` to cancel the thinking-text rotation timers.
- Resets `activeStreamingMessageId` to `null` and calls `refreshProcessedMessages()` so the message list reflects the stopped state immediately.
- Clears the `error` state so no stale error banner is shown after an intentional stop.

`handleConnectionError()`:
- Added an early return when `!isStreaming`. `handleStop()` sets `isStreaming = false` synchronously before the EventSource fires its `error` event, so this guard reliably distinguishes an intentional stop from a genuine connection failure.

`afterNavigate()`:
- Now closes and nulls the active `eventSource` before applying the new chat's data.
- Resets `isStreaming`, `error`, and the thinking-text timers so the new conversation starts from a clean state.