### PR TITLE
fix(ai): handle null embedding chunk size

### DIFF
--- a/services/ai/embeddings/bedrock.py
+++ b/services/ai/embeddings/bedrock.py
@@ -5,6 +5,7 @@ import boto3
 import json
 
 from . import EmbeddingProvider, Chunk
+from .options import resolve_chunk_size
 from processing import Chunker
 
 logger = logging.getLogger(__name__)
@@ -33,7 +34,7 @@ class BedrockEmbeddingProvider(EmbeddingProvider):
         self,
         text: str,
         task: str,
-        chunk_size: int,
+        chunk_size: int | None,
         chunking_mode: str,
     ) -> list[Chunk]:
         """
@@ -58,16 +59,12 @@ class BedrockEmbeddingProvider(EmbeddingProvider):
         self,
         text: str,
         task: str,
-        chunk_size: int,
+        chunk_size: int | None,
         chunking_mode: str,
     ) -> list[Chunk]:
         """Generate embeddings using AWS Bedrock with chunking support."""
 
         start_time = time.time()
-
-        # Cap chunk_size at max_model_len and convert to chars
-        effective_chunk_size = min(chunk_size, self.max_model_len)
-        max_chars = effective_chunk_size * self.CHARS_PER_TOKEN
 
         try:
             if chunking_mode == "none":
@@ -75,6 +72,10 @@ class BedrockEmbeddingProvider(EmbeddingProvider):
                 chunks = [Chunk((0, len(text)), embeddings[0])]
 
             elif chunking_mode == "sentence":
+                max_chars = (
+                    resolve_chunk_size(chunk_size, self.max_model_len)
+                    * self.CHARS_PER_TOKEN
+                )
                 char_spans = Chunker.chunk_sentences_by_chars(text, max_chars)
 
                 chunk_texts = [text[start:end] for start, end in char_spans]
@@ -90,6 +91,10 @@ class BedrockEmbeddingProvider(EmbeddingProvider):
                     chunks = [Chunk((0, len(text)), embeddings[0])]
 
             elif chunking_mode == "fixed":
+                max_chars = (
+                    resolve_chunk_size(chunk_size, self.max_model_len)
+                    * self.CHARS_PER_TOKEN
+                )
                 char_spans = Chunker.chunk_by_chars(text, max_chars)
 
                 chunk_texts = [text[start:end] for start, end in char_spans]

--- a/services/ai/embeddings/cohere.py
+++ b/services/ai/embeddings/cohere.py
@@ -4,6 +4,7 @@ import time
 import cohere
 
 from . import EmbeddingProvider, Chunk
+from .options import resolve_chunk_size
 from processing import Chunker
 
 logger = logging.getLogger(__name__)
@@ -80,12 +81,11 @@ class CohereEmbeddingProvider(EmbeddingProvider):
         self,
         text: str,
         task: str,
-        chunk_size: int,
+        chunk_size: int | None,
         chunking_mode: str,
     ) -> list[Chunk]:
         start_time = time.time()
 
-        max_chars = min(chunk_size, self.max_model_len) * self.CHARS_PER_TOKEN
         cohere_task = self._map_task(task)
 
         try:
@@ -94,6 +94,10 @@ class CohereEmbeddingProvider(EmbeddingProvider):
                 chunks = [Chunk((0, len(text)), embeddings[0])]
 
             elif chunking_mode == "sentence":
+                max_chars = (
+                    resolve_chunk_size(chunk_size, self.max_model_len)
+                    * self.CHARS_PER_TOKEN
+                )
                 char_spans = Chunker.chunk_sentences_by_chars(text, max_chars)
                 chunk_texts = [text[start:end] for start, end in char_spans]
 
@@ -104,6 +108,10 @@ class CohereEmbeddingProvider(EmbeddingProvider):
                 ]
 
             elif chunking_mode == "fixed":
+                max_chars = (
+                    resolve_chunk_size(chunk_size, self.max_model_len)
+                    * self.CHARS_PER_TOKEN
+                )
                 char_spans = Chunker.chunk_by_chars(text, max_chars)
                 chunk_texts = [text[start:end] for start, end in char_spans]
 

--- a/services/ai/embeddings/jina.py
+++ b/services/ai/embeddings/jina.py
@@ -6,6 +6,7 @@ import asyncio
 from transformers import AutoTokenizer
 
 from . import EmbeddingProvider, Chunk
+from .options import resolve_chunk_size
 from processing import Chunker
 
 logger = logging.getLogger(__name__)
@@ -56,7 +57,7 @@ class JinaEmbeddingProvider(EmbeddingProvider):
         self,
         text: str,
         task: str,
-        chunk_size: int,
+        chunk_size: int | None,
         chunking_mode: str,
     ) -> list[Chunk]:
         """Generate embeddings using JINA API with chunking support."""
@@ -64,15 +65,15 @@ class JinaEmbeddingProvider(EmbeddingProvider):
         start_time = time.time()
         api_task = self.TASK_MAP.get(task, task)
 
-        # Cap chunk_size at max_model_len
-        effective_chunk_size = min(chunk_size, self.max_model_len)
-
         try:
             if chunking_mode == "none":
                 embeddings = await self.client.generate_embeddings([text], api_task)
                 chunks = [Chunk((0, len(text)), embeddings[0])]
 
             elif chunking_mode == "sentence":
+                effective_chunk_size = resolve_chunk_size(
+                    chunk_size, self.max_model_len
+                )
                 _, char_spans = await self.chunker.chunk_by_sentences_async(
                     text, effective_chunk_size, self.tokenizer
                 )
@@ -92,6 +93,9 @@ class JinaEmbeddingProvider(EmbeddingProvider):
                     chunks = [Chunk((0, len(text)), embeddings[0])]
 
             elif chunking_mode == "fixed":
+                effective_chunk_size = resolve_chunk_size(
+                    chunk_size, self.max_model_len
+                )
                 _, char_spans = await self.chunker.chunk_by_tokens_async(
                     text, effective_chunk_size, self.tokenizer
                 )

--- a/services/ai/embeddings/openai.py
+++ b/services/ai/embeddings/openai.py
@@ -4,6 +4,7 @@ import httpx
 import asyncio
 
 from . import EmbeddingProvider, Chunk
+from .options import resolve_chunk_size
 from processing import Chunker
 
 logger = logging.getLogger(__name__)
@@ -73,12 +74,6 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
 
         start_time = time.time()
 
-        # Convert token-based sizes to chars for char-based chunking
-        if chunk_size:
-            max_chars = chunk_size * CHARS_PER_TOKEN
-            if self.max_model_len:
-                max_chars = min(max_chars, self.max_model_len * CHARS_PER_TOKEN)
-
         try:
             if chunking_mode == "none":
                 t0 = time.monotonic()
@@ -89,6 +84,10 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
                 chunks = [Chunk((0, len(text)), embeddings[0])]
 
             elif chunking_mode == "sentence":
+                max_chars = (
+                    resolve_chunk_size(chunk_size, self.max_model_len)
+                    * CHARS_PER_TOKEN
+                )
                 char_spans = Chunker.chunk_sentences_by_chars(text, max_chars)
                 chunk_texts = [text[start:end] for start, end in char_spans]
 
@@ -103,6 +102,10 @@ class OpenAIEmbeddingProvider(EmbeddingProvider):
                 ]
 
             elif chunking_mode == "fixed":
+                max_chars = (
+                    resolve_chunk_size(chunk_size, self.max_model_len)
+                    * CHARS_PER_TOKEN
+                )
                 char_spans = Chunker.chunk_by_chars(text, max_chars)
                 chunk_texts = [text[start:end] for start, end in char_spans]
 

--- a/services/ai/embeddings/options.py
+++ b/services/ai/embeddings/options.py
@@ -1,0 +1,13 @@
+"""Shared embedding request option handling."""
+
+DEFAULT_CHUNK_SIZE = 512
+
+
+def resolve_chunk_size(chunk_size: int | None, max_model_len: int | None = None) -> int:
+    """Return a valid token chunk size, capped by the provider's model limit."""
+    effective_chunk_size = chunk_size if chunk_size is not None else DEFAULT_CHUNK_SIZE
+    if effective_chunk_size < 1:
+        raise ValueError("chunk_size must be greater than 0")
+    if max_model_len is not None:
+        return min(effective_chunk_size, max_model_len)
+    return effective_chunk_size

