### PR TITLE
feat(ui): make frontend responsive for smartphone displays

### DIFF
--- a/web/src/lib/components/sidebar-navigation-close.svelte
+++ b/web/src/lib/components/sidebar-navigation-close.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+    import { afterNavigate } from '$app/navigation'
+    import { useSidebar } from '$lib/components/ui/sidebar'
+
+    const sidebar = useSidebar()
+
+    afterNavigate(() => {
+        sidebar.setOpenMobile(false)
+    })
+</script>

--- a/web/src/lib/components/sidebar-navigation-close.svelte
+++ b/web/src/lib/components/sidebar-navigation-close.svelte
@@ -4,7 +4,9 @@
 
     const sidebar = useSidebar()
 
-    afterNavigate(() => {
-        sidebar.setOpenMobile(false)
+    afterNavigate((navigation) => {
+        if (navigation.from !== null) {
+            sidebar.setOpenMobile(false)
+        }
     })
 </script>

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -320,13 +320,13 @@
         <Accordion.Item value={message.toolUse.id}>
             <Accordion.Trigger
                 class={cn(
-                    'border-border flex cursor-pointer items-center justify-between border px-3 py-3 text-sm hover:no-underline',
+                    'border-border flex w-full min-w-0 cursor-pointer items-center justify-between border px-3 py-3 text-sm hover:no-underline',
                     selectedItem === message.toolUse.id && 'bg-card rounded-b-none border-b-0',
                 )}>
                 <div class="flex w-full items-center justify-between">
-                    <div class="flex items-center gap-2">
+                    <div class="flex min-w-0 items-center gap-2">
                         {#if sources.length > 0}
-                            <div class="flex items-center gap-1">
+                            <div class="flex shrink-0 items-center gap-1">
                                 {#each sources as source}
                                     {#if getSourceIconPath(source)}
                                         <img
@@ -342,7 +342,7 @@
                         {:else}
                             <Search class="h-4 w-4" />
                         {/if}
-                        <div class="max-w-screen-md truncate text-sm font-normal">
+                        <div class="min-w-0 truncate text-sm font-normal">
                             {#if sources.length > 0}
                                 {statusIndicator}
                                 {sources
@@ -366,7 +366,7 @@
                     <div class="px-4 py-2">
                         <div class="flex flex-col gap-2">
                             {#each message.toolResult.content as result}
-                                <div class="flex items-center gap-2">
+                                <div class="flex min-w-0 items-center gap-2">
                                     {#if getSearchResultIconPath(result)}
                                         <img
                                             src={getSearchResultIconPath(result)}
@@ -381,12 +381,11 @@
                                             href={result.source.split('#')[0]}
                                             target="_blank"
                                             rel="noopener noreferrer"
-                                            class="block max-w-screen-sm overflow-hidden font-normal text-ellipsis whitespace-nowrap no-underline hover:underline">
+                                            class="block min-w-0 flex-1 truncate font-normal no-underline hover:underline">
                                             {result.title}
                                         </a>
                                     {:else}
-                                        <span
-                                            class="block max-w-screen-sm overflow-hidden text-ellipsis whitespace-nowrap font-normal">
+                                        <span class="block min-w-0 flex-1 truncate font-normal">
                                             {result.title}
                                         </span>
                                     {/if}

--- a/web/src/routes/(admin)/admin/settings/+layout.svelte
+++ b/web/src/routes/(admin)/admin/settings/+layout.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import * as Sidebar from '$lib/components/ui/sidebar'
+    import SidebarNavigationClose from '$lib/components/sidebar-navigation-close.svelte'
     import type { Snippet } from 'svelte'
     import { cn } from '$lib/utils'
     import { page } from '$app/state'
@@ -30,6 +31,7 @@
 </script>
 
 <Sidebar.Provider>
+    <SidebarNavigationClose />
     <Sidebar.Root variant="floating" collapsible="offcanvas" class="h-svh shrink-0 border-r">
         <Sidebar.Header class="flex justify-start">
             <Button

--- a/web/src/routes/(admin)/admin/settings/+layout.svelte
+++ b/web/src/routes/(admin)/admin/settings/+layout.svelte
@@ -30,7 +30,7 @@
 </script>
 
 <Sidebar.Provider>
-    <Sidebar.Root variant="floating" collapsible="none" class="h-svh shrink-0 border-r">
+    <Sidebar.Root variant="floating" collapsible="offcanvas" class="h-svh shrink-0 border-r">
         <Sidebar.Header class="flex justify-start">
             <Button
                 variant="ghost"
@@ -193,6 +193,10 @@
 
     <!-- Main content area -->
     <div class="flex max-h-[100svh] min-h-screen w-full flex-col">
+        <header class="bg-background sticky top-0 z-50 flex h-14 items-center border-b px-4 md:hidden">
+            <Sidebar.Trigger class="cursor-pointer" />
+            <span class="ml-2 text-sm font-medium">Admin Settings</span>
+        </header>
         <main class="min-h-0 flex-1">
             {@render children()}
         </main>

--- a/web/src/routes/(admin)/admin/settings/+layout.svelte
+++ b/web/src/routes/(admin)/admin/settings/+layout.svelte
@@ -190,14 +190,13 @@
                 isAdmin={data.user.role === 'admin'}
                 memoryEnabled={data.memoryEnabled} />
         </Sidebar.Footer>
-        <Sidebar.Rail />
     </Sidebar.Root>
 
     <!-- Main content area -->
     <div class="flex max-h-[100svh] min-h-screen w-full flex-col">
-        <header class="bg-background sticky top-0 z-50 flex h-14 items-center border-b px-4">
+        <header class="bg-background sticky top-0 z-50 flex h-14 items-center border-b px-4 md:hidden">
             <Sidebar.Trigger class="cursor-pointer size-11" />
-            <span class="ml-2 text-sm font-medium md:hidden">Admin Settings</span>
+            <span class="ml-2 text-sm font-medium">Admin Settings</span>
         </header>
         <main class="min-h-0 flex-1">
             {@render children()}

--- a/web/src/routes/(admin)/admin/settings/+layout.svelte
+++ b/web/src/routes/(admin)/admin/settings/+layout.svelte
@@ -195,9 +195,9 @@
 
     <!-- Main content area -->
     <div class="flex max-h-[100svh] min-h-screen w-full flex-col">
-        <header class="bg-background sticky top-0 z-50 flex h-14 items-center border-b px-4 md:hidden">
-            <Sidebar.Trigger class="cursor-pointer" />
-            <span class="ml-2 text-sm font-medium">Admin Settings</span>
+        <header class="bg-background sticky top-0 z-50 flex h-14 items-center border-b px-4">
+            <Sidebar.Trigger class="cursor-pointer size-11" />
+            <span class="ml-2 text-sm font-medium md:hidden">Admin Settings</span>
         </header>
         <main class="min-h-0 flex-1">
             {@render children()}

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -43,6 +43,7 @@
     import { page } from '$app/state'
     import { invalidate, invalidateAll, goto, afterNavigate } from '$app/navigation'
     import SidebarUserMenu from '$lib/components/sidebar-user-menu.svelte'
+    import SidebarNavigationClose from '$lib/components/sidebar-navigation-close.svelte'
     import type { Chat } from '$lib/server/db/schema'
 
     import { themeStore } from '$lib/themes/store.svelte'
@@ -231,6 +232,7 @@
 </Dialog.Root>
 
 <SidebarProvider>
+    <SidebarNavigationClose />
     <!-- Chat History Sidebar -->
     <Sidebar collapsible="icon" variant="sidebar">
         <SidebarHeader class="h-16">

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -386,7 +386,7 @@
             <div class="flex h-16 w-full items-center justify-between px-3 sm:px-6">
                 <div class="text-foreground flex h-16 min-w-0 flex-1 items-center">
                     <SidebarTrigger class="md:hidden mr-1 shrink-0 cursor-pointer" />
-                    <div class="min-w-0 flex-1 truncate px-2 sm:px-4 text-base font-medium">
+                    <div class="min-w-0 flex-1 overflow-hidden px-2 sm:px-4 text-base font-medium">
                         {#if page.url.pathname === '/search'}
                             Search
                         {:else if page.url.pathname.startsWith('/chat') && currentChatTitle}
@@ -404,7 +404,7 @@
                                     onblur={() => saveHeaderTitle()} />
                             {:else}
                                 <button
-                                    class="text-foreground cursor-pointer text-left transition-opacity hover:opacity-70"
+                                    class="text-foreground block w-full truncate cursor-pointer text-left transition-opacity hover:opacity-70"
                                     onclick={() => {
                                         isEditingHeaderTitle = true
                                         headerTitleValue = currentChatTitle || ''

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -383,9 +383,10 @@
     <!-- Main content area -->
     <div class="flex max-h-[100vh] w-full min-w-0 flex-1 flex-col">
         <header class={cn('bg-background sticky top-0 z-50 transition-shadow')}>
-            <div class="flex h-16 w-full items-center justify-between px-6">
-                <div class="text-foreground flex h-16 flex-1 items-center">
-                    <div class="min-w-0 flex-1 px-4 text-base font-medium">
+            <div class="flex h-16 w-full items-center justify-between px-3 sm:px-6">
+                <div class="text-foreground flex h-16 min-w-0 flex-1 items-center">
+                    <SidebarTrigger class="md:hidden mr-1 shrink-0 cursor-pointer" />
+                    <div class="min-w-0 flex-1 truncate px-2 sm:px-4 text-base font-medium">
                         {#if page.url.pathname === '/search'}
                             Search
                         {:else if page.url.pathname.startsWith('/chat') && currentChatTitle}

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -387,7 +387,7 @@
         <header class={cn('bg-background sticky top-0 z-50 transition-shadow')}>
             <div class="flex h-16 w-full items-center justify-between px-3 sm:px-6">
                 <div class="text-foreground flex h-16 min-w-0 flex-1 items-center">
-                    <SidebarTrigger class="md:hidden mr-1 shrink-0 cursor-pointer" />
+                    <SidebarTrigger class="md:hidden mr-1 shrink-0 cursor-pointer size-11" />
                     <div class="min-w-0 flex-1 overflow-hidden px-2 sm:px-4 text-base font-medium">
                         {#if page.url.pathname === '/search'}
                             Search

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -1950,10 +1950,10 @@
         </div>
         <div
             bind:this={chatContainerRef}
-            class="flex h-full w-full flex-col overflow-y-auto px-4 pt-6">
+            class="flex h-full w-full flex-col overflow-x-hidden overflow-y-auto px-4 pt-6">
             <div
                 bind:this={chatContentRef}
-                class="mx-auto flex w-full max-w-4xl flex-1 flex-col gap-1"
+                class="mx-auto flex w-full max-w-4xl min-w-0 flex-1 flex-col gap-1"
                 style:padding-bottom="{bottomPadding}px">
                 {#if data.agent}
                     <div

--- a/web/src/routes/(app)/search/+page.svelte
+++ b/web/src/routes/(app)/search/+page.svelte
@@ -147,7 +147,7 @@
     <title>Search Results - Omni</title>
 </svelte:head>
 
-<div class="mt-4 px-8 pb-24">
+<div class="mt-4 px-4 pb-24 sm:px-8">
     <!-- Search Header -->
     <div class="mb-8">
         <div class="mb-4 flex items-center gap-4">
@@ -167,7 +167,7 @@
         </div>
 
         {#if data.searchResults}
-            <div class="px-6 text-sm text-gray-600">
+            <div class="px-2 text-sm text-gray-600 sm:px-6">
                 Found {data.searchResults.total_count >= MAX_COUNTED_RESULTS
                     ? `${MAX_COUNTED_RESULTS.toLocaleString()}+`
                     : data.searchResults.total_count.toLocaleString()} results in
@@ -247,7 +247,7 @@
             }} />
     {/if}
 
-    <div class="flex gap-6 px-6">
+    <div class="flex flex-col gap-4 sm:flex-row sm:gap-6 sm:px-6">
         <!-- Search Results -->
         <div class="min-w-0 flex-1">
             {#if data.searchResults}
@@ -357,7 +357,7 @@
 
         <!-- Source Facets Sidebar -->
         {#if data.searchResults && sourceFacet}
-            <div class="w-80">
+            <div class="w-full sm:w-64 sm:shrink-0">
                 <div class="">
                     <div class="mb-4 flex items-center justify-between">
                         <h3 class="flex flex-1 items-center gap-2 px-4 text-base font-semibold">

--- a/web/src/routes/(app)/search/+page.svelte
+++ b/web/src/routes/(app)/search/+page.svelte
@@ -247,7 +247,7 @@
             }} />
     {/if}
 
-    <div class="flex flex-col gap-4 sm:flex-row sm:gap-6 sm:px-6">
+    <div class="flex flex-col gap-4 md:flex-row md:gap-6 md:px-6">
         <!-- Search Results -->
         <div class="min-w-0 flex-1">
             {#if data.searchResults}
@@ -357,7 +357,7 @@
 
         <!-- Source Facets Sidebar -->
         {#if data.searchResults && sourceFacet}
-            <div class="w-full sm:w-64 sm:shrink-0">
+            <div class="w-full md:w-80 md:shrink-0">
                 <div class="">
                     <div class="mb-4 flex items-center justify-between">
                         <h3 class="flex flex-1 items-center gap-2 px-4 text-base font-semibold">


### PR DESCRIPTION
## Mobile source accordion overflow fix

- Clamp the chat container and content wrappers to overflow-x-hidden on mobile.

- Make the source accordion trigger and result rows shrinkable so long fetched:/searched: labels truncate instead of widening the viewport.
## Summary

- **Mobile sidebar access**: Added a hamburger `SidebarTrigger` (`md:hidden`, 44 px touch target) to the app header so the sidebar is reachable on mobile as a Sheet overlay.
- **Mobile sidebar auto-close**: Added `SidebarNavigationClose` — a zero-DOM child component inside each `SidebarProvider` that calls `setOpenMobile(false)` via `afterNavigate`. Without this, the Sheet remained open after tapping a chat or settings link, blocking the content view. A separate component is required because `useSidebar()` calls `getContext()` and can only be used in a descendant of the provider — not in the layout script that renders the provider itself. The callback is guarded with `navigation.from !== null` so it does not fire on the initial mount.
- **Admin settings on mobile**: Changed `collapsible="none"` to `collapsible="offcanvas"` so the admin sidebar becomes a Sheet on mobile, and added a mobile-only sticky header (`md:hidden`) with a 44 px `SidebarTrigger`. `SidebarRail` is omitted to avoid exposing a desktop collapse affordance that would leave users without a visible way to reopen the sidebar.
- **Title truncation**: Fixed CSS — `truncate` must be on the element directly containing the text, not on a parent container. The container gets `overflow-hidden`; the `<button>` inside gets `block w-full truncate`.
- **Search layout breakpoint**: Changed `sm:` (640 px) to `md:` (768 px) for the two-column results + facets layout, and restored the facets sidebar to its original `w-80` (320 px). At 640 px the results column was only ~248 px — too cramped for readable content.

## Files changed

| File | Change |
|------|--------|
| `web/src/routes/(app)/+layout.svelte` | Mobile trigger (44 px), title truncation fix |
| `web/src/routes/(admin)/admin/settings/+layout.svelte` | Mobile sidebar + header, no rail |
| `web/src/routes/(app)/search/+page.svelte` | Responsive two-column layout |
| `web/src/lib/components/sidebar-navigation-close.svelte` | Auto-close Sheet on navigation (new file) |

## Test plan

- [ ] Mobile (<768 px): hamburger opens sidebar Sheet; tapping a chat navigates AND dismisses the Sheet automatically
- [ ] Mobile: admin settings hamburger opens Sheet; tapping a nav item navigates AND dismisses the Sheet
- [ ] Desktop: sidebar toggle, icon-collapse, and cookie-persisted state still work normally
- [ ] Desktop: admin settings sidebar is always visible; no SidebarRail collapse affordance
- [ ] Search page: stacks vertically on mobile, two-column at 768 px+; facets sidebar is full-width on mobile
- [ ] Title truncates with ellipsis when long chat titles overflow the header