### PR TITLE
fix(nextcloud): skip unsupported-format files instead of indexing empty content

### DIFF
--- a/connectors/nextcloud/src/sync.rs
+++ b/connectors/nextcloud/src/sync.rs
@@ -96,6 +96,10 @@ async fn execute_sync(
     let mut total_scanned = 0usize;
     let mut total_processed = 0usize;
     let mut current_keys = HashSet::<String>::new();
+    // Keys for files that exist on the server but whose format is not supported for extraction.
+    // Kept separate from current_keys (which drives deletion detection) so that their
+    // "skipped:{etag}" etag entries survive the retain() pruning pass at the end.
+    let mut skipped_server_keys = HashSet::<String>::new();
 
     // TODO: this is not real incremental sync, we do a full PROPFIND every run,
     // and skip based on e-tags. Also, we save state (checkpoint) only at the end.
@@ -136,6 +140,7 @@ async fn execute_sync(
             total_processed += p;
             for key in unsupported {
                 current_keys.remove(&key);
+                skipped_server_keys.insert(key);
             }
         }
         Err(_) => {
@@ -197,6 +202,7 @@ async fn execute_sync(
                 total_processed += p;
                 for key in unsupported {
                     current_keys.remove(&key);
+                    skipped_server_keys.insert(key);
                 }
             }
         }
@@ -222,8 +228,15 @@ async fn execute_sync(
             }
         }
 
-        // Remove stale etags
-        state.etags.retain(|k, _| current_keys.contains(k));
+        // Remove stale etags. Keep etags for:
+        //   - indexed files (current_keys)
+        //   - unsupported-format files that still exist on the server (skipped_server_keys),
+        //     so their "skipped:{etag}" marker is not erased and the file is not
+        //     re-downloaded on every subsequent sync.
+        state.etags.retain(|k, v| {
+            current_keys.contains(k)
+                || (v.starts_with("skipped:") && skipped_server_keys.contains(k))
+        });
     }
 
     // Persist current file key set

--- a/connectors/nextcloud/src/sync.rs
+++ b/connectors/nextcloud/src/sync.rs
@@ -122,7 +122,7 @@ async fn execute_sync(
                 current_keys.insert(entry.file_key());
             }
 
