### PR TITLE
fix: avoid duplicate embedding work

### DIFF
--- a/services/ai/db/documents.py
+++ b/services/ai/db/documents.py
@@ -1,8 +1,9 @@
 """Repository for document-related database operations."""
 
 import logging
-from typing import Optional
 from dataclasses import dataclass
+from typing import Optional
+
 from asyncpg import Pool
 
 from .connection import get_db_pool
@@ -56,6 +57,29 @@ class DocumentsRepository:
             return self.pool
         return await get_db_pool()
 
+    async def get_by_ids(self, document_ids: list[str]) -> dict[str, Document]:
+        """Get documents by ID, keyed by document ID."""
+        if not document_ids:
+            return {}
+
+        pool = await self._get_pool()
+        rows = await pool.fetch(
+            f"SELECT {_COLUMNS} FROM documents WHERE id = ANY($1)",
+            document_ids,
+        )
+
+        return {
+            row["id"]: Document(
+                id=row["id"],
+                content_id=row["content_id"],
+                source_id=row["source_id"],
+                external_id=row["external_id"],
+                title=row["title"],
+                content_type=row["content_type"],
+            )
+            for row in rows
+        }
+
     async def get_by_id(
         self, document_id: str, user_email: str | None = None
     ) -> Optional[Document]:
@@ -101,10 +125,7 @@ class DocumentsRepository:
 
         if user_email:
             perm_filter = _permission_filter(user_email.lower())
-            query = (
-                f"SELECT {_COLUMNS} FROM documents "
-                f"WHERE external_id = $1 {perm_filter} LIMIT 1"
-            )
+            query = f"SELECT {_COLUMNS} FROM documents WHERE external_id = $1 {perm_filter} LIMIT 1"
         else:
             query = f"SELECT {_COLUMNS} FROM documents WHERE external_id = $1 LIMIT 1"
         row = await pool.fetchrow(query, external_id)
@@ -119,6 +140,58 @@ class DocumentsRepository:
                 content_type=row["content_type"],
             )
         return None
+
+    async def find_embedded_content_donors(
+        self,
+        content_ids: list[str],
+        exclude_document_ids: list[str],
+        model_name: str,
+    ) -> dict[str, str]:
+        """Find embedded donor documents for content IDs.
+
+        Returns content_id -> donor_document_id for donors that already have embeddings for
+        the current model. Donors with pending/processing work, or failed work newer than
+        their embeddings, are excluded because their embeddings may be stale relative to
+        their current content_id.
+        """
+        if not content_ids:
+            return {}
+
+        pool = await self._get_pool()
+        rows = await pool.fetch(
+            """
+            WITH embedded_documents AS (
+                SELECT document_id, max(created_at) AS latest_embedding_at
+                FROM embeddings
+                WHERE model_name = $3
+                GROUP BY document_id
+            )
+            SELECT DISTINCT ON (d.content_id) d.content_id, d.id
+            FROM documents d
+            JOIN embedded_documents ed ON ed.document_id = d.id
+            WHERE d.content_id = ANY($1)
+              AND d.id <> ALL($2::text[])
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM embedding_queue q
+                  WHERE q.document_id = d.id
+                    AND q.status IN ('pending', 'processing')
+              )
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM embedding_queue q
+                  WHERE q.document_id = d.id
+                    AND q.status = 'failed'
+                    AND GREATEST(q.created_at, q.updated_at, COALESCE(q.processed_at, q.updated_at))
+                        > ed.latest_embedding_at
+              )
+            ORDER BY d.content_id, d.id
+            """,
+            content_ids,
+            exclude_document_ids,
+            model_name,
+        )
+        return {row["content_id"]: row["id"] for row in rows}
 
     async def find_embedded_duplicate(
         self, external_id: str, exclude_document_id: str

--- a/services/ai/db/embeddings.py
+++ b/services/ai/db/embeddings.py
@@ -1,9 +1,10 @@
 """Repository for embeddings table database operations."""
 
 import logging
-from typing import List, Dict, Any, Optional
 from dataclasses import dataclass
 from datetime import datetime
+from typing import Any, Dict, List, Optional
+
 from asyncpg import Pool
 
 from .connection import get_db_pool
@@ -121,6 +122,116 @@ class EmbeddingsRepository:
             ],
         )
         logger.info(f"Bulk inserted {len(embeddings)} embeddings")
