### PR TITLE
Limit Google Drive buffered bytes

### DIFF
--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -1,6 +1,7 @@
 use anyhow::{anyhow, Context, Result};
 use reqwest::Client;
 use serde::Deserialize;
+use std::env;
 use std::sync::{Arc, RwLock};
 use std::time::Duration;
 use tracing::{debug, warn};
@@ -31,6 +32,10 @@ const DRIVE_API_BASE: &str = "https://www.googleapis.com/drive/v3";
 const DOCS_API_BASE: &str = "https://docs.googleapis.com/v1";
 const SHEETS_API_BASE: &str = "https://sheets.googleapis.com/v4";
 const SLIDES_API_BASE: &str = "https://slides.googleapis.com/v1";
+
+fn drive_api_base() -> String {
+    env::var("GOOGLE_DRIVE_API_BASE").unwrap_or_else(|_| DRIVE_API_BASE.to_string())
+}
 
 #[derive(Clone)]
 pub struct DriveClient {
@@ -94,7 +99,7 @@ impl DriveClient {
             let page_token = page_token.clone();
             let created_after = created_after.clone();
             async move {
-            let url = format!("{}/files", DRIVE_API_BASE);
+            let url = format!("{}/files", drive_api_base().as_str());
 
             // Build the query filter
             let mut query_parts = vec!["trashed=false".to_string()];
@@ -417,7 +422,7 @@ impl DriveClient {
         execute_with_auth_retry(auth, user_email, rate_limiter.clone(), |token| {
             let file_id = file_id.clone();
             async move {
-                let url = format!("{}/files/{}?alt=media", DRIVE_API_BASE, &file_id);
+                let url = format!("{}/files/{}?alt=media", drive_api_base().as_str(), &file_id);
 
                 debug!(
                     "Downloading file: {} (user={}, url={})",
@@ -465,7 +470,7 @@ impl DriveClient {
             async move {
                 let url = format!(
                     "{}/files/{}?fields=id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents",
-                    DRIVE_API_BASE, &file_id
+                    drive_api_base().as_str(), &file_id
                 );
 
                 debug!("Getting file metadata: {} (user={}, url={})", file_id, user_email, url);
@@ -513,7 +518,9 @@ impl DriveClient {
             async move {
                 let url = format!(
                     "{}/files/{}/export?mimeType={}",
-                    DRIVE_API_BASE, &file_id, &export_mime_type
+                    drive_api_base().as_str(),
+                    &file_id,
+                    &export_mime_type
                 );
 
                 debug!(
@@ -559,7 +566,7 @@ impl DriveClient {
         execute_with_auth_retry(auth, user_email, rate_limiter.clone(), |token| {
             let file_id = file_id.clone();
             async move {
-                let url = format!("{}/files/{}?alt=media", DRIVE_API_BASE, &file_id);
+                let url = format!("{}/files/{}?alt=media", drive_api_base().as_str(), &file_id);
 
                 debug!(
                     "Downloading binary file: {} (user={}, url={})",
@@ -623,7 +630,7 @@ impl DriveClient {
         webhook_channel: &WebhookChannel,
         page_token: &str,
     ) -> Result<WebhookChannelResponse> {
-        let url = format!("{}/changes/watch", DRIVE_API_BASE);
+        let url = format!("{}/changes/watch", drive_api_base().as_str());
 
         let params = vec![
             ("pageToken", page_token),
@@ -664,7 +671,7 @@ impl DriveClient {
         channel_id: &str,
         resource_id: &str,
     ) -> Result<()> {
-        let url = format!("{}/channels/stop", DRIVE_API_BASE);
+        let url = format!("{}/channels/stop", drive_api_base().as_str());
 
         let stop_request = serde_json::json!({
             "id": channel_id,
@@ -689,7 +696,7 @@ impl DriveClient {
     }
 
     pub async fn get_start_page_token(&self, token: &str) -> Result<String> {
-        let url = format!("{}/changes/startPageToken", DRIVE_API_BASE);
+        let url = format!("{}/changes/startPageToken", drive_api_base().as_str());
 
         let params = vec![("supportsAllDrives", "true")];
 
@@ -725,7 +732,7 @@ impl DriveClient {
         execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
             let folder_id = folder_id.clone();
             async move {
-                let url = format!("{}/files/{}", DRIVE_API_BASE, folder_id);
+                let url = format!("{}/files/{}", drive_api_base().as_str(), folder_id);
 
                 let params = vec![
                     ("fields", "id,name,parents,mimeType"),
@@ -772,7 +779,7 @@ impl DriveClient {
         token: &str,
         page_token: &str,
     ) -> Result<DriveChangesResponse> {
-        let url = format!("{}/changes", DRIVE_API_BASE);
+        let url = format!("{}/changes", drive_api_base().as_str());
 
         let params = vec![
             ("pageToken", page_token),

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -7,10 +7,32 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::{Duration, Instant};
 use time::{self, OffsetDateTime};
-use tokio::sync::Notify;
+use tokio::sync::{Notify, OwnedSemaphorePermit, Semaphore};
 use tracing::{debug, error, info, warn};
 
 const GOOGLE_FILE_CONCURRENCY: usize = 8;
+const GOOGLE_MAX_BUFFERED_BYTES: usize = 512 * 1024 * 1024;
+const GOOGLE_BUFFER_PERMIT_UNIT: usize = 64 * 1024;
+const GOOGLE_BUFFER_PERMITS: usize = GOOGLE_MAX_BUFFERED_BYTES / GOOGLE_BUFFER_PERMIT_UNIT;
+
+pub(crate) fn permits_for_bytes(bytes: usize) -> u32 {
+    if bytes == 0 {
+        return 0;
+    }
+
+    bytes.div_ceil(GOOGLE_BUFFER_PERMIT_UNIT) as u32
+}
+
+fn file_content_len(content: &FileContent) -> usize {
+    match content {
+        FileContent::Text(text) => text.len(),
+        FileContent::Binary { data, .. } => data.len(),
+    }
+}
+
+fn estimated_file_size_bytes(file: &crate::models::GoogleDriveFile) -> Option<usize> {
+    file.size.as_ref()?.parse::<usize>().ok()
+}
 
 use crate::admin::AdminClient;
 use crate::auth::{google_max_retries, GoogleAuth, OAuthAuth};
@@ -46,6 +68,7 @@ pub struct SyncManager {
     webhook_url: Option<String>,
     pub webhook_debounce: DashMap<String, WebhookDebounce>,
     webhook_notify: Arc<Notify>,
+    drive_buffer_memory_budget: Arc<Semaphore>,
     pub debounce_duration_ms: AtomicU64,
 }
 
@@ -80,6 +103,7 @@ impl SyncManager {
             webhook_url,
             webhook_debounce: DashMap::new(),
             webhook_notify: Arc::new(Notify::new()),
+            drive_buffer_memory_budget: Arc::new(Semaphore::new(GOOGLE_BUFFER_PERMITS)),
             debounce_duration_ms: AtomicU64::new(10 * 60 * 1000),
         }
     }
@@ -476,12 +500,47 @@ impl SyncManager {
             let source_id = source_id_owned.clone();
             let sync_run_id = sync_run_id_owned.clone();
             let drive_client = self.drive_client.clone();
+            let memory_budget = self.drive_buffer_memory_budget.clone();
 
             async move {
                 debug!(
                     "Processing file: {} ({}) for user: {}",
                     user_file.file.name, user_file.file.id, user_file.user_email
                 );
+
+                let reserved_bytes = estimated_file_size_bytes(&user_file.file);
+                let reserved_permits = match reserved_bytes {
+                    Some(size) if size > GOOGLE_MAX_BUFFERED_BYTES => {
+                        warn!(
+                            "Skipping Drive file {} ({}) because its declared size {} bytes exceeds the {} byte buffer budget",
+                            user_file.file.name,
+                            user_file.file.id,
+                            size,
+                            GOOGLE_MAX_BUFFERED_BYTES
+                        );
+                        return (1, 0);
+                    }
+                    Some(size) => permits_for_bytes(size),
+                    // Google Workspace exports do not reliably expose their exported text size.
+                    // Reserve the full budget before download so unknown-size content cannot
+                    // accumulate concurrently in memory.
+                    None => GOOGLE_BUFFER_PERMITS as u32,
+                };
+
+                let buffer_permit: Option<OwnedSemaphorePermit> = if reserved_permits > 0 {
+                    match memory_budget.clone().acquire_many_owned(reserved_permits).await {
+                        Ok(permit) => Some(permit),
+                        Err(e) => {
+                            error!(
+                                "Drive buffer memory semaphore closed while processing file {} ({}): {:?}",
+                                user_file.file.name, user_file.file.id, e
+                            );
+                            return (1, 0);
+                        }
+                    }
+                } else {
+                    None
+                };
 
                 let result = drive_client
                     .get_file_content(&service_auth, &user_file.user_email, &user_file.file)
@@ -495,6 +554,43 @@ impl SyncManager {
 
                 match result {
                     Ok(file_content) => {
+                        let actual_size = file_content_len(&file_content);
+                        if actual_size > GOOGLE_MAX_BUFFERED_BYTES {
+                            warn!(
+                                "Skipping Drive file {} ({}) because buffered content is {} bytes, exceeding the {} byte budget",
+                                user_file.file.name,
+                                user_file.file.id,
+                                actual_size,
+                                GOOGLE_MAX_BUFFERED_BYTES
+                            );
+                            return (1, 0);
+                        }
+
+                        if let Some(size) = reserved_bytes {
+                            if actual_size > size {
+                                warn!(
+                                    "Skipping Drive file {} ({}) because buffered content is {} bytes, exceeding its declared size of {} bytes used for pre-download memory reservation",
+                                    user_file.file.name,
+                                    user_file.file.id,
+                                    actual_size,
+                                    size
+                                );
+                                return (1, 0);
+                            }
+                        }
+
+                        // Keep the pre-download permit alive until content has been
+                        // stored/extracted and the corresponding event has been emitted.
+                        // Dropping this value releases the connector-wide memory budget via RAII.
+                        let _buffer_permit = buffer_permit;
+                        debug!(
+                            "Drive file {} ({}) holds {} pre-download buffer permits for {} bytes",
+                            user_file.file.name,
+                            user_file.file.id,
+                            reserved_permits,
+                            actual_size
+                        );
+
                         let store_result = match file_content {
                             FileContent::Text(ref text) if text.is_empty() => {
                                 debug!("File {} has empty content, skipping", user_file.file.name);
@@ -2242,5 +2338,41 @@ impl SyncManager {
             total_members
         );
         Ok(group_emails)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::Arc;
+    use tokio::sync::Semaphore;
+
+    #[test]
+    fn permits_for_bytes_rounds_up_to_64k_units() {
+        assert_eq!(permits_for_bytes(0), 0);
+        assert_eq!(permits_for_bytes(1), 1);
+        assert_eq!(permits_for_bytes(GOOGLE_BUFFER_PERMIT_UNIT), 1);
+        assert_eq!(permits_for_bytes(GOOGLE_BUFFER_PERMIT_UNIT + 1), 2);
+        assert_eq!(
+            permits_for_bytes(GOOGLE_MAX_BUFFERED_BYTES),
+            GOOGLE_BUFFER_PERMITS as u32
+        );
+    }
+
+    #[test]
+    fn oversized_single_buffer_requires_more_than_full_budget() {
+        assert!(permits_for_bytes(GOOGLE_MAX_BUFFERED_BYTES + 1) > GOOGLE_BUFFER_PERMITS as u32);
+    }
+
+    #[tokio::test]
+    async fn owned_buffer_permits_release_on_drop() {
+        let semaphore = Arc::new(Semaphore::new(2));
+        let permit = semaphore.clone().acquire_many_owned(2).await.unwrap();
+
+        assert!(semaphore.clone().try_acquire_owned().is_err());
+
+        drop(permit);
+
+        assert!(semaphore.try_acquire_many_owned(2).is_ok());
     }
 }

--- a/connectors/google/tests/common/mod.rs
+++ b/connectors/google/tests/common/mod.rs
@@ -12,6 +12,7 @@ use shared::ObjectStorage;
 use sqlx::PgPool;
 use std::sync::Arc;
 use tokio::net::TcpListener;
+use tokio::sync::Semaphore;
 
 const TEST_SOURCE_ID: &str = "01JGF7V3E0Y2R1X8P5Q7W9T4N7";
 
@@ -56,6 +57,8 @@ impl GoogleConnectorTestFixture {
             sync_backoff_base_seconds: 30,
             sync_backoff_max_seconds: 3600,
             sync_max_consecutive_failures: 10,
+            extraction_concurrency: 2,
+            extraction_retry_after_seconds: 1,
         };
 
         let content_storage: Arc<dyn ObjectStorage> =
@@ -69,12 +72,14 @@ impl GoogleConnectorTestFixture {
             redis_client.clone(),
         ));
 
+        let extraction_semaphore = Arc::new(Semaphore::new(config.extraction_concurrency));
         let app_state = AppState {
             db_pool: test_env.db_pool.clone(),
             redis_client,
             config,
             sync_manager: cm_sync_manager,
             content_storage,
+            extraction_semaphore,
         };
 
         let app = create_app(app_state);

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -189,3 +189,317 @@ async fn test_webhook_debounce_retains_unexpired() -> Result<()> {
 
     Ok(())
 }
+
+// ============================================================================
+// Drive buffer memory budget tests
+// ============================================================================
+
+mod drive_buffer_budget_tests {
+    use anyhow::Result;
+    use axum::{
+        extract::{Path, Query, State},
+        response::Json,
+        routing::{get, post, put},
+        Router,
+    };
+    use omni_connector_sdk::{
+        AuthType, SdkClient, ServiceCredential, ServiceProvider, Source, SourceType, SyncContext,
+        SyncType,
+    };
+    use omni_google_connector::{admin::AdminClient, sync::SyncManager};
+    use serde_json::{json, Value as JsonValue};
+    use shared::models::{SourceScope, UserFilterMode};
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::Arc;
+    use time::OffsetDateTime;
+    use tokio::net::TcpListener;
+
+    const SOURCE_ID: &str = "google-drive-budget-source";
+    const SYNC_RUN_ID: &str = "google-drive-budget-sync";
+    const USER_EMAIL: &str = "user@example.com";
+    const MIB: usize = 1024 * 1024;
+    const BUDGET_BYTES: usize = 512 * MIB;
+
+    static DRIVE_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    #[derive(Clone)]
+    struct MockDriveFile {
+        id: &'static str,
+        name: &'static str,
+        declared_size: usize,
+    }
+
+    const MOCK_FILES: &[MockDriveFile] = &[
+        MockDriveFile {
+            id: "file-256",
+            name: "256mb.txt",
+            declared_size: 256 * MIB,
+        },
+        MockDriveFile {
+            id: "file-128-a",
+            name: "128mb-a.txt",
+            declared_size: 128 * MIB,
+        },
+        MockDriveFile {
+            id: "file-64",
+            name: "64mb.txt",
+            declared_size: 64 * MIB,
+        },
+        MockDriveFile {
+            id: "file-32",
+            name: "32mb.txt",
+            declared_size: 32 * MIB,
+        },
+        MockDriveFile {
+            id: "file-400",
+            name: "400mb.txt",
+            declared_size: 400 * MIB,
+        },
+        MockDriveFile {
+            id: "file-300",
+            name: "300mb.txt",
+            declared_size: 300 * MIB,
+        },
+        MockDriveFile {
+            id: "file-96",
+            name: "96mb.txt",
+            declared_size: 96 * MIB,
+        },
+        MockDriveFile {
+            id: "file-128-b",
+            name: "128mb-b.txt",
+            declared_size: 128 * MIB,
+        },
+    ];
+
+    #[derive(Clone, Default)]
+    struct MockDriveState {
+        active_downloads: Arc<AtomicUsize>,
+        max_active_downloads: Arc<AtomicUsize>,
+        active_declared_bytes: Arc<AtomicUsize>,
+        max_active_declared_bytes: Arc<AtomicUsize>,
+        budget_breached: Arc<AtomicBool>,
+    }
+
+    impl MockDriveState {
+        fn enter_download(&self, declared_size: usize) {
+            let active_downloads = self.active_downloads.fetch_add(1, Ordering::SeqCst) + 1;
+            self.max_active_downloads
+                .fetch_max(active_downloads, Ordering::SeqCst);
+
+            let active_bytes = self
+                .active_declared_bytes
+                .fetch_add(declared_size, Ordering::SeqCst)
+                + declared_size;
+            self.max_active_declared_bytes
+                .fetch_max(active_bytes, Ordering::SeqCst);
+            if active_bytes > BUDGET_BYTES {
+                self.budget_breached.store(true, Ordering::SeqCst);
+            }
+        }
+
+        fn exit_download(&self, declared_size: usize) {
+            self.active_declared_bytes
+                .fetch_sub(declared_size, Ordering::SeqCst);
+            self.active_downloads.fetch_sub(1, Ordering::SeqCst);
+        }
+    }
+
+    async fn spawn_mock_drive() -> Result<(String, MockDriveState)> {
+        let state = MockDriveState::default();
+        let app = Router::new()
+            .route("/drive/v3/files", get(list_files))
+            .route("/drive/v3/files/:file_id", get(get_file_or_media))
+            .route("/drive/v3/changes/startPageToken", get(start_page_token))
+            .with_state(state.clone());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        Ok((format!("http://{}", addr), state))
+    }
+
+    async fn list_files() -> Json<JsonValue> {
+        let files: Vec<JsonValue> = MOCK_FILES
+            .iter()
+            .map(|file| {
+                json!({
+                    "id": file.id,
+                    "name": file.name,
+                    "mimeType": "text/plain",
+                    "size": file.declared_size.to_string(),
+                    "webViewLink": format!("https://example.test/{}", file.id),
+                    "createdTime": "2024-01-01T00:00:00Z",
+                    "modifiedTime": "2024-01-01T00:00:00Z"
+                })
+            })
+            .collect();
+
+        Json(json!({ "files": files }))
+    }
+
+    async fn get_file_or_media(
+        State(state): State<MockDriveState>,
+        Path(file_id): Path<String>,
+        Query(query): Query<HashMap<String, String>>,
+    ) -> Json<JsonValue> {
+        if query.get("alt").map(String::as_str) == Some("media") {
+            let declared_size = MOCK_FILES
+                .iter()
+                .find(|file| file.id == file_id)
+                .map(|file| file.declared_size)
+                .expect("mock file id should exist");
+
+            state.enter_download(declared_size);
+            tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+            state.exit_download(declared_size);
+            return Json(json!(format!("content for {}", file_id)));
+        }
+
+        Json(json!({
+            "id": file_id,
+            "name": "metadata.txt",
+            "mimeType": "text/plain"
+        }))
+    }
+
+    async fn start_page_token() -> Json<JsonValue> {
+        Json(json!({"startPageToken": "next-page-token"}))
+    }
+
+    async fn spawn_mock_connector_manager() -> Result<String> {
+        let app = Router::new()
+            .route("/sdk/connector-configs/:provider", get(connector_config))
+            .route("/sdk/content", post(store_content))
+            .route("/sdk/events/batch", post(ok_json))
+            .route("/sdk/sync/:sync_run_id/scanned", post(ok_json))
+            .route("/sdk/sync/:sync_run_id/updated", post(ok_json))
+            .route("/sdk/sync/:sync_run_id/complete", post(ok_json))
+            .route("/sdk/source/:source_id/connector-state", put(ok_json));
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        Ok(format!("http://{}", addr))
+    }
+
+    async fn connector_config() -> Json<JsonValue> {
+        Json(json!({
+            "oauth_client_id": "test-client-id",
+            "oauth_client_secret": "test-client-secret"
+        }))
+    }
+
+    async fn store_content() -> Json<JsonValue> {
+        Json(json!({"content_id": "content-id"}))
+    }
+
+    async fn ok_json() -> Json<JsonValue> {
+        Json(json!({}))
+    }
+
+    fn test_source() -> Source {
+        let now = OffsetDateTime::now_utc();
+        Source {
+            id: SOURCE_ID.to_string(),
+            name: "Google Drive Budget Test".to_string(),
+            source_type: SourceType::GoogleDrive,
+            config: json!({}),
+            is_active: true,
+            is_deleted: false,
+            scope: SourceScope::User,
+            user_filter_mode: UserFilterMode::All,
+            user_whitelist: None,
+            user_blacklist: None,
+            connector_state: None,
+            sync_interval_seconds: None,
+            created_at: now,
+            updated_at: now,
+            created_by: "user-id".to_string(),
+        }
+    }
+
+    fn oauth_credentials() -> ServiceCredential {
+        let now = OffsetDateTime::now_utc();
+        ServiceCredential {
+            id: "credential-id".to_string(),
+            source_id: SOURCE_ID.to_string(),
+            user_id: Some("user-id".to_string()),
+            provider: ServiceProvider::Google,
+            auth_type: AuthType::OAuth,
+            principal_email: Some(USER_EMAIL.to_string()),
+            credentials: json!({
+                "access_token": "access-token",
+                "refresh_token": "refresh-token",
+                "expires_at": now.unix_timestamp() + 3600,
+                "user_email": USER_EMAIL
+            }),
+            config: json!({}),
+            expires_at: None,
+            last_validated_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[tokio::test]
+    async fn drive_buffer_budget_never_exceeds_declared_in_flight_bytes() -> Result<()> {
+        let _env_guard = DRIVE_ENV_LOCK.lock().await;
+        let (drive_base_url, drive_state) = spawn_mock_drive().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        std::env::set_var(
+            "GOOGLE_DRIVE_API_BASE",
+            format!("{}/drive/v3", drive_base_url),
+        );
+
+        let cm_url = spawn_mock_connector_manager().await?;
+        let sdk_client = SdkClient::new(&cm_url);
+        sdk_client.register_sync(SYNC_RUN_ID, SyncType::Full).await;
+
+        let sync_manager = SyncManager::new(Arc::new(AdminClient::new()), sdk_client.clone(), None);
+        let ctx = SyncContext::new(
+            sdk_client,
+            SYNC_RUN_ID.to_string(),
+            SOURCE_ID.to_string(),
+            SourceType::GoogleDrive,
+            SyncType::Full,
+            Arc::new(std::sync::atomic::AtomicBool::new(false)),
+        );
+
+        let sync_result = sync_manager
+            .run_sync(test_source(), Some(oauth_credentials()), None, ctx)
+            .await;
+
+        if let Some(value) = previous_drive_base {
+            std::env::set_var("GOOGLE_DRIVE_API_BASE", value);
+        } else {
+            std::env::remove_var("GOOGLE_DRIVE_API_BASE");
+        }
+
+        sync_result?;
+
+        assert!(
+            drive_state.max_active_downloads.load(Ordering::SeqCst) > 1,
+            "test should exercise concurrent downloads for smaller files"
+        );
+        assert!(
+            !drive_state.budget_breached.load(Ordering::SeqCst),
+            "declared in-flight download bytes breached the 512 MiB budget"
+        );
+        assert!(
+            drive_state.max_active_declared_bytes.load(Ordering::SeqCst) <= BUDGET_BYTES,
+            "max declared in-flight bytes ({}) exceeded budget ({})",
+            drive_state.max_active_declared_bytes.load(Ordering::SeqCst),
+            BUDGET_BYTES
+        );
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
- Add a byte-weighted semaphore for Drive file content buffering.
- Acquire permits before downloads using Drive size metadata, with full-budget reservation for unknown sizes.
- Warn and skip files that exceed the configured buffer budget.
- Add a mock Drive integration test covering mixed file sizes and budget enforcement.
- Update Google integration fixture for current connector-manager extraction fields.