### PR TITLE
fix(notion): honor requested sync mode

### DIFF
--- a/connectors/notion/notion_connector/connector.py
+++ b/connectors/notion/notion_connector/connector.py
@@ -7,7 +7,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from fastapi.responses import JSONResponse, Response
-from omni_connector import ActionDefinition, ActionResponse, Connector, SyncContext
+from omni_connector import ActionDefinition, ActionResponse, Connector, SyncContext, SyncMode
 
 from .client import AuthenticationError, ForbiddenError, NotionClient, NotionError
 from .config import CHECKPOINT_INTERVAL, RATE_LIMIT_DELAY
@@ -149,7 +149,7 @@ class NotionConnector(Connector):
         state = state or {}
 
         try:
-            if state.get("last_sync_at"):
+            if ctx.sync_mode == SyncMode.INCREMENTAL and state.get("last_sync_at"):
                 await self._incremental_sync(client, state, permission_group, ctx)
             else:
                 await self._full_sync(client, permission_group, ctx)
@@ -222,6 +222,7 @@ class NotionConnector(Connector):
         ctx: SyncContext,
     ) -> None:
         """Full sync: index all accessible data sources and pages."""
+        sync_started_at = datetime.now(UTC).isoformat()
         docs_emitted = 0
         data_source_entry_ids: set[str] = set()
 
@@ -251,6 +252,10 @@ class NotionConnector(Connector):
                         client, ds_id, permission_group, ctx, docs_emitted
                     )
                     data_source_entry_ids.update(entries)
+
+                    if docs_emitted >= CHECKPOINT_INTERVAL:
+                        await ctx.save_checkpoint(ctx.state)
+                        docs_emitted = 0
                 except NotionError as e:
                     logger.error("Error syncing data source %s: %s", ds_id, e)
                     await ctx.emit_error(f"notion:data_source:{ds_id}", str(e))
@@ -294,17 +299,14 @@ class NotionConnector(Connector):
                     await ctx.emit_error(eid, str(e))
 
                 if docs_emitted >= CHECKPOINT_INTERVAL:
-                    await ctx.save_checkpoint({})
+                    await ctx.save_checkpoint(ctx.state)
                     docs_emitted = 0
 
             if not response.get("has_more"):
                 break
             cursor = response.get("next_cursor")
 
-        now = datetime.now(UTC).isoformat()
-        # save_state actually persists; complete()'s new_state is dropped by CM.
-        await ctx.save_checkpoint({"last_sync_at": now})
-        await ctx.complete()
+        await ctx.complete(new_state={"last_sync_at": sync_started_at})
         logger.info(
             "Full sync completed: %d scanned, %d emitted",
             ctx.documents_scanned,
@@ -320,6 +322,7 @@ class NotionConnector(Connector):
     ) -> None:
         """Incremental sync: re-index pages/data sources modified since last sync."""
         last_sync_at = state["last_sync_at"]
+        sync_started_at = datetime.now(UTC).isoformat()
         docs_emitted = 0
 
         # Pages: search returns most-recently-edited first; stop once we cross
@@ -398,13 +401,15 @@ class NotionConnector(Connector):
                     logger.warning("Error processing data source %s: %s", ds_id, e)
                     await ctx.emit_error(f"notion:data_source:{ds_id}", str(e))
 
+                if docs_emitted >= CHECKPOINT_INTERVAL:
+                    await ctx.save_checkpoint({"last_sync_at": last_sync_at})
+                    docs_emitted = 0
+
             if found_old or not response.get("has_more"):
                 break
             cursor = response.get("next_cursor")
 
-        now = datetime.now(UTC).isoformat()
-        await ctx.save_checkpoint({"last_sync_at": now})
-        await ctx.complete()
+        await ctx.complete(new_state={"last_sync_at": sync_started_at})
         logger.info(
             "Incremental sync completed: %d scanned, %d emitted",
             ctx.documents_scanned,
@@ -523,7 +528,7 @@ class NotionConnector(Connector):
                     await ctx.emit_error(eid, str(e))
 
                 if docs_emitted >= CHECKPOINT_INTERVAL:
-                    await ctx.save_checkpoint({})
+                    await ctx.save_checkpoint(ctx.state)
                     docs_emitted = 0
 
             if not response.get("has_more"):

--- a/connectors/notion/tests/test_full_sync.py
+++ b/connectors/notion/tests/test_full_sync.py
@@ -11,6 +11,7 @@ pytestmark = pytest.mark.integration
 DS_ID = "ds-00000000-0000-0000-0000-000000000001"
 ENTRY_PAGE_ID = "pg-00000000-0000-0000-0000-000000000001"
 STANDALONE_PAGE_ID = "pg-00000000-0000-0000-0000-000000000002"
+OLD_FULL_SYNC_PAGE_ID = "pg-00000000-0000-0000-0000-fullsyncold"
 
 
 async def test_full_sync_indexes_pages_and_data_sources(
@@ -150,3 +151,38 @@ async def test_full_sync_indexes_pages_and_data_sources(
     assert (
         row["documents_scanned"] >= 3
     ), f"Expected >=3 documents_scanned, got {row['documents_scanned']}"
+
+
+async def test_full_sync_honors_requested_mode_when_state_exists(
+    harness, seed, source_id, mock_notion_api, cm_client: httpx.AsyncClient
+):
+    """A requested full sync must not be demoted to incremental by connector state."""
+    cutoff = "2024-06-01T00:00:00.000Z"
+    await seed.set_connector_state(source_id, {"last_sync_at": cutoff})
+
+    mock_notion_api.add_page(
+        OLD_FULL_SYNC_PAGE_ID,
+        "Old Page Included By Full Sync",
+        [_block_payload("blk-full-old", "paragraph", "old full-sync content")],
+        last_edited_time="2024-01-01T00:00:00.000Z",
+    )
+
+    resp = await cm_client.post(
+        "/sync",
+        json={"source_id": source_id, "sync_type": "full"},
+    )
+    assert resp.status_code == 200, resp.text
+    sync_run_id = resp.json()["sync_run_id"]
+
+    row = await wait_for_sync(harness.db_pool, sync_run_id, timeout=30)
+    assert (
+        row["status"] == "completed"
+    ), f"status={row['status']}, error={row.get('error_message')}"
+
+    events = await get_events(harness.db_pool, source_id)
+    doc_ids = {
+        e["payload"]["document_id"]
+        for e in events
+        if e["event_type"] == "document_created"
+    }
+    assert f"notion:page:{OLD_FULL_SYNC_PAGE_ID}" in doc_ids


### PR DESCRIPTION
- Use SyncContext sync_mode so manual full syncs do not run incremental logic.
- Preserve run checkpoints during long Notion syncs and publish final state via complete().
- Store sync-start timestamps as last_sync_at to catch edits made during a run.