--- a/services/ai/tests/unit/test_embedding_providers.py
+++ b/services/ai/tests/unit/test_embedding_providers.py
@@ -1,0 +1,70 @@
+from __future__ import annotations
+
+from unittest.mock import AsyncMock
+
+import pytest
+
+from embeddings.bedrock import BedrockEmbeddingProvider
+from embeddings.cohere import CohereEmbeddingProvider
+from embeddings.jina import JinaEmbeddingProvider
+from embeddings.openai import OpenAIEmbeddingProvider
+
+pytestmark = pytest.mark.unit
+
+
+class _SyncEmbeddingClient:
+    def generate_embeddings(self, texts: list[str]) -> list[list[float]]:
+        return [[0.1, 0.2, 0.3] for _ in texts]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_cls", "provider_fields"),
+    [
+        (OpenAIEmbeddingProvider, {"model": "openai-test", "max_model_len": None}),
+        (JinaEmbeddingProvider, {"model": "jina-test", "max_model_len": 8192}),
+    ],
+)
+async def test_async_embedding_providers_allow_null_chunk_size_when_chunking_disabled(
+    provider_cls, provider_fields
+):
+    provider = provider_cls.__new__(provider_cls)
+    for field, value in provider_fields.items():
+        setattr(provider, field, value)
+    provider.client = AsyncMock()
+    provider.client.generate_embeddings.return_value = [[0.1, 0.2, 0.3]]
+
+    chunks = await provider.generate_embeddings("hello", "query", None, "none")
+
+    assert len(chunks) == 1
+    assert chunks[0].span == (0, 5)
+    assert chunks[0].embedding == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_cohere_allows_null_chunk_size_when_chunking_disabled():
+    provider = CohereEmbeddingProvider.__new__(CohereEmbeddingProvider)
+    provider.model = "cohere-test"
+    provider.max_model_len = 8192
+    provider.dimensions = None
+    provider._embed_texts = AsyncMock(return_value=[[0.1, 0.2, 0.3]])
+
+    chunks = await provider.generate_embeddings("hello", "query", None, "none")
+
+    assert len(chunks) == 1
+    assert chunks[0].span == (0, 5)
+    assert chunks[0].embedding == [0.1, 0.2, 0.3]
+
+
+@pytest.mark.asyncio
+async def test_bedrock_allows_null_chunk_size_when_chunking_disabled():
+    provider = BedrockEmbeddingProvider.__new__(BedrockEmbeddingProvider)
+    provider.model_id = "bedrock-test"
+    provider.max_model_len = 8192
+    provider.client = _SyncEmbeddingClient()
+
+    chunks = await provider.generate_embeddings("hello", "query", None, "none")
+
+    assert len(chunks) == 1
+    assert chunks[0].span == (0, 5)
+    assert chunks[0].embedding == [0.1, 0.2, 0.3]


### PR DESCRIPTION
- Avoid comparing null chunk_size with provider model limits.
- Resolve default chunk size only when chunking is enabled.