+
+    async def bulk_clone_for_documents(
+        self, document_pairs: list[tuple[str, str]], model_name: str
+    ) -> dict[str, int]:
+        """Clone current-model embeddings for many donor/target document pairs.
+
+        document_pairs contains (source_document_id, target_document_id). Returns
+        target_document_id -> cloned row count. Existing embeddings are replaced for targets
+        that successfully clone rows.
+        """
+        if not document_pairs:
+            return {}
+
+        source_document_ids = [source_id for source_id, _ in document_pairs]
+        target_document_ids = [target_id for _, target_id in document_pairs]
+        pool = await self._get_pool()
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                count_rows = await conn.fetch(
+                    """
+                    WITH raw_pairs AS (
+                        SELECT source_document_id, target_document_id
+                        FROM UNNEST($1::text[], $2::text[])
+                            AS p(source_document_id, target_document_id)
+                    ),
+                    clone_pairs AS (
+                        SELECT DISTINCT ON (target_document_id)
+                               source_document_id, target_document_id
+                        FROM raw_pairs
+                        ORDER BY target_document_id, source_document_id
+                    )
+                    SELECT p.target_document_id AS document_id, count(*) AS cloned_count
+                    FROM clone_pairs p
+                    JOIN embeddings e
+                      ON e.document_id = p.source_document_id
+                     AND e.model_name = $3
+                    GROUP BY p.target_document_id
+                    """,
+                    source_document_ids,
+                    target_document_ids,
+                    model_name,
+                )
+                clone_counts = {
+                    row["document_id"]: int(row["cloned_count"]) for row in count_rows
+                }
+                if not clone_counts:
+                    return {}
+
+                await conn.execute(
+                    """
+                    DELETE FROM embeddings
+                    WHERE document_id = ANY($1)
+                    """,
+                    list(clone_counts.keys()),
+                )
+
+                await conn.execute(
+                    """
+                    WITH raw_pairs AS (
+                        SELECT source_document_id, target_document_id
+                        FROM UNNEST($1::text[], $2::text[])
+                            AS p(source_document_id, target_document_id)
+                    ),
+                    clone_pairs AS (
+                        SELECT DISTINCT ON (target_document_id)
+                               source_document_id, target_document_id
+                        FROM raw_pairs
+                        ORDER BY target_document_id, source_document_id
+                    )
+                    INSERT INTO embeddings (
+                        id,
+                        document_id,
+                        chunk_index,
+                        chunk_start_offset,
+                        chunk_end_offset,
+                        embedding,
+                        model_name,
+                        dimensions
+                    )
+                    SELECT
+                        substring(
+                            md5(
+                                p.target_document_id || ':' || e.chunk_index || ':' || e.model_name
+                                || ':' || e.chunk_start_offset || ':' || e.chunk_end_offset
+                            ),
+                            1,
+                            26
+                        ) AS id,
+                        p.target_document_id,
+                        e.chunk_index,
+                        e.chunk_start_offset,
+                        e.chunk_end_offset,
+                        e.embedding,
+                        e.model_name,
+                        e.dimensions
+                    FROM clone_pairs p
+                    JOIN embeddings e
+                      ON e.document_id = p.source_document_id
+                     AND e.model_name = $3
+                    """,
+                    source_document_ids,
+                    target_document_ids,
+                    model_name,
+                )
+
+        logger.info(
+            f"Cloned {sum(clone_counts.values())} embeddings for {len(clone_counts)} documents"
+        )
+        return clone_counts
 
     async def clone_for_document(
         self, source_document_id: str, target_document_id: str

--- a/services/ai/db/embeddings.py
+++ b/services/ai/db/embeddings.py
@@ -124,19 +124,20 @@ class EmbeddingsRepository:
         logger.info(f"Bulk inserted {len(embeddings)} embeddings")
 
     async def bulk_clone_for_documents(
-        self, document_pairs: list[tuple[str, str]], model_name: str
+        self, clone_requests: list[tuple[str, str, str]], model_name: str
     ) -> dict[str, int]:
-        """Clone current-model embeddings for many donor/target document pairs.
+        """Clone current-model embeddings and complete queue items atomically.
 
-        document_pairs contains (source_document_id, target_document_id). Returns
-        target_document_id -> cloned row count. Existing embeddings are replaced for targets
-        that successfully clone rows.
+        clone_requests contains (source_document_id, target_document_id, queue_item_id).
+        Returns target_document_id -> cloned row count. Existing embeddings are replaced
+        for targets that successfully clone rows.
         """
-        if not document_pairs:
+        if not clone_requests:
             return {}
 
-        source_document_ids = [source_id for source_id, _ in document_pairs]
-        target_document_ids = [target_id for _, target_id in document_pairs]
+        source_document_ids = [source_id for source_id, _, _ in clone_requests]
+        target_document_ids = [target_id for _, target_id, _ in clone_requests]
+        queue_item_ids = [queue_item_id for _, _, queue_item_id in clone_requests]
         pool = await self._get_pool()
 
         async with pool.acquire() as conn:
@@ -144,30 +145,35 @@ class EmbeddingsRepository:
                 count_rows = await conn.fetch(
                     """
                     WITH raw_pairs AS (
-                        SELECT source_document_id, target_document_id
-                        FROM UNNEST($1::text[], $2::text[])
-                            AS p(source_document_id, target_document_id)
+                        SELECT source_document_id, target_document_id, queue_item_id
+                        FROM UNNEST($1::text[], $2::text[], $3::text[])
+                            AS p(source_document_id, target_document_id, queue_item_id)
                     ),
                     clone_pairs AS (
                         SELECT DISTINCT ON (target_document_id)
-                               source_document_id, target_document_id
+                               source_document_id, target_document_id, queue_item_id
                         FROM raw_pairs
                         ORDER BY target_document_id, source_document_id
                     )
-                    SELECT p.target_document_id AS document_id, count(*) AS cloned_count
+                    SELECT
+                        p.target_document_id AS document_id,
+                        p.queue_item_id,
+                        count(*) AS cloned_count
                     FROM clone_pairs p
                     JOIN embeddings e
                       ON e.document_id = p.source_document_id
-                     AND e.model_name = $3
-                    GROUP BY p.target_document_id
+                     AND e.model_name = $4
+                    GROUP BY p.target_document_id, p.queue_item_id
                     """,
                     source_document_ids,
                     target_document_ids,
+                    queue_item_ids,
                     model_name,
                 )
                 clone_counts = {
                     row["document_id"]: int(row["cloned_count"]) for row in count_rows
                 }
+                cloned_queue_item_ids = [row["queue_item_id"] for row in count_rows]
                 if not clone_counts:
                     return {}
 
@@ -190,6 +196,7 @@ class EmbeddingsRepository:
                         SELECT DISTINCT ON (target_document_id)
                                source_document_id, target_document_id
                         FROM raw_pairs
+                        WHERE target_document_id = ANY($4)
                         ORDER BY target_document_id, source_document_id
                     )
                     INSERT INTO embeddings (
@@ -226,6 +233,19 @@ class EmbeddingsRepository:
                     source_document_ids,
                     target_document_ids,
                     model_name,
+                    list(clone_counts.keys()),
+                )
+
+                await conn.execute(
+                    """
+                    UPDATE embedding_queue
+                    SET status = 'completed',
+                        processed_at = CURRENT_TIMESTAMP,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE id = ANY($1)
+                      AND status = 'processing'
+                    """,
+                    cloned_queue_item_ids,
                 )
 
         logger.info(

--- a/services/ai/embeddings/batch_processor.py
+++ b/services/ai/embeddings/batch_processor.py
@@ -13,18 +13,18 @@ from typing import Optional
 import ulid
 
 from config import EMBEDDING_MAX_MODEL_LEN
-
-from . import Chunk
 from db import (
-    get_db_pool,
+    Document,
     DocumentsRepository,
+    EmbeddingQueueItem,
     EmbeddingQueueRepository,
     EmbeddingsRepository,
-    EmbeddingQueueItem,
     QueueStatus,
+    get_db_pool,
 )
 from state import AppState
 
+from . import Chunk
 
 logger = logging.getLogger(__name__)
 
@@ -121,9 +121,18 @@ class EmbeddingBatchProcessor:
 
         logger.info(f"Processing {len(items)} documents via online embedding API")
 
-        for item in items:
+        documents_by_id = await self.documents_repo.get_by_ids(
+            [item.document_id for item in items]
+        )
+        items_to_process = await self._clone_same_content_embeddings(
+            items, documents_by_id
+        )
+
+        for item in items_to_process:
             try:
-                await self._process_single_document(item)
+                await self._process_single_document(
+                    item, documents_by_id.get(item.document_id)
+                )
             except Exception as e:
                 logger.error(
                     f"Failed to process document {item.document_id}: {e}", exc_info=True
@@ -137,7 +146,66 @@ class EmbeddingBatchProcessor:
 
         return True
 
-    async def _process_single_document(self, item: EmbeddingQueueItem):
+    async def _clone_same_content_embeddings(
+        self,
+        items: list[EmbeddingQueueItem],
+        documents_by_id: dict[str, Document],
+    ) -> list[EmbeddingQueueItem]:
+        docs_with_content = [
+            doc for doc in documents_by_id.values() if doc.content_id is not None
+        ]
+        if not docs_with_content:
+            return items
+
+        model_name = self.embedding_provider.get_model_name()
+        donor_by_content_id = await self.documents_repo.find_embedded_content_donors(
+            list(
+                {
+                    doc.content_id
+                    for doc in docs_with_content
+                    if doc.content_id is not None
+                }
+            ),
+            [item.document_id for item in items],
+            model_name,
+        )
+        if not donor_by_content_id:
+            return items
+
+        clone_pairs: list[tuple[str, str]] = []
+        item_by_document_id = {item.document_id: item for item in items}
+        for doc in docs_with_content:
+            donor_id = donor_by_content_id.get(doc.content_id)
+            if donor_id:
+                clone_pairs.append((donor_id, doc.id))
+
+        if not clone_pairs:
+            return items
+
+        clone_counts = await self.embeddings_repo.bulk_clone_for_documents(
+            clone_pairs, model_name
+        )
+        if not clone_counts:
+            return items
+
+        cloned_item_ids = [
+            item_by_document_id[document_id].id for document_id in clone_counts
+        ]
+        await self.queue_repo.mark_completed(cloned_item_ids)
+        self._docs_completed += len(cloned_item_ids)
+        self._embeddings_written += sum(clone_counts.values())
+        logger.info(
+            "Cloned embeddings for %d documents with duplicate content (%d chunks)",
+            len(cloned_item_ids),
+            sum(clone_counts.values()),
+        )
+
+        cloned_document_ids = set(clone_counts.keys())
+        return [item for item in items if item.document_id not in cloned_document_ids]
+
+    async def _process_single_document(
+        self, item: EmbeddingQueueItem, doc: Document | None = None
+    ):
         """Process a single document using the embedding provider"""
         if item.retry_count > 0:
             logger.debug(
@@ -146,7 +214,8 @@ class EmbeddingBatchProcessor:
 
         # Use semaphore to limit concurrent embedding operations and yield more frequently
         async with self._embedding_semaphore:
-            doc = await self.documents_repo.get_by_id(item.document_id)
+            if doc is None:
+                doc = await self.documents_repo.get_by_id(item.document_id)
 
             if not doc or not doc.content_id:
                 logger.warning(

--- a/services/ai/embeddings/batch_processor.py
+++ b/services/ai/embeddings/batch_processor.py
@@ -172,31 +172,28 @@ class EmbeddingBatchProcessor:
         if not donor_by_content_id:
             return items
 
-        clone_pairs: list[tuple[str, str]] = []
+        clone_requests: list[tuple[str, str, str]] = []
         item_by_document_id = {item.document_id: item for item in items}
         for doc in docs_with_content:
             donor_id = donor_by_content_id.get(doc.content_id)
-            if donor_id:
-                clone_pairs.append((donor_id, doc.id))
+            item = item_by_document_id.get(doc.id)
+            if donor_id and item:
+                clone_requests.append((donor_id, doc.id, item.id))
 
-        if not clone_pairs:
+        if not clone_requests:
             return items
 
         clone_counts = await self.embeddings_repo.bulk_clone_for_documents(
-            clone_pairs, model_name
+            clone_requests, model_name
         )
         if not clone_counts:
             return items
 
-        cloned_item_ids = [
-            item_by_document_id[document_id].id for document_id in clone_counts
-        ]
-        await self.queue_repo.mark_completed(cloned_item_ids)
-        self._docs_completed += len(cloned_item_ids)
+        self._docs_completed += len(clone_counts)
         self._embeddings_written += sum(clone_counts.values())
         logger.info(
             "Cloned embeddings for %d documents with duplicate content (%d chunks)",
-            len(cloned_item_ids),
+            len(clone_counts),
             sum(clone_counts.values()),
         )
 

--- a/services/ai/tests/integration/test_batch_processor.py
+++ b/services/ai/tests/integration/test_batch_processor.py
@@ -3,17 +3,25 @@
 Tests the embedding processor with real database and a mocked embedding provider.
 """
 
+from unittest.mock import AsyncMock, MagicMock
+
 import pytest
 import ulid
-from unittest.mock import AsyncMock, MagicMock
 
 from embeddings.batch_processor import EmbeddingBatchProcessor
 from state import AppState
 from tests.helpers import (
-    create_test_user as _create_test_user_full,
-    create_test_source,
+    create_test_document as create_document_record,
+)
+from tests.helpers import (
     create_test_document_with_content as create_test_document,
+)
+from tests.helpers import (
+    create_test_source,
     enqueue_document,
+)
+from tests.helpers import (
+    create_test_user as _create_test_user_full,
 )
 
 
@@ -92,6 +100,138 @@ async def test_online_processes_document_end_to_end(
 
     queue_item = await queue_repo.get_by_id(queue_id)
     assert queue_item.status == "completed"
+
+
+@pytest.mark.integration
+async def test_online_clones_embeddings_for_duplicate_content(
+    db_pool,
+    online_processor,
+    queue_repo,
+    embeddings_repo,
+    mock_embedding_provider,
+):
+    """Same-content documents clone existing embeddings instead of calling provider."""
+    user_id = await create_test_user(db_pool)
+    source_id = await create_test_source(db_pool, user_id)
+    content_id = str(ulid.ULID())
+    donor_doc_id = await create_document_record(
+        db_pool,
+        source_id,
+        "Donor Document",
+        "Duplicate content for cloning.",
+        content_id=content_id,
+        external_id="donor-duplicate-content",
+    )
+    target_doc_id = str(ulid.ULID())
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO documents (id, source_id, external_id, title, content_id, content)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            target_doc_id,
+            source_id,
+            "target-duplicate-content",
+            "Target Document",
+            content_id,
+            "Duplicate content for cloning.",
+        )
+
+    await embeddings_repo.bulk_insert(
+        [
+            {
+                "id": str(ulid.ULID()),
+                "document_id": donor_doc_id,
+                "chunk_index": 0,
+                "chunk_start_offset": 0,
+                "chunk_end_offset": 30,
+                "embedding": [0.1, 0.2, 0.3],
+                "model_name": "test-embedding-model",
+                "dimensions": 3,
+            }
+        ]
+    )
+    queue_id = await enqueue_document(db_pool, target_doc_id)
+
+    await online_processor._process_online_batch()
+
+    queue_item = await queue_repo.get_by_id(queue_id)
+    assert queue_item.status == "completed"
+
+    target_embeddings = await embeddings_repo.get_for_document(target_doc_id)
+    assert len(target_embeddings) == 1
+    assert target_embeddings[0].chunk_index == 0
+    assert target_embeddings[0].model_name == "test-embedding-model"
+    mock_embedding_provider.generate_embeddings.assert_not_called()
+
+
+@pytest.mark.integration
+async def test_online_does_not_clone_from_donor_with_unresolved_embedding_work(
+    db_pool,
+    online_processor,
+    queue_repo,
+    embeddings_repo,
+    mock_embedding_provider,
+):
+    """A donor with active embedding queue work may have stale embeddings."""
+    user_id = await create_test_user(db_pool)
+    source_id = await create_test_source(db_pool, user_id)
+    content_id = str(ulid.ULID())
+    donor_doc_id = await create_document_record(
+        db_pool,
+        source_id,
+        "Donor Document",
+        "Duplicate content with stale donor risk.",
+        content_id=content_id,
+        external_id="donor-unresolved-content",
+    )
+    target_doc_id = str(ulid.ULID())
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO documents (id, source_id, external_id, title, content_id, content)
+            VALUES ($1, $2, $3, $4, $5, $6)
+            """,
+            target_doc_id,
+            source_id,
+            "target-unresolved-content",
+            "Target Document",
+            content_id,
+            "Duplicate content with stale donor risk.",
+        )
+        await conn.execute(
+            """
+            INSERT INTO embedding_queue (id, document_id, status)
+            VALUES ($1, $2, 'processing')
+            """,
+            str(ulid.ULID()),
+            donor_doc_id,
+        )
+
+    await embeddings_repo.bulk_insert(
+        [
+            {
+                "id": str(ulid.ULID()),
+                "document_id": donor_doc_id,
+                "chunk_index": 0,
+                "chunk_start_offset": 0,
+                "chunk_end_offset": 42,
+                "embedding": [0.4, 0.5, 0.6],
+                "model_name": "test-embedding-model",
+                "dimensions": 3,
+            }
+        ]
+    )
+    queue_id = await enqueue_document(db_pool, target_doc_id)
+
+    await online_processor._process_online_batch()
+
+    queue_item = await queue_repo.get_by_id(queue_id)
+    assert queue_item.status == "completed"
+    target_embeddings = await embeddings_repo.get_for_document(target_doc_id)
+    assert len(target_embeddings) == 1
+    assert len(target_embeddings[0].embedding) == 1024
+    mock_embedding_provider.generate_embeddings.assert_called_once()
 
 
 @pytest.mark.integration

--- a/services/indexer/src/queue_processor.rs
+++ b/services/indexer/src/queue_processor.rs
@@ -1183,6 +1183,13 @@ impl QueueProcessor {
         );
 
         let repo = DocumentRepository::new(self.state.db_pool.pool());
+        let document_keys: Vec<(String, String)> = documents
+            .iter()
+            .map(|doc| (doc.source_id.clone(), doc.external_id.clone()))
+            .collect();
+        let existing_content_state = repo
+            .batch_get_content_state_by_source_external_ids(&document_keys)
+            .await?;
 
         // Batch upsert documents with content
         let upsert_start = std::time::Instant::now();
@@ -1193,22 +1200,74 @@ impl QueueProcessor {
             upsert_start.elapsed()
         );
 
-        // Batch add documents to embedding queue
+        let changed_content_doc_ids: Vec<String> = upserted_documents
+            .iter()
+            .filter(|doc| {
+                existing_content_state
+                    .get(&(doc.source_id.clone(), doc.external_id.clone()))
+                    .is_some_and(|existing| existing.content_id != doc.content_id)
+            })
+            .map(|doc| doc.id.clone())
+            .collect();
+
+        let changed_content_doc_id_set: std::collections::HashSet<String> =
+            changed_content_doc_ids.iter().cloned().collect();
+
+        // Batch add documents to embedding queue. Content changes must be requeued even if
+        // embeddings already exist; the embedding processor replaces embeddings when it handles
+        // the queue item. Unchanged content is queued only when current-model embeddings are
+        // missing, so metadata/permission-only updates do not regenerate embeddings.
         let embedding_start = std::time::Instant::now();
-        let doc_ids_for_embedding: Vec<String> =
-            upserted_documents.iter().map(|d| d.id.clone()).collect();
-        if !doc_ids_for_embedding.is_empty() {
-            if let Err(e) = self
+        if !changed_content_doc_ids.is_empty() {
+            match self
                 .state
                 .embedding_queue
-                .enqueue_batch(doc_ids_for_embedding.clone())
+                .enqueue_batch(changed_content_doc_ids.clone())
                 .await
             {
-                error!(
-                    "Failed to batch queue embeddings for {} documents: {}",
-                    doc_ids_for_embedding.len(),
-                    e
-                );
+                Ok(enqueued_ids) => {
+                    debug!(
+                        "Queued {} of {} content-changed documents for embedding",
+                        enqueued_ids.len(),
+                        changed_content_doc_ids.len()
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to batch queue embeddings for {} content-changed documents: {}",
+                        changed_content_doc_ids.len(),
+                        e
+                    );
+                }
+            }
+        }
+
+        let doc_ids_missing_embeddings: Vec<String> = upserted_documents
+            .iter()
+            .filter(|doc| !changed_content_doc_id_set.contains(&doc.id))
+            .map(|doc| doc.id.clone())
+            .collect();
+        if !doc_ids_missing_embeddings.is_empty() {
+            match self
+                .state
+                .embedding_queue
+                .enqueue_batch_missing_current_embeddings(doc_ids_missing_embeddings.clone())
+                .await
+            {
+                Ok(enqueued_ids) => {
+                    debug!(
+                        "Queued {} of {} unchanged/new documents missing embeddings",
+                        enqueued_ids.len(),
+                        doc_ids_missing_embeddings.len()
+                    );
+                }
+                Err(e) => {
+                    error!(
+                        "Failed to batch queue embeddings for {} unchanged/new documents: {}",
+                        doc_ids_missing_embeddings.len(),
+                        e
+                    );
+                }
             }
         }
         debug!(

--- a/services/indexer/src/queue_processor.rs
+++ b/services/indexer/src/queue_processor.rs
@@ -1187,9 +1187,11 @@ impl QueueProcessor {
             .iter()
             .map(|doc| (doc.source_id.clone(), doc.external_id.clone()))
             .collect();
-        let existing_content_state = repo
-            .batch_get_content_state_by_source_external_ids(&document_keys)
-            .await?;
+        let existing_documents = repo.find_by_external_ids(&document_keys).await?;
+        let existing_content_by_key: HashMap<(String, String), Option<String>> = existing_documents
+            .into_iter()
+            .map(|doc| ((doc.source_id, doc.external_id), doc.content_id))
+            .collect();
 
         // Batch upsert documents with content
         let upsert_start = std::time::Instant::now();
@@ -1203,9 +1205,9 @@ impl QueueProcessor {
         let changed_content_doc_ids: Vec<String> = upserted_documents
             .iter()
             .filter(|doc| {
-                existing_content_state
+                existing_content_by_key
                     .get(&(doc.source_id.clone(), doc.external_id.clone()))
-                    .is_some_and(|existing| existing.content_id != doc.content_id)
+                    .is_some_and(|existing_content_id| existing_content_id != &doc.content_id)
             })
             .map(|doc| doc.id.clone())
             .collect();

--- a/services/indexer/src/queue_processor.rs
+++ b/services/indexer/src/queue_processor.rs
@@ -2,7 +2,7 @@ use crate::people_extractor;
 use crate::AppState;
 use anyhow::{Context, Result};
 use shared::db::repositories::{
-    DocumentRepository, EmbeddingRepository, GroupRepository, PersonRepository, SyncRunRepository,
+    DocumentRepository, GroupRepository, PersonRepository, SyncRunRepository,
 };
 use shared::embedding_queue::EmbeddingQueue;
 use shared::models::{
@@ -1219,27 +1219,22 @@ impl QueueProcessor {
         // missing, so metadata/permission-only updates do not regenerate embeddings.
         let embedding_start = std::time::Instant::now();
         if !changed_content_doc_ids.is_empty() {
-            match self
+            let enqueued_ids = self
                 .state
                 .embedding_queue
                 .enqueue_batch(changed_content_doc_ids.clone())
                 .await
-            {
-                Ok(enqueued_ids) => {
-                    debug!(
-                        "Queued {} of {} content-changed documents for embedding",
-                        enqueued_ids.len(),
+                .with_context(|| {
+                    format!(
+                        "Failed to batch queue embeddings for {} content-changed documents",
                         changed_content_doc_ids.len()
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to batch queue embeddings for {} content-changed documents: {}",
-                        changed_content_doc_ids.len(),
-                        e
-                    );
-                }
-            }
+                    )
+                })?;
+            debug!(
+                "Queued {} of {} content-changed documents for embedding",
+                enqueued_ids.len(),
+                changed_content_doc_ids.len()
+            );
         }
 
         let doc_ids_missing_embeddings: Vec<String> = upserted_documents
@@ -1248,27 +1243,22 @@ impl QueueProcessor {
             .map(|doc| doc.id.clone())
             .collect();
         if !doc_ids_missing_embeddings.is_empty() {
-            match self
+            let enqueued_ids = self
                 .state
                 .embedding_queue
                 .enqueue_batch_missing_current_embeddings(doc_ids_missing_embeddings.clone())
                 .await
-            {
-                Ok(enqueued_ids) => {
-                    debug!(
-                        "Queued {} of {} unchanged/new documents missing embeddings",
-                        enqueued_ids.len(),
+                .with_context(|| {
+                    format!(
+                        "Failed to batch queue embeddings for {} unchanged/new documents",
                         doc_ids_missing_embeddings.len()
-                    );
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to batch queue embeddings for {} unchanged/new documents: {}",
-                        doc_ids_missing_embeddings.len(),
-                        e
-                    );
-                }
-            }
+                    )
+                })?;
+            debug!(
+                "Queued {} of {} unchanged/new documents missing embeddings",
+                enqueued_ids.len(),
+                doc_ids_missing_embeddings.len()
+            );
         }
         debug!(
             "Embedding queue batch operation took {:?}",
@@ -1296,7 +1286,6 @@ impl QueueProcessor {
     ) -> Result<Vec<String>> {
         let start_time = std::time::Instant::now();
         let repo = DocumentRepository::new(self.state.db_pool.pool());
-        let embedding_repo = EmbeddingRepository::new(self.state.db_pool.pool());
 
         // All deletion events are considered successful (even if doc not found)
         let successful_event_ids: Vec<String> = deletions
@@ -1323,19 +1312,8 @@ impl QueueProcessor {
         }
 
         if !document_ids_to_delete.is_empty() {
-            // Delete embeddings in batch
-            if let Err(e) = embedding_repo
-                .bulk_delete_by_document_ids(&document_ids_to_delete)
-                .await
-            {
-                error!(
-                    "Failed to batch delete embeddings for {} documents: {}",
-                    document_ids_to_delete.len(),
-                    e
-                );
-            }
-
-            // Delete documents in batch
+            // embeddings.document_id has ON DELETE CASCADE, so embeddings are removed only if
+            // the document delete commits successfully.
             let delete_start = std::time::Instant::now();
             let deleted_count = repo.batch_delete(document_ids_to_delete.clone()).await?;
             debug!("Batch document deletion took {:?}", delete_start.elapsed());

--- a/services/indexer/tests/integration_tests.rs
+++ b/services/indexer/tests/integration_tests.rs
@@ -197,6 +197,17 @@ async fn test_event_driven_document_lifecycle() {
         "documents.file_extension column must update when URL extension changes"
     );
 
+    sqlx::query(
+        r#"
+        INSERT INTO embeddings (id, document_id, chunk_index, chunk_start_offset, chunk_end_offset, embedding, model_name, dimensions)
+        VALUES ('01TESTLIFECYCLEDEL000001AA', $1, 0, 0, 10, '[0.1,0.2,0.3]'::vector, 'test-model', 3)
+        "#,
+    )
+    .bind(&updated_doc.id)
+    .execute(fixture.state.db_pool.pool())
+    .await
+    .unwrap();
+
     // --- Delete ---
     let delete_event = ConnectorEvent::DocumentDeleted {
         sync_run_id: "sync_lifecycle".to_string(),
@@ -212,6 +223,14 @@ async fn test_event_driven_document_lifecycle() {
     common::wait_for_document_deleted(&repo, TEST_SOURCE_ID, doc_id, Duration::from_secs(5))
         .await
         .expect("Document should be deleted");
+
+    let embedding_count_after_delete: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM embeddings WHERE document_id = $1")
+            .bind(&updated_doc.id)
+            .fetch_one(fixture.state.db_pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(embedding_count_after_delete.0, 0);
 
     processor_handle.abort();
 }

--- a/services/indexer/tests/integration_tests.rs
+++ b/services/indexer/tests/integration_tests.rs
@@ -217,6 +217,191 @@ async fn test_event_driven_document_lifecycle() {
 }
 
 #[tokio::test]
+async fn test_unchanged_content_upsert_does_not_requeue_existing_embeddings() {
+    let fixture = common::setup_test_fixture().await.unwrap();
+    let event_queue = EventQueue::new(fixture.state.db_pool.pool().clone());
+    let repo = DocumentRepository::new(fixture.state.db_pool.pool());
+
+    let processor =
+        QueueProcessor::new(fixture.state.clone()).with_poll_interval(Duration::from_millis(200));
+    let processor_handle = tokio::spawn(async move {
+        let _ = processor.start().await;
+    });
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let doc_id = "embedding_idempotency_doc";
+    let content_id = fixture
+        .state
+        .content_storage
+        .store_content(b"stable content", None)
+        .await
+        .unwrap();
+
+    let create_event = ConnectorEvent::DocumentCreated {
+        sync_run_id: "sync_embedding_idempotency".to_string(),
+        source_id: TEST_SOURCE_ID.to_string(),
+        document_id: doc_id.to_string(),
+        content_id: content_id.clone(),
+        metadata: DocumentMetadata {
+            title: Some("Stable Content".to_string()),
+            author: None,
+            created_at: None,
+            updated_at: Some(OffsetDateTime::now_utc()),
+            content_type: None,
+            mime_type: Some("text/plain".to_string()),
+            size: Some("14".to_string()),
+            url: Some("https://example.com/stable.txt".to_string()),
+            path: Some("/stable.txt".to_string()),
+            extra: None,
+        },
+        permissions: DocumentPermissions {
+            public: false,
+            users: vec!["user@example.com".to_string()],
+            groups: vec![],
+        },
+        attributes: None,
+    };
+
+    event_queue
+        .enqueue(TEST_SOURCE_ID, &create_event)
+        .await
+        .unwrap();
+
+    let document =
+        common::wait_for_document_exists(&repo, TEST_SOURCE_ID, doc_id, Duration::from_secs(5))
+            .await
+            .expect("Document should be created");
+    common::wait_for_completed(fixture.state.db_pool.pool(), 1, Duration::from_secs(5)).await;
+
+    sqlx::query("UPDATE embedding_queue SET status = 'completed' WHERE document_id = $1")
+        .bind(&document.id)
+        .execute(fixture.state.db_pool.pool())
+        .await
+        .unwrap();
+    sqlx::query(
+        r#"
+        INSERT INTO embeddings (id, document_id, chunk_index, chunk_start_offset, chunk_end_offset, embedding, model_name, dimensions)
+        VALUES ('emb_idempotency_existing', $1, 0, 0, 14, '[0.1,0.2,0.3]'::vector, 'test-model', 3)
+        "#,
+    )
+    .bind(&document.id)
+    .execute(fixture.state.db_pool.pool())
+    .await
+    .unwrap();
+
+    let metadata_only_update = ConnectorEvent::DocumentUpdated {
+        sync_run_id: "sync_embedding_idempotency".to_string(),
+        source_id: TEST_SOURCE_ID.to_string(),
+        document_id: doc_id.to_string(),
+        content_id: content_id.clone(),
+        metadata: DocumentMetadata {
+            title: Some("Stable Content Renamed".to_string()),
+            author: None,
+            created_at: None,
+            updated_at: Some(OffsetDateTime::now_utc()),
+            content_type: None,
+            mime_type: Some("text/plain".to_string()),
+            size: Some("14".to_string()),
+            url: Some("https://example.com/stable-renamed.txt".to_string()),
+            path: Some("/stable-renamed.txt".to_string()),
+            extra: None,
+        },
+        permissions: Some(DocumentPermissions {
+            public: false,
+            users: vec![
+                "user@example.com".to_string(),
+                "other@example.com".to_string(),
+            ],
+            groups: vec![],
+        }),
+        attributes: None,
+    };
+
+    event_queue
+        .enqueue(TEST_SOURCE_ID, &metadata_only_update)
+        .await
+        .unwrap();
+    common::wait_for_document_with_title(
+        &repo,
+        TEST_SOURCE_ID,
+        doc_id,
+        "Stable Content Renamed",
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("Document should be updated");
+    common::wait_for_completed(fixture.state.db_pool.pool(), 2, Duration::from_secs(5)).await;
+
+    let queue_rows_after_metadata_update: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM embedding_queue WHERE document_id = $1")
+            .bind(&document.id)
+            .fetch_one(fixture.state.db_pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(queue_rows_after_metadata_update.0, 1);
+
+    let new_content_id = fixture
+        .state
+        .content_storage
+        .store_content(b"changed content", None)
+        .await
+        .unwrap();
+    let content_update = ConnectorEvent::DocumentUpdated {
+        sync_run_id: "sync_embedding_idempotency".to_string(),
+        source_id: TEST_SOURCE_ID.to_string(),
+        document_id: doc_id.to_string(),
+        content_id: new_content_id,
+        metadata: DocumentMetadata {
+            title: Some("Changed Content".to_string()),
+            author: None,
+            created_at: None,
+            updated_at: Some(OffsetDateTime::now_utc()),
+            content_type: None,
+            mime_type: Some("text/plain".to_string()),
+            size: Some("15".to_string()),
+            url: Some("https://example.com/changed.txt".to_string()),
+            path: Some("/changed.txt".to_string()),
+            extra: None,
+        },
+        permissions: None,
+        attributes: None,
+    };
+
+    event_queue
+        .enqueue(TEST_SOURCE_ID, &content_update)
+        .await
+        .unwrap();
+    common::wait_for_document_with_title(
+        &repo,
+        TEST_SOURCE_ID,
+        doc_id,
+        "Changed Content",
+        Duration::from_secs(5),
+    )
+    .await
+    .expect("Document should be updated with changed content");
+    common::wait_for_completed(fixture.state.db_pool.pool(), 3, Duration::from_secs(5)).await;
+
+    let queue_rows_after_content_update: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM embedding_queue WHERE document_id = $1")
+            .bind(&document.id)
+            .fetch_one(fixture.state.db_pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(queue_rows_after_content_update.0, 2);
+
+    let embeddings_after_content_update: (i64,) =
+        sqlx::query_as("SELECT COUNT(*) FROM embeddings WHERE document_id = $1")
+            .bind(&document.id)
+            .fetch_one(fixture.state.db_pool.pool())
+            .await
+            .unwrap();
+    assert_eq!(embeddings_after_content_update.0, 1);
+
+    processor_handle.abort();
+}
+
+#[tokio::test]
 async fn test_latest_document_event_wins_within_indexer_batch() {
     let fixture = common::setup_test_fixture().await.unwrap();
     let event_queue = EventQueue::new(fixture.state.db_pool.pool().clone());

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -16,14 +16,6 @@ pub struct TitleEntry {
     pub source_id: String,
 }
 
-#[derive(Debug, Clone, FromRow)]
-pub struct DocumentContentState {
-    pub id: String,
-    pub source_id: String,
-    pub external_id: String,
-    pub content_id: Option<String>,
-}
-
 pub struct DocumentRepository {
     pool: PgPool,
 }
@@ -523,43 +515,6 @@ impl DocumentRepository {
         .await?;
 
         Ok(upserted_document)
-    }
-
-    pub async fn batch_get_content_state_by_source_external_ids(
-        &self,
-        keys: &[(String, String)],
-    ) -> Result<HashMap<(String, String), DocumentContentState>, DatabaseError> {
-        if keys.is_empty() {
-            return Ok(HashMap::new());
-        }
-
-        let source_ids: Vec<String> = keys
-            .iter()
-            .map(|(source_id, _)| source_id.clone())
-            .collect();
-        let external_ids: Vec<String> = keys
-            .iter()
-            .map(|(_, external_id)| external_id.clone())
-            .collect();
-
-        let rows = sqlx::query_as::<_, DocumentContentState>(
-            r#"
-            SELECT d.id, d.source_id, d.external_id, d.content_id
-            FROM UNNEST($1::text[], $2::text[]) AS t(source_id, external_id)
-            JOIN documents d
-              ON d.source_id = t.source_id
-             AND d.external_id = t.external_id
-            "#,
-        )
-        .bind(&source_ids)
-        .bind(&external_ids)
-        .fetch_all(&self.pool)
-        .await?;
-
-        Ok(rows
-            .into_iter()
-            .map(|row| ((row.source_id.clone(), row.external_id.clone()), row))
-            .collect())
     }
 
     /// Directly populates the content field since we use the ParadeDB BM25 index now

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -16,6 +16,14 @@ pub struct TitleEntry {
     pub source_id: String,
 }
 
+#[derive(Debug, Clone, FromRow)]
+pub struct DocumentContentState {
+    pub id: String,
+    pub source_id: String,
+    pub external_id: String,
+    pub content_id: Option<String>,
+}
+
 pub struct DocumentRepository {
     pool: PgPool,
 }
@@ -515,6 +523,43 @@ impl DocumentRepository {
         .await?;
 
         Ok(upserted_document)
+    }
+
+    pub async fn batch_get_content_state_by_source_external_ids(
+        &self,
+        keys: &[(String, String)],
+    ) -> Result<HashMap<(String, String), DocumentContentState>, DatabaseError> {
+        if keys.is_empty() {
+            return Ok(HashMap::new());
+        }
+
+        let source_ids: Vec<String> = keys
+            .iter()
+            .map(|(source_id, _)| source_id.clone())
+            .collect();
+        let external_ids: Vec<String> = keys
+            .iter()
+            .map(|(_, external_id)| external_id.clone())
+            .collect();
+
+        let rows = sqlx::query_as::<_, DocumentContentState>(
+            r#"
+            SELECT d.id, d.source_id, d.external_id, d.content_id
+            FROM UNNEST($1::text[], $2::text[]) AS t(source_id, external_id)
+            JOIN documents d
+              ON d.source_id = t.source_id
+             AND d.external_id = t.external_id
+            "#,
+        )
+        .bind(&source_ids)
+        .bind(&external_ids)
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(rows
+            .into_iter()
+            .map(|row| ((row.source_id.clone(), row.external_id.clone()), row))
+            .collect())
     }
 
     /// Directly populates the content field since we use the ParadeDB BM25 index now

--- a/shared/src/embedding_queue.rs
+++ b/shared/src/embedding_queue.rs
@@ -156,6 +156,55 @@ impl EmbeddingQueue {
         Ok(ids)
     }
 
+    pub async fn enqueue_batch_missing_current_embeddings(
+        &self,
+        document_ids: Vec<String>,
+    ) -> Result<Vec<String>> {
+        if !self.provider_repo.has_active_provider().await? {
+            return Ok(vec![]);
+        }
+
+        let mut tx = self.pool.begin().await?;
+        let mut ids = Vec::new();
+
+        for document_id in document_ids {
+            let id = Ulid::new().to_string();
+
+            let result = sqlx::query(
+                r#"
+                INSERT INTO embedding_queue (id, document_id)
+                SELECT $1, $2
+                WHERE NOT EXISTS (
+                    SELECT 1 FROM embedding_queue
+                    WHERE document_id = $2 AND status IN ('pending', 'processing')
+                )
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM embeddings e
+                    WHERE e.document_id = $2
+                      AND e.model_name = (
+                          SELECT config->>'model'
+                          FROM embedding_providers
+                          WHERE is_current = TRUE AND is_deleted = FALSE
+                          LIMIT 1
+                      )
+                )
+                "#,
+            )
+            .bind(&id)
+            .bind(&document_id)
+            .execute(&mut *tx)
+            .await?;
+
+            if result.rows_affected() > 0 {
+                ids.push(id);
+            }
+        }
+
+        tx.commit().await?;
+        Ok(ids)
+    }
+
     pub async fn dequeue_batch(&self, batch_size: i32) -> Result<Vec<EmbeddingQueueItem>> {
         let items = sqlx::query_as::<_, EmbeddingQueueItem>(
             r#"

--- a/shared/src/embedding_queue.rs
+++ b/shared/src/embedding_queue.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, Row};
 use ulid::Ulid;
 
-use crate::db::repositories::EmbeddingProviderRepository;
+use crate::{db::repositories::EmbeddingProviderRepository, utils::generate_ulid};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -160,49 +160,53 @@ impl EmbeddingQueue {
         &self,
         document_ids: Vec<String>,
     ) -> Result<Vec<String>> {
-        if !self.provider_repo.has_active_provider().await? {
+        if document_ids.is_empty() || !self.provider_repo.has_active_provider().await? {
             return Ok(vec![]);
         }
 
-        let mut tx = self.pool.begin().await?;
-        let mut ids = Vec::new();
-
-        for document_id in document_ids {
-            let id = Ulid::new().to_string();
-
-            let result = sqlx::query(
-                r#"
-                INSERT INTO embedding_queue (id, document_id)
-                SELECT $1, $2
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM embedding_queue
-                    WHERE document_id = $2 AND status IN ('pending', 'processing')
-                )
-                AND NOT EXISTS (
-                    SELECT 1
-                    FROM embeddings e
-                    WHERE e.document_id = $2
-                      AND e.model_name = (
-                          SELECT config->>'model'
-                          FROM embedding_providers
-                          WHERE is_current = TRUE AND is_deleted = FALSE
-                          LIMIT 1
-                      )
-                )
-                "#,
+        let ids: Vec<String> = document_ids.iter().map(|_| generate_ulid()).collect();
+        let rows = sqlx::query(
+            r#"
+            WITH active_provider AS (
+                SELECT config->>'model' AS model_name
+                FROM embedding_providers
+                WHERE is_current = TRUE AND is_deleted = FALSE
+                LIMIT 1
+            ),
+            input_rows AS (
+                SELECT id, document_id, ordinality
+                FROM UNNEST($1::text[], $2::text[]) WITH ORDINALITY AS t(id, document_id, ordinality)
+            ),
+            deduped_input AS (
+                SELECT DISTINCT ON (document_id) id, document_id
+                FROM input_rows
+                ORDER BY document_id, ordinality
             )
-            .bind(&id)
-            .bind(&document_id)
-            .execute(&mut *tx)
-            .await?;
+            INSERT INTO embedding_queue (id, document_id)
+            SELECT input.id, input.document_id
+            FROM deduped_input input
+            CROSS JOIN active_provider provider
+            WHERE NOT EXISTS (
+                SELECT 1
+                FROM embedding_queue q
+                WHERE q.document_id = input.document_id
+                  AND q.status IN ('pending', 'processing')
+            )
+            AND NOT EXISTS (
+                SELECT 1
+                FROM embeddings e
+                WHERE e.document_id = input.document_id
+                  AND e.model_name = provider.model_name
+            )
+            RETURNING id
+            "#,
+        )
+        .bind(&ids)
+        .bind(&document_ids)
+        .fetch_all(&self.pool)
+        .await?;
 
-            if result.rows_affected() > 0 {
-                ids.push(id);
-            }
-        }
-
-        tx.commit().await?;
-        Ok(ids)
+        Ok(rows.into_iter().map(|row| row.get("id")).collect())
     }
 
     pub async fn dequeue_batch(&self, batch_size: i32) -> Result<Vec<EmbeddingQueueItem>> {

--- a/shared/tests/embedding_queue_test.rs
+++ b/shared/tests/embedding_queue_test.rs
@@ -11,8 +11,8 @@ mod tests {
         let id = Ulid::new().to_string();
         sqlx::query(
             r#"
-            INSERT INTO embedding_providers (id, name, provider_type, is_current, is_deleted)
-            VALUES ($1, 'test-provider', 'local', TRUE, FALSE)
+            INSERT INTO embedding_providers (id, name, provider_type, config, is_current, is_deleted)
+            VALUES ($1, 'test-provider', 'local', '{"model":"test-model"}', TRUE, FALSE)
             ON CONFLICT DO NOTHING
             "#,
         )
@@ -78,6 +78,87 @@ mod tests {
 
         let batch = queue.dequeue_batch(10).await.unwrap();
         assert_eq!(batch.len(), 3);
+    }
+
+    #[tokio::test]
+    async fn test_enqueue_batch_missing_current_embeddings_enqueues_multiple_missing_only() {
+        let env = TestEnvironment::new().await.unwrap();
+        let pool = env.db_pool.pool().clone();
+        let queue = EmbeddingQueue::new(pool.clone());
+        insert_active_embedding_provider(&pool).await;
+
+        let doc_with_embedding = create_document(&pool).await;
+        let doc_with_active_queue = create_document(&pool).await;
+        let missing_doc_1 = create_document(&pool).await;
+        let missing_doc_2 = create_document(&pool).await;
+
+        sqlx::query(
+            r#"
+            INSERT INTO embeddings (id, document_id, chunk_index, chunk_start_offset, chunk_end_offset, embedding, model_name, dimensions)
+            VALUES ($1, $2, 0, 0, 10, '[0.1,0.2,0.3]'::vector, 'test-model', 3)
+            "#,
+        )
+        .bind(Ulid::new().to_string())
+        .bind(&doc_with_embedding)
+        .execute(&pool)
+        .await
+        .unwrap();
+
+        queue
+            .enqueue(doc_with_active_queue.clone())
+            .await
+            .unwrap()
+            .unwrap();
+
+        let queue_ids = queue
+            .enqueue_batch_missing_current_embeddings(vec![
+                doc_with_embedding.clone(),
+                doc_with_active_queue.clone(),
+                missing_doc_1.clone(),
+                missing_doc_2.clone(),
+            ])
+            .await
+            .unwrap();
+        assert_eq!(queue_ids.len(), 2);
+
+        let queued_missing_doc_count: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM embedding_queue
+            WHERE document_id = ANY($1)
+            "#,
+        )
+        .bind(vec![missing_doc_1, missing_doc_2])
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(queued_missing_doc_count.0, 2);
+
+        let skipped_doc_count: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM embedding_queue
+            WHERE document_id = $1
+            "#,
+        )
+        .bind(&doc_with_embedding)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(skipped_doc_count.0, 0);
+
+        let existing_active_queue_count: (i64,) = sqlx::query_as(
+            r#"
+            SELECT COUNT(*)
+            FROM embedding_queue
+            WHERE document_id = $1
+            "#,
+        )
+        .bind(&doc_with_active_queue)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(existing_active_queue_count.0, 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Avoid requeueing embeddings for unchanged document content that already has current-model vectors.
- Requeue documents when content_id changes without deleting embeddings in the indexer.
- Clone embeddings in omni-ai for duplicate content_id documents using batch donor lookups.
- Add integration tests for indexer idempotency and duplicate-content embedding clone behavior.