-            let (s, p) = process_file_batch(
+            let (s, p, unsupported) = process_file_batch(
                 &file_entries,
                 &client,
                 config,
@@ -134,6 +134,9 @@ async fn execute_sync(
             .await;
             total_scanned += s;
             total_processed += p;
+            for key in unsupported {
+                current_keys.remove(&key);
+            }
         }
         Err(_) => {
             info!("Depth: infinity not supported, using paginated directory traversal");
@@ -180,7 +183,7 @@ async fn execute_sync(
                     }
                 }
 
-                let (s, p) = process_file_batch(
+                let (s, p, unsupported) = process_file_batch(
                     &page_files,
                     &client,
                     config,
@@ -192,6 +195,9 @@ async fn execute_sync(
                 .await;
                 total_scanned += s;
                 total_processed += p;
+                for key in unsupported {
+                    current_keys.remove(&key);
+                }
             }
         }
     }
@@ -227,7 +233,9 @@ async fn execute_sync(
 }
 
 /// Process a batch of file entries: check etag, download, extract, store, emit.
-/// Returns (scanned, processed) counts.
+/// Returns (scanned, processed, unsupported_keys) where unsupported_keys are file keys
+/// whose content could not be extracted. The caller must remove these from current_keys
+/// so that already-indexed documents for these files get deletion events.
 async fn process_file_batch(
     entries: &[DavEntry],
     client: &NextcloudClient,
@@ -236,9 +244,10 @@ async fn process_file_batch(
     ctx: &SyncContext,
     user_email: Option<&str>,
     state: &mut NextcloudConnectorState,
-) -> (usize, usize) {
+) -> (usize, usize, Vec<String>) {
     let mut scanned = 0usize;
     let mut processed = 0usize;
+    let mut unsupported_keys = Vec::new();
 
     for batch in entries.chunks(BATCH_SIZE) {
         if ctx.is_cancelled() {
@@ -249,15 +258,30 @@ async fn process_file_batch(
             scanned += 1;
             let key = entry.file_key();
 
-            // Skip unchanged files (compare effective etag — real or synthetic)
+            // Skip unchanged files (compare effective etag — real or synthetic).
+            // Etags prefixed with "skipped:" were stored for unsupported-format files;
+            // strip the prefix before comparing, and re-add to unsupported_keys so they
+            // continue to be excluded from current_keys.
             let effective = entry.effective_etag();
             if let Some(stored) = state.etags.get(&key) {
-                if effective.as_deref() == Some(stored.as_str()) {
+                let (was_skipped, stored_etag) = stored
+                    .strip_prefix("skipped:")
+                    .map(|rest| (true, rest))
+                    .unwrap_or((false, stored.as_str()));
+
+                if effective.as_deref() == Some(stored_etag) {
+                    if was_skipped {
+                        unsupported_keys.push(key.clone());
+                    }
                     continue;
                 }
             }
 
-            let is_update = state.etags.contains_key(&key);
+            // is_update is true only when we have previously indexed this file
+            // (etag stored without a "skipped:" prefix).
+            let is_update = state.etags.get(&key)
+                .map(|e| !e.starts_with("skipped:"))
+                .unwrap_or(false);
 
             // Enforce file size limit
             let file_size = entry.content_length.or(entry.oc_size).unwrap_or(0);
@@ -277,9 +301,25 @@ async fn process_file_batch(
                 Ok(text) => text,
                 Err(e) => {
                     warn!("Failed to process file '{}': {}", entry.filename(), e);
+                    // Transient failure (download error): keep in current_keys so we don't
+                    // spuriously emit a deletion event. Do not store an etag — retry next sync.
                     continue;
                 }
             };
+
+            if content_text.is_empty() {
+                // Unsupported format: extraction succeeded but returned no text.
+                // Don't index the file. Store a "skipped:" marker etag so we avoid
+                // re-downloading on every sync until the file actually changes.
+                warn!(
+                    "Skipping '{}': unsupported format, no text content could be extracted",
+                    entry.filename()
+                );
+                let marker = format!("skipped:{}", effective.as_deref().unwrap_or(""));
+                state.etags.insert(key.clone(), marker);
+                unsupported_keys.push(key.clone());
+                continue;
+            }
 
             let markdown = entry.to_markdown(username, &config.server_url, &content_text);
 
@@ -317,7 +357,7 @@ async fn process_file_batch(
         let _ = ctx.increment_scanned(batch.len() as i32).await;
     }
 
-    (scanned, processed)
+    (scanned, processed, unsupported_keys)
 }
 
 /// Try to parse a date string as RFC 3339 first, then RFC 2822.

--- a/connectors/nextcloud/src/sync.rs
+++ b/connectors/nextcloud/src/sync.rs
@@ -237,10 +237,15 @@ async fn execute_sync(
             current_keys.contains(k)
                 || (v.starts_with("skipped:") && skipped_server_keys.contains(k))
         });
-    }
 
-    // Persist current file key set
-    state.known_files = current_keys.into_iter().collect();
+        // Only update known_files when the scan completed in full. A cancelled
+        // paginated scan produces a partial current_keys (only directories visited
+        // so far), and persisting that would silently drop unvisited files from
+        // known_files. On the next complete sync, any of those files that were
+        // deleted from Nextcloud during the gap would never appear in deleted_keys
+        // and their documents would linger in the RAG index forever.
+        state.known_files = current_keys.into_iter().collect();
+    }
 
     Ok((total_scanned, total_processed))
 }
@@ -282,7 +287,16 @@ async fn process_file_batch(
                     .map(|rest| (true, rest))
                     .unwrap_or((false, stored.as_str()));
 
-                if effective.as_deref() == Some(stored_etag) {
+                // When effective is None (server provides no change metadata) treat it
+                // as matching an empty stored_etag. This is the case when we stored
+                // "skipped:" (no suffix) for a file with no etag/last-modified: without
+                // this special case, None == Some("") is always false and the file is
+                // re-downloaded and re-skipped on every sync.
+                let etags_match = match effective.as_deref() {
+                    None => stored_etag.is_empty(),
+                    Some(e) => e == stored_etag,
+                };
+                if etags_match {
                     if was_skipped {
                         unsupported_keys.push(key.clone());
                     }


### PR DESCRIPTION
## Problem

Files like `.msg` (Outlook) cannot be converted to text by the built-in extractor because they use the Compound File Binary (OLE2) format, for which there is no parser in `content_extractor.rs`. Extraction returned `Ok("")` silently.

Previously the connector still emitted a `DocumentCreated` event with only a metadata table (filename, path, size, owner) and no `## Content` section. That metadata-only document was embedded in the RAG vector store. Because Outlook `.msg` files often have descriptive names (e.g. `"Zusage Kostenübernahme für Neubau Hütte auch in 2021 durch Gemeinde.msg"`), keyword searches matched those filenames — so RAG returned `.msg` results even though the actual email content had never been read.

Additionally, `read_document` on such files returned HTTP 412 because the connector had no binary download action at the time (since fixed in a separate PR), causing confusing errors in the AI conversation.

## Fix

**`connectors/nextcloud/src/sync.rs`**

- When `extract_text` returns an empty string, log a warning and skip the file entirely — no `DocumentCreated` / `DocumentUpdated` event is emitted, so nothing gets into the RAG index.
- Store a `"skipped:{etag}"` marker in connector state so the file is not re-downloaded on every sync cycle. If the file changes (new etag) it is tried again automatically.
- Remove the skipped file's key from `current_keys`. This makes the deletion-detection pass emit a `DocumentDeleted` event for any `.msg` files that were previously indexed with empty content, cleaning them out of the database on the next full sync.
- Distinguish **transient failures** (download error → keep in `current_keys`, retry next sync) from **permanent format failures** (empty content → remove from `current_keys`, store marker etag).
- Correct the `is_update` flag: it is now only `true` when a file was previously indexed successfully (stored etag without `"skipped:"` prefix), not when it was previously skipped.

## Behaviour after this fix

| Scenario | Before | After |
|---|---|---|
| `.msg` file encountered first time | Indexed with metadata only; appears in RAG results | Skipped; `"skipped:{etag}"` stored; not indexed |
| `.msg` file unchanged on next sync | No-op (etag match) | No-op (etag match via stripped prefix); still excluded from `current_keys` |
| `.msg` file changed | Re-indexed with metadata only | Re-tried; still skipped if still unreadable |
| Previously-indexed `.msg` on first full sync after upgrade | Stays in DB forever | `DocumentDeleted` emitted; removed from DB |
| Download error on any file | Kept in `current_keys` (correct) | Unchanged (kept in `current_keys`) |