### PR TITLE
Add per-run sync checkpoints

### DIFF
--- a/connectors/atlassian/src/connector.rs
+++ b/connectors/atlassian/src/connector.rs
@@ -13,7 +13,7 @@ use tracing::info;
 
 use crate::auth::{AtlassianCredentials, AuthManager};
 use crate::client::{AtlassianApi, AtlassianClient};
-use crate::models::AtlassianConnectorState;
+use crate::models::AtlassianSyncCheckpoint;
 use crate::sync::SyncManager;
 
 pub struct AtlassianConnector {
@@ -30,7 +30,7 @@ impl AtlassianConnector {
 impl Connector for AtlassianConnector {
     type Config = JsonValue;
     type Credentials = JsonValue;
-    type State = AtlassianConnectorState;
+    type State = AtlassianSyncCheckpoint;
 
     fn name(&self) -> &'static str {
         "atlassian"

--- a/connectors/atlassian/src/models.rs
+++ b/connectors/atlassian/src/models.rs
@@ -807,6 +807,10 @@ impl ConfluenceCqlPage {
 pub struct AtlassianConnectorState {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub webhook_id: Option<u64>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct AtlassianSyncCheckpoint {
     #[serde(skip_serializing_if = "Option::is_none")]
     pub last_successful_sync_at: Option<chrono::DateTime<chrono::Utc>>,
     /// Confluence page version by "{space_id}:{page_id}". Used by full-sync

--- a/connectors/atlassian/src/sync.rs
+++ b/connectors/atlassian/src/sync.rs
@@ -182,7 +182,7 @@ impl SyncManager {
         // The SDK server constructs its own SdkClient for the SyncContext, so
         // emit/flush must go through `ctx.sdk_client()` — using a different
         // SdkClient instance would buffer events on a client whose buffer
-        // ctx.complete()/ctx.save_connector_state() never flush, stranding
+        // ctx.complete()/ctx.save_checkpoint() never flush, stranding
         // events at end-of-sync.
         let sync_sdk_client = ctx.sdk_client().clone();
 
@@ -315,7 +315,7 @@ impl SyncManager {
             last_successful_sync_at: Some(sync_start),
             confluence_page_versions: new_page_versions,
         };
-        ctx.save_connector_state(serde_json::to_value(new_state)?)
+        ctx.save_checkpoint(serde_json::to_value(new_state)?)
             .await?;
 
         Ok(Some(total_processed))

--- a/connectors/atlassian/src/sync.rs
+++ b/connectors/atlassian/src/sync.rs
@@ -12,7 +12,7 @@ use crate::auth::{AtlassianCredentials, AuthManager};
 use crate::client::{AtlassianApi, OrgGroupInfo};
 use crate::confluence::ConfluenceProcessor;
 use crate::jira::JiraProcessor;
-use crate::models::{AtlassianConnectorState, AtlassianWebhookEvent};
+use crate::models::{AtlassianConnectorState, AtlassianSyncCheckpoint, AtlassianWebhookEvent};
 use crate::user_resolver::UserResolver;
 
 pub struct SyncManager {
@@ -49,7 +49,7 @@ impl SyncManager {
         &self,
         _source: Source,
         _credentials: Option<ServiceCredential>,
-        state: Option<AtlassianConnectorState>,
+        state: Option<AtlassianSyncCheckpoint>,
         ctx: SyncContext,
     ) -> Result<()> {
         let sync_run_id = ctx.sync_run_id().to_string();
@@ -86,7 +86,7 @@ impl SyncManager {
         source_id: &str,
         sync_run_id: &str,
         ctx: &SyncContext,
-        state: Option<AtlassianConnectorState>,
+        state: Option<AtlassianSyncCheckpoint>,
     ) -> Result<Option<u32>> {
         let source = self
             .sdk_client
@@ -172,10 +172,10 @@ impl SyncManager {
         }
         let user_resolver = Arc::new(UserResolver::new(self.client.clone(), user_directory));
 
-        let existing_state = state.unwrap_or_default();
+        let existing_checkpoint = state.unwrap_or_default();
         let sync_mode = ctx.sync_mode();
         let sync_start = Utc::now();
-        let last_sync = existing_state
+        let last_sync = existing_checkpoint
             .last_successful_sync_at
             .unwrap_or_else(|| sync_start - chrono::Duration::hours(24));
 
@@ -191,7 +191,7 @@ impl SyncManager {
                 let page_versions = if sync_mode == SyncType::Full {
                     HashMap::new()
                 } else {
-                    existing_state.confluence_page_versions.clone()
+                    existing_checkpoint.confluence_page_versions.clone()
                 };
                 let processor = ConfluenceProcessor::with_page_versions_and_resolver(
                     self.client.clone(),
@@ -264,7 +264,7 @@ impl SyncManager {
                 let groups = processor.drain_encountered_groups();
                 (
                     count,
-                    existing_state.confluence_page_versions.clone(),
+                    existing_checkpoint.confluence_page_versions.clone(),
                     groups,
                 )
             }
@@ -292,8 +292,6 @@ impl SyncManager {
             source.name, total_processed
         );
 
-        // ensure_webhook_registered may write webhook_id to connector state; we
-        // re-read state afterward so our checkpoint preserves any change.
         if let Err(e) = self
             .ensure_webhook_registered(source_id, &credentials)
             .await
@@ -301,21 +299,11 @@ impl SyncManager {
             warn!("Failed to register webhook for source {}: {}", source_id, e);
         }
 
-        let post_webhook_state: AtlassianConnectorState = self
-            .sdk_client
-            .get_connector_state(source_id)
-            .await
-            .ok()
-            .flatten()
-            .and_then(|v| serde_json::from_value(v).ok())
-            .unwrap_or_default();
-
-        let new_state = AtlassianConnectorState {
-            webhook_id: post_webhook_state.webhook_id.or(existing_state.webhook_id),
+        let new_checkpoint = AtlassianSyncCheckpoint {
             last_successful_sync_at: Some(sync_start),
             confluence_page_versions: new_page_versions,
         };
-        ctx.save_checkpoint(serde_json::to_value(new_state)?)
+        ctx.save_checkpoint(serde_json::to_value(new_checkpoint)?)
             .await?;
 
         Ok(Some(total_processed))
@@ -502,12 +490,14 @@ impl SyncManager {
             None => return Ok(()),
         };
 
-        let state: AtlassianConnectorState = self
+        let existing_state = self
             .sdk_client
             .get_connector_state(source_id)
             .await
             .ok()
-            .flatten()
+            .flatten();
+        let state: AtlassianConnectorState = existing_state
+            .clone()
             .and_then(|v| serde_json::from_value(v).ok())
             .unwrap_or_default();
 
@@ -536,14 +526,12 @@ impl SyncManager {
         let webhook_id = self.client.register_webhook(creds, &full_url).await?;
         info!("Registered webhook {} for source {}", webhook_id, source_id);
 
-        // Preserve other state fields — run_sync writes page versions and
-        // last_successful_sync_at, which we must not clobber from this path.
-        let new_state = AtlassianConnectorState {
-            webhook_id: Some(webhook_id),
-            ..state
-        };
+        let mut new_state = existing_state
+            .filter(|value| value.is_object())
+            .unwrap_or_else(|| serde_json::json!({}));
+        new_state["webhook_id"] = serde_json::json!(webhook_id);
         self.sdk_client
-            .save_connector_state(source_id, serde_json::to_value(&new_state)?)
+            .save_connector_state(source_id, new_state)
             .await?;
 
         Ok(())

--- a/connectors/atlassian/tests/common/mod.rs
+++ b/connectors/atlassian/tests/common/mod.rs
@@ -53,6 +53,8 @@ pub async fn setup_test_fixture(source_type: SourceType) -> Result<TestFixture> 
         max_concurrent_syncs_per_type: 3,
         scheduler_interval_seconds: 600,
         stale_sync_timeout_minutes: 1,
+        extraction_concurrency: 2,
+        extraction_retry_after_seconds: 30,
         sync_backoff_base_seconds: 30,
         sync_backoff_max_seconds: 3600,
         sync_max_consecutive_failures: 10,
@@ -100,6 +102,7 @@ pub async fn setup_test_fixture(source_type: SourceType) -> Result<TestFixture> 
     let app_state = AppState {
         db_pool: test_env.db_pool.clone(),
         redis_client,
+        extraction_semaphore: Arc::new(tokio::sync::Semaphore::new(config.extraction_concurrency)),
         config,
         sync_manager,
         content_storage,

--- a/connectors/clickup/clickup_connector/connector.py
+++ b/connectors/clickup/clickup_connector/connector.py
@@ -197,7 +197,7 @@ class ClickUpConnector(Connector):
                 }
 
                 if docs_since_checkpoint >= CHECKPOINT_INTERVAL:
-                    await ctx.save_state({"workspaces": new_workspace_states})
+                    await ctx.save_checkpoint({"workspaces": new_workspace_states})
                     docs_since_checkpoint = 0
 
             await ctx.complete(new_state={"workspaces": new_workspace_states})

--- a/connectors/fireflies/src/sync.rs
+++ b/connectors/fireflies/src/sync.rs
@@ -88,7 +88,7 @@ pub async fn run_sync(
     );
 
     let new_state = json!({ "last_sync_time": Utc::now().to_rfc3339() });
-    ctx.save_connector_state(new_state).await?;
+    ctx.save_checkpoint(new_state).await?;
     ctx.complete().await?;
 
     Ok(())

--- a/connectors/github/github_connector/connector.py
+++ b/connectors/github/github_connector/connector.py
@@ -291,7 +291,7 @@ class GitHubConnector(Connector):
                     new_repo_states[full_name] = new_state_entry
 
                 if docs_since_checkpoint >= CHECKPOINT_INTERVAL:
-                    await ctx.save_state({"repos": new_repo_states})
+                    await ctx.save_checkpoint({"repos": new_repo_states})
                     docs_since_checkpoint = 0
 
             await ctx.complete(new_state={"repos": new_repo_states})

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -4,7 +4,7 @@ use crate::admin::AdminClient;
 use crate::auth::{create_service_auth, get_domain_from_credentials, GoogleAuth};
 use crate::drive::DriveClient;
 use crate::gmail::{MessageFormat, MessagePart};
-use crate::models::{GoogleConnectorState, GoogleDirectoryUser, SearchUsersResponse};
+use crate::models::{GoogleDirectoryUser, GoogleSyncCheckpoint, SearchUsersResponse};
 use crate::sync::SyncManager;
 use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
@@ -383,7 +383,7 @@ impl GoogleConnector {
 impl Connector for GoogleConnector {
     type Config = JsonValue;
     type Credentials = JsonValue;
-    type State = GoogleConnectorState;
+    type State = GoogleSyncCheckpoint;
 
     fn name(&self) -> &'static str {
         "google"

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -41,7 +41,6 @@ pub struct GoogleConnectorState {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GoogleSyncCheckpoint {
-    pub sync_run_id: Option<String>,
     pub gmail_history_ids: Option<HashMap<String, String>>,
     pub drive_page_tokens: Option<HashMap<String, String>>,
 }

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -37,6 +37,10 @@ pub struct GoogleConnectorState {
     pub webhook_channel_id: Option<String>,
     pub webhook_resource_id: Option<String>,
     pub webhook_expires_at: Option<i64>,
+}
+
+#[derive(Debug, Clone, Default, Serialize, Deserialize)]
+pub struct GoogleSyncCheckpoint {
     pub gmail_history_ids: Option<HashMap<String, String>>,
     pub drive_page_tokens: Option<HashMap<String, String>>,
 }

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -41,6 +41,7 @@ pub struct GoogleConnectorState {
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GoogleSyncCheckpoint {
+    pub sync_run_id: Option<String>,
     pub gmail_history_ids: Option<HashMap<String, String>>,
     pub drive_page_tokens: Option<HashMap<String, String>>,
 }

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -351,14 +351,14 @@ impl SyncManager {
                 // checkpoints mid-sync — the inner pass might have made
                 // additional state mutations after the last checkpoint.
                 let state_json = serde_json::to_value(&final_state)?;
-                ctx.save_connector_state(state_json).await?;
+                ctx.save_checkpoint(state_json).await?;
                 ctx.complete().await?;
                 Ok(())
             }
             // Cancelled mid-sync: tell the SDK so the run is marked
             // `cancelled` rather than `failed`. Returning Ok keeps the
             // SDK's default-fail branch from firing. Per-user state was
-            // already checkpointed mid-sync via `ctx.save_connector_state`.
+            // already checkpointed mid-sync via `ctx.save_checkpoint`.
             Ok(None) => {
                 info!("Sync {} was cancelled", sync_run_id);
                 ctx.cancel().await?;
@@ -1047,7 +1047,7 @@ impl SyncManager {
         }
 
         // Push counts to the manager. Note: counts can over-count on resume
-        // since save_connector_state only fires per-user; an in-flight batch
+        // since save_checkpoint only fires per-user; an in-flight batch
         // re-runs after crash. Counts are advisory progress, not exact.
         if scanned > 0 {
             ctx.increment_scanned(scanned as i32).await?;
@@ -1263,7 +1263,7 @@ impl SyncManager {
                             Some(new_page_tokens.clone())
                         },
                     };
-                    ctx.save_connector_state(serde_json::to_value(&checkpoint_state)?)
+                    ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
                         .await
                         .with_context(|| {
                             format!(
@@ -1489,7 +1489,7 @@ impl SyncManager {
                             },
                             drive_page_tokens: drive_page_tokens.clone(),
                         };
-                        ctx.save_connector_state(serde_json::to_value(&checkpoint_state)?)
+                        ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
                             .await
                             .with_context(|| {
                                 format!(

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -1115,8 +1115,7 @@ impl SyncManager {
 
         let gmail_history_ids = existing_state.gmail_history_ids.clone();
         let old_page_tokens = existing_state.drive_page_tokens.unwrap_or_default();
-        let can_resume_full = sync_type == SyncType::Full
-            && existing_state.sync_run_id.as_deref() == Some(sync_run_id);
+        let can_resume_full = sync_type == SyncType::Full && ctx.is_resume();
         let mut new_page_tokens: HashMap<String, String> = if can_resume_full {
             old_page_tokens.clone()
         } else {
@@ -1264,7 +1263,6 @@ impl SyncManager {
                     }
 
                     let checkpoint_state = GoogleSyncCheckpoint {
-                        sync_run_id: Some(sync_run_id.to_string()),
                         gmail_history_ids: gmail_history_ids.clone(),
                         drive_page_tokens: if new_page_tokens.is_empty() {
                             None
@@ -1304,7 +1302,6 @@ impl SyncManager {
         info!("Completed sync for source: {}", source.id);
 
         Ok(GoogleSyncCheckpoint {
-            sync_run_id: Some(sync_run_id.to_string()),
             gmail_history_ids,
             drive_page_tokens: if new_page_tokens.is_empty() {
                 None
@@ -1366,8 +1363,7 @@ impl SyncManager {
 
         let drive_page_tokens = existing_state.drive_page_tokens.clone();
         let old_history_ids = existing_state.gmail_history_ids.unwrap_or_default();
-        let can_resume_full = sync_type == SyncType::Full
-            && existing_state.sync_run_id.as_deref() == Some(sync_run_id);
+        let can_resume_full = sync_type == SyncType::Full && ctx.is_resume();
         let mut new_history_ids: HashMap<String, String> = if can_resume_full {
             old_history_ids.clone()
         } else {
@@ -1496,7 +1492,6 @@ impl SyncManager {
                         }
 
                         let checkpoint_state = GoogleSyncCheckpoint {
-                            sync_run_id: Some(sync_run_id.to_string()),
                             gmail_history_ids: if new_history_ids.is_empty() {
                                 None
                             } else {
@@ -1528,7 +1523,6 @@ impl SyncManager {
         info!("Completed Gmail sync for source: {}", source.id);
 
         Ok(GoogleSyncCheckpoint {
-            sync_run_id: Some(sync_run_id.to_string()),
             gmail_history_ids: if new_history_ids.is_empty() {
                 None
             } else {

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -1115,7 +1115,13 @@ impl SyncManager {
 
         let gmail_history_ids = existing_state.gmail_history_ids.clone();
         let old_page_tokens = existing_state.drive_page_tokens.unwrap_or_default();
-        let mut new_page_tokens: HashMap<String, String> = HashMap::new();
+        let can_resume_full = sync_type == SyncType::Full
+            && existing_state.sync_run_id.as_deref() == Some(sync_run_id);
+        let mut new_page_tokens: HashMap<String, String> = if can_resume_full {
+            old_page_tokens.clone()
+        } else {
+            HashMap::new()
+        };
 
         info!(
             "Starting user processing for {} users (Drive, incremental={})",
@@ -1140,6 +1146,14 @@ impl SyncManager {
             let stored_page_token = old_page_tokens.get(cur_user_email.as_str()).cloned();
 
             async move {
+                if can_resume_full && stored_page_token.is_some() {
+                    info!(
+                        "Skipping Drive user {} already checkpointed for sync {}",
+                        cur_user_email, sync_run_id
+                    );
+                    return (cur_user_email, Ok((0, 0, None)));
+                }
+
                 if ctx.is_cancelled() {
                     info!(
                         "Sync {} cancelled, skipping Drive sync for user {}",
@@ -1250,6 +1264,7 @@ impl SyncManager {
                     }
 
                     let checkpoint_state = GoogleSyncCheckpoint {
+                        sync_run_id: Some(sync_run_id.to_string()),
                         gmail_history_ids: gmail_history_ids.clone(),
                         drive_page_tokens: if new_page_tokens.is_empty() {
                             None
@@ -1289,6 +1304,7 @@ impl SyncManager {
         info!("Completed sync for source: {}", source.id);
 
         Ok(GoogleSyncCheckpoint {
+            sync_run_id: Some(sync_run_id.to_string()),
             gmail_history_ids,
             drive_page_tokens: if new_page_tokens.is_empty() {
                 None
@@ -1350,7 +1366,13 @@ impl SyncManager {
 
         let drive_page_tokens = existing_state.drive_page_tokens.clone();
         let old_history_ids = existing_state.gmail_history_ids.unwrap_or_default();
-        let mut new_history_ids: HashMap<String, String> = HashMap::new();
+        let can_resume_full = sync_type == SyncType::Full
+            && existing_state.sync_run_id.as_deref() == Some(sync_run_id);
+        let mut new_history_ids: HashMap<String, String> = if can_resume_full {
+            old_history_ids.clone()
+        } else {
+            HashMap::new()
+        };
 
         let processed_threads = Arc::new(std::sync::Mutex::new(HashSet::<String>::new()));
         let known_groups = Arc::new(known_groups);
@@ -1375,6 +1397,13 @@ impl SyncManager {
                     info!("Processing user: {}", cur_user_email);
 
                     let stored_history_id = old_history_ids.get(cur_user_email.as_str());
+                    if can_resume_full && stored_history_id.is_some() {
+                        info!(
+                            "Skipping Gmail user {} already checkpointed for sync {}",
+                            cur_user_email, sync_run_id
+                        );
+                        continue;
+                    }
                     let use_incremental = is_incremental && stored_history_id.is_some();
 
                     let result = if use_incremental {
@@ -1467,6 +1496,7 @@ impl SyncManager {
                         }
 
                         let checkpoint_state = GoogleSyncCheckpoint {
+                            sync_run_id: Some(sync_run_id.to_string()),
                             gmail_history_ids: if new_history_ids.is_empty() {
                                 None
                             } else {
@@ -1498,6 +1528,7 @@ impl SyncManager {
         info!("Completed Gmail sync for source: {}", source.id);
 
         Ok(GoogleSyncCheckpoint {
+            sync_run_id: Some(sync_run_id.to_string()),
             gmail_history_ids: if new_history_ids.is_empty() {
                 None
             } else {

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -244,8 +244,8 @@ use crate::connector::build_attachment_doc_id;
 use crate::drive::{DriveClient, FileContent};
 use crate::gmail::{BatchThreadResult, ExtractedAttachment, GmailClient, MessageFormat};
 use crate::models::{
-    mime_type_to_content_type, AttachmentPointer, GmailThread, GoogleConnectorState, UserFile,
-    WebhookChannel, WebhookChannelResponse, WebhookNotification,
+    mime_type_to_content_type, AttachmentPointer, GmailThread, GoogleConnectorState,
+    GoogleSyncCheckpoint, UserFile, WebhookChannel, WebhookChannelResponse, WebhookNotification,
 };
 use omni_connector_sdk::RateLimiter;
 use omni_connector_sdk::SdkClient;
@@ -322,7 +322,7 @@ impl SyncManager {
         &self,
         source: Source,
         credentials: Option<ServiceCredential>,
-        state: Option<GoogleConnectorState>,
+        state: Option<GoogleSyncCheckpoint>,
         ctx: SyncContext,
     ) -> Result<()> {
         let sync_run_id = ctx.sync_run_id().to_string();
@@ -376,9 +376,9 @@ impl SyncManager {
         &self,
         source: &Source,
         service_creds: &ServiceCredential,
-        existing_state: Option<GoogleConnectorState>,
+        existing_state: Option<GoogleSyncCheckpoint>,
         ctx: &SyncContext,
-    ) -> Result<Option<GoogleConnectorState>> {
+    ) -> Result<Option<GoogleSyncCheckpoint>> {
         let source_id = ctx.source_id();
         let sync_type = ctx.sync_mode();
 
@@ -1068,9 +1068,9 @@ impl SyncManager {
         source: &Source,
         service_creds: &ServiceCredential,
         sync_type: SyncType,
-        existing_state: GoogleConnectorState,
+        existing_state: GoogleSyncCheckpoint,
         ctx: &SyncContext,
-    ) -> Result<GoogleConnectorState> {
+    ) -> Result<GoogleSyncCheckpoint> {
         let sync_run_id = ctx.sync_run_id();
 
         let service_auth = Arc::new(self.create_auth(service_creds, source.source_type).await?);
@@ -1113,9 +1113,6 @@ impl SyncManager {
 
         let is_incremental = matches!(sync_type, SyncType::Incremental);
 
-        let webhook_channel_id = existing_state.webhook_channel_id.clone();
-        let webhook_resource_id = existing_state.webhook_resource_id.clone();
-        let webhook_expires_at = existing_state.webhook_expires_at;
         let gmail_history_ids = existing_state.gmail_history_ids.clone();
         let old_page_tokens = existing_state.drive_page_tokens.unwrap_or_default();
         let mut new_page_tokens: HashMap<String, String> = HashMap::new();
@@ -1252,10 +1249,7 @@ impl SyncManager {
                         new_page_tokens.insert(cur_user_email.clone(), token);
                     }
 
-                    let checkpoint_state = GoogleConnectorState {
-                        webhook_channel_id: webhook_channel_id.clone(),
-                        webhook_resource_id: webhook_resource_id.clone(),
-                        webhook_expires_at,
+                    let checkpoint_state = GoogleSyncCheckpoint {
                         gmail_history_ids: gmail_history_ids.clone(),
                         drive_page_tokens: if new_page_tokens.is_empty() {
                             None
@@ -1294,10 +1288,7 @@ impl SyncManager {
 
         info!("Completed sync for source: {}", source.id);
 
-        Ok(GoogleConnectorState {
-            webhook_channel_id,
-            webhook_resource_id,
-            webhook_expires_at,
+        Ok(GoogleSyncCheckpoint {
             gmail_history_ids,
             drive_page_tokens: if new_page_tokens.is_empty() {
                 None
@@ -1312,10 +1303,10 @@ impl SyncManager {
         source: &Source,
         service_creds: &ServiceCredential,
         sync_type: SyncType,
-        existing_state: GoogleConnectorState,
+        existing_state: GoogleSyncCheckpoint,
         known_groups: HashSet<String>,
         ctx: &SyncContext,
-    ) -> Result<GoogleConnectorState> {
+    ) -> Result<GoogleSyncCheckpoint> {
         let sync_run_id = ctx.sync_run_id();
 
         let service_auth = Arc::new(self.create_auth(service_creds, source.source_type).await?);
@@ -1357,9 +1348,6 @@ impl SyncManager {
 
         let is_incremental = matches!(sync_type, SyncType::Incremental);
 
-        let webhook_channel_id = existing_state.webhook_channel_id.clone();
-        let webhook_resource_id = existing_state.webhook_resource_id.clone();
-        let webhook_expires_at = existing_state.webhook_expires_at;
         let drive_page_tokens = existing_state.drive_page_tokens.clone();
         let old_history_ids = existing_state.gmail_history_ids.unwrap_or_default();
         let mut new_history_ids: HashMap<String, String> = HashMap::new();
@@ -1478,10 +1466,7 @@ impl SyncManager {
                             }
                         }
 
-                        let checkpoint_state = GoogleConnectorState {
-                            webhook_channel_id: webhook_channel_id.clone(),
-                            webhook_resource_id: webhook_resource_id.clone(),
-                            webhook_expires_at,
+                        let checkpoint_state = GoogleSyncCheckpoint {
                             gmail_history_ids: if new_history_ids.is_empty() {
                                 None
                             } else {
@@ -1512,10 +1497,7 @@ impl SyncManager {
 
         info!("Completed Gmail sync for source: {}", source.id);
 
-        Ok(GoogleConnectorState {
-            webhook_channel_id,
-            webhook_resource_id,
-            webhook_expires_at,
+        Ok(GoogleSyncCheckpoint {
             gmail_history_ids: if new_history_ids.is_empty() {
                 None
             } else {
@@ -1838,22 +1820,19 @@ impl SyncManager {
             .as_ref()
             .and_then(|exp| exp.parse::<i64>().ok());
 
-        // Store new channel info in connector_state, preserving existing gmail_history_ids
-        let existing_state: GoogleConnectorState =
-            if let Ok(Some(raw)) = self.sdk_client.get_connector_state(source_id).await {
-                serde_json::from_value(raw).unwrap_or_default()
-            } else {
-                GoogleConnectorState::default()
-            };
-        let webhook_state = GoogleConnectorState {
-            webhook_channel_id: Some(webhook_response.id.clone()),
-            webhook_resource_id: Some(webhook_response.resource_id.clone()),
-            webhook_expires_at: expires_at,
-            gmail_history_ids: existing_state.gmail_history_ids,
-            drive_page_tokens: existing_state.drive_page_tokens,
-        };
+        let mut webhook_state = self
+            .sdk_client
+            .get_connector_state(source_id)
+            .await
+            .ok()
+            .flatten()
+            .filter(|value| value.is_object())
+            .unwrap_or_else(|| json!({}));
+        webhook_state["webhook_channel_id"] = json!(webhook_response.id.clone());
+        webhook_state["webhook_resource_id"] = json!(webhook_response.resource_id.clone());
+        webhook_state["webhook_expires_at"] = json!(expires_at);
         self.sdk_client
-            .save_connector_state(source_id, serde_json::to_value(&webhook_state)?)
+            .save_connector_state(source_id, webhook_state)
             .await?;
 
         info!(

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -419,6 +419,7 @@ mod drive_buffer_budget_tests {
             user_whitelist: None,
             user_blacklist: None,
             connector_state: None,
+            checkpoint: None,
             sync_interval_seconds: None,
             created_at: now,
             updated_at: now,

--- a/connectors/imap/src/sync.rs
+++ b/connectors/imap/src/sync.rs
@@ -105,7 +105,7 @@ impl SyncManager {
 
         if ctx.is_cancelled() {
             info!("IMAP sync {} was cancelled", sync_run_id);
-            let _ = ctx.save_connector_state(connector_state.to_json()).await;
+            let _ = ctx.save_checkpoint(connector_state.to_json()).await;
             ctx.cancel().await?;
             return Ok(());
         }
@@ -117,12 +117,12 @@ impl SyncManager {
                     source_id, total_scanned, total_processed
                 );
                 ctx.increment_updated(total_processed as i32).await?;
-                ctx.save_connector_state(connector_state.to_json()).await?;
+                ctx.save_checkpoint(connector_state.to_json()).await?;
                 ctx.complete().await?;
                 Ok(())
             }
             Err(e) => {
-                let _ = ctx.save_connector_state(connector_state.to_json()).await;
+                let _ = ctx.save_checkpoint(connector_state.to_json()).await;
                 error!("IMAP sync failed for source {}: {}", source_id, e);
                 Err(e)
             }
@@ -317,8 +317,7 @@ impl SyncManager {
         let mut new_uids: Vec<u32> = if ctx.sync_mode() == SyncType::Full {
             server_uids
         } else {
-            let indexed_uid_set: HashSet<u32> =
-                folder_state.indexed_uids.iter().copied().collect();
+            let indexed_uid_set: HashSet<u32> = folder_state.indexed_uids.iter().copied().collect();
             server_uids
                 .into_iter()
                 .filter(|uid| {
@@ -382,10 +381,7 @@ impl SyncManager {
                                         folder
                                     )));
                                 }
-                                warn!(
-                                    "Skipping UID {} in '{}': {}",
-                                    uid, folder, single_err
-                                );
+                                warn!("Skipping UID {} in '{}': {}", uid, folder, single_err);
                             }
                         }
                     }

--- a/connectors/linear/src/connector.ts
+++ b/connectors/linear/src/connector.ts
@@ -178,7 +178,7 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
             await ctx.incrementUpdated(1);
             docsSinceCheckpoint++;
             if (docsSinceCheckpoint >= CHECKPOINT_INTERVAL) {
-              await ctx.saveState({ last_sync_at: new Date().toISOString() });
+              await ctx.saveCheckpoint({ last_sync_at: new Date().toISOString() });
               docsSinceCheckpoint = 0;
             }
           } catch (e) {
@@ -238,7 +238,7 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
           }
 
           if (docsSinceCheckpoint >= CHECKPOINT_INTERVAL) {
-            await ctx.saveState({ last_sync_at: new Date().toISOString() });
+            await ctx.saveCheckpoint({ last_sync_at: new Date().toISOString() });
             docsSinceCheckpoint = 0;
           }
         } catch (e) {
@@ -278,7 +278,7 @@ export class LinearConnector extends Connector<LinearSourceConfig, LinearCredent
           await ctx.incrementUpdated(1);
           docsSinceCheckpoint++;
           if (docsSinceCheckpoint >= CHECKPOINT_INTERVAL) {
-            await ctx.saveState({ last_sync_at: new Date().toISOString() });
+            await ctx.saveCheckpoint({ last_sync_at: new Date().toISOString() });
             docsSinceCheckpoint = 0;
           }
         } catch (e) {

--- a/connectors/microsoft/ms_connector/syncers/base.py
+++ b/connectors/microsoft/ms_connector/syncers/base.py
@@ -50,7 +50,7 @@ class BaseSyncer(abc.ABC):
     ) -> None:
         """Persist a delta token while preserving the full token map."""
         delta_tokens[token_key] = token
-        await ctx.save_state({"delta_tokens": delta_tokens})
+        await ctx.save_checkpoint({"delta_tokens": delta_tokens})
 
     async def sync(
         self,
@@ -113,7 +113,7 @@ class BaseSyncer(abc.ABC):
             if new_token:
                 await self.save_delta_token(ctx, new_tokens, user_id, new_token)
             else:
-                await ctx.save_state({"delta_tokens": new_tokens})
+                await ctx.save_checkpoint({"delta_tokens": new_tokens})
 
         if attempted > 0 and failed == attempted:
             raise RuntimeError(f"[{self.name}] sync failed for all {attempted} users")

--- a/connectors/microsoft/ms_connector/syncers/mail.py
+++ b/connectors/microsoft/ms_connector/syncers/mail.py
@@ -71,7 +71,7 @@ class MailSyncer(BaseSyncer):
                 )
                 if new_token:
                     new_tokens[token_key] = new_token
-                    await ctx.save_state({"delta_tokens": new_tokens})
+                    await ctx.save_checkpoint({"delta_tokens": new_tokens})
 
         return {"delta_tokens": new_tokens}
 

--- a/connectors/microsoft/ms_connector/syncers/sharepoint.py
+++ b/connectors/microsoft/ms_connector/syncers/sharepoint.py
@@ -183,7 +183,7 @@ class SharePointSyncer:
                 )
                 if new_token:
                     delta_tokens[drive.id] = new_token
-                    await ctx.save_state({DRIVE_DELTA_TOKENS_KEY: delta_tokens})
+                    await ctx.save_checkpoint({DRIVE_DELTA_TOKENS_KEY: delta_tokens})
 
             logger.info("[sharepoint] Finished site %s", site.display_name)
 

--- a/connectors/microsoft/ms_connector/syncers/teams.py
+++ b/connectors/microsoft/ms_connector/syncers/teams.py
@@ -404,7 +404,7 @@ class TeamsSyncer:
                     new_tokens[token_key] = new_token
                     new_sync_ts[token_key] = now_iso
 
-                await ctx.save_state(
+                await ctx.save_checkpoint(
                     {
                         "delta_tokens": new_tokens,
                         "last_sync_ts": new_sync_ts,
@@ -921,7 +921,7 @@ class TeamsSyncer:
                 if ok:
                     new_chat_sync_ts[chat_id] = now_iso
 
-                await ctx.save_state(
+                await ctx.save_checkpoint(
                     {
                         **(channel_state or {}),
                         "chat_last_sync_ts": new_chat_sync_ts,

--- a/connectors/nextcloud/src/sync.rs
+++ b/connectors/nextcloud/src/sync.rs
@@ -58,7 +58,7 @@ pub async fn run_sync(
 
     if ctx.is_cancelled() {
         info!("Nextcloud sync {} was cancelled", sync_run_id);
-        let _ = ctx.save_connector_state(state.to_json()).await;
+        let _ = ctx.save_checkpoint(state.to_json()).await;
         let _ = ctx.cancel().await;
         return Ok(());
     }
@@ -69,12 +69,12 @@ pub async fn run_sync(
                 "Nextcloud sync completed for source {}: {} scanned, {} processed",
                 source_id, total_scanned, total_processed
             );
-            ctx.save_connector_state(state.to_json()).await?;
+            ctx.save_checkpoint(state.to_json()).await?;
             ctx.complete().await?;
             Ok(())
         }
         Err(e) => {
-            let _ = ctx.save_connector_state(state.to_json()).await;
+            let _ = ctx.save_checkpoint(state.to_json()).await;
             error!("Nextcloud sync failed for source {}: {}", source_id, e);
             Err(e)
         }
@@ -306,7 +306,9 @@ async fn process_file_batch(
 
             // is_update is true only when we have previously indexed this file
             // (etag stored without a "skipped:" prefix).
-            let is_update = state.etags.get(&key)
+            let is_update = state
+                .etags
+                .get(&key)
                 .map(|e| !e.starts_with("skipped:"))
                 .unwrap_or(false);
 

--- a/connectors/notion/notion_connector/connector.py
+++ b/connectors/notion/notion_connector/connector.py
@@ -294,7 +294,7 @@ class NotionConnector(Connector):
                     await ctx.emit_error(eid, str(e))
 
                 if docs_emitted >= CHECKPOINT_INTERVAL:
-                    await ctx.save_state({})
+                    await ctx.save_checkpoint({})
                     docs_emitted = 0
 
             if not response.get("has_more"):
@@ -303,7 +303,7 @@ class NotionConnector(Connector):
 
         now = datetime.now(UTC).isoformat()
         # save_state actually persists; complete()'s new_state is dropped by CM.
-        await ctx.save_state({"last_sync_at": now})
+        await ctx.save_checkpoint({"last_sync_at": now})
         await ctx.complete()
         logger.info(
             "Full sync completed: %d scanned, %d emitted",
@@ -364,7 +364,7 @@ class NotionConnector(Connector):
                     await ctx.emit_error(eid, str(e))
 
                 if docs_emitted >= CHECKPOINT_INTERVAL:
-                    await ctx.save_state({"last_sync_at": last_sync_at})
+                    await ctx.save_checkpoint({"last_sync_at": last_sync_at})
                     docs_emitted = 0
 
             if found_old or not response.get("has_more"):
@@ -403,7 +403,7 @@ class NotionConnector(Connector):
             cursor = response.get("next_cursor")
 
         now = datetime.now(UTC).isoformat()
-        await ctx.save_state({"last_sync_at": now})
+        await ctx.save_checkpoint({"last_sync_at": now})
         await ctx.complete()
         logger.info(
             "Incremental sync completed: %d scanned, %d emitted",
@@ -523,7 +523,7 @@ class NotionConnector(Connector):
                     await ctx.emit_error(eid, str(e))
 
                 if docs_emitted >= CHECKPOINT_INTERVAL:
-                    await ctx.save_state({})
+                    await ctx.save_checkpoint({})
                     docs_emitted = 0
 
             if not response.get("has_more"):

--- a/connectors/paperless/paperless_connector/connector.py
+++ b/connectors/paperless/paperless_connector/connector.py
@@ -122,7 +122,7 @@ class PaperlessConnector(Connector):
                     continue
 
                 if docs_since_checkpoint >= CHECKPOINT_INTERVAL:
-                    await ctx.save_state(
+                    await ctx.save_checkpoint(
                         {"last_sync_at": sync_started_at.isoformat()}
                     )
                     docs_since_checkpoint = 0

--- a/connectors/slack/src/connector.rs
+++ b/connectors/slack/src/connector.rs
@@ -205,6 +205,7 @@ mod tests {
             user_whitelist: None,
             user_blacklist: None,
             connector_state: None,
+            checkpoint: None,
             sync_interval_seconds: Some(3600),
             created_at: now,
             updated_at: now,

--- a/connectors/slack/src/sync.rs
+++ b/connectors/slack/src/sync.rs
@@ -206,7 +206,7 @@ impl SyncManager {
                 // Persist completed-channel timestamps before exiting so the
                 // next run doesn't redo the work that completed before cancel.
                 ctx.flush().await?;
-                ctx.save_connector_state(serde_json::to_value(&connector_state)?)
+                ctx.save_checkpoint(serde_json::to_value(&connector_state)?)
                     .await?;
                 ctx.cancel().await?;
                 return Ok(());
@@ -279,7 +279,7 @@ impl SyncManager {
                     match ctx.flush().await {
                         Ok(()) => {
                             if let Err(e) = ctx
-                                .save_connector_state(serde_json::to_value(&connector_state)?)
+                                .save_checkpoint(serde_json::to_value(&connector_state)?)
                                 .await
                             {
                                 warn!(
@@ -314,7 +314,7 @@ impl SyncManager {
         );
 
         ctx.flush().await?;
-        ctx.save_connector_state(serde_json::to_value(&connector_state)?)
+        ctx.save_checkpoint(serde_json::to_value(&connector_state)?)
             .await?;
         ctx.complete().await?;
 
@@ -369,7 +369,7 @@ impl SyncManager {
 
             let mut connector_state: SlackConnectorState = self
                 .sdk_client
-                .get_connector_state(source_id)
+                .get_checkpoint(source_id)
                 .await?
                 .and_then(|state| serde_json::from_value(state).ok())
                 .unwrap_or_default();
@@ -406,7 +406,7 @@ impl SyncManager {
             }
 
             ctx.flush().await?;
-            ctx.save_connector_state(serde_json::to_value(&connector_state)?)
+            ctx.save_checkpoint(serde_json::to_value(&connector_state)?)
                 .await?;
 
             let updated = outcome.published_groups + outcome.published_files;

--- a/connectors/slack/tests/common/mod.rs
+++ b/connectors/slack/tests/common/mod.rs
@@ -39,6 +39,8 @@ impl SlackConnectorTestFixture {
             max_concurrent_syncs_per_type: 3,
             scheduler_interval_seconds: 30,
             stale_sync_timeout_minutes: 10,
+            extraction_concurrency: 2,
+            extraction_retry_after_seconds: 30,
             sync_backoff_base_seconds: 30,
             sync_backoff_max_seconds: 3600,
             sync_max_consecutive_failures: 10,
@@ -58,6 +60,9 @@ impl SlackConnectorTestFixture {
         let cm_state = CMAppState {
             db_pool: test_env.db_pool.clone(),
             redis_client,
+            extraction_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                cm_config.extraction_concurrency,
+            )),
             config: cm_config,
             sync_manager: cm_sync_manager,
             content_storage,
@@ -192,7 +197,7 @@ impl SlackConnectorTestFixture {
     }
 
     pub async fn get_connector_state(&self, source_id: &str) -> Result<Option<serde_json::Value>> {
-        let row = sqlx::query("SELECT connector_state FROM sources WHERE id = $1")
+        let row = sqlx::query("SELECT checkpoint FROM sources WHERE id = $1")
             .bind(source_id)
             .fetch_optional(self.pool())
             .await?;
@@ -200,7 +205,7 @@ impl SlackConnectorTestFixture {
         Ok(row
             .map(|r| {
                 use sqlx::Row;
-                r.get::<Option<serde_json::Value>, _>("connector_state")
+                r.get::<Option<serde_json::Value>, _>("checkpoint")
             })
             .flatten())
     }

--- a/connectors/web/src/models.rs
+++ b/connectors/web/src/models.rs
@@ -276,7 +276,7 @@ impl PageSyncState {
 }
 
 /// Persistent state for the web connector, stored via
-/// `SyncContext::save_connector_state` and hydrated on the next sync. Replaces
+/// `SyncContext::save_checkpoint` and hydrated on the next sync. Replaces
 /// the previous per-URL Redis cache: change detection, deletion detection, and
 /// all per-page incremental state live here.
 #[derive(Debug, Clone, Serialize, Deserialize, Default)]

--- a/connectors/web/src/sync.rs
+++ b/connectors/web/src/sync.rs
@@ -111,7 +111,7 @@ impl SyncManager {
         let previous_doc_ids: HashSet<String> = prior.pages.keys().cloned().collect();
 
         // In-memory state accumulated during this sync run. On completion it
-        // replaces `prior` and is persisted via `ctx.save_connector_state`.
+        // replaces `prior` and is persisted via `ctx.save_checkpoint`.
         let state: Arc<Mutex<HashMap<String, PageSyncState>>> =
             Arc::new(Mutex::new(prior.pages.clone()));
         let current_doc_ids: Arc<Mutex<HashSet<String>>> = Arc::new(Mutex::new(HashSet::new()));
@@ -210,7 +210,7 @@ impl SyncManager {
             pages: state.lock().await.clone(),
             last_sync_completed_at: Some(chrono::Utc::now().to_rfc3339()),
         };
-        ctx.save_connector_state(serde_json::to_value(&new_state)?)
+        ctx.save_checkpoint(serde_json::to_value(&new_state)?)
             .await?;
         ctx.complete().await?;
         Ok(())

--- a/connectors/web/tests/common/mod.rs
+++ b/connectors/web/tests/common/mod.rs
@@ -57,6 +57,8 @@ impl WebConnectorTestFixture {
             max_concurrent_syncs_per_type: 3,
             scheduler_interval_seconds: 30,
             stale_sync_timeout_minutes: 10,
+            extraction_concurrency: 2,
+            extraction_retry_after_seconds: 30,
             sync_backoff_base_seconds: 30,
             sync_backoff_max_seconds: 3600,
             sync_max_consecutive_failures: 10,
@@ -79,6 +81,9 @@ impl WebConnectorTestFixture {
         let cm_state = CMAppState {
             db_pool: test_env.db_pool.clone(),
             redis_client,
+            extraction_semaphore: Arc::new(tokio::sync::Semaphore::new(
+                cm_config.extraction_concurrency,
+            )),
             config: cm_config,
             sync_manager: cm_sync_manager,
             content_storage,
@@ -207,7 +212,7 @@ impl WebConnectorTestFixture {
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))?;
         let config = WebSourceConfig::from_json(&source.config)?;
-        let prior_state = match source.connector_state {
+        let prior_state = match source.checkpoint {
             Some(value) => Some(serde_json::from_value::<WebConnectorState>(value)?),
             None => None,
         };
@@ -242,7 +247,7 @@ impl WebConnectorTestFixture {
     /// Get connector state for a source via SDK
     pub async fn get_connector_state(&self, source_id: &str) -> Result<Option<serde_json::Value>> {
         self.sdk_client
-            .get_connector_state(source_id)
+            .get_checkpoint(source_id)
             .await
             .map_err(|e| anyhow::anyhow!("{}", e))
     }

--- a/sdk/python/examples/rss_connector.py
+++ b/sdk/python/examples/rss_connector.py
@@ -164,7 +164,7 @@ class RSSConnector(Connector):
             docs_since_checkpoint += 1
 
             if docs_since_checkpoint >= 50:
-                await ctx.save_state({"last_sync_time": current_time.isoformat()})
+                await ctx.save_checkpoint({"last_sync_time": current_time.isoformat()})
                 docs_since_checkpoint = 0
 
         await ctx.complete(new_state={"last_sync_time": current_time.isoformat()})

--- a/sdk/python/omni_connector/client.py
+++ b/sdk/python/omni_connector/client.py
@@ -245,10 +245,27 @@ class SdkClient:
 
         return response.json()["content_id"]
 
+    async def update_checkpoint(
+        self, sync_run_id: str, checkpoint: dict[str, Any]
+    ) -> None:
+        """Persist a run-scoped sync checkpoint to the manager."""
+        logger.debug("SDK: Updating checkpoint for sync_run=%s", sync_run_id)
+
+        client = await self._get_client()
+        response = await client.put(
+            f"{self.base_url}/sdk/sync/{sync_run_id}/checkpoint",
+            json=checkpoint,
+        )
+
+        if not response.is_success:
+            raise SdkClientError(
+                f"Failed to update checkpoint: {response.status_code} - {response.text}"
+            )
+
     async def update_connector_state(
         self, source_id: str, state: dict[str, Any]
     ) -> None:
-        """Persist connector state to the manager (used by save_state checkpoints)."""
+        """Persist non-checkpoint connector metadata to the manager."""
         logger.debug("SDK: Updating connector state for source=%s", source_id)
 
         client = await self._get_client()
@@ -306,7 +323,7 @@ class SdkClient:
             "documents_updated": documents_updated,
         }
         if new_state is not None:
-            payload["new_state"] = new_state
+            await self.update_checkpoint(sync_run_id, new_state)
 
         client = await self._get_client()
         response = await client.post(

--- a/sdk/python/omni_connector/context.py
+++ b/sdk/python/omni_connector/context.py
@@ -216,27 +216,34 @@ class SyncContext:
         self._documents_scanned += 1
         await self._client.increment_scanned(self._sync_run_id)
 
-    async def save_state(self, state: dict[str, Any]) -> None:
+    async def save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
         """Checkpoint state for resumability. Call periodically for long syncs.
 
-        Persists `state` to the manager so an interrupted sync can resume from
-        this point. Flushes buffered events first — without this, a crash
+        Persists `checkpoint` to the manager so an interrupted sync can resume
+        from this point. Flushes buffered events first — without this, a crash
         right after checkpointing would lose events that the connector
         considered emitted (the next run resumes past them).
         """
         await self.flush()
-        self._state = state
-        await self._client.update_connector_state(self._source_id, state)
+        self._state = checkpoint
+        await self._client.update_checkpoint(self._sync_run_id, checkpoint)
         await self._client.heartbeat(self._sync_run_id)
 
+    async def save_state(self, state: dict[str, Any]) -> None:
+        """Deprecated alias for save_checkpoint."""
+        await self.save_checkpoint(state)
+
     async def complete(self, new_state: dict[str, Any] | None = None) -> None:
-        """Mark sync as successfully completed. Saves final state."""
+        """Mark sync as successfully completed. Saves final checkpoint first."""
         await self.flush()
+        if new_state is not None:
+            self._state = new_state
+            await self._client.update_checkpoint(self._sync_run_id, new_state)
         await self._client.complete(
             self._sync_run_id,
             self._documents_scanned,
             self._documents_emitted,
-            new_state,
+            None,
         )
 
     async def fail(self, error: str) -> None:

--- a/sdk/python/omni_connector/context.py
+++ b/sdk/python/omni_connector/context.py
@@ -48,6 +48,7 @@ class SyncContext:
         sync_mode: SyncMode = SyncMode.INCREMENTAL,
         documents_scanned: int = 0,
         documents_updated: int = 0,
+        is_resume: bool = False,
     ):
         self._client = sdk_client
         self._sync_run_id = sync_run_id
@@ -65,6 +66,7 @@ class SyncContext:
         self._user_whitelist = {e.lower() for e in (user_whitelist or [])}
         self._user_blacklist = {e.lower() for e in (user_blacklist or [])}
         self._sync_mode = sync_mode
+        self._is_resume = is_resume
         self._buffer_size_threshold, self._buffer_time_threshold = _thresholds_for(
             sync_mode
         )
@@ -98,6 +100,14 @@ class SyncContext:
     @property
     def documents_scanned(self) -> int:
         return self._documents_scanned
+
+    @property
+    def sync_mode(self) -> SyncMode:
+        return self._sync_mode
+
+    @property
+    def is_resume(self) -> bool:
+        return self._is_resume
 
     def should_index_user(self, user_email: str) -> bool:
         """Check if a user should be indexed based on filter settings."""

--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -214,6 +214,7 @@ class SyncRequest(BaseModel):
     sync_run_id: str
     source_id: str
     sync_mode: str
+    checkpoint: dict[str, Any] | None = None
     # Manager's running tally at dispatch time. Zero on a fresh sync;
     # non-zero on resume so the connector can keep counting from there.
     documents_scanned: int = 0
@@ -289,6 +290,7 @@ class SdkSourceSyncData(BaseModel):
     config: dict[str, Any]
     credentials: dict[str, Any]
     connector_state: dict[str, Any] | None = None
+    checkpoint: dict[str, Any] | None = None
     source_type: str | None = None
     user_filter_mode: UserFilterMode = UserFilterMode.ALL
     user_whitelist: list[str] | None = None

--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -215,6 +215,7 @@ class SyncRequest(BaseModel):
     source_id: str
     sync_mode: str
     checkpoint: dict[str, Any] | None = None
+    is_resume: bool = False
     # Manager's running tally at dispatch time. Zero on a fresh sync;
     # non-zero on resume so the connector can keep counting from there.
     documents_scanned: int = 0

--- a/sdk/python/omni_connector/server.py
+++ b/sdk/python/omni_connector/server.py
@@ -132,7 +132,7 @@ def create_app(connector: "Connector") -> FastAPI:
             sync_data = await server.sdk_client.fetch_source_sync_data(source_id)
             source_config = sync_data.config
             credentials = sync_data.credentials
-            state = sync_data.connector_state
+            state = request.checkpoint if request.checkpoint is not None else sync_data.checkpoint
             source_type = sync_data.source_type
         except SdkClientError as e:
             error_msg = str(e)

--- a/sdk/python/omni_connector/server.py
+++ b/sdk/python/omni_connector/server.py
@@ -181,6 +181,7 @@ def create_app(connector: "Connector") -> FastAPI:
             user_whitelist=sync_data.user_whitelist,
             user_blacklist=sync_data.user_blacklist,
             sync_mode=sync_mode,
+            is_resume=request.is_resume,
             documents_scanned=request.documents_scanned,
             documents_updated=request.documents_updated,
         )

--- a/sdk/python/omni_connector/testing/seed.py
+++ b/sdk/python/omni_connector/testing/seed.py
@@ -117,22 +117,30 @@ class SeedHelper:
             source_id,
         )
 
-    async def get_connector_state(self, source_id: str) -> Any:
+    async def get_checkpoint(self, source_id: str) -> Any:
         row = await self._pool.fetchrow(
-            "SELECT connector_state FROM sources WHERE id = $1::char(26)",
+            "SELECT checkpoint FROM sources WHERE id = $1::char(26)",
             source_id,
         )
-        if row and row["connector_state"]:
-            return json.loads(row["connector_state"])
+        if row and row["checkpoint"]:
+            return json.loads(row["checkpoint"])
         return None
 
-    async def set_connector_state(self, source_id: str, state: dict[str, Any]) -> None:
-        """Seed a source's connector_state, e.g. to simulate a prior sync run."""
+    async def set_checkpoint(self, source_id: str, checkpoint: dict[str, Any]) -> None:
+        """Seed a source's latest successful sync checkpoint."""
         await self._pool.execute(
-            "UPDATE sources SET connector_state = $1::jsonb WHERE id = $2::char(26)",
-            json.dumps(state),
+            "UPDATE sources SET checkpoint = $1::jsonb WHERE id = $2::char(26)",
+            json.dumps(checkpoint),
             source_id,
         )
+
+    async def get_connector_state(self, source_id: str) -> Any:
+        """Deprecated alias for tests that historically asserted checkpoint state."""
+        return await self.get_checkpoint(source_id)
+
+    async def set_connector_state(self, source_id: str, state: dict[str, Any]) -> None:
+        """Deprecated alias for tests that historically seeded checkpoint state."""
+        await self.set_checkpoint(source_id, state)
 
     async def get_sync_run(self, sync_run_id: str) -> asyncpg.Record | None:
         return await self._pool.fetchrow(

--- a/sdk/python/tests/conftest.py
+++ b/sdk/python/tests/conftest.py
@@ -36,6 +36,9 @@ def mock_connector_manager():
         respx_mock.put(path__regex=r"/sdk/source/.*/connector-state").mock(
             return_value=Response(200, json={"status": "ok"})
         )
+        respx_mock.put(path__regex=r"/sdk/sync/.*/checkpoint").mock(
+            return_value=Response(200, json={"status": "ok"})
+        )
 
         yield respx_mock
 

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -225,7 +225,8 @@ async def test_fetch_source_sync_data_returns_typed_model(
             json={
                 "config": {"folder_id": "abc"},
                 "credentials": {"access_token": "token"},
-                "connector_state": {"cursor": "xyz"},
+                "connector_state": {"webhook": "meta"},
+                "checkpoint": {"cursor": "xyz"},
                 "source_type": "one_drive",
                 "user_filter_mode": "whitelist",
                 "user_whitelist": ["alice@example.com"],
@@ -239,7 +240,8 @@ async def test_fetch_source_sync_data_returns_typed_model(
     assert isinstance(result, SdkSourceSyncData)
     assert result.config == {"folder_id": "abc"}
     assert result.credentials == {"access_token": "token"}
-    assert result.connector_state == {"cursor": "xyz"}
+    assert result.connector_state == {"webhook": "meta"}
+    assert result.checkpoint == {"cursor": "xyz"}
     assert result.source_type == "one_drive"
     assert result.user_filter_mode == UserFilterMode.WHITELIST
     assert result.user_whitelist == ["alice@example.com"]

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -170,10 +170,10 @@ async def test_save_state_persists_and_heartbeats(sdk_client, mock_connector_man
     state_calls = [
         c
         for c in mock_connector_manager.calls
-        if "connector-state" in str(c.request.url)
+        if "checkpoint" in str(c.request.url)
     ]
     assert len(state_calls) == 1
-    assert "source-456" in str(state_calls[0].request.url)
+    assert "sync-123" in str(state_calls[0].request.url)
     assert state_calls[0].request.method == "PUT"
     assert json.loads(state_calls[0].request.content) == {"page": 2, "cursor": "abc"}
 

--- a/sdk/rust/src/client.rs
+++ b/sdk/rust/src/client.rs
@@ -92,7 +92,7 @@ fn thresholds_for(sync_type: SyncType) -> (usize, Option<Duration>) {
 /// Unknown sync_run_ids default to `Incremental` — safe middle ground.
 ///
 /// **Invariant**: any operation that persists a checkpoint or terminates a sync
-/// (`save_connector_state`, `complete`, `fail`) must flush the relevant buffered
+/// (`save_checkpoint`, `complete`, `fail`) must flush the relevant buffered
 /// events first — otherwise a crash after checkpoint would lose those events forever.
 #[derive(Clone)]
 pub struct SdkClient {
@@ -124,6 +124,7 @@ struct StoreContentResponse {
 #[derive(Debug, Deserialize)]
 struct SyncConfigResponse {
     connector_state: Option<serde_json::Value>,
+    checkpoint: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Serialize)]
@@ -622,6 +623,23 @@ impl SdkClient {
         Ok(config.connector_state)
     }
 
+    /// Get checkpoint for a source (latest successfully completed sync).
+    pub async fn get_checkpoint(&self, source_id: &str) -> SdkResult<Option<serde_json::Value>> {
+        debug!("SDK: Getting checkpoint for source_id={}", source_id);
+
+        let response = self
+            .client
+            .get(format!(
+                "{}/sdk/source/{}/sync-config",
+                self.base_url, source_id
+            ))
+            .send()
+            .await?;
+        let response = ensure_ok(response, "get_checkpoint").await?;
+        let config: SyncConfigResponse = response.json().await?;
+        Ok(config.checkpoint)
+    }
+
     /// Get credentials for a source
     pub async fn get_credentials(&self, source_id: &str) -> SdkResult<ServiceCredential> {
         debug!("SDK: Getting credentials for source_id={}", source_id);
@@ -725,18 +743,40 @@ impl SdkClient {
         Ok(result.sync_run_id)
     }
 
-    /// Save connector state for a source. **Critical**: buffered events for
-    /// this source are flushed before the checkpoint is persisted. Without
-    /// this, a crash after save_state could lose events that the connector
-    /// already considers emitted (the next run resumes past them).
+    /// Save a run-scoped sync checkpoint. **Critical**: buffered events for
+    /// this sync/source pair are flushed before the checkpoint is persisted.
+    /// Without this, a crash after checkpointing could lose events that the
+    /// connector already considers emitted (the next resume runs past them).
+    pub async fn save_checkpoint(
+        &self,
+        sync_run_id: &str,
+        source_id: &str,
+        checkpoint: serde_json::Value,
+    ) -> SdkResult<()> {
+        debug!("SDK: Saving checkpoint for sync_run={}", sync_run_id);
+
+        self.flush_events(sync_run_id, source_id).await?;
+
+        let response = self
+            .client
+            .put(format!(
+                "{}/sdk/sync/{}/checkpoint",
+                self.base_url, sync_run_id
+            ))
+            .json(&checkpoint)
+            .send()
+            .await?;
+        ensure_ok(response, "save_checkpoint").await?;
+
+        Ok(())
+    }
+
     pub async fn save_connector_state(
         &self,
         source_id: &str,
         state: serde_json::Value,
     ) -> SdkResult<()> {
-        debug!("SDK: Saving connector state for source_id={}", source_id);
-
-        self.flush_source(source_id).await?;
+        debug!("SDK: Saving connector metadata for source_id={}", source_id);
 
         let response = self
             .client

--- a/sdk/rust/src/context.rs
+++ b/sdk/rust/src/context.rs
@@ -123,7 +123,7 @@ impl SyncContext {
     /// Mark sync as completed. Flushes any buffered events first so the
     /// completion never races ahead of the final events for this sync.
     /// Status flip only — counts come from `increment_scanned`/`updated`,
-    /// connector state from `save_connector_state`.
+    /// checkpoint from `save_checkpoint`.
     pub async fn complete(&self) -> Result<()> {
         self.sdk_client.complete(&self.sync_run_id).await?;
         Ok(())
@@ -156,11 +156,16 @@ impl SyncContext {
     /// Checkpoint state for resumability. Flushes buffered events first —
     /// without this, a crash after checkpointing would lose events that the
     /// connector considered emitted (the next run resumes past them).
-    pub async fn save_connector_state(&self, state: serde_json::Value) -> Result<()> {
+    pub async fn save_checkpoint(&self, checkpoint: serde_json::Value) -> Result<()> {
         self.sdk_client
-            .save_connector_state(&self.source_id, state)
+            .save_checkpoint(&self.sync_run_id, &self.source_id, checkpoint)
             .await?;
         Ok(())
+    }
+
+    #[deprecated(note = "use save_checkpoint")]
+    pub async fn save_connector_state(&self, state: serde_json::Value) -> Result<()> {
+        self.save_checkpoint(state).await
     }
 
     pub async fn get_user_email_for_source(&self) -> Result<String> {

--- a/sdk/rust/src/context.rs
+++ b/sdk/rust/src/context.rs
@@ -12,6 +12,7 @@ pub struct SyncContext {
     source_id: String,
     source_type: SourceType,
     sync_mode: SyncType,
+    is_resume: bool,
     cancelled: Arc<AtomicBool>,
 }
 
@@ -24,12 +25,33 @@ impl SyncContext {
         sync_mode: SyncType,
         cancelled: Arc<AtomicBool>,
     ) -> Self {
+        Self::new_with_resume(
+            sdk_client,
+            sync_run_id,
+            source_id,
+            source_type,
+            sync_mode,
+            false,
+            cancelled,
+        )
+    }
+
+    pub fn new_with_resume(
+        sdk_client: SdkClient,
+        sync_run_id: String,
+        source_id: String,
+        source_type: SourceType,
+        sync_mode: SyncType,
+        is_resume: bool,
+        cancelled: Arc<AtomicBool>,
+    ) -> Self {
         Self {
             sdk_client,
             sync_run_id,
             source_id,
             source_type,
             sync_mode,
+            is_resume,
             cancelled,
         }
     }
@@ -52,6 +74,10 @@ impl SyncContext {
 
     pub fn sync_mode(&self) -> SyncType {
         self.sync_mode
+    }
+
+    pub fn is_resume(&self) -> bool {
+        self.is_resume
     }
 
     pub fn is_cancelled(&self) -> bool {

--- a/sdk/rust/src/models.rs
+++ b/sdk/rust/src/models.rs
@@ -70,6 +70,8 @@ pub struct SyncRequest {
     pub sync_mode: SyncType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_sync_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<JsonValue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/sdk/rust/src/models.rs
+++ b/sdk/rust/src/models.rs
@@ -72,6 +72,8 @@ pub struct SyncRequest {
     pub last_sync_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<JsonValue>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_resume: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -440,12 +440,13 @@ where
         .register_sync(&sync_run_id, request.sync_mode)
         .await;
 
-    let ctx = SyncContext::new(
+    let ctx = SyncContext::new_with_resume(
         state.sdk_client.clone(),
         sync_run_id.clone(),
         source_id.clone(),
         source.source_type,
         request.sync_mode,
+        request.is_resume,
         cancelled,
     );
     let connector = Arc::clone(&state.connector);

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -381,15 +381,14 @@ where
         })?;
     }
 
-    let typed_state =
-        decode_optional::<C::State>(source.connector_state.as_ref(), "connector state").map_err(
-            |error| {
-                (
-                    StatusCode::BAD_REQUEST,
-                    Json(SyncResponse::error(error.to_string())),
-                )
-            },
-        )?;
+    let effective_checkpoint = request.checkpoint.as_ref().or(source.checkpoint.as_ref());
+    let typed_state = decode_optional::<C::State>(effective_checkpoint, "sync checkpoint")
+        .map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(SyncResponse::error(error.to_string())),
+            )
+        })?;
 
     state
         .connector

--- a/sdk/rust/tests/common/mod.rs
+++ b/sdk/rust/tests/common/mod.rs
@@ -153,6 +153,7 @@ fn test_source_json(id: &str, config: JsonValue, connector_state: Option<JsonVal
         "user_whitelist": null,
         "user_blacklist": null,
         "connector_state": connector_state,
+        "checkpoint": connector_state,
         "sync_interval_seconds": null,
         "created_at": "2024-01-01T00:00:00Z",
         "updated_at": "2024-01-01T00:00:00Z",

--- a/sdk/typescript/examples/rss-connector.ts
+++ b/sdk/typescript/examples/rss-connector.ts
@@ -148,7 +148,7 @@ class RSSConnector extends Connector {
       docsSinceCheckpoint++;
 
       if (docsSinceCheckpoint >= 50) {
-        await ctx.saveState({ last_sync_time: currentTime.toISOString() });
+        await ctx.saveCheckpoint({ last_sync_time: currentTime.toISOString() });
         docsSinceCheckpoint = 0;
       }
     }

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -159,6 +159,23 @@ export class SdkClient {
     return data.content_id;
   }
 
+  async updateCheckpoint(
+    syncRunId: string,
+    checkpoint: Record<string, unknown>
+  ): Promise<void> {
+    const response = await this.put(
+      `/sdk/sync/${syncRunId}/checkpoint`,
+      checkpoint
+    );
+    if (!response.ok) {
+      const text = await response.text();
+      throw new SdkClientError(
+        `Failed to update checkpoint: ${response.status} - ${text}`,
+        response.status
+      );
+    }
+  }
+
   async updateConnectorState(
     sourceId: string,
     state: Record<string, unknown>

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -271,21 +271,22 @@ export class SyncContext {
    * checkpointing would lose events that the connector considered emitted
    * (the next run resumes past them).
    */
-  async saveState(state: Record<string, unknown>): Promise<void> {
+  async saveCheckpoint(checkpoint: Record<string, unknown>): Promise<void> {
     await this.flush();
-    this._state = state;
-    await this.client.updateConnectorState(this._sourceId, state);
+    this._state = checkpoint;
+    await this.client.updateCheckpoint(this._syncRunId, checkpoint);
     await this.client.heartbeat(this._syncRunId);
+  }
+
+  async saveState(state: Record<string, unknown>): Promise<void> {
+    await this.saveCheckpoint(state);
   }
 
   async complete(newState?: Record<string, unknown>): Promise<void> {
     await this.flush();
-    // sdk_complete is body-less since 7c21fd10 — newState in the /complete
-    // body is silently dropped server-side. Persist via the connector-state
-    // endpoint instead (same path saveState() takes).
     if (newState !== undefined) {
       this._state = newState;
-      await this.client.updateConnectorState(this._sourceId, newState);
+      await this.client.updateCheckpoint(this._syncRunId, newState);
     }
     await this.client.complete(this._syncRunId);
   }

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -31,6 +31,7 @@ export class SyncContext {
   private _documentsScanned = 0;
   private readonly _contentStorage: ContentStorage;
   private readonly _syncMode: SyncMode;
+  private readonly _isResume: boolean;
   private readonly bufferSizeThreshold: number;
   private readonly bufferTimeThresholdMs: number | null;
   private eventBuffer: ConnectorEventPayload[] = [];
@@ -49,6 +50,7 @@ export class SyncContext {
     documentsScanned = 0,
     documentsUpdated = 0,
     options?: {
+      isResume?: boolean;
       sourceType?: string | null;
       userFilterMode?: UserFilterMode;
       userWhitelist?: string[] | null;
@@ -62,6 +64,7 @@ export class SyncContext {
     this.abortController = new AbortController();
     this._contentStorage = new ContentStorage(client, syncRunId);
     this._syncMode = syncMode;
+    this._isResume = options?.isResume ?? false;
     const thresholds = thresholdsFor(syncMode);
     this.bufferSizeThreshold = thresholds.size;
     this.bufferTimeThresholdMs = thresholds.timeMs;
@@ -116,7 +119,11 @@ export class SyncContext {
   get syncMode(): SyncMode {
     return this._syncMode;
   }
-  
+
+  get isResume(): boolean {
+    return this._isResume;
+  }
+
   get sourceType(): string | null {
     return this._sourceType;
   }

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -131,6 +131,7 @@ export const SyncRequestSchema = z.object({
   source_id: z.string(),
   sync_mode: z.string(),
   checkpoint: z.record(z.unknown()).nullable().default(null),
+  is_resume: z.boolean().default(false),
   // Manager's running tally at dispatch time. Zero on a fresh sync;
   // non-zero on resume so the connector can keep counting from there.
   documents_scanned: z.number().int().default(0),

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -130,6 +130,7 @@ export const SyncRequestSchema = z.object({
   sync_run_id: z.string(),
   source_id: z.string(),
   sync_mode: z.string(),
+  checkpoint: z.record(z.unknown()).nullable().default(null),
   // Manager's running tally at dispatch time. Zero on a fresh sync;
   // non-zero on resume so the connector can keep counting from there.
   documents_scanned: z.number().int().default(0),
@@ -297,6 +298,7 @@ export const SdkSourceSyncDataSchema = z.object({
   config: z.record(z.unknown()).default({}),
   credentials: z.record(z.unknown()).default({}),
   connector_state: z.record(z.unknown()).nullable().default(null),
+  checkpoint: z.record(z.unknown()).nullable().default(null),
   source_type: z.string().nullable().default(null),
   user_filter_mode: z
     .enum([UserFilterMode.ALL, UserFilterMode.WHITELIST, UserFilterMode.BLACKLIST])

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -100,6 +100,7 @@ export function createServer(connector: Connector): Express {
       documents_scanned: documentsScanned,
       documents_updated: documentsUpdated,
       checkpoint: requestCheckpoint,
+      is_resume: isResume,
     } = parseResult.data;
 
     const isValidSyncMode = (Object.values(SyncMode) as string[]).includes(syncModeStr);
@@ -146,6 +147,7 @@ export function createServer(connector: Connector): Express {
       documentsScanned,
       documentsUpdated,
       {
+        isResume,
         sourceType: sourceData.source_type,
         userFilterMode: sourceData.user_filter_mode,
         userWhitelist: sourceData.user_whitelist,

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -99,6 +99,7 @@ export function createServer(connector: Connector): Express {
       sync_mode: syncModeStr,
       documents_scanned: documentsScanned,
       documents_updated: documentsUpdated,
+      checkpoint: requestCheckpoint,
     } = parseResult.data;
 
     const isValidSyncMode = (Object.values(SyncMode) as string[]).includes(syncModeStr);
@@ -140,7 +141,7 @@ export function createServer(connector: Connector): Express {
       getSdkClient(),
       syncRunId,
       sourceId,
-      sourceData.connector_state ?? undefined,
+      (requestCheckpoint ?? sourceData.checkpoint) ?? undefined,
       syncMode,
       documentsScanned,
       documentsUpdated,
@@ -158,7 +159,7 @@ export function createServer(connector: Connector): Express {
         await connector.sync(
           sourceData.config,
           sourceData.credentials,
-          sourceData.connector_state,
+          (requestCheckpoint ?? sourceData.checkpoint),
           ctx
         );
       } catch (error) {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -236,7 +236,8 @@ describe('SdkClient', () => {
       const mockData = {
         config: { folder_id: 'abc' },
         credentials: { access_token: 'token' },
-        connector_state: { cursor: 'xyz' },
+        connector_state: { webhook: 'meta' },
+        checkpoint: { cursor: 'xyz' },
       };
 
       server.use(
@@ -309,7 +310,8 @@ describe('SdkClient', () => {
           HttpResponse.json({
             config: { workspaces: ['ws1'] },
             credentials: { token: 'redacted' },
-            connector_state: { cursor: 'abc' },
+            connector_state: { webhook: 'meta' },
+            checkpoint: { cursor: 'abc' },
             source_type: 'linear',
             user_filter_mode: 'whitelist',
             user_whitelist: ['alice@example.com', 'bob@example.com'],
@@ -323,7 +325,8 @@ describe('SdkClient', () => {
 
       expect(cfg.config).toEqual({ workspaces: ['ws1'] });
       expect(cfg.credentials).toEqual({ token: 'redacted' });
-      expect(cfg.connector_state).toEqual({ cursor: 'abc' });
+      expect(cfg.connector_state).toEqual({ webhook: 'meta' });
+      expect(cfg.checkpoint).toEqual({ cursor: 'abc' });
       expect(cfg.source_type).toBe('linear');
       expect(cfg.user_filter_mode).toBe('whitelist');
       expect(cfg.user_whitelist).toEqual(['alice@example.com', 'bob@example.com']);

--- a/sdk/typescript/tests/context.test.ts
+++ b/sdk/typescript/tests/context.test.ts
@@ -259,8 +259,8 @@ describe('SyncContext.incrementUpdated', () => {
 });
 
 describe('SyncContext.complete', () => {
-  it('persists newState via updateConnectorState before the status flip', async () => {
-    let stateUpdate: { sourceId: string; body: unknown } | null = null;
+  it('persists newState via updateCheckpoint before the status flip', async () => {
+    let stateUpdate: { syncRunId: string; body: unknown } | null = null;
     let completeCalled = false;
     let completeAfterStateUpdate = false;
 
@@ -269,10 +269,10 @@ describe('SyncContext.complete', () => {
         HttpResponse.json({ success: true })
       ),
       http.put(
-        `${BASE_URL}/sdk/source/:sourceId/connector-state`,
+        `${BASE_URL}/sdk/sync/:syncRunId/checkpoint`,
         async ({ request, params }) => {
           stateUpdate = {
-            sourceId: params.sourceId as string,
+            syncRunId: params.syncRunId as string,
             body: await request.json(),
           };
           return HttpResponse.json({ success: true });
@@ -293,7 +293,7 @@ describe('SyncContext.complete', () => {
     await ctx.complete({ last_sync_at: '2026-04-28T00:00:00Z' });
 
     expect(stateUpdate).toEqual({
-      sourceId: 'source-c',
+      syncRunId: 'sync-c',
       body: { last_sync_at: '2026-04-28T00:00:00Z' },
     });
     expect(completeCalled).toBe(true);
@@ -307,7 +307,7 @@ describe('SyncContext.complete', () => {
       http.post(`${BASE_URL}/sdk/events/batch`, () =>
         HttpResponse.json({ success: true })
       ),
-      http.put(`${BASE_URL}/sdk/source/:sourceId/connector-state`, () => {
+      http.put(`${BASE_URL}/sdk/sync/:syncRunId/checkpoint`, () => {
         stateUpdated = true;
         return HttpResponse.json({ success: true });
       }),

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -1824,10 +1824,9 @@ pub async fn sdk_complete(
 
     let sync_run_repo = SyncRunRepository::new(state.db_pool.pool());
 
-    // Status flip only. Counts come from increment_scanned/updated;
-    // connector state from save_connector_state.
+    // Atomically mark completed and publish this run's checkpoint to the source.
     let updated = sync_run_repo
-        .mark_completed(&sync_run_id)
+        .complete_and_publish_checkpoint(&sync_run_id)
         .await
         .map_err(|e| ApiError::Internal(format!("Failed to mark completed: {}", e)))?;
     if !updated {
@@ -1999,6 +1998,7 @@ pub async fn sdk_get_source_sync_config(
         config: source.config,
         credentials,
         connector_state: source.connector_state,
+        checkpoint: source.checkpoint,
         source_type: source.source_type,
         user_filter_mode: source.user_filter_mode,
         user_whitelist: source.user_whitelist,
@@ -2130,6 +2130,30 @@ pub async fn sdk_notify_webhook(
         .map_err(|e| ApiError::Internal(format!("Failed to trigger sync: {}", e)))?;
 
     Ok(Json(SdkWebhookResponse { sync_run_id }))
+}
+
+pub async fn sdk_update_checkpoint(
+    State(state): State<AppState>,
+    Path(sync_run_id): Path<String>,
+    Json(checkpoint): Json<serde_json::Value>,
+) -> Result<Json<SdkStatusResponse>, ApiError> {
+    debug!("SDK: Updating checkpoint for sync_run={}", sync_run_id);
+
+    let sync_run_repo = SyncRunRepository::new(state.db_pool.pool());
+    let updated = sync_run_repo
+        .update_checkpoint(&sync_run_id, checkpoint)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Failed to update checkpoint: {}", e)))?;
+    if !updated {
+        warn!(
+            "SDK: Ignoring stale checkpoint update for non-running sync_run={}",
+            sync_run_id
+        );
+    }
+
+    Ok(Json(SdkStatusResponse {
+        status: "ok".to_string(),
+    }))
 }
 
 // ============================================================================

--- a/services/connector-manager/src/lib.rs
+++ b/services/connector-manager/src/lib.rs
@@ -67,6 +67,10 @@ pub fn create_app(state: AppState) -> Router {
         .route("/sdk/sync/:id/complete", post(handlers::sdk_complete))
         .route("/sdk/sync/:id/fail", post(handlers::sdk_fail))
         .route(
+            "/sdk/sync/:id/checkpoint",
+            put(handlers::sdk_update_checkpoint),
+        )
+        .route(
             "/sdk/sync/:id/scanned",
             post(handlers::sdk_increment_scanned),
         )

--- a/services/connector-manager/src/models.rs
+++ b/services/connector-manager/src/models.rs
@@ -129,6 +129,7 @@ pub struct SdkSourceSyncConfigResponse {
     pub config: JsonValue,
     pub credentials: JsonValue,
     pub connector_state: Option<JsonValue>,
+    pub checkpoint: Option<JsonValue>,
     pub source_type: SourceType,
     pub user_filter_mode: shared::models::UserFilterMode,
     pub user_whitelist: Option<JsonValue>,

--- a/services/connector-manager/src/scheduler.rs
+++ b/services/connector-manager/src/scheduler.rs
@@ -635,6 +635,7 @@ mod tests {
             user_whitelist: None,
             user_blacklist: None,
             connector_state: None,
+            checkpoint: None,
             sync_interval_seconds: interval_seconds,
             created_at: now,
             updated_at: now,
@@ -671,6 +672,7 @@ mod tests {
             documents_processed: 0,
             documents_updated: 0,
             error_message: None,
+            checkpoint: None,
             created_at: now,
             updated_at: now,
         }

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -145,6 +145,7 @@ impl SyncManager {
             sync_mode: effective_sync_type,
             last_sync_at,
             checkpoint: source.checkpoint.clone(),
+            is_resume: false,
         };
 
         let trigger_result = timeout(
@@ -470,6 +471,7 @@ impl SyncManager {
                 .checkpoint
                 .clone()
                 .or_else(|| source.checkpoint.clone()),
+            is_resume: true,
         };
 
         match timeout(

--- a/services/connector-manager/src/sync_manager.rs
+++ b/services/connector-manager/src/sync_manager.rs
@@ -144,6 +144,7 @@ impl SyncManager {
             source_id: source_id.to_string(),
             sync_mode: effective_sync_type,
             last_sync_at,
+            checkpoint: source.checkpoint.clone(),
         };
 
         let trigger_result = timeout(
@@ -465,6 +466,10 @@ impl SyncManager {
             source_id: source_id.to_string(),
             sync_mode: sync_run.sync_type,
             last_sync_at,
+            checkpoint: sync_run
+                .checkpoint
+                .clone()
+                .or_else(|| source.checkpoint.clone()),
         };
 
         match timeout(

--- a/services/connector-manager/tests/common/mock_connector.rs
+++ b/services/connector-manager/tests/common/mock_connector.rs
@@ -20,6 +20,8 @@ pub struct RecordedSyncRequest {
     pub sync_mode: String,
     #[serde(default)]
     pub last_sync_at: Option<String>,
+    #[serde(default)]
+    pub checkpoint: Option<JsonValue>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/services/connector-manager/tests/common/mock_connector.rs
+++ b/services/connector-manager/tests/common/mock_connector.rs
@@ -22,6 +22,8 @@ pub struct RecordedSyncRequest {
     pub last_sync_at: Option<String>,
     #[serde(default)]
     pub checkpoint: Option<JsonValue>,
+    #[serde(default)]
+    pub is_resume: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/services/connector-manager/tests/common/mod.rs
+++ b/services/connector-manager/tests/common/mod.rs
@@ -41,6 +41,8 @@ pub async fn setup_test_fixture() -> Result<TestFixture> {
         max_concurrent_syncs_per_type: 3,
         scheduler_interval_seconds: 600,
         stale_sync_timeout_minutes: 1,
+        extraction_concurrency: 2,
+        extraction_retry_after_seconds: 30,
         sync_backoff_base_seconds: 30,
         sync_backoff_max_seconds: 3600,
         sync_max_consecutive_failures: 10,

--- a/services/connector-manager/tests/integration_tests.rs
+++ b/services/connector-manager/tests/integration_tests.rs
@@ -854,6 +854,7 @@ async fn test_initial_sync_request_uses_latest_successful_source_checkpoint() {
     let requests = fixture.mock_connector.get_sync_requests();
     assert_eq!(requests.len(), 1);
     assert_eq!(requests[0].sync_run_id, sync_run_id);
+    assert!(!requests[0].is_resume);
     assert_eq!(
         requests[0].checkpoint.as_ref().unwrap()["cursor"].as_str(),
         Some("last-success")
@@ -885,6 +886,7 @@ async fn test_full_sync_resume_prefers_run_checkpoint_over_source_checkpoint() {
 
     let requests = fixture.mock_connector.get_sync_requests();
     assert_eq!(requests.len(), 2, "expected resume /sync call");
+    assert!(requests[1].is_resume);
     assert_eq!(
         requests[1].checkpoint.as_ref().unwrap()["cursor"].as_str(),
         Some("current-run")
@@ -911,6 +913,7 @@ async fn test_resume_falls_back_to_source_checkpoint_before_first_run_checkpoint
     let requests = fixture.mock_connector.get_sync_requests();
     assert_eq!(requests.len(), 2);
     assert_eq!(requests[1].sync_run_id, sync_run_id);
+    assert!(requests[1].is_resume);
     assert_eq!(
         requests[1].checkpoint.as_ref().unwrap()["cursor"].as_str(),
         Some("last-success")

--- a/services/connector-manager/tests/integration_tests.rs
+++ b/services/connector-manager/tests/integration_tests.rs
@@ -63,6 +63,23 @@ async fn create_running_sync(pool: &sqlx::PgPool, source_id: &str) -> String {
     sync_run.id
 }
 
+async fn set_source_checkpoint(pool: &sqlx::PgPool, checkpoint: serde_json::Value) {
+    sqlx::query("UPDATE sources SET checkpoint = $1 WHERE id = $2")
+        .bind(checkpoint)
+        .bind(TEST_SOURCE_ID)
+        .execute(pool)
+        .await
+        .unwrap();
+}
+
+async fn get_source_checkpoint(pool: &sqlx::PgPool) -> Option<serde_json::Value> {
+    sqlx::query_scalar("SELECT checkpoint FROM sources WHERE id = $1")
+        .bind(TEST_SOURCE_ID)
+        .fetch_one(pool)
+        .await
+        .unwrap()
+}
+
 // ============================================================================
 // 1. test_sync_lifecycle — golden-path end-to-end
 // ============================================================================
@@ -112,15 +129,14 @@ async fn test_sync_lifecycle() {
         .unwrap();
     assert_eq!(run.documents_scanned, 8);
 
-    // Save connector state — its own endpoint, decoupled from complete.
+    // Save run checkpoint — it is promoted to the source on successful complete.
     server
-        .put(&format!("/sdk/source/{}/connector-state", TEST_SOURCE_ID))
+        .put(&format!("/sdk/sync/{}/checkpoint", sync_run_id))
         .json(&json!({"cursor": "abc"}))
         .await
         .assert_status(StatusCode::OK);
 
-    // SDK complete is a status-only flip. Counts come from increment_*;
-    // connector state from save_connector_state.
+    // SDK complete atomically flips status and publishes the checkpoint.
     server
         .post(&format!("/sdk/sync/{}/complete", sync_run_id))
         .await
@@ -136,7 +152,7 @@ async fn test_sync_lifecycle() {
     assert_eq!(run.documents_updated, 0);
 
     let source_row: (Option<serde_json::Value>,) =
-        sqlx::query_as("SELECT connector_state FROM sources WHERE id = $1")
+        sqlx::query_as("SELECT checkpoint FROM sources WHERE id = $1")
             .bind(TEST_SOURCE_ID)
             .fetch_one(pool)
             .await
@@ -820,5 +836,197 @@ async fn test_source_cleanup() {
     assert_eq!(
         source_count, 0,
         "Source row should be deleted after second cleanup call"
+    );
+}
+
+// ============================================================================
+// Checkpoint regression coverage
+// ============================================================================
+#[tokio::test]
+async fn test_initial_sync_request_uses_latest_successful_source_checkpoint() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+
+    set_source_checkpoint(pool, json!({"cursor": "last-success"})).await;
+
+    let sync_run_id = trigger_sync(&server).await;
+    let requests = fixture.mock_connector.get_sync_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].sync_run_id, sync_run_id);
+    assert_eq!(
+        requests[0].checkpoint.as_ref().unwrap()["cursor"].as_str(),
+        Some("last-success")
+    );
+}
+
+#[tokio::test]
+async fn test_full_sync_resume_prefers_run_checkpoint_over_source_checkpoint() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+
+    set_source_checkpoint(pool, json!({"cursor": "previous-success"})).await;
+    let sync_run_id = trigger_sync(&server).await;
+
+    server
+        .put(&format!("/sdk/sync/{}/checkpoint", sync_run_id))
+        .json(&json!({"cursor": "current-run"}))
+        .await
+        .assert_status(StatusCode::OK);
+
+    fixture.mock_connector.restart().await.unwrap();
+    fixture
+        .state
+        .sync_manager
+        .monitor_running_syncs()
+        .await
+        .unwrap();
+
+    let requests = fixture.mock_connector.get_sync_requests();
+    assert_eq!(requests.len(), 2, "expected resume /sync call");
+    assert_eq!(
+        requests[1].checkpoint.as_ref().unwrap()["cursor"].as_str(),
+        Some("current-run")
+    );
+}
+
+#[tokio::test]
+async fn test_resume_falls_back_to_source_checkpoint_before_first_run_checkpoint() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+
+    set_source_checkpoint(pool, json!({"cursor": "last-success"})).await;
+    let sync_run_id = trigger_sync(&server).await;
+
+    fixture.mock_connector.restart().await.unwrap();
+    fixture
+        .state
+        .sync_manager
+        .monitor_running_syncs()
+        .await
+        .unwrap();
+
+    let requests = fixture.mock_connector.get_sync_requests();
+    assert_eq!(requests.len(), 2);
+    assert_eq!(requests[1].sync_run_id, sync_run_id);
+    assert_eq!(
+        requests[1].checkpoint.as_ref().unwrap()["cursor"].as_str(),
+        Some("last-success")
+    );
+}
+
+#[tokio::test]
+async fn test_failed_or_cancelled_run_checkpoint_is_not_promoted() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+
+    set_source_checkpoint(pool, json!({"cursor": "previous-success"})).await;
+    let sync_run_id = trigger_sync(&server).await;
+
+    server
+        .put(&format!("/sdk/sync/{}/checkpoint", sync_run_id))
+        .json(&json!({"cursor": "failed-run"}))
+        .await
+        .assert_status(StatusCode::OK);
+    server
+        .post(&format!("/sdk/sync/{}/fail", sync_run_id))
+        .json(&json!({"error": "boom"}))
+        .await
+        .assert_status(StatusCode::OK);
+
+    let checkpoint = get_source_checkpoint(pool).await.unwrap();
+    assert_eq!(checkpoint["cursor"].as_str(), Some("previous-success"));
+}
+
+#[tokio::test]
+async fn test_completion_promotes_checkpoint_and_preserves_connector_metadata() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+
+    sqlx::query("UPDATE sources SET connector_state = $1 WHERE id = $2")
+        .bind(json!({"webhook_id": "wh-1"}))
+        .bind(TEST_SOURCE_ID)
+        .execute(pool)
+        .await
+        .unwrap();
+
+    let sync_run_id = trigger_sync(&server).await;
+    let before: time::OffsetDateTime =
+        sqlx::query_scalar("SELECT updated_at FROM sources WHERE id = $1")
+            .bind(TEST_SOURCE_ID)
+            .fetch_one(pool)
+            .await
+            .unwrap();
+
+    server
+        .put(&format!("/sdk/sync/{}/checkpoint", sync_run_id))
+        .json(&json!({"cursor": "completed"}))
+        .await
+        .assert_status(StatusCode::OK);
+    server
+        .post(&format!("/sdk/sync/{}/complete", sync_run_id))
+        .await
+        .assert_status(StatusCode::OK);
+
+    let row: (
+        Option<serde_json::Value>,
+        Option<serde_json::Value>,
+        time::OffsetDateTime,
+    ) = sqlx::query_as("SELECT checkpoint, connector_state, updated_at FROM sources WHERE id = $1")
+        .bind(TEST_SOURCE_ID)
+        .fetch_one(pool)
+        .await
+        .unwrap();
+    assert_eq!(row.0.unwrap()["cursor"].as_str(), Some("completed"));
+    assert_eq!(row.1.unwrap()["webhook_id"].as_str(), Some("wh-1"));
+    assert!(row.2 >= before);
+}
+
+#[tokio::test]
+async fn test_incremental_after_failed_sync_starts_from_previous_successful_checkpoint() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let server = test_server(&fixture);
+    let pool = fixture.state.db_pool.pool();
+    let sync_run_repo = SyncRunRepository::new(pool);
+
+    let completed = sync_run_repo
+        .create(TEST_SOURCE_ID, SyncType::Full, "manual")
+        .await
+        .unwrap();
+    sync_run_repo
+        .update_checkpoint(&completed.id, json!({"cursor": "successful"}))
+        .await
+        .unwrap();
+    sync_run_repo
+        .complete_and_publish_checkpoint(&completed.id)
+        .await
+        .unwrap();
+
+    let failed = sync_run_repo
+        .create(TEST_SOURCE_ID, SyncType::Incremental, "manual")
+        .await
+        .unwrap();
+    sync_run_repo
+        .update_checkpoint(&failed.id, json!({"cursor": "failed"}))
+        .await
+        .unwrap();
+    sync_run_repo.mark_failed(&failed.id, "boom").await.unwrap();
+
+    let resp = server
+        .post("/sync")
+        .json(&json!({"source_id": TEST_SOURCE_ID, "sync_mode": "incremental"}))
+        .await;
+    resp.assert_status(StatusCode::OK);
+
+    let requests = fixture.mock_connector.get_sync_requests();
+    assert_eq!(requests.len(), 1);
+    assert_eq!(requests[0].sync_mode, "incremental");
+    assert_eq!(
+        requests[0].checkpoint.as_ref().unwrap()["cursor"].as_str(),
+        Some("successful")
     );
 }

--- a/services/migrations/094_add_sync_checkpoints.sql
+++ b/services/migrations/094_add_sync_checkpoints.sql
@@ -1,0 +1,11 @@
+-- Add explicit sync checkpoint storage separate from connector metadata.
+-- `sync_runs.checkpoint` stores in-progress/resume checkpoints for a single run.
+-- `sources.checkpoint` stores the checkpoint from the latest successfully completed sync.
+-- Existing connector_state is left unchanged. Checkpoints start empty after
+-- upgrade, so sources need a full sync to establish the first checkpoint.
+
+ALTER TABLE sync_runs
+ADD COLUMN IF NOT EXISTS checkpoint JSONB;
+
+ALTER TABLE sources
+ADD COLUMN IF NOT EXISTS checkpoint JSONB;

--- a/shared/src/db/repositories/source.rs
+++ b/shared/src/db/repositories/source.rs
@@ -18,7 +18,7 @@ impl SourceRepository {
             r#"
             SELECT id, name, source_type, config, is_active, is_deleted, scope,
                    user_filter_mode, user_whitelist, user_blacklist,
-                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                   connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             FROM sources
             WHERE source_type = $1 AND is_deleted = false
             ORDER BY created_at DESC
@@ -36,7 +36,7 @@ impl SourceRepository {
             r#"
             SELECT id, name, source_type, config, is_active, is_deleted, scope,
                    user_filter_mode, user_whitelist, user_blacklist,
-                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                   connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             FROM sources
             WHERE is_deleted = false
             ORDER BY created_at DESC
@@ -53,7 +53,7 @@ impl SourceRepository {
             r#"
             SELECT id, name, source_type, config, is_active, is_deleted, scope,
                    user_filter_mode, user_whitelist, user_blacklist,
-                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                   connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             FROM sources
             WHERE is_active = true AND is_deleted = false
             ORDER BY created_at DESC
@@ -70,7 +70,7 @@ impl SourceRepository {
             r#"
             SELECT id, name, source_type, config, is_active, is_deleted, scope,
                    user_filter_mode, user_whitelist, user_blacklist,
-                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                   connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             FROM sources
             WHERE is_active = false OR is_deleted = true
             ORDER BY created_at DESC
@@ -114,7 +114,7 @@ impl SourceRepository {
             r#"
             SELECT id, name, source_type, config, is_active, is_deleted, scope,
                    user_filter_mode, user_whitelist, user_blacklist,
-                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                   connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             FROM sources
             WHERE is_active = true AND is_deleted = false
             "#,
@@ -195,7 +195,7 @@ impl Repository<Source, String> for SourceRepository {
             r#"
             SELECT id, name, source_type, config, is_active, is_deleted, scope,
                    user_filter_mode, user_whitelist, user_blacklist,
-                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                   connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             FROM sources
             WHERE id = $1
             "#,
@@ -212,7 +212,7 @@ impl Repository<Source, String> for SourceRepository {
             r#"
             SELECT id, name, source_type, config, is_active, is_deleted, scope,
                    user_filter_mode, user_whitelist, user_blacklist,
-                   connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                   connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             FROM sources
             WHERE is_deleted = false
             ORDER BY created_at DESC
@@ -234,7 +234,7 @@ impl Repository<Source, String> for SourceRepository {
             VALUES ($1, $2, $3, $4, $5, $6)
             RETURNING id, name, source_type, config, is_active, is_deleted, scope,
                       user_filter_mode, user_whitelist, user_blacklist,
-                      connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                      connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             "#,
         )
         .bind(&source.id)
@@ -263,7 +263,7 @@ impl Repository<Source, String> for SourceRepository {
             WHERE id = $1
             RETURNING id, name, source_type, config, is_active, is_deleted, scope,
                       user_filter_mode, user_whitelist, user_blacklist,
-                      connector_state, sync_interval_seconds, created_at, updated_at, created_by
+                      connector_state, checkpoint, sync_interval_seconds, created_at, updated_at, created_by
             "#,
         )
         .bind(&id)

--- a/shared/src/db/repositories/sync_run.rs
+++ b/shared/src/db/repositories/sync_run.rs
@@ -64,6 +64,7 @@ impl SyncRunRepository {
             documents_processed: 0,
             documents_updated: 0,
             error_message: None,
+            checkpoint: None,
         })
     }
 
@@ -72,7 +73,7 @@ impl SyncRunRepository {
             r#"
             SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   created_at, updated_at
+                   checkpoint, created_at, updated_at
             FROM sync_runs
             WHERE id = $1
             "#,
@@ -86,7 +87,9 @@ impl SyncRunRepository {
 
     /// Flip status to `Completed`. Counters are maintained by
     /// `increment_scanned` / `increment_updated`, so this only touches
-    /// status fields.
+    /// status fields. Prefer [`complete_and_publish_checkpoint`] for normal
+    /// SDK completion so the successful checkpoint is atomically promoted to
+    /// the source.
     pub async fn mark_completed(&self, id: &str) -> Result<bool, DatabaseError> {
         let result = sqlx::query(
             "UPDATE sync_runs
@@ -101,6 +104,72 @@ impl SyncRunRepository {
         .await?;
 
         Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn update_checkpoint(
+        &self,
+        id: &str,
+        checkpoint: serde_json::Value,
+    ) -> Result<bool, DatabaseError> {
+        let result = sqlx::query(
+            "UPDATE sync_runs
+             SET checkpoint = $1,
+                 last_activity_at = CURRENT_TIMESTAMP,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2 AND status = $3",
+        )
+        .bind(&checkpoint)
+        .bind(id)
+        .bind(SyncStatus::Running)
+        .execute(&self.pool)
+        .await?;
+
+        Ok(result.rows_affected() > 0)
+    }
+
+    pub async fn complete_and_publish_checkpoint(&self, id: &str) -> Result<bool, DatabaseError> {
+        let mut tx = self.pool.begin().await?;
+
+        let row: Option<(String, Option<serde_json::Value>)> = sqlx::query_as(
+            "SELECT source_id, checkpoint
+             FROM sync_runs
+             WHERE id = $1 AND status = $2
+             FOR UPDATE",
+        )
+        .bind(id)
+        .bind(SyncStatus::Running)
+        .fetch_optional(&mut *tx)
+        .await?;
+
+        let Some((source_id, checkpoint)) = row else {
+            tx.rollback().await?;
+            return Ok(false);
+        };
+
+        sqlx::query(
+            "UPDATE sync_runs
+             SET status = $1, completed_at = CURRENT_TIMESTAMP,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2",
+        )
+        .bind(SyncStatus::Completed)
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
+
+        sqlx::query(
+            "UPDATE sources
+             SET checkpoint = $1,
+                 updated_at = CURRENT_TIMESTAMP
+             WHERE id = $2",
+        )
+        .bind(&checkpoint)
+        .bind(&source_id)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(true)
     }
 
     pub async fn mark_failed(&self, id: &str, error: &str) -> Result<bool, DatabaseError> {
@@ -186,7 +255,7 @@ impl SyncRunRepository {
                     r#"
                     SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                            documents_scanned, documents_processed, documents_updated, error_message,
-                           created_at, updated_at
+                   checkpoint, created_at, updated_at
                     FROM sync_runs
                     WHERE source_id = $1 AND sync_type = $2 AND status = $3
                     ORDER BY completed_at DESC
@@ -204,7 +273,7 @@ impl SyncRunRepository {
                     r#"
                     SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                            documents_scanned, documents_processed, documents_updated, error_message,
-                           created_at, updated_at
+                   checkpoint, created_at, updated_at
                     FROM sync_runs
                     WHERE source_id = $1 AND status = $2
                     ORDER BY completed_at DESC
@@ -229,7 +298,7 @@ impl SyncRunRepository {
             r#"
             SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   created_at, updated_at
+                   checkpoint, created_at, updated_at
             FROM sync_runs
             WHERE source_id = $1 AND status = $2
             ORDER BY created_at DESC
@@ -261,7 +330,7 @@ impl SyncRunRepository {
             r#"
             SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   created_at, updated_at
+                   checkpoint, created_at, updated_at
             FROM sync_runs
             WHERE source_id = $1 AND status = $2 AND sync_type::text = ANY($3)
             ORDER BY created_at DESC
@@ -282,7 +351,7 @@ impl SyncRunRepository {
             r#"
             SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   created_at, updated_at
+                   checkpoint, created_at, updated_at
             FROM sync_runs
             WHERE status = $1
             ORDER BY created_at DESC
@@ -307,7 +376,7 @@ impl SyncRunRepository {
             r#"
             SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   created_at, updated_at
+                   checkpoint, created_at, updated_at
             FROM sync_runs
             WHERE status = $1 AND source_id = ANY($2)
             ORDER BY created_at DESC
@@ -417,7 +486,7 @@ impl SyncRunRepository {
             SELECT DISTINCT ON (source_id)
                    id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   created_at, updated_at
+                   checkpoint, created_at, updated_at
             FROM sync_runs
             WHERE source_id = ANY($1)
             ORDER BY source_id, started_at DESC
@@ -454,7 +523,7 @@ impl SyncRunRepository {
             r#"
             SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   created_at, updated_at
+                   checkpoint, created_at, updated_at
             FROM (
                 SELECT sr.*,
                        ROW_NUMBER() OVER (

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -674,6 +674,8 @@ pub struct SyncRequest {
     pub last_sync_at: Option<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub checkpoint: Option<JsonValue>,
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub is_resume: bool,
 }
 
 /// Response from connector after receiving a sync request.

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -75,6 +75,8 @@ pub struct Source {
     pub user_whitelist: Option<JsonValue>,
     pub user_blacklist: Option<JsonValue>,
     pub connector_state: Option<JsonValue>,
+    #[serde(default)]
+    pub checkpoint: Option<JsonValue>,
     pub sync_interval_seconds: Option<i32>,
     #[serde(with = "time::serde::iso8601")]
     pub created_at: OffsetDateTime,
@@ -653,6 +655,8 @@ pub struct SyncRun {
     pub documents_processed: i32,
     pub documents_updated: i32,
     pub error_message: Option<String>,
+    #[serde(default)]
+    pub checkpoint: Option<JsonValue>,
     #[serde(with = "time::serde::iso8601")]
     pub created_at: OffsetDateTime,
     #[serde(with = "time::serde::iso8601")]
@@ -668,6 +672,8 @@ pub struct SyncRequest {
     pub sync_mode: SyncType,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_sync_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub checkpoint: Option<JsonValue>,
 }
 
 /// Response from connector after receiving a sync request.
@@ -753,6 +759,7 @@ mod tests {
             user_whitelist: whitelist,
             user_blacklist: blacklist,
             connector_state: None,
+            checkpoint: None,
             sync_interval_seconds: None,
             created_at: OffsetDateTime::now_utc(),
             updated_at: OffsetDateTime::now_utc(),


### PR DESCRIPTION
- Store in-progress checkpoints on sync_runs and publish them to sources on successful completion.
- Add a run-scoped checkpoint SDK endpoint and pass checkpoints through sync requests/resume.
- Update Rust, Python, and TypeScript SDKs plus connectors to use checkpoint APIs.
- Keep connector_state for connector metadata and preserve it during checkpoint promotion.
- Add regression coverage for resume, completion promotion, and failed-run behavior.