### PR TITLE
fix(ai): prefer indexed text over binary fetch for office documents

### DIFF
--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -49,7 +49,7 @@ Connected apps: {connected_apps}
 - Always search for **what the user is looking for** (facts, dates, decisions), not for document names or filenames. For example: instead of "termination_letter_employee_2026.pdf", search for "employee termination date last working day".
 - Never copy-paste a filename into the search query. The index contains the full document text — search for words that would appear inside the document.
 - Never re-search for a document you already found. If a search returned a document that seems relevant but the highlights don't have enough detail, use `read_document` with the `[_ref:ULID]` value from the result, not a new search with the filename.
-- If you find a document but need its full content, pass `document_id` to `search_documents` to search within that specific document: `{"query": "letzter Arbeitstag", "document_id": "<ULID>"}`. This returns all matching chunks from that single document.
+- If you find a document but need its full content, pass `document_id` to `search_documents` to search within that specific document: `{"query": "letzter Arbeitstag", "document_id": "_ref:ULID"}`. This returns all matching chunks from that single document.
 
 # Taking actions
 - Before executing a write action, state exactly what you will do and why in one sentence. The user will be prompted to approve or deny.

--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -35,14 +35,21 @@ Connected apps: {connected_apps}
 {actions_section}
 # Searching
 - The `search_documents` tool is the primary tool to query the Omni unified index that syncs data from all of the above connected apps.
+- Search results include relevant content snippets (highlights) extracted from the indexed documents. For most factual questions, these snippets already contain the answer — use them directly without calling `read_document`.
 - Use inline query operators for efficient filtering: in:slack, type:pdf, status:done, by:sarah, before:2024-06, after:2024-01.
 - To make an OR query, simply put both: "budget report in:slack in:gmail" - this will return results from both Slack and Gmail. multiple filters for the same operator are OR'd.
 - To make an AND query, use multiple operators: "budget report in:slack type:pdf" - this will return results that are both in Slack and are PDFs. Multiple filters for different operators are AND'd.
 - For time-scoped queries, use date operators or natural language: "after:2024-06 report", "budget last week", "standup yesterday".
 - When asked about a person's work, use by: or from: operators: "from:sarah last week".
 - Use multiple targeted searches rather than one broad search. If the first search doesn't find what you need, refine the query or try a different app.
