### PR TITLE
fix(web): allow Slack token updates

### DIFF
--- a/web/src/routes/(admin)/admin/settings/integrations/slack/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/slack/[sourceId]/+page.server.ts
@@ -3,6 +3,8 @@ import type { PageServerLoad, Actions } from './$types'
 import { requireAdmin } from '$lib/server/authHelpers'
 import { getSourceById, updateSourceById } from '$lib/server/db/sources'
 import { getConfig } from '$lib/server/config'
+import { decryptConfig } from '$lib/server/crypto/encryption'
+import { serviceCredentialsRepository } from '$lib/server/repositories/service-credentials'
 import { SourceType } from '$lib/types'
 
 export const load: PageServerLoad = async ({ params, locals }) => {
@@ -41,12 +43,64 @@ export const actions: Actions = {
 
         const formData = await request.formData()
         const isActive = formData.has('enabled')
+        const botToken = ((formData.get('botToken') as string | null) ?? '').trim()
+        const appToken = ((formData.get('appToken') as string | null) ?? '').trim()
+
+        if (botToken && !botToken.startsWith('xoxb-')) {
+            throw error(400, 'Bot token must start with xoxb-')
+        }
+
+        if (appToken && !appToken.startsWith('xapp-')) {
+            throw error(400, 'App-Level Token must start with xapp-')
+        }
+
+        const credentialUpdates: Record<string, string> = {}
+        if (botToken) {
+            credentialUpdates.bot_token = botToken
+        }
+        if (appToken) {
+            credentialUpdates.app_token = appToken
+        }
+
+        let mergedCredentials: Record<string, unknown> | null = null
+        if (Object.keys(credentialUpdates).length > 0) {
+            const existingCredentials = await serviceCredentialsRepository.getOrgCredsBySourceId(
+                source.id,
+            )
+
+            if (!existingCredentials) {
+                throw error(404, 'No Slack credentials exist for this source')
+            }
+
+            try {
+                mergedCredentials = {
+                    ...decryptConfig(existingCredentials.credentials),
+                    ...credentialUpdates,
+                }
+            } catch (err) {
+                console.error(`Failed to decrypt Slack credentials for source ${source.id}:`, err)
+                throw error(500, 'Failed to read existing Slack credentials')
+            }
+        }
 
         try {
             await updateSourceById(source.id, {
                 isActive,
                 config: source.config || {},
             })
+
+            if (mergedCredentials) {
+                const updatedCredentials = await serviceCredentialsRepository.updateBySourceId(
+                    source.id,
+                    {
+                        credentials: mergedCredentials,
+                    },
+                )
+
+                if (!updatedCredentials) {
+                    throw new Error('Failed to update Slack credentials')
+                }
+            }
 
             if (isActive) {
                 const connectorManagerUrl = getConfig().services.connectorManagerUrl

--- a/web/src/routes/(admin)/admin/settings/integrations/slack/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/slack/[sourceId]/+page.svelte
@@ -1,10 +1,12 @@
 <script lang="ts">
     import { enhance } from '$app/forms'
     import { Button } from '$lib/components/ui/button'
+    import { Input } from '$lib/components/ui/input'
     import { Label } from '$lib/components/ui/label'
     import { Switch } from '$lib/components/ui/switch'
+    import * as Alert from '$lib/components/ui/alert'
     import * as Card from '$lib/components/ui/card'
-    import { Loader2 } from '@lucide/svelte'
+    import { AlertCircle, Loader2 } from '@lucide/svelte'
     import { onMount } from 'svelte'
     import { beforeNavigate } from '$app/navigation'
     import type { PageProps } from './$types'
@@ -13,8 +15,11 @@
     let { data }: PageProps = $props()
 
     let enabled = $state(data.source.isActive)
+    let botToken = $state('')
+    let appToken = $state('')
 
     let isSubmitting = $state(false)
+    let formErrors = $state<string[]>([])
     let hasUnsavedChanges = $state(false)
     let skipUnsavedCheck = $state(false)
 
@@ -51,16 +56,54 @@
     })
 
     $effect(() => {
-        hasUnsavedChanges = enabled !== originalEnabled
+        hasUnsavedChanges =
+            enabled !== originalEnabled || botToken.trim() !== '' || appToken.trim() !== ''
     })
+
+    function validateForm(): boolean {
+        formErrors = []
+
+        const trimmedBotToken = botToken.trim()
+        const trimmedAppToken = appToken.trim()
+
+        if (trimmedBotToken && !trimmedBotToken.startsWith('xoxb-')) {
+            formErrors = [...formErrors, 'Bot token must start with xoxb-']
+        }
+
+        if (trimmedAppToken && !trimmedAppToken.startsWith('xapp-')) {
+            formErrors = [...formErrors, 'App-Level Token must start with xapp-']
+        }
+
+        return formErrors.length === 0
+    }
 </script>
 
 <svelte:head>
     <title>Configure Slack - {data.source.name}</title>
 </svelte:head>
+
+{#if formErrors.length > 0}
+    <Alert.Root variant="destructive">
+        <AlertCircle class="h-4 w-4" />
+        <Alert.Title>Configuration Error</Alert.Title>
+        <Alert.Description>
+            <ul class="list-inside list-disc">
+                {#each formErrors as err}
+                    <li>{err}</li>
+                {/each}
+            </ul>
+        </Alert.Description>
+    </Alert.Root>
+{/if}
+
 <form
     method="POST"
-    use:enhance={() => {
+    use:enhance={({ cancel }) => {
+        if (!validateForm()) {
+            cancel()
+            return
+        }
+
         isSubmitting = true
         return async ({ result, update }) => {
             if (result.type === 'redirect') {
@@ -100,10 +143,54 @@
             </div>
         </Card.Header>
 
-        <Card.Content>
+        <Card.Content class="space-y-6">
             <p class="text-muted-foreground text-sm">
                 All public channels the bot has been added to will be indexed.
             </p>
+
+            <div class="space-y-4 border-t pt-4">
+                <div>
+                    <h3 class="text-sm font-semibold">Credentials</h3>
+                    <p class="text-muted-foreground mt-1 text-sm">
+                        Leave token fields blank to keep the current saved values. Fill either field
+                        to update only that Slack token.
+                    </p>
+                </div>
+
+                <div class="space-y-2">
+                    <Label for="bot-token">Bot Token</Label>
+                    <Input
+                        id="bot-token"
+                        name="botToken"
+                        bind:value={botToken}
+                        placeholder="xoxb-..."
+                        type="password"
+                        autocomplete="new-password" />
+                    <p class="text-muted-foreground text-sm">
+                        Create a Slack app and get a bot token at <a
+                            href="https://api.slack.com/apps"
+                            target="_blank"
+                            rel="noreferrer"
+                            class="text-blue-600 hover:underline">api.slack.com/apps</a>
+                    </p>
+                </div>
+
+                <div class="space-y-2">
+                    <Label for="app-token">App-Level Token (optional)</Label>
+                    <Input
+                        id="app-token"
+                        name="appToken"
+                        bind:value={appToken}
+                        placeholder="xapp-..."
+                        type="password"
+                        autocomplete="new-password" />
+                    <p class="text-muted-foreground text-sm">
+                        Enables realtime updates via Socket Mode. Generate one under your Slack App
+                        &rarr; Settings &rarr; Basic Information &rarr; App-Level Tokens with the
+                        <code class="bg-muted rounded px-1">connections:write</code> scope.
+                    </p>
+                </div>
+            </div>
         </Card.Content>
         <Card.Footer class="flex justify-end">
             <Button


### PR DESCRIPTION
- Add write-only Slack bot and app token fields to integration settings.
- Validate token prefixes client-side and server-side.
- Merge token updates into encrypted credentials without exposing secrets.