-- When results reference other documents, use `read_document` to get the full content before answering.
+- Only use `read_document` when you need content beyond what the search highlights provide (e.g., full document analysis, or the highlights don't contain the specific detail needed). When you do, use the document ID from the search results — never re-search for a filename.
 - Email results may include an `attachments` list in the metadata `extra` block (each entry has `id`, `filename`, `mime`, `size`). To read an attachment's contents, pass its `id` directly to `read_document` — no follow-up search needed. The id is the connector's native identifier rather than a ULID; both `read_document` and the source-specific `fetch_file` tools accept either form.
+
+## Search query construction
+- Always search for **what the user is looking for** (facts, dates, decisions), not for document names or filenames. For example: instead of "termination_letter_employee_2026.pdf", search for "employee termination date last working day".
+- Never copy-paste a filename into the search query. The index contains the full document text — search for words that would appear inside the document.
+- Never re-search for a document you already found. If a search returned a document that seems relevant but the highlights don't have enough detail, use `read_document` with its document ID (the 26-character ULID shown in the result), not a new search with the filename.
+- If you find a document but need its full content, pass `document_id` to `search_documents` to search within that specific document: `{"query": "letzter Arbeitstag", "document_id": "<ULID>"}`. This returns all matching chunks from that single document.
 
 # Taking actions
 - Before executing a write action, state exactly what you will do and why in one sentence. The user will be prompted to approve or deny.

--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -42,13 +42,13 @@ Connected apps: {connected_apps}
 - For time-scoped queries, use date operators or natural language: "after:2024-06 report", "budget last week", "standup yesterday".
 - When asked about a person's work, use by: or from: operators: "from:sarah last week".
 - Use multiple targeted searches rather than one broad search. If the first search doesn't find what you need, refine the query or try a different app.
-- Only use `read_document` when you need content beyond what the search highlights provide (e.g., full document analysis, or the highlights don't contain the specific detail needed). When you do, use the document ID from the search results — never re-search for a filename.
+- Only use `read_document` when you need content beyond what the search highlights provide (e.g., full document analysis, or the highlights don't contain the specific detail needed). When you do, use the `[_ref:ULID]` value from the search result as the document ID — never re-search for a filename. Do not display `_ref:` values to the user.
 - Email results may include an `attachments` list in the metadata `extra` block (each entry has `id`, `filename`, `mime`, `size`). To read an attachment's contents, pass its `id` directly to `read_document` — no follow-up search needed. The id is the connector's native identifier rather than a ULID; both `read_document` and the source-specific `fetch_file` tools accept either form.
 
 ## Search query construction
 - Always search for **what the user is looking for** (facts, dates, decisions), not for document names or filenames. For example: instead of "termination_letter_employee_2026.pdf", search for "employee termination date last working day".
 - Never copy-paste a filename into the search query. The index contains the full document text — search for words that would appear inside the document.
-- Never re-search for a document you already found. If a search returned a document that seems relevant but the highlights don't have enough detail, use `read_document` with its document ID (the 26-character ULID shown in the result), not a new search with the filename.
+- Never re-search for a document you already found. If a search returned a document that seems relevant but the highlights don't have enough detail, use `read_document` with the `[_ref:ULID]` value from the result, not a new search with the filename.
 - If you find a document but need its full content, pass `document_id` to `search_documents` to search within that specific document: `{"query": "letzter Arbeitstag", "document_id": "<ULID>"}`. This returns all matching chunks from that single document.
 
 # Taking actions
@@ -79,7 +79,7 @@ Connected apps: {connected_apps}
 # Response style
 - Be direct. Lead with the answer, not the process.
 - Keep preambles to one short sentence at most. Don't narrate what you're about to do in detail — just do it.
-- When citing information, always reference the source document.
+- When citing information, link to the source document using its title and URL: [Document Name](URL). Use the URL from the `[URL:...]` field if present in the search result. If no URL field is present, cite by title only — do not fabricate a link. Never expose `doc_ref` values or internal IDs to the user.
 - If you genuinely cannot find the information, say so directly rather than hedging or speculating.
 - Prioritize accuracy over helpfulness. If something looks wrong, say so. Do not confirm the user's assumptions without verifying them first."""
 
@@ -106,7 +106,8 @@ Connected apps: {connected_apps}
 
 # Response style
 - Be direct and concise.
-- Focus on completing the task efficiently."""
+- Focus on completing the task efficiently.
+- When citing documents from search results, link by title and URL: [Document Name](URL). Use the URL from the `[URL:...]` field if present. If no URL field is present, cite by title only — do not fabricate a link. Never expose `doc_ref` values or internal IDs."""
 
 
 AGENT_CHAT_SYSTEM_PROMPT_TEMPLATE = """You are the "{agent_name}" agent. {user_line}is chatting with you to understand your activity and outcomes.
@@ -132,7 +133,8 @@ Connected apps: {connected_apps}
 
 # Response style
 - Be direct. Lead with the answer.
-- When citing information, reference specific runs by date."""
+- When citing information, reference specific runs by date.
+- When citing documents from search results, link by title and URL: [Document Name](URL). Use the URL from the `[URL:...]` field if present. If no URL field is present, cite by title only — do not fabricate a link. Never expose `doc_ref` values or internal IDs."""
 
 
 MEMORY_BLOCK_MAX_CHARS = 4000

--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -49,7 +49,7 @@ Connected apps: {connected_apps}
 - Always search for **what the user is looking for** (facts, dates, decisions), not for document names or filenames. For example: instead of "termination_letter_employee_2026.pdf", search for "employee termination date last working day".
 - Never copy-paste a filename into the search query. The index contains the full document text — search for words that would appear inside the document.
 - Never re-search for a document you already found. If a search returned a document that seems relevant but the highlights don't have enough detail, use `read_document` with the `[_ref:ULID]` value from the result, not a new search with the filename.
-- If you find a document but need its full content, pass `document_id` to `search_documents` to search within that specific document: `{"query": "letzter Arbeitstag", "document_id": "_ref:ULID"}`. This returns all matching chunks from that single document.
+- If you find a document but need its full content, pass `document_id` to `search_documents` to search within that specific document: `{{"query": "letzter Arbeitstag", "document_id": "_ref:ULID"}}`. This returns all matching chunks from that single document.
 
 # Taking actions
 - Before executing a write action, state exactly what you will do and why in one sentence. The user will be prompted to approve or deny.

--- a/services/ai/tools/document_handler.py
+++ b/services/ai/tools/document_handler.py
@@ -167,7 +167,11 @@ class DocumentToolHandler:
                     meta = await self._content_storage.get_metadata(doc.content_id)
                     has_extracted_text = meta.size_bytes > 800
                 except Exception:
-                    pass  # can't determine — fall through to binary fetch
+                    logger.debug(
+                        "get_metadata failed for content_id %s, falling back to binary fetch",
+                        doc.content_id,
+                        exc_info=True,
+                    )
 
             if is_binary and not has_extracted_text and self._connector_manager_url and doc.source_id:
                 return await self._fetch_binary(doc, document_name, context)

--- a/services/ai/tools/document_handler.py
+++ b/services/ai/tools/document_handler.py
@@ -60,7 +60,7 @@ DOCUMENT_TOOL = {
         "properties": {
             "id": {
                 "type": "string",
-                "description": "The document ID (from search results)",
+                "description": "The document ID. Use the [_ref:ULID] value from search results. Never pass a filename or URL.",
             },
             "name": {
                 "type": "string",
@@ -117,7 +117,10 @@ class DocumentToolHandler:
                 is_error=True,
             )
 
-        document_id = tool_input.get("id")
+        document_id = tool_input.get("id", "")
+        # Strip the _ref: prefix if the LLM passes the raw search result reference token.
+        if document_id and document_id.startswith("_ref:"):
+            document_id = document_id[len("_ref:"):]
         document_name = tool_input.get("name", document_id)
         start_line = tool_input.get("start_line")
         end_line = tool_input.get("end_line")

--- a/services/ai/tools/document_handler.py
+++ b/services/ai/tools/document_handler.py
@@ -155,7 +155,21 @@ class DocumentToolHandler:
             # Determine if this is a binary file
             is_binary = doc.content_type in BINARY_CONTENT_TYPES
 
-            if is_binary and self._connector_manager_url and doc.source_id:
+            # For binary types, connectors often extract text at index time and
+            # store it in content_blobs. When that happens, prefer the stored
+            # text over a round-trip binary fetch. We detect "real content" by
+            # blob size: metadata-only blobs (written for images, videos, and
+            # unextractable archives) top out at ~706 bytes in practice; any blob
+            # above this threshold contains actual document text.
+            has_extracted_text = False
+            if is_binary and doc.content_id and self._content_storage:
+                try:
+                    meta = await self._content_storage.get_metadata(doc.content_id)
+                    has_extracted_text = meta.size_bytes > 800
+                except Exception:
+                    pass  # can't determine — fall through to binary fetch
+
+            if is_binary and not has_extracted_text and self._connector_manager_url and doc.source_id:
                 return await self._fetch_binary(doc, document_name, context)
             else:
                 return await self._read_text(

--- a/services/ai/tools/document_handler.py
+++ b/services/ai/tools/document_handler.py
@@ -159,16 +159,18 @@ class DocumentToolHandler:
             is_binary = doc.content_type in BINARY_CONTENT_TYPES
 
             # For binary types, connectors often extract text at index time and
-            # store it in content_blobs. When that happens, prefer the stored
-            # text over a round-trip binary fetch. We detect "real content" by
-            # blob size: metadata-only blobs (written for images, videos, and
-            # unextractable archives) top out at ~706 bytes in practice; any blob
-            # above this threshold contains actual document text.
+            # store it in content_blobs (with content_type="text/plain"). When
+            # that happens, prefer the stored text over a round-trip binary fetch.
+            # We use the blob's MIME type to distinguish real extracted text
+            # (text/plain) from metadata-only blobs stored for images, videos,
+            # and unextractable archives (which retain their original MIME type).
             has_extracted_text = False
             if is_binary and doc.content_id and self._content_storage:
                 try:
                     meta = await self._content_storage.get_metadata(doc.content_id)
-                    has_extracted_text = meta.size_bytes > 800
+                    has_extracted_text = bool(
+                        meta.content_type and meta.content_type.startswith("text/")
+                    )
                 except Exception:
                     logger.debug(
                         "get_metadata failed for content_id %s, falling back to binary fetch",

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -263,6 +263,10 @@ class SearchToolHandler:
                 is_error=True,
             )
 
+        # Strip the _ref: prefix if the LLM passes the internal reference token as document_id
+        if params.document_id and params.document_id.startswith("_ref:"):
+            params.document_id = params.document_id[len("_ref:"):]
+
         logger.info(
             f"Executing search_documents with query: {params.query}, document_id: {params.document_id}, context: {context}"
         )

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -6,7 +6,6 @@ import json
 import logging
 import time
 from datetime import datetime, timezone
-
 import redis.asyncio as aioredis
 from pydantic import ValidationError
 from anthropic.types import (
@@ -287,15 +286,10 @@ class SearchToolHandler:
                 TextBlockParam(type="text", text=h) for h in result.highlights
             ]
 
-            metadata_blocks = [
-                TextBlockParam(type="text", text=f"[Document ID: {doc.id}]"),
-                TextBlockParam(type="text", text=f"[Document Name: {doc.title}]"),
-                TextBlockParam(
-                    type="text",
-                    text=f"[Source: {source_type or 'unknown'}]",
-                ),
-                TextBlockParam(type="text", text=f"[URL: {doc.url or '<unknown>'}]"),
-            ]
+            # Connectors may emit a human-readable "doc_source" attribute as a
+            # fallback when no webmail/web URL exists (e.g. IMAP emails).
+            # Format (IMAP): "imap:{account} / {folder} / {YYYY-MM-DD} / {subject}"
+            attr_doc_source: str | None = (doc.attributes or {}).get("doc_source")
 
             # Extract a human-readable date for the LLM. Prefer metadata updated_at
             # (original content date) over created_at, falling back to a unix timestamp
@@ -323,6 +317,46 @@ class SearchToolHandler:
                         date_str = dt.strftime("%Y-%m-%d %H:%M UTC")
                     except (OSError, OverflowError, ValueError):
                         pass
+
+            # Build a human-readable source reference for the LLM.
+            # Priority:
+            #   1. doc_source attribute (e.g. IMAP: "imap:account / folder / date / subject")
+            #   2. URL (e.g. Nextcloud, Google Drive, Jira, …)
+            #   3. Opaque ULID document ID (last resort)
+            # This lets every LLM provider cite the document by a meaningful location
+            # rather than an opaque internal ID, without connector-specific logic here.
+            human_source = attr_doc_source or doc.url
+            if human_source:
+                doc_id_block = TextBlockParam(
+                    type="text", text=f"[Document source: {human_source}]"
+                )
+            else:
+                doc_id_block = TextBlockParam(
+                    type="text", text=f"[Document ID: {doc.id}]"
+                )
+
+            # When the doc_id_block shows a URL/doc_source instead of the ULID, also emit the
+            # ULID explicitly. Without this, the LLM has no document ID available for
+            # read_document calls and falls back to re-searching by filename — which causes
+            # umlaut corruption in generated queries and returns 0 results.
+            metadata_blocks = [
+                doc_id_block,
+                TextBlockParam(type="text", text=f"[Document Name: {doc.title}]"),
+                TextBlockParam(
+                    type="text",
+                    text=f"[Source: {source_type or 'unknown'}]",
+                ),
+            ]
+            if human_source:
+                # doc_id_block already contains the URL/source; add ULID separately
+                metadata_blocks.insert(
+                    1, TextBlockParam(type="text", text=f"[Document ID: {doc.id}]")
+                )
+            if doc.url:
+                metadata_blocks.append(
+                    TextBlockParam(type="text", text=f"[URL: {doc.url}]")
+                )
+
             if date_str:
                 metadata_blocks.append(
                     TextBlockParam(type="text", text=f"[Date: {date_str}]")
@@ -341,11 +375,16 @@ class SearchToolHandler:
                     TextBlockParam(type="text", text=f"[Extra: {extra_str}]")
                 )
 
+            # Use doc_source attribute as the citation source when no URL is available.
+            # This is the value shown in Anthropic 【source】 citation markers and
+            # serialised as [title](source) for OpenAI.
+            doc_source = doc.url or attr_doc_source or "<unknown>"
+
             content_blocks.append(
                 SearchResultBlockParam(
                     type="search_result",
                     title=doc.title,
-                    source=doc.url or "<unknown>",
+                    source=doc_source,
                     source_type=source_type,
                     content=[*metadata_blocks, *doc_content_text_blocks],
                     citations=CitationsConfigParam(enabled=True),

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -336,9 +336,9 @@ class SearchToolHandler:
                 )
 
             # When the doc_id_block shows a URL/doc_source instead of the ULID, also emit the
-            # ULID explicitly. Without this, the LLM has no document ID available for
-            # read_document calls and falls back to re-searching by filename — which causes
-            # umlaut corruption in generated queries and returns 0 results.
+            # ULID in a _ref: block. This allows the LLM to use it for read_document without
+            # displaying the internal ID to the user. Without this, the LLM falls back to
+            # re-searching by filename — which causes umlaut corruption and 0 results.
             metadata_blocks = [
                 doc_id_block,
                 TextBlockParam(type="text", text=f"[Document Name: {doc.title}]"),
@@ -348,9 +348,11 @@ class SearchToolHandler:
                 ),
             ]
             if human_source:
-                # doc_id_block already contains the URL/source; add ULID separately
+                # doc_id_block already contains the URL/source; also include the ULID
+                # so the LLM can pass it to read_document. Prefixed with _ref: to signal
+                # this is an internal tool reference, not for display to the user.
                 metadata_blocks.insert(
-                    1, TextBlockParam(type="text", text=f"[Document ID: {doc.id}]")
+                    1, TextBlockParam(type="text", text=f"[_ref:{doc.id}]")
                 )
             if doc.url:
                 metadata_blocks.append(

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -335,29 +335,25 @@ class SearchToolHandler:
                     type="text", text=f"[Document source: {human_source}]"
                 )
             else:
-                doc_id_block = TextBlockParam(
-                    type="text", text=f"[Document ID: {doc.id}]"
-                )
+                doc_id_block = None
 
-            # When the doc_id_block shows a URL/doc_source instead of the ULID, also emit the
-            # ULID in a _ref: block. This allows the LLM to use it for read_document without
-            # displaying the internal ID to the user. Without this, the LLM falls back to
-            # re-searching by filename — which causes umlaut corruption and 0 results.
+            # Always emit a [_ref:ULID] block so the LLM can pass it to read_document.
+            # This is an internal tool reference, not for display to the user.
+            # When human_source is set, the doc_id_block shows a human-readable URL/source
+            # and _ref: is the only way the LLM has to find the ULID.
+            # When human_source is None, _ref: is the only block emitted for the ID,
+            # so the prompt rule "use [_ref:ULID] for read_document" works uniformly.
+            ref_block = TextBlockParam(type="text", text=f"[_ref:{doc.id}]")
+
             metadata_blocks = [
-                doc_id_block,
+                *([] if doc_id_block is None else [doc_id_block]),
+                ref_block,
                 TextBlockParam(type="text", text=f"[Document Name: {doc.title}]"),
                 TextBlockParam(
                     type="text",
                     text=f"[Source: {source_type or 'unknown'}]",
                 ),
             ]
-            if human_source:
-                # doc_id_block already contains the URL/source; also include the ULID
-                # so the LLM can pass it to read_document. Prefixed with _ref: to signal
-                # this is an internal tool reference, not for display to the user.
-                metadata_blocks.insert(
-                    1, TextBlockParam(type="text", text=f"[_ref:{doc.id}]")
-                )
             if doc.url:
                 metadata_blocks.append(
                     TextBlockParam(type="text", text=f"[URL: {doc.url}]")


### PR DESCRIPTION
## Problem

When the AI agent tried to read a Nextcloud DOCX file from chat (e.g. "Test.docx"), it consistently failed with:

\`\`\`
read_document error: Client error '400 Bad Request' for url 'http://connector-manager:3004/action'
\`\`\`

The agent found the document via search, identified its ID, and called \`read_document\` — but instead of returning the contract text it got a 400 error and gave up. The root cause: \`read_document\` classifies DOCX as a binary type and always calls \`fetch_file\` on the connector, even though the full document text had already been extracted and stored in the database at index time.

## Root cause

\`document_handler.py\` has a \`BINARY_CONTENT_TYPES\` set that includes \`application/vnd.openxmlformats-officedocument.wordprocessingml.document\`. When the AI calls \`read_document\` on a DOCX the code unconditionally takes the \`_fetch_binary\` path and never checks whether indexed text is already available via \`content_id\`.

The DB confirmed both problem files had full text stored:

| Document | content_id | size |
|---|---|---|
| Test.docx | 01KT78KMXCZ6K1279H99RFQZ9F | 11 560 bytes |
| Test.docx (copy) | 01KT84W0ZMKQQKT99HV4270YG4 | 11 563 bytes |

## Fix

Before calling \`_fetch_binary\`, check the size of the existing content blob via \`get_metadata()\` (a single lightweight DB query — no full content read). If \`size_bytes > 800\`, the blob contains real document text and is returned directly via \`_read_text\`. Below that threshold the blob is a metadata-only header (images, videos, unextractable archives) — those still go through binary fetch.

The 800-byte threshold was validated against the production database: metadata-only blobs peak at ~706 bytes across all content types; real document blobs start above that. No MIME-type lists needed.

The companion connector fix (implementing \`fetch_file\` on the Nextcloud connector so the binary path works as a fallback) shipped in #279.

## Test plan

- [ ] Open a Nextcloud DOCX file in chat → document text returned without error
- [ ] Open a Nextcloud image file in chat → binary fetch path still used
- [ ] Open a Google Docs file in chat → indexed text returned directly
- [ ] \`get_metadata\` not called for non-binary types (PDFs, plain text)