### PR TITLE
feat(ai): validate model provider configs before saving

### DIFF
--- a/services/ai/providers/__init__.py
+++ b/services/ai/providers/__init__.py
@@ -5,9 +5,11 @@ LLM Provider abstraction layer for supporting multiple AI providers.
 from abc import ABC, abstractmethod
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, ClassVar
 
 from anthropic import MessageStreamEvent
+
+from .types import ProviderError, ProviderType
 
 
 @dataclass
@@ -43,10 +45,11 @@ class LLMProvider(ABC):
     the stream/generate calls and let one provider serve many models.
     """
 
+    provider_type: ClassVar[ProviderType]
+
     # ID of this model's record in the models table
     model_record_id: str | None = None
     model_name: str | None = None
-    provider_type: str | None = None
     # Wire-level config exposed for downstream integrations (e.g. mem0
     # which needs to talk to the same endpoint with the same credentials).
     # Subclasses set these in __init__; left None when not applicable.
@@ -94,6 +97,7 @@ class LLMProvider(ABC):
         pass
 
 
+
 # Import all providers after base class definition
 from .anthropic import AnthropicProvider
 from .openai_compatible import OpenAICompatibleProvider
@@ -104,62 +108,68 @@ from .azure_foundry import AzureFoundryProvider
 from .vertex_ai import VertexAIProvider
 
 
-# Factory function to create LLM providers
-def create_llm_provider(provider_type: str, **kwargs) -> LLMProvider:
+def create_llm_provider(provider_type: ProviderType | str, **kwargs) -> LLMProvider:
     """Factory function to create LLM provider based on type."""
-    if provider_type.lower() == "openai_compatible":
+    pt = ProviderType(provider_type)
+
+    if pt is ProviderType.OPENAI_COMPATIBLE:
         base_url = kwargs.get("base_url")
         if not base_url:
             raise ValueError("base_url is required for OpenAI-compatible provider")
-        api_key = kwargs.get("api_key")
-        model = kwargs.get("model", "default")
-        return OpenAICompatibleProvider(base_url, api_key=api_key, model=model)
+        return OpenAICompatibleProvider(
+            base_url,
+            api_key=kwargs.get("api_key"),
+            model=kwargs.get("model", "default"),
+        )
 
-    elif provider_type.lower() == "anthropic":
+    if pt is ProviderType.ANTHROPIC:
         api_key = kwargs.get("api_key")
         if not api_key:
             raise ValueError("api_key is required for Anthropic provider")
-        model = kwargs.get("model", "claude-3-5-sonnet-20241022")
-        return AnthropicProvider(api_key, model)
+        return AnthropicProvider(
+            api_key, kwargs.get("model", "claude-3-5-sonnet-20241022")
+        )
 
-    elif provider_type.lower() == "bedrock":
-        model_id = kwargs.get("model_id", "us.anthropic.claude-sonnet-4-20250514-v1:0")
-        region_name = kwargs.get("region_name")
-        return BedrockProvider(model_id, region_name=region_name)
+    if pt is ProviderType.BEDROCK:
+        model_id = (
+            kwargs.get("model_id")
+            or kwargs.get("model")
+            or "us.anthropic.claude-sonnet-4-20250514-v1:0"
+        )
+        return BedrockProvider(model_id, region_name=kwargs.get("region_name"))
 
-    elif provider_type.lower() == "openai":
+    if pt is ProviderType.OPENAI:
         api_key = kwargs.get("api_key")
         if not api_key:
             raise ValueError("api_key is required for OpenAI provider")
-        model = kwargs.get("model", "gpt-4o")
-        return OpenAIProvider(api_key, model)
+        return OpenAIProvider(api_key, kwargs.get("model", "gpt-4o"))
 
-    elif provider_type.lower() == "gemini":
+    if pt is ProviderType.GEMINI:
         api_key = kwargs.get("api_key")
         if not api_key:
             raise ValueError("api_key is required for Gemini provider")
-        model = kwargs.get("model", "gemini-2.5-flash")
-        return GeminiProvider(api_key, model)
+        return GeminiProvider(api_key, kwargs.get("model", "gemini-2.5-flash"))
 
-    elif provider_type.lower() == "azure_foundry":
+    if pt is ProviderType.AZURE_FOUNDRY:
         endpoint_url = kwargs.get("endpoint_url")
         if not endpoint_url:
             raise ValueError("endpoint_url is required for Azure AI Foundry provider")
-        model = kwargs.get("model", "gpt-4o")
-        return AzureFoundryProvider(endpoint_url, model)
+        return AzureFoundryProvider(endpoint_url, kwargs.get("model", "gpt-4o"))
 
-    elif provider_type.lower() == "vertex_ai":
+    if pt is ProviderType.VERTEX_AI:
         region = kwargs.get("region")
         project_id = kwargs.get("project_id")
         if not region or not project_id:
             raise ValueError(
                 "region and project_id are required for Vertex AI provider"
             )
-        model = kwargs.get("model", "gemini-2.5-flash")
-        return VertexAIProvider(region=region, project_id=project_id, model=model)
+        return VertexAIProvider(
+            region=region,
+            project_id=project_id,
+            model=kwargs.get("model", "gemini-2.5-flash"),
+        )
 
-    else:
-        raise ValueError(f"Unknown provider type: {provider_type}")
+    raise ValueError(f"Unhandled provider type: {pt!r}")
 
 
 __all__ = [
@@ -167,6 +177,8 @@ __all__ = [
     "LLMProviderError",
     "LLMProviderStreamError",
     "LLMProvider",
+    "ProviderType",
+    "ProviderError",
     "AnthropicProvider",
     "OpenAICompatibleProvider",
     "BedrockProvider",

--- a/services/ai/providers/anthropic.py
+++ b/services/ai/providers/anthropic.py
@@ -5,13 +5,18 @@ Anthropic Claude Provider.
 import json
 import logging
 from collections.abc import AsyncIterator, Iterable
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
-from anthropic import AsyncAnthropic, AsyncStream, MessageStreamEvent
+from anthropic import APIStatusError, AsyncAnthropic, AsyncStream, MessageStreamEvent
 from anthropic.types import MessageParam, ToolParam
 
-from . import LLMProvider, LLMProviderStreamError, TokenUsage
+from . import LLMProvider, TokenUsage
 from .anthropic_message_adapter import build_messages_for_anthropic_api
+from .types import ProviderError, ProviderType
+
+
+def _anthropic_status_code(e: BaseException) -> int | None:
+    return e.status_code if isinstance(e, APIStatusError) else None
 
 logger = logging.getLogger(__name__)
 
@@ -19,10 +24,13 @@ logger = logging.getLogger(__name__)
 class AnthropicProvider(LLMProvider):
     """Provider for Anthropic Claude API."""
 
+    provider_type: ClassVar[ProviderType] = ProviderType.ANTHROPIC
+
     def __init__(self, api_key: str, model: str):
         self.api_key = api_key
         self.client = AsyncAnthropic(api_key=api_key)
         self.model = model
+        self.model_name = model
 
     def add_cache_control(
         self,
@@ -148,7 +156,13 @@ class AnthropicProvider(LLMProvider):
 
         except Exception as e:
             logger.error(f"Failed to stream from Anthropic: {str(e)}", exc_info=True)
-            raise LLMProviderStreamError(str(e)) from e
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_anthropic_status_code(e),
+                cause=e,
+            ) from e
 
     async def generate_response(
         self,
@@ -188,7 +202,13 @@ class AnthropicProvider(LLMProvider):
 
         except Exception as e:
             logger.error(f"Failed to generate response from Anthropic: {str(e)}")
-            raise Exception(f"Failed to generate response: {str(e)}")
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_anthropic_status_code(e),
+                cause=e,
+            ) from e
 
     async def health_check(self) -> bool:
         """Check if Anthropic API is accessible."""

--- a/services/ai/providers/azure_foundry.py
+++ b/services/ai/providers/azure_foundry.py
@@ -12,7 +12,7 @@ For OpenAI models, uses the v1 API (no dated api-version required):
 import asyncio
 import logging
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, ClassVar
 
 from anthropic import AsyncAnthropicFoundry, MessageStreamEvent
 from azure.identity import DefaultAzureCredential, get_bearer_token_provider
@@ -21,6 +21,7 @@ from openai import AsyncOpenAI
 from . import LLMProvider, TokenUsage
 from .anthropic import AnthropicProvider
 from .openai import OpenAIProvider
+from .types import ProviderError, ProviderType
 
 logger = logging.getLogger(__name__)
 
@@ -41,9 +42,12 @@ class AzureFoundryProvider(LLMProvider):
     and authenticates via Azure Managed Identity (DefaultAzureCredential).
     """
 
+    provider_type: ClassVar[ProviderType] = ProviderType.AZURE_FOUNDRY
+
     def __init__(self, endpoint_url: str, model: str):
         self.endpoint_url = endpoint_url.rstrip("/")
         self.model = model
+        self.model_name = model
 
         credential = DefaultAzureCredential()
 
@@ -88,16 +92,25 @@ class AzureFoundryProvider(LLMProvider):
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
-        async for event in self._delegate.stream_response(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            tools=tools,
-            messages=messages,
-            system_prompt=system_prompt,
-        ):
-            yield event
+        try:
+            async for event in self._delegate.stream_response(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                tools=tools,
+                messages=messages,
+                system_prompt=system_prompt,
+            ):
+                yield event
+        except ProviderError as e:
+            raise ProviderError(
+                e.message,
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=e.status_code,
+                cause=e,
+            ) from e
 
     async def generate_response(
         self,
@@ -106,12 +119,21 @@ class AzureFoundryProvider(LLMProvider):
         temperature: float | None = None,
         top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
-        return await self._delegate.generate_response(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-        )
+        try:
+            return await self._delegate.generate_response(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+            )
+        except ProviderError as e:
+            raise ProviderError(
+                e.message,
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=e.status_code,
+                cause=e,
+            ) from e
 
     async def health_check(self) -> bool:
         return await self._delegate.health_check()

--- a/services/ai/providers/bedrock.py
+++ b/services/ai/providers/bedrock.py
@@ -6,10 +6,10 @@ import json
 import logging
 import time
 from collections.abc import AsyncIterator
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
 import boto3
-from anthropic import AnthropicBedrock
+from anthropic import APIStatusError, AnthropicBedrock
 from anthropic.types import (
     MessageParam,
     Message,
@@ -38,8 +38,9 @@ from anthropic.types.message_stream_event import MessageStreamEvent
 from anthropic.types.raw_message_delta_event import Delta
 from botocore.exceptions import ClientError
 
-from . import LLMProvider, LLMProviderStreamError, TokenUsage
+from . import LLMProvider, TokenUsage
 from .anthropic_message_adapter import build_messages_for_anthropic_api
+from .types import ProviderError, ProviderType
 
 logger = logging.getLogger(__name__)
 
@@ -87,10 +88,12 @@ def sanitize_document_name(name: str) -> str:
 class BedrockProvider(LLMProvider):
     """Provider for AWS Bedrock Claude models."""
 
+    provider_type: ClassVar[ProviderType] = ProviderType.BEDROCK
     MODEL_FAMILIES = ["anthropic", "amazon"]
 
     def __init__(self, model_id: str, region_name: str | None = None):
         self.model_id = model_id
+        self.model_name = model_id
         self.model_family = self._determine_model_family(model_id)
         self.region_name = region_name
 
@@ -102,6 +105,24 @@ class BedrockProvider(LLMProvider):
             )
         else:
             self.client = boto3.client("bedrock-runtime", region_name=region_name)
+
+    def _to_provider_error(self, e: Exception) -> ProviderError:
+        if isinstance(e, ClientError):
+            error = e.response.get("Error", {})
+            code = error.get("Code", "Unknown")
+            message = error.get("Message", str(e))
+            status = e.response.get("ResponseMetadata", {}).get("HTTPStatusCode")
+            body = f"{code}: {message}"
+        else:
+            body = str(e)
+            status = e.status_code if isinstance(e, APIStatusError) else None
+        return ProviderError(
+            body,
+            provider_type=self.provider_type,
+            model=self.model_name,
+            status_code=status,
+            cause=e,
+        )
 
     def _determine_model_family(self, model_id: str) -> str:
         """Determine the model family from the model ID."""
@@ -594,12 +615,12 @@ class BedrockProvider(LLMProvider):
                 f"[BEDROCK] AWS Bedrock client error ({error_code}): {str(e)}",
                 exc_info=True,
             )
-            raise LLMProviderStreamError(str(e)) from e
+            raise self._to_provider_error(e) from e
         except Exception as e:
             logger.error(
                 f"[BEDROCK] Failed to stream from AWS Bedrock: {str(e)}", exc_info=True
             )
-            raise LLMProviderStreamError(str(e)) from e
+            raise self._to_provider_error(e) from e
 
     async def generate_response(
         self,
@@ -677,10 +698,10 @@ class BedrockProvider(LLMProvider):
 
         except ClientError as e:
             logger.error(f"AWS Bedrock client error: {str(e)}")
-            raise Exception(f"AWS Bedrock service error: {e.response['Error']['Code']}")
+            raise self._to_provider_error(e) from e
         except Exception as e:
             logger.error(f"Failed to generate response from AWS Bedrock: {str(e)}")
-            raise Exception(f"Failed to generate response: {str(e)}")
+            raise self._to_provider_error(e) from e
 
     async def health_check(self) -> bool:
         """Check if AWS Bedrock service is accessible."""

--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -16,10 +16,11 @@ import json
 import logging
 import time
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, ClassVar
 
 from google import genai
 from google.genai import types
+from google.genai.errors import APIError
 from anthropic.types import (
     Message,
     MessageDeltaUsage,
@@ -37,7 +38,13 @@ from anthropic.types import (
 from anthropic.types.message_stream_event import MessageStreamEvent
 from anthropic.types.raw_message_delta_event import Delta
 
-from . import LLMProvider, LLMProviderStreamError, TokenUsage
+from . import LLMProvider, TokenUsage
+from .types import ProviderError, ProviderType
+
+
+def _gemini_status_code(e: BaseException) -> int | None:
+    return e.code if isinstance(e, APIError) else None
+
 
 logger = logging.getLogger(__name__)
 
@@ -177,12 +184,14 @@ def _convert_messages_to_gemini(
 class GeminiProvider(LLMProvider):
     """Provider for Google Gemini API."""
 
+    provider_type: ClassVar[ProviderType] = ProviderType.GEMINI
     PERSISTED_BLOCK_EXTRAS = (THOUGHT_SIGNATURE_KEY,)
 
     def __init__(self, api_key: str, model: str):
         self.api_key = api_key
         self.client = genai.Client(api_key=api_key)
         self.model = model
+        self.model_name = model
 
     async def stream_response(
         self,
@@ -348,7 +357,13 @@ class GeminiProvider(LLMProvider):
 
         except Exception as e:
             logger.error(f"Failed to stream from Gemini: {str(e)}", exc_info=True)
-            raise LLMProviderStreamError(str(e)) from e
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_gemini_status_code(e),
+                cause=e,
+            ) from e
 
     async def generate_response(
         self,
@@ -388,7 +403,13 @@ class GeminiProvider(LLMProvider):
 
         except Exception as e:
             logger.error(f"Failed to generate response: {str(e)}")
-            raise Exception(f"Failed to generate response: {str(e)}")
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_gemini_status_code(e),
+                cause=e,
+            ) from e
 
     async def health_check(self) -> bool:
         """Check if Gemini API is accessible."""

--- a/services/ai/providers/openai.py
+++ b/services/ai/providers/openai.py
@@ -7,9 +7,9 @@ Uses the OpenAI Responses API (client.responses.create).
 import json
 import logging
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, ClassVar
 
-from openai import AsyncOpenAI
+from openai import APIStatusError, AsyncOpenAI
 from anthropic.types import (
     Message,
     MessageDeltaUsage,
@@ -28,7 +28,13 @@ from anthropic.types import (
 from anthropic.types.message_stream_event import MessageStreamEvent
 from anthropic.types.raw_message_delta_event import Delta
 
-from . import LLMProvider, LLMProviderStreamError, TokenUsage
+from . import LLMProvider, TokenUsage
+from .types import ProviderError, ProviderType
+
+
+def _openai_status_code(e: BaseException) -> int | None:
+    return e.status_code if isinstance(e, APIStatusError) else None
+
 
 logger = logging.getLogger(__name__)
 
@@ -82,10 +88,13 @@ def _convert_tools_to_openai(tools: list[dict[str, Any]]) -> list[dict[str, Any]
 class OpenAIProvider(LLMProvider):
     """Provider for OpenAI API (GPT-4, etc.) using the Responses API."""
 
+    provider_type: ClassVar[ProviderType] = ProviderType.OPENAI
+
     def __init__(self, api_key: str, model: str):
         self.api_key = api_key
         self.client = AsyncOpenAI(api_key=api_key)
         self.model = model
+        self.model_name = model
 
     async def stream_response(
         self,
@@ -278,18 +287,22 @@ class OpenAIProvider(LLMProvider):
                 elif event_type == "response.failed":
                     error = getattr(event.response, "error", None)
                     msg = getattr(error, "message", None) or "Response failed"
-                    raise LLMProviderStreamError(msg)
+                    raise RuntimeError(msg)
 
                 elif event_type == "error":
-                    raise LLMProviderStreamError(
-                        getattr(event, "message", "Unknown stream error")
-                    )
+                    raise RuntimeError(getattr(event, "message", "Unknown stream error"))
 
             yield RawMessageStopEvent(type="message_stop")
 
         except Exception as e:
             logger.error(f"Failed to stream from OpenAI: {str(e)}", exc_info=True)
-            raise LLMProviderStreamError(str(e)) from e
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_openai_status_code(e),
+                cause=e,
+            ) from e
 
     def _convert_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         """Convert Anthropic-style messages to OpenAI Responses API input items."""
@@ -436,7 +449,13 @@ class OpenAIProvider(LLMProvider):
 
         except Exception as e:
             logger.error(f"Failed to generate response: {str(e)}")
-            raise Exception(f"Failed to generate response: {str(e)}") from e
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_openai_status_code(e),
+                cause=e,
+            ) from e
 
     async def health_check(self) -> bool:
         """Check if OpenAI API is accessible."""

--- a/services/ai/providers/openai_compatible.py
+++ b/services/ai/providers/openai_compatible.py
@@ -10,9 +10,9 @@ import json
 import logging
 import time
 from collections.abc import AsyncIterator
-from typing import Any, cast
+from typing import Any, ClassVar, cast
 
-from openai import AsyncOpenAI
+from openai import APIStatusError, AsyncOpenAI
 from openai.types.chat import (
     ChatCompletionAssistantMessageParam,
     ChatCompletionChunk,
@@ -47,7 +47,13 @@ from anthropic.types import (
 from anthropic.types.message_stream_event import MessageStreamEvent
 from anthropic.types.raw_message_delta_event import Delta
 
-from . import LLMProvider, LLMProviderEmptyResponseError, LLMProviderStreamError, TokenUsage
+from . import LLMProvider, LLMProviderEmptyResponseError, TokenUsage
+from .types import ProviderError, ProviderType
+
+
+def _openai_compat_status_code(e: BaseException) -> int | None:
+    return e.status_code if isinstance(e, APIStatusError) else None
+
 
 logger = logging.getLogger(__name__)
 
@@ -225,6 +231,7 @@ class OpenAICompatibleProvider(LLMProvider):
     Completions with full tool/function-calling support.
     """
 
+    provider_type: ClassVar[ProviderType] = ProviderType.OPENAI_COMPATIBLE
     PERSISTED_BLOCK_EXTRAS = ASSISTANT_MESSAGE_PASSTHROUGH_KEYS
 
     def __init__(
@@ -233,6 +240,7 @@ class OpenAICompatibleProvider(LLMProvider):
         self.base_url = base_url.rstrip("/")
         self.api_key = api_key
         self.model = model
+        self.model_name = model
         # Some keyless local endpoints (vLLM without --api-key, Ollama, etc.)
         # still require the SDK to send *something* — fall back to a placeholder.
         self.client = AsyncOpenAI(
@@ -442,7 +450,13 @@ class OpenAICompatibleProvider(LLMProvider):
                 f"Failed to stream from OpenAI-compatible endpoint: {e}",
                 exc_info=True,
             )
-            raise LLMProviderStreamError(str(e)) from e
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_openai_compat_status_code(e),
+                cause=e,
+            ) from e
 
     async def generate_response(
         self,
@@ -491,9 +505,16 @@ class OpenAICompatibleProvider(LLMProvider):
         except LLMProviderEmptyResponseError:
             raise
         except Exception as e:
-            raise Exception(
+            logger.error(
                 f"Failed to generate response from OpenAI-compatible endpoint: {e}"
             )
+            raise ProviderError(
+                str(e),
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=_openai_compat_status_code(e),
+                cause=e,
+            ) from e
 
     async def health_check(self) -> bool:
         """Liveness is determined by inference calls themselves; no separate probe

--- a/services/ai/providers/types.py
+++ b/services/ai/providers/types.py
@@ -1,0 +1,45 @@
+"""Shared types for the LLM provider layer."""
+
+from enum import StrEnum
+
+
+class ProviderType(StrEnum):
+    """Canonical identifier for each supported LLM provider.
+
+    The string value is what crosses the wire (DB column, JSON API, SSE error
+    payload), so changing a value is a breaking change.
+    """
+
+    ANTHROPIC = "anthropic"
+    OPENAI = "openai"
+    BEDROCK = "bedrock"
+    OPENAI_COMPATIBLE = "openai_compatible"
+    GEMINI = "gemini"
+    AZURE_FOUNDRY = "azure_foundry"
+    VERTEX_AI = "vertex_ai"
+
+
+class ProviderError(Exception):
+    """Raised when an LLM provider call fails.
+
+    Carries enough structure for the chat router and the test-connection
+    endpoint to render an actionable message in the UI without losing the
+    original SDK message body.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        provider_type: ProviderType,
+        model: str | None = None,
+        status_code: int | None = None,
+        cause: BaseException | None = None,
+    ):
+        super().__init__(message)
+        self.message = message
+        self.provider_type = provider_type
+        self.model = model
+        self.status_code = status_code
+        if cause is not None:
+            self.__cause__ = cause

--- a/services/ai/providers/vertex_ai.py
+++ b/services/ai/providers/vertex_ai.py
@@ -8,7 +8,7 @@ Uses Application Default Credentials (ADC) for authentication — no API key nee
 
 import logging
 from collections.abc import AsyncIterator
-from typing import Any
+from typing import Any, ClassVar
 
 from anthropic import AsyncAnthropicVertex, MessageStreamEvent
 from google import genai
@@ -16,6 +16,7 @@ from google import genai
 from . import LLMProvider, TokenUsage
 from .anthropic import AnthropicProvider
 from .gemini import GeminiProvider
+from .types import ProviderError, ProviderType
 
 logger = logging.getLogger(__name__)
 
@@ -33,10 +34,13 @@ class VertexAIProvider(LLMProvider):
     and authenticates via Application Default Credentials (ADC).
     """
 
+    provider_type: ClassVar[ProviderType] = ProviderType.VERTEX_AI
+
     def __init__(self, region: str, project_id: str, model: str):
         self.region = region
         self.project_id = project_id
         self.model = model
+        self.model_name = model
 
         if _is_claude_model(model):
             client = AsyncAnthropicVertex(region=region, project_id=project_id)
@@ -63,16 +67,25 @@ class VertexAIProvider(LLMProvider):
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
-        async for event in self._delegate.stream_response(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-            tools=tools,
-            messages=messages,
-            system_prompt=system_prompt,
-        ):
-            yield event
+        try:
+            async for event in self._delegate.stream_response(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+                tools=tools,
+                messages=messages,
+                system_prompt=system_prompt,
+            ):
+                yield event
+        except ProviderError as e:
+            raise ProviderError(
+                e.message,
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=e.status_code,
+                cause=e,
+            ) from e
 
     async def generate_response(
         self,
@@ -81,12 +94,21 @@ class VertexAIProvider(LLMProvider):
         temperature: float | None = None,
         top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
-        return await self._delegate.generate_response(
-            prompt=prompt,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            top_p=top_p,
-        )
+        try:
+            return await self._delegate.generate_response(
+                prompt=prompt,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                top_p=top_p,
+            )
+        except ProviderError as e:
+            raise ProviderError(
+                e.message,
+                provider_type=self.provider_type,
+                model=self.model_name,
+                status_code=e.status_code,
+                cause=e,
+            ) from e
 
     async def health_check(self) -> bool:
         return await self._delegate.health_check()

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -53,6 +53,7 @@ from memory import (
 )
 from prompts import build_agent_chat_system_prompt, build_chat_system_prompt
 from providers import LLMProvider, LLMProviderStreamError
+from providers import ProviderError
 from services.compaction import ConversationCompactor
 from services.title_generation import generate_title_for_conversation
 from services.usage import UsageContext, UsagePurpose, UsageTracker, track_usage
@@ -83,6 +84,9 @@ logger = logging.getLogger(__name__)
 
 
 def _chat_error_message(exc: Exception) -> str:
+    if isinstance(exc, ProviderError) and exc.message:
+        return f"Failed to generate response: {exc.message}"
+
     if isinstance(exc, LLMProviderStreamError) and exc.message:
         return f"Failed to generate response: {exc.message}"
 
@@ -91,6 +95,15 @@ def _chat_error_message(exc: Exception) -> str:
         return f"Failed to generate response: {message}"
 
     return "Failed to generate response. Please try again."
+
+
+def _chat_error_payload(exc: Exception) -> dict[str, object]:
+    payload: dict[str, object] = {"message": _chat_error_message(exc)}
+    if isinstance(exc, ProviderError):
+        payload["provider"] = exc.provider_type
+        payload["model"] = exc.model
+        payload["statusCode"] = exc.status_code
+    return payload
 
 
 def _sse_event(event_type: str, data: object) -> str:
@@ -1669,7 +1682,7 @@ async def stream_chat(
             logger.error(
                 f"Failed to generate AI response with tools: {e}", exc_info=True
             )
-            yield _sse_event("stream_error", {"message": _chat_error_message(e)})
+            yield _sse_event("stream_error", _chat_error_payload(e))
 
     # First new message persisted by omni-web is the parent of the run's output.
     parent_id = chat_messages[-1].id if chat_messages else None

--- a/services/ai/routers/model_providers.py
+++ b/services/ai/routers/model_providers.py
@@ -287,8 +287,8 @@ async def test_model_provider(
     provider_type: ProviderType,
     req: TestModelRequest,
 ) -> TestModelResponse:
-    """Send a tiny prompt to a not-necessarily-saved provider config and surface
-    the real error if it fails. Used by the admin Test Connection button."""
+    """List provider models to validate a not-necessarily-saved provider config.
+    Used by the admin Test Connection button."""
     try:
         provider = _build_provider(provider_type, req)
     except Exception as e:
@@ -301,41 +301,15 @@ async def test_model_provider(
 
     start = time.monotonic()
     try:
-        no_model = req.model is None and req.model_id is None
-        provider_level_model: str | None = None
-        if no_model and provider_type in {
-            ProviderType.OPENAI_COMPATIBLE,
-            ProviderType.BEDROCK,
-            ProviderType.AZURE_FOUNDRY,
-            ProviderType.VERTEX_AI,
-        }:
-            provider_level_model = await asyncio.wait_for(
-                _first_provider_model(provider_type, provider, req),
-                timeout=15,
-            )
-            if provider_level_model is not None or provider_type in {
-                ProviderType.OPENAI_COMPATIBLE,
-                ProviderType.BEDROCK,
-                ProviderType.AZURE_FOUNDRY,
-                ProviderType.VERTEX_AI,
-            }:
-                latency = int((time.monotonic() - start) * 1000)
-                return TestModelResponse(
-                    ok=True,
-                    provider=provider.provider_type,
-                    model=provider_level_model,
-                    latency_ms=latency,
-                )
-
-        await asyncio.wait_for(
-            provider.generate_response("Hi", max_tokens=5),
+        models = await asyncio.wait_for(
+            _list_provider_models(provider_type, provider, req, limit=1),
             timeout=15,
         )
         latency = int((time.monotonic() - start) * 1000)
         return TestModelResponse(
             ok=True,
             provider=provider.provider_type,
-            model=provider.model_name,
+            model=models[0].model_id if models else None,
             latency_ms=latency,
         )
     except ProviderError as e:

--- a/services/ai/routers/model_providers.py
+++ b/services/ai/routers/model_providers.py
@@ -1,11 +1,15 @@
 import asyncio
 import logging
 import time
+
 from fastapi import APIRouter, Request
 from pydantic import BaseModel
 
 from db import ModelsRepository
 from providers import LLMProvider, ProviderError, ProviderType, create_llm_provider
+from providers.azure_foundry import AzureFoundryProvider
+from providers.openai_compatible import OpenAICompatibleProvider
+from providers.vertex_ai import VertexAIProvider
 from services.providers import load_models
 
 router = APIRouter(tags=["model-providers"])
@@ -61,6 +65,76 @@ def _build_provider(provider_type: ProviderType, req: TestModelRequest) -> LLMPr
     return create_llm_provider(provider_type, **kwargs)
 
 
+def _error_status_code(e: BaseException) -> int | None:
+    status_code = getattr(e, "status_code", None)
+    if isinstance(status_code, int):
+        return status_code
+
+    response = getattr(e, "response", None)
+    if isinstance(response, dict):
+        metadata = response.get("ResponseMetadata")
+        if isinstance(metadata, dict):
+            aws_status_code = metadata.get("HTTPStatusCode")
+            if isinstance(aws_status_code, int):
+                return aws_status_code
+
+    return None
+
+
+async def _test_openai_compatible_connection_without_model(
+    provider: OpenAICompatibleProvider,
+) -> str | None:
+    models_page = await provider.client.models.list()
+    models = getattr(models_page, "data", None) or []
+    if not models:
+        return None
+    first_model = models[0]
+    model_id = getattr(first_model, "id", None)
+    return model_id if isinstance(model_id, str) else None
+
+
+async def _test_bedrock_connection_without_model(req: TestModelRequest) -> str | None:
+    import boto3
+
+    client = boto3.client("bedrock", region_name=req.region_name)
+    response = await asyncio.to_thread(client.list_foundation_models)
+    summaries = response.get("modelSummaries", [])
+    if not summaries:
+        return None
+    model_id = summaries[0].get("modelId")
+    return model_id if isinstance(model_id, str) else None
+
+
+async def _test_azure_foundry_connection_without_model(
+    provider: AzureFoundryProvider,
+) -> str | None:
+    delegate = provider._delegate
+    client = delegate.client
+    models_page = await client.models.list()
+    models = getattr(models_page, "data", None) or []
+    if not models:
+        return None
+    first_model = models[0]
+    model_id = getattr(first_model, "id", None)
+    return model_id if isinstance(model_id, str) else None
+
+
+async def _test_vertex_ai_connection_without_model(
+    provider: VertexAIProvider,
+) -> str | None:
+    delegate = provider._delegate
+    client = delegate.client
+    async_models = client.aio.models.list()
+    async for model in async_models:
+        model_name = getattr(model, "name", None)
+        if isinstance(model_name, str):
+            return model_name
+        model_id = getattr(model, "id", None)
+        if isinstance(model_id, str):
+            return model_id
+    return None
+
+
 @router.post("/admin/provider/{provider_type}/test", response_model=TestModelResponse)
 async def test_model_provider(
     provider_type: ProviderType,
@@ -80,6 +154,44 @@ async def test_model_provider(
 
     start = time.monotonic()
     try:
+        no_model = req.model is None and req.model_id is None
+        provider_level_model: str | None = None
+        if no_model:
+            if provider_type == ProviderType.OPENAI_COMPATIBLE:
+                provider_level_model = await asyncio.wait_for(
+                    _test_openai_compatible_connection_without_model(provider),
+                    timeout=15,
+                )
+            elif provider_type == ProviderType.BEDROCK:
+                provider_level_model = await asyncio.wait_for(
+                    _test_bedrock_connection_without_model(req),
+                    timeout=15,
+                )
+            elif provider_type == ProviderType.AZURE_FOUNDRY:
+                provider_level_model = await asyncio.wait_for(
+                    _test_azure_foundry_connection_without_model(provider),
+                    timeout=15,
+                )
+            elif provider_type == ProviderType.VERTEX_AI:
+                provider_level_model = await asyncio.wait_for(
+                    _test_vertex_ai_connection_without_model(provider),
+                    timeout=15,
+                )
+
+            if provider_level_model is not None or provider_type in {
+                ProviderType.OPENAI_COMPATIBLE,
+                ProviderType.BEDROCK,
+                ProviderType.AZURE_FOUNDRY,
+                ProviderType.VERTEX_AI,
+            }:
+                latency = int((time.monotonic() - start) * 1000)
+                return TestModelResponse(
+                    ok=True,
+                    provider=provider.provider_type,
+                    model=provider_level_model,
+                    latency_ms=latency,
+                )
+
         await asyncio.wait_for(
             provider.generate_response("Hi", max_tokens=5),
             timeout=15,
@@ -99,7 +211,7 @@ async def test_model_provider(
             status_code=e.status_code,
             model=e.model,
         )
-    except asyncio.TimeoutError:
+    except TimeoutError:
         return TestModelResponse(
             ok=False,
             error="Test timed out after 15s",
@@ -112,5 +224,6 @@ async def test_model_provider(
             ok=False,
             error=str(e),
             provider=provider.provider_type,
+            status_code=_error_status_code(e),
             model=provider.model_name,
         )

--- a/services/ai/routers/model_providers.py
+++ b/services/ai/routers/model_providers.py
@@ -318,7 +318,7 @@ async def test_model_provider(
             error=e.message,
             provider=e.provider_type,
             status_code=e.status_code,
-            model=e.model,
+            model=None,
         )
     except TimeoutError:
         return TestModelResponse(
@@ -334,5 +334,5 @@ async def test_model_provider(
             error=str(e),
             provider=provider.provider_type,
             status_code=_error_status_code(e),
-            model=provider.model_name,
+            model=None,
         )

--- a/services/ai/routers/model_providers.py
+++ b/services/ai/routers/model_providers.py
@@ -1,8 +1,11 @@
+import asyncio
 import logging
-
+import time
 from fastapi import APIRouter, Request
+from pydantic import BaseModel
 
 from db import ModelsRepository
+from providers import LLMProvider, ProviderError, ProviderType, create_llm_provider
 from services.providers import load_models
 
 router = APIRouter(tags=["model-providers"])
@@ -31,3 +34,83 @@ async def reload_providers(request: Request):
     """Reload model instances from the database."""
     await load_models(request.app.state)
     return {"status": "ok"}
+
+
+class TestModelRequest(BaseModel):
+    api_key: str | None = None
+    model: str | None = None
+    region_name: str | None = None
+    model_id: str | None = None
+    region: str | None = None
+    project_id: str | None = None
+    endpoint_url: str | None = None
+    base_url: str | None = None
+
+
+class TestModelResponse(BaseModel):
+    ok: bool
+    error: str | None = None
+    provider: ProviderType | None = None
+    status_code: int | None = None
+    model: str | None = None
+    latency_ms: int | None = None
+
+
+def _build_provider(provider_type: ProviderType, req: TestModelRequest) -> LLMProvider:
+    kwargs = req.model_dump(exclude_none=True)
+    return create_llm_provider(provider_type, **kwargs)
+
+
+@router.post("/admin/provider/{provider_type}/test", response_model=TestModelResponse)
+async def test_model_provider(
+    provider_type: ProviderType,
+    req: TestModelRequest,
+) -> TestModelResponse:
+    """Send a tiny prompt to a not-necessarily-saved provider config and surface
+    the real error if it fails. Used by the admin Test Connection button."""
+    try:
+        provider = _build_provider(provider_type, req)
+    except Exception as e:
+        logger.warning(f"Test connection: failed to instantiate {provider_type}: {e}")
+        return TestModelResponse(
+            ok=False,
+            error=f"Configuration error: {e}",
+            provider=provider_type,
+        )
+
+    start = time.monotonic()
+    try:
+        await asyncio.wait_for(
+            provider.generate_response("Hi", max_tokens=5),
+            timeout=15,
+        )
+        latency = int((time.monotonic() - start) * 1000)
+        return TestModelResponse(
+            ok=True,
+            provider=provider.provider_type,
+            model=provider.model_name,
+            latency_ms=latency,
+        )
+    except ProviderError as e:
+        return TestModelResponse(
+            ok=False,
+            error=e.message,
+            provider=e.provider_type,
+            status_code=e.status_code,
+            model=e.model,
+        )
+    except asyncio.TimeoutError:
+        return TestModelResponse(
+            ok=False,
+            error="Test timed out after 15s",
+            provider=provider.provider_type,
+            model=provider.model_name,
+        )
+    except Exception as e:
+        logger.warning(f"Test connection: unexpected error for {provider_type}: {e}")
+        return TestModelResponse(
+            ok=False,
+            error=str(e),
+            provider=provider.provider_type,
+            model=provider.model_name,
+        )

--- a/services/ai/routers/model_providers.py
+++ b/services/ai/routers/model_providers.py
@@ -7,7 +7,11 @@ from pydantic import BaseModel
 
 from db import ModelsRepository
 from providers import LLMProvider, ProviderError, ProviderType, create_llm_provider
+from providers.anthropic import AnthropicProvider
 from providers.azure_foundry import AzureFoundryProvider
+from providers.bedrock import BedrockProvider
+from providers.gemini import GeminiProvider
+from providers.openai import OpenAIProvider
 from providers.openai_compatible import OpenAICompatibleProvider
 from providers.vertex_ai import VertexAIProvider
 from services.providers import load_models
@@ -60,6 +64,18 @@ class TestModelResponse(BaseModel):
     latency_ms: int | None = None
 
 
+class AvailableModel(BaseModel):
+    model_id: str
+    display_name: str
+
+
+class ListProviderModelsResponse(BaseModel):
+    models: list[AvailableModel]
+
+
+DISCOVERED_MODELS_LIMIT = 3
+
+
 def _build_provider(provider_type: ProviderType, req: TestModelRequest) -> LLMProvider:
     kwargs = req.model_dump(exclude_none=True)
     return create_llm_provider(provider_type, **kwargs)
@@ -81,58 +97,189 @@ def _error_status_code(e: BaseException) -> int | None:
     return None
 
 
-async def _test_openai_compatible_connection_without_model(
-    provider: OpenAICompatibleProvider,
-) -> str | None:
-    models_page = await provider.client.models.list()
-    models = getattr(models_page, "data", None) or []
-    if not models:
+def _display_name(model_id: str, candidate: object = None) -> str:
+    return candidate if isinstance(candidate, str) and candidate else model_id
+
+
+def _google_model_id(name: object) -> str | None:
+    if not isinstance(name, str) or not name:
         return None
-    first_model = models[0]
-    model_id = getattr(first_model, "id", None)
-    return model_id if isinstance(model_id, str) else None
+    if "/models/" in name:
+        return name.rsplit("/models/", 1)[1]
+    if name.startswith("models/"):
+        return name.removeprefix("models/")
+    return name
 
 
-async def _test_bedrock_connection_without_model(req: TestModelRequest) -> str | None:
+def _is_openai_chat_model(model_id: str) -> bool:
+    normalized = model_id.lower()
+    if any(
+        part in normalized
+        for part in (
+            "audio",
+            "dall-e",
+            "embedding",
+            "image",
+            "moderation",
+            "realtime",
+            "search",
+            "tts",
+            "transcribe",
+            "whisper",
+        )
+    ):
+        return False
+    return normalized.startswith(("gpt-", "chatgpt-", "o1", "o3", "o4", "o5"))
+
+
+async def _list_openai_sdk_models(
+    client: object,
+    *,
+    limit: int = DISCOVERED_MODELS_LIMIT,
+    chat_only: bool = False,
+) -> list[AvailableModel]:
+    models_page = await client.models.list()
+    models = getattr(models_page, "data", None) or []
+    result: list[AvailableModel] = []
+    for model in models:
+        model_id = getattr(model, "id", None)
+        if not isinstance(model_id, str) or not model_id:
+            continue
+        if chat_only and not _is_openai_chat_model(model_id):
+            continue
+        result.append(AvailableModel(model_id=model_id, display_name=model_id))
+        if len(result) >= limit:
+            break
+    return result
+
+
+async def _list_anthropic_models(
+    provider: AnthropicProvider,
+    limit: int = DISCOVERED_MODELS_LIMIT,
+) -> list[AvailableModel]:
+    models_page = await provider.client.models.list(limit=limit)
+    models = getattr(models_page, "data", None) or []
+    result: list[AvailableModel] = []
+    for model in models:
+        model_id = getattr(model, "id", None)
+        if not isinstance(model_id, str) or not model_id:
+            continue
+        result.append(
+            AvailableModel(
+                model_id=model_id,
+                display_name=_display_name(model_id, getattr(model, "display_name", None)),
+            )
+        )
+        if len(result) >= limit:
+            break
+    return result
+
+
+async def _list_gemini_models(
+    provider: GeminiProvider | VertexAIProvider,
+    limit: int = DISCOVERED_MODELS_LIMIT,
+) -> list[AvailableModel]:
+    client = provider.client if isinstance(provider, GeminiProvider) else provider._delegate.client
+    async_models = client.aio.models.list()
+    result: list[AvailableModel] = []
+    async for model in async_models:
+        supported_actions = getattr(model, "supported_actions", None) or []
+        if supported_actions and "generateContent" not in supported_actions:
+            continue
+        model_id = _google_model_id(getattr(model, "name", None))
+        if not model_id:
+            continue
+        result.append(
+            AvailableModel(
+                model_id=model_id,
+                display_name=_display_name(model_id, getattr(model, "display_name", None)),
+            )
+        )
+        if len(result) >= limit:
+            break
+    return result
+
+
+async def _list_bedrock_models(
+    req: TestModelRequest,
+    limit: int = DISCOVERED_MODELS_LIMIT,
+) -> list[AvailableModel]:
     import boto3
 
     client = boto3.client("bedrock", region_name=req.region_name)
     response = await asyncio.to_thread(client.list_foundation_models)
     summaries = response.get("modelSummaries", [])
-    if not summaries:
-        return None
-    model_id = summaries[0].get("modelId")
-    return model_id if isinstance(model_id, str) else None
+    result: list[AvailableModel] = []
+    for summary in summaries:
+        model_id = summary.get("modelId")
+        if not isinstance(model_id, str) or not model_id:
+            continue
+        if not any(family in model_id.lower() for family in BedrockProvider.MODEL_FAMILIES):
+            continue
+        result.append(
+            AvailableModel(
+                model_id=model_id,
+                display_name=_display_name(model_id, summary.get("modelName")),
+            )
+        )
+        if len(result) >= limit:
+            break
+    return result
 
 
-async def _test_azure_foundry_connection_without_model(
-    provider: AzureFoundryProvider,
+async def _list_provider_models(
+    provider_type: ProviderType,
+    provider: LLMProvider,
+    req: TestModelRequest,
+    limit: int = DISCOVERED_MODELS_LIMIT,
+) -> list[AvailableModel]:
+    if provider_type == ProviderType.ANTHROPIC and isinstance(provider, AnthropicProvider):
+        return await _list_anthropic_models(provider, limit)
+    if provider_type == ProviderType.OPENAI and isinstance(provider, OpenAIProvider):
+        return await _list_openai_sdk_models(provider.client, limit=limit, chat_only=True)
+    if provider_type == ProviderType.GEMINI and isinstance(provider, GeminiProvider):
+        return await _list_gemini_models(provider, limit)
+    if provider_type == ProviderType.OPENAI_COMPATIBLE and isinstance(
+        provider, OpenAICompatibleProvider
+    ):
+        return await _list_openai_sdk_models(provider.client, limit=limit)
+    if provider_type == ProviderType.BEDROCK:
+        return await _list_bedrock_models(req, limit)
+    if provider_type == ProviderType.AZURE_FOUNDRY and isinstance(
+        provider, AzureFoundryProvider
+    ):
+        return await _list_openai_sdk_models(provider._delegate.client, limit=limit)
+    if provider_type == ProviderType.VERTEX_AI and isinstance(provider, VertexAIProvider):
+        return await _list_gemini_models(provider, limit)
+    return []
+
+
+async def _first_provider_model(
+    provider_type: ProviderType,
+    provider: LLMProvider,
+    req: TestModelRequest,
 ) -> str | None:
-    delegate = provider._delegate
-    client = delegate.client
-    models_page = await client.models.list()
-    models = getattr(models_page, "data", None) or []
-    if not models:
-        return None
-    first_model = models[0]
-    model_id = getattr(first_model, "id", None)
-    return model_id if isinstance(model_id, str) else None
+    models = await _list_provider_models(provider_type, provider, req, limit=1)
+    return models[0].model_id if models else None
 
 
-async def _test_vertex_ai_connection_without_model(
-    provider: VertexAIProvider,
-) -> str | None:
-    delegate = provider._delegate
-    client = delegate.client
-    async_models = client.aio.models.list()
-    async for model in async_models:
-        model_name = getattr(model, "name", None)
-        if isinstance(model_name, str):
-            return model_name
-        model_id = getattr(model, "id", None)
-        if isinstance(model_id, str):
-            return model_id
-    return None
+@router.post(
+    "/admin/provider/{provider_type}/models", response_model=ListProviderModelsResponse
+)
+async def list_provider_models(
+    provider_type: ProviderType,
+    req: TestModelRequest,
+) -> ListProviderModelsResponse:
+    try:
+        provider = _build_provider(provider_type, req)
+        models = await asyncio.wait_for(
+            _list_provider_models(provider_type, provider, req),
+            timeout=15,
+        )
+        return ListProviderModelsResponse(models=models)
+    except Exception as e:
+        logger.warning(f"List models: failed for {provider_type}: {e}")
+        return ListProviderModelsResponse(models=[])
 
 
 @router.post("/admin/provider/{provider_type}/test", response_model=TestModelResponse)
@@ -156,28 +303,16 @@ async def test_model_provider(
     try:
         no_model = req.model is None and req.model_id is None
         provider_level_model: str | None = None
-        if no_model:
-            if provider_type == ProviderType.OPENAI_COMPATIBLE:
-                provider_level_model = await asyncio.wait_for(
-                    _test_openai_compatible_connection_without_model(provider),
-                    timeout=15,
-                )
-            elif provider_type == ProviderType.BEDROCK:
-                provider_level_model = await asyncio.wait_for(
-                    _test_bedrock_connection_without_model(req),
-                    timeout=15,
-                )
-            elif provider_type == ProviderType.AZURE_FOUNDRY:
-                provider_level_model = await asyncio.wait_for(
-                    _test_azure_foundry_connection_without_model(provider),
-                    timeout=15,
-                )
-            elif provider_type == ProviderType.VERTEX_AI:
-                provider_level_model = await asyncio.wait_for(
-                    _test_vertex_ai_connection_without_model(provider),
-                    timeout=15,
-                )
-
+        if no_model and provider_type in {
+            ProviderType.OPENAI_COMPATIBLE,
+            ProviderType.BEDROCK,
+            ProviderType.AZURE_FOUNDRY,
+            ProviderType.VERTEX_AI,
+        }:
+            provider_level_model = await asyncio.wait_for(
+                _first_provider_model(provider_type, provider, req),
+                timeout=15,
+            )
             if provider_level_model is not None or provider_type in {
                 ProviderType.OPENAI_COMPATIBLE,
                 ProviderType.BEDROCK,

--- a/services/ai/services/providers.py
+++ b/services/ai/services/providers.py
@@ -103,9 +103,9 @@ async def load_models(app_state: AppState) -> None:
     for record in records:
         try:
             provider = _create_provider_from_model_record(record)
+            # provider_type is a class attribute on each leaf provider; model_name
+            # is set in the factory. Only model_record_id needs the loader.
             provider.model_record_id = record.id
-            provider.model_name = record.model_id
-            provider.provider_type = record.provider_type
             models[record.id] = provider
             logger.info(
                 f"Initialized model '{record.display_name}' (type={record.provider_type}, model={record.model_id}, id={record.id})"

--- a/services/ai/tests/integration/test_admin_test_llm.py
+++ b/services/ai/tests/integration/test_admin_test_llm.py
@@ -1,0 +1,87 @@
+"""API contract tests for POST /admin/provider/{provider_type}/test."""
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+
+from providers import ProviderError, ProviderType
+from routers.model_providers import router as model_providers_router
+
+
+def _build_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(model_providers_router)
+    return app
+
+
+@pytest.fixture
+async def admin_client():
+    async with AsyncClient(
+        transport=ASGITransport(app=_build_app()), base_url="http://test"
+    ) as client:
+        yield client
+
+
+@pytest.mark.integration
+async def test_test_provider_surfaces_provider_error(admin_client):
+    fake_provider = AsyncMock()
+    fake_provider.generate_response = AsyncMock(
+        side_effect=ProviderError(
+            "404: Model use case details have not been submitted for this account.",
+            provider_type=ProviderType.BEDROCK,
+            model="anthropic.claude-sonnet-4-20250514-v1:0",
+            status_code=404,
+        )
+    )
+    fake_provider.model_name = "anthropic.claude-sonnet-4-20250514-v1:0"
+    fake_provider.provider_type = ProviderType.BEDROCK
+
+    with patch(
+        "routers.model_providers.create_llm_provider", return_value=fake_provider
+    ):
+        resp = await admin_client.post(
+            "/admin/provider/bedrock/test",
+            json={
+                "region_name": "us-east-1",
+                "model_id": "anthropic.claude-sonnet-4-20250514-v1:0",
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is False
+    assert "Model use case details" in body["error"]
+    assert body["provider"] == "bedrock"
+    assert body["status_code"] == 404
+    assert body["model"] == "anthropic.claude-sonnet-4-20250514-v1:0"
+
+
+@pytest.mark.integration
+async def test_test_provider_uses_provider_type_from_path(admin_client):
+    fake_provider = AsyncMock()
+    fake_provider.generate_response = AsyncMock(return_value=("Hi there", None))
+    fake_provider.model_name = "llama-3"
+    fake_provider.provider_type = ProviderType.OPENAI_COMPATIBLE
+
+    with patch(
+        "routers.model_providers.create_llm_provider", return_value=fake_provider
+    ) as create_provider:
+        resp = await admin_client.post(
+            "/admin/provider/openai_compatible/test",
+            json={
+                "base_url": "http://llama-cpp:8000",
+                "api_key": "x",
+                "model": "llama-3",
+            },
+        )
+
+    assert resp.status_code == 200
+    assert resp.json()["ok"] is True
+    create_provider.assert_called_once_with(
+        ProviderType.OPENAI_COMPATIBLE,
+        base_url="http://llama-cpp:8000",
+        api_key="x",
+        model="llama-3",
+    )

--- a/services/ai/tests/integration/test_admin_test_llm.py
+++ b/services/ai/tests/integration/test_admin_test_llm.py
@@ -85,3 +85,104 @@ async def test_test_provider_uses_provider_type_from_path(admin_client):
         api_key="x",
         model="llama-3",
     )
+
+
+@pytest.mark.integration
+async def test_openai_compatible_without_model_tests_models_endpoint(admin_client):
+    list_models = AsyncMock(return_value="deepseek-v4-flash")
+
+    with patch(
+        "routers.model_providers._test_openai_compatible_connection_without_model",
+        list_models,
+    ):
+        resp = await admin_client.post(
+            "/admin/provider/openai_compatible/test",
+            json={
+                "base_url": "https://api.deepseek.com",
+                "api_key": "x",
+            },
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["model"] == "deepseek-v4-flash"
+    list_models.assert_awaited_once()
+
+
+@pytest.mark.integration
+async def test_bedrock_without_model_tests_provider_level_connection(admin_client):
+    fake_provider = AsyncMock()
+    fake_provider.model_name = "default-bedrock-model"
+    fake_provider.provider_type = ProviderType.BEDROCK
+    test_connection = AsyncMock(return_value="anthropic.claude-sonnet-4-5")
+
+    with (
+        patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
+        patch(
+            "routers.model_providers._test_bedrock_connection_without_model",
+            test_connection,
+        ),
+    ):
+        resp = await admin_client.post(
+            "/admin/provider/bedrock/test",
+            json={"region_name": "us-east-1"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["model"] == "anthropic.claude-sonnet-4-5"
+    test_connection.assert_awaited_once()
+
+
+@pytest.mark.integration
+async def test_azure_foundry_without_model_tests_provider_level_connection(admin_client):
+    fake_provider = AsyncMock()
+    fake_provider.model_name = "gpt-4o"
+    fake_provider.provider_type = ProviderType.AZURE_FOUNDRY
+    test_connection = AsyncMock(return_value="gpt-4o")
+
+    with (
+        patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
+        patch(
+            "routers.model_providers._test_azure_foundry_connection_without_model",
+            test_connection,
+        ),
+    ):
+        resp = await admin_client.post(
+            "/admin/provider/azure_foundry/test",
+            json={"endpoint_url": "https://example.services.ai.azure.com"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["model"] == "gpt-4o"
+    test_connection.assert_awaited_once()
+
+
+@pytest.mark.integration
+async def test_vertex_ai_without_model_tests_provider_level_connection(admin_client):
+    fake_provider = AsyncMock()
+    fake_provider.model_name = "gemini-2.5-flash"
+    fake_provider.provider_type = ProviderType.VERTEX_AI
+    test_connection = AsyncMock(return_value="publishers/google/models/gemini-2.5-flash")
+
+    with (
+        patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
+        patch(
+            "routers.model_providers._test_vertex_ai_connection_without_model",
+            test_connection,
+        ),
+    ):
+        resp = await admin_client.post(
+            "/admin/provider/vertex_ai/test",
+            json={"region": "us-central1", "project_id": "project"},
+        )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ok"] is True
+    assert body["model"] == "publishers/google/models/gemini-2.5-flash"
+    test_connection.assert_awaited_once()

--- a/services/ai/tests/integration/test_admin_test_llm.py
+++ b/services/ai/tests/integration/test_admin_test_llm.py
@@ -28,7 +28,9 @@ async def admin_client():
 @pytest.mark.integration
 async def test_test_provider_surfaces_provider_error(admin_client):
     fake_provider = AsyncMock()
-    fake_provider.generate_response = AsyncMock(
+    fake_provider.model_name = "anthropic.claude-sonnet-4-20250514-v1:0"
+    fake_provider.provider_type = ProviderType.BEDROCK
+    list_models = AsyncMock(
         side_effect=ProviderError(
             "404: Model use case details have not been submitted for this account.",
             provider_type=ProviderType.BEDROCK,
@@ -36,11 +38,10 @@ async def test_test_provider_surfaces_provider_error(admin_client):
             status_code=404,
         )
     )
-    fake_provider.model_name = "anthropic.claude-sonnet-4-20250514-v1:0"
-    fake_provider.provider_type = ProviderType.BEDROCK
 
-    with patch(
-        "routers.model_providers.create_llm_provider", return_value=fake_provider
+    with (
+        patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
+        patch("routers.model_providers._list_provider_models", list_models),
     ):
         resp = await admin_client.post(
             "/admin/provider/bedrock/test",
@@ -62,13 +63,18 @@ async def test_test_provider_surfaces_provider_error(admin_client):
 @pytest.mark.integration
 async def test_test_provider_uses_provider_type_from_path(admin_client):
     fake_provider = AsyncMock()
-    fake_provider.generate_response = AsyncMock(return_value=("Hi there", None))
     fake_provider.model_name = "llama-3"
     fake_provider.provider_type = ProviderType.OPENAI_COMPATIBLE
+    list_models = AsyncMock(
+        return_value=[AvailableModel(model_id="llama-3", display_name="llama-3")]
+    )
 
-    with patch(
-        "routers.model_providers.create_llm_provider", return_value=fake_provider
-    ) as create_provider:
+    with (
+        patch(
+            "routers.model_providers.create_llm_provider", return_value=fake_provider
+        ) as create_provider,
+        patch("routers.model_providers._list_provider_models", list_models),
+    ):
         resp = await admin_client.post(
             "/admin/provider/openai_compatible/test",
             json={
@@ -80,6 +86,8 @@ async def test_test_provider_uses_provider_type_from_path(admin_client):
 
     assert resp.status_code == 200
     assert resp.json()["ok"] is True
+    assert resp.json()["model"] == "llama-3"
+    list_models.assert_awaited_once()
     create_provider.assert_called_once_with(
         ProviderType.OPENAI_COMPATIBLE,
         base_url="http://llama-cpp:8000",
@@ -90,9 +98,11 @@ async def test_test_provider_uses_provider_type_from_path(admin_client):
 
 @pytest.mark.integration
 async def test_openai_compatible_without_model_tests_models_endpoint(admin_client):
-    first_model = AsyncMock(return_value="deepseek-v4-flash")
+    list_models = AsyncMock(
+        return_value=[AvailableModel(model_id="deepseek-v4-flash", display_name="DeepSeek")]
+    )
 
-    with patch("routers.model_providers._first_provider_model", first_model):
+    with patch("routers.model_providers._list_provider_models", list_models):
         resp = await admin_client.post(
             "/admin/provider/openai_compatible/test",
             json={
@@ -105,7 +115,7 @@ async def test_openai_compatible_without_model_tests_models_endpoint(admin_clien
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "deepseek-v4-flash"
-    first_model.assert_awaited_once()
+    list_models.assert_awaited_once()
 
 
 @pytest.mark.integration
@@ -113,11 +123,17 @@ async def test_bedrock_without_model_tests_provider_level_connection(admin_clien
     fake_provider = AsyncMock()
     fake_provider.model_name = "default-bedrock-model"
     fake_provider.provider_type = ProviderType.BEDROCK
-    first_model = AsyncMock(return_value="anthropic.claude-sonnet-4-5")
+    list_models = AsyncMock(
+        return_value=[
+            AvailableModel(
+                model_id="anthropic.claude-sonnet-4-5", display_name="Claude Sonnet"
+            )
+        ]
+    )
 
     with (
         patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
-        patch("routers.model_providers._first_provider_model", first_model),
+        patch("routers.model_providers._list_provider_models", list_models),
     ):
         resp = await admin_client.post(
             "/admin/provider/bedrock/test",
@@ -128,7 +144,7 @@ async def test_bedrock_without_model_tests_provider_level_connection(admin_clien
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "anthropic.claude-sonnet-4-5"
-    first_model.assert_awaited_once()
+    list_models.assert_awaited_once()
 
 
 @pytest.mark.integration
@@ -136,11 +152,13 @@ async def test_azure_foundry_without_model_tests_provider_level_connection(admin
     fake_provider = AsyncMock()
     fake_provider.model_name = "gpt-4o"
     fake_provider.provider_type = ProviderType.AZURE_FOUNDRY
-    first_model = AsyncMock(return_value="gpt-4o")
+    list_models = AsyncMock(
+        return_value=[AvailableModel(model_id="gpt-4o", display_name="GPT-4o")]
+    )
 
     with (
         patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
-        patch("routers.model_providers._first_provider_model", first_model),
+        patch("routers.model_providers._list_provider_models", list_models),
     ):
         resp = await admin_client.post(
             "/admin/provider/azure_foundry/test",
@@ -151,7 +169,7 @@ async def test_azure_foundry_without_model_tests_provider_level_connection(admin
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "gpt-4o"
-    first_model.assert_awaited_once()
+    list_models.assert_awaited_once()
 
 
 @pytest.mark.integration
@@ -159,11 +177,18 @@ async def test_vertex_ai_without_model_tests_provider_level_connection(admin_cli
     fake_provider = AsyncMock()
     fake_provider.model_name = "gemini-2.5-flash"
     fake_provider.provider_type = ProviderType.VERTEX_AI
-    first_model = AsyncMock(return_value="publishers/google/models/gemini-2.5-flash")
+    list_models = AsyncMock(
+        return_value=[
+            AvailableModel(
+                model_id="publishers/google/models/gemini-2.5-flash",
+                display_name="Gemini 2.5 Flash",
+            )
+        ]
+    )
 
     with (
         patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
-        patch("routers.model_providers._first_provider_model", first_model),
+        patch("routers.model_providers._list_provider_models", list_models),
     ):
         resp = await admin_client.post(
             "/admin/provider/vertex_ai/test",
@@ -174,7 +199,7 @@ async def test_vertex_ai_without_model_tests_provider_level_connection(admin_cli
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "publishers/google/models/gemini-2.5-flash"
-    first_model.assert_awaited_once()
+    list_models.assert_awaited_once()
 
 
 @pytest.mark.integration

--- a/services/ai/tests/integration/test_admin_test_llm.py
+++ b/services/ai/tests/integration/test_admin_test_llm.py
@@ -57,7 +57,7 @@ async def test_test_provider_surfaces_provider_error(admin_client):
     assert "Model use case details" in body["error"]
     assert body["provider"] == "bedrock"
     assert body["status_code"] == 404
-    assert body["model"] == "anthropic.claude-sonnet-4-20250514-v1:0"
+    assert body["model"] is None
 
 
 @pytest.mark.integration

--- a/services/ai/tests/integration/test_admin_test_llm.py
+++ b/services/ai/tests/integration/test_admin_test_llm.py
@@ -7,6 +7,7 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 
 from providers import ProviderError, ProviderType
+from routers.model_providers import AvailableModel
 from routers.model_providers import router as model_providers_router
 
 
@@ -89,12 +90,9 @@ async def test_test_provider_uses_provider_type_from_path(admin_client):
 
 @pytest.mark.integration
 async def test_openai_compatible_without_model_tests_models_endpoint(admin_client):
-    list_models = AsyncMock(return_value="deepseek-v4-flash")
+    first_model = AsyncMock(return_value="deepseek-v4-flash")
 
-    with patch(
-        "routers.model_providers._test_openai_compatible_connection_without_model",
-        list_models,
-    ):
+    with patch("routers.model_providers._first_provider_model", first_model):
         resp = await admin_client.post(
             "/admin/provider/openai_compatible/test",
             json={
@@ -107,7 +105,7 @@ async def test_openai_compatible_without_model_tests_models_endpoint(admin_clien
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "deepseek-v4-flash"
-    list_models.assert_awaited_once()
+    first_model.assert_awaited_once()
 
 
 @pytest.mark.integration
@@ -115,14 +113,11 @@ async def test_bedrock_without_model_tests_provider_level_connection(admin_clien
     fake_provider = AsyncMock()
     fake_provider.model_name = "default-bedrock-model"
     fake_provider.provider_type = ProviderType.BEDROCK
-    test_connection = AsyncMock(return_value="anthropic.claude-sonnet-4-5")
+    first_model = AsyncMock(return_value="anthropic.claude-sonnet-4-5")
 
     with (
         patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
-        patch(
-            "routers.model_providers._test_bedrock_connection_without_model",
-            test_connection,
-        ),
+        patch("routers.model_providers._first_provider_model", first_model),
     ):
         resp = await admin_client.post(
             "/admin/provider/bedrock/test",
@@ -133,7 +128,7 @@ async def test_bedrock_without_model_tests_provider_level_connection(admin_clien
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "anthropic.claude-sonnet-4-5"
-    test_connection.assert_awaited_once()
+    first_model.assert_awaited_once()
 
 
 @pytest.mark.integration
@@ -141,14 +136,11 @@ async def test_azure_foundry_without_model_tests_provider_level_connection(admin
     fake_provider = AsyncMock()
     fake_provider.model_name = "gpt-4o"
     fake_provider.provider_type = ProviderType.AZURE_FOUNDRY
-    test_connection = AsyncMock(return_value="gpt-4o")
+    first_model = AsyncMock(return_value="gpt-4o")
 
     with (
         patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
-        patch(
-            "routers.model_providers._test_azure_foundry_connection_without_model",
-            test_connection,
-        ),
+        patch("routers.model_providers._first_provider_model", first_model),
     ):
         resp = await admin_client.post(
             "/admin/provider/azure_foundry/test",
@@ -159,7 +151,7 @@ async def test_azure_foundry_without_model_tests_provider_level_connection(admin
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "gpt-4o"
-    test_connection.assert_awaited_once()
+    first_model.assert_awaited_once()
 
 
 @pytest.mark.integration
@@ -167,14 +159,11 @@ async def test_vertex_ai_without_model_tests_provider_level_connection(admin_cli
     fake_provider = AsyncMock()
     fake_provider.model_name = "gemini-2.5-flash"
     fake_provider.provider_type = ProviderType.VERTEX_AI
-    test_connection = AsyncMock(return_value="publishers/google/models/gemini-2.5-flash")
+    first_model = AsyncMock(return_value="publishers/google/models/gemini-2.5-flash")
 
     with (
         patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
-        patch(
-            "routers.model_providers._test_vertex_ai_connection_without_model",
-            test_connection,
-        ),
+        patch("routers.model_providers._first_provider_model", first_model),
     ):
         resp = await admin_client.post(
             "/admin/provider/vertex_ai/test",
@@ -185,4 +174,34 @@ async def test_vertex_ai_without_model_tests_provider_level_connection(admin_cli
     body = resp.json()
     assert body["ok"] is True
     assert body["model"] == "publishers/google/models/gemini-2.5-flash"
-    test_connection.assert_awaited_once()
+    first_model.assert_awaited_once()
+
+
+@pytest.mark.integration
+async def test_list_provider_models_returns_normalized_models(admin_client):
+    fake_provider = AsyncMock()
+    fake_provider.provider_type = ProviderType.OPENAI_COMPATIBLE
+    discovered_models = AsyncMock(
+        return_value=[
+            AvailableModel(model_id="deepseek-v4-flash", display_name="DeepSeek v4 Flash"),
+            AvailableModel(model_id="deepseek-v4-pro", display_name="DeepSeek v4 Pro"),
+        ]
+    )
+
+    with (
+        patch("routers.model_providers.create_llm_provider", return_value=fake_provider),
+        patch("routers.model_providers._list_provider_models", discovered_models),
+    ):
+        resp = await admin_client.post(
+            "/admin/provider/openai_compatible/models",
+            json={"base_url": "https://api.deepseek.com", "api_key": "x"},
+        )
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "models": [
+            {"model_id": "deepseek-v4-flash", "display_name": "DeepSeek v4 Flash"},
+            {"model_id": "deepseek-v4-pro", "display_name": "DeepSeek v4 Pro"},
+        ]
+    }
+    discovered_models.assert_awaited_once()

--- a/services/ai/tests/unit/test_provider_errors.py
+++ b/services/ai/tests/unit/test_provider_errors.py
@@ -1,0 +1,244 @@
+"""Unit tests for ProviderError wrapping in LLM providers.
+
+Each provider's generate_response and stream_response should wrap underlying SDK
+exceptions in ProviderError with the original message, provider name, and (where
+the SDK exposes it) HTTP status code preserved.
+"""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+
+from providers import ProviderError, ProviderType
+
+
+def _anthropic_status_error(message: str, status_code: int):
+    """Build a real anthropic.APIStatusError so isinstance checks work."""
+    from anthropic import APIStatusError
+
+    request = httpx.Request("POST", "https://api.anthropic.com/v1/messages")
+    response = httpx.Response(status_code, request=request, json={"error": message})
+    return APIStatusError(message, response=response, body=None)
+
+
+def _openai_status_error(message: str, status_code: int):
+    from openai import APIStatusError
+
+    request = httpx.Request("POST", "https://api.openai.com/v1/responses")
+    response = httpx.Response(status_code, request=request, json={"error": message})
+    return APIStatusError(message, response=response, body=None)
+
+
+def _gemini_api_error(message: str, status_code: int):
+    from google.genai.errors import APIError
+
+    return APIError(status_code, {"error": {"message": message}})
+
+
+@pytest.mark.unit
+class TestAnthropicProviderError:
+    @pytest.fixture
+    def provider(self):
+        from providers.anthropic import AnthropicProvider
+
+        return AnthropicProvider(api_key="test", model="claude-3-5-sonnet-20241022")
+
+    @pytest.mark.asyncio
+    async def test_generate_response_wraps_exception(self, provider):
+        provider.client.messages.create = AsyncMock(
+            side_effect=_anthropic_status_error(
+                "use case details have not been submitted", 404
+            )
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.generate_response("hello")
+
+        assert "use case details" in exc.value.message
+        assert exc.value.provider_type is ProviderType.ANTHROPIC
+        assert exc.value.status_code == 404
+        assert exc.value.model == "claude-3-5-sonnet-20241022"
+
+    @pytest.mark.asyncio
+    async def test_stream_response_wraps_exception(self, provider):
+        provider.client.messages.create = AsyncMock(
+            side_effect=_anthropic_status_error("invalid api key", 401)
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            async for _ in provider.stream_response("hello"):
+                pass
+
+        assert "invalid api key" in exc.value.message
+        assert exc.value.provider_type is ProviderType.ANTHROPIC
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_stream_response_does_not_swallow_errors(self, provider):
+        """Regression: previously stream_response only logged errors, never
+        re-raised — silently truncating responses. It must re-raise now."""
+        provider.client.messages.create = AsyncMock(
+            side_effect=Exception("transport failure")
+        )
+
+        # If the generator silently terminates we'd never enter the except.
+        raised = False
+        try:
+            async for _ in provider.stream_response("hello"):
+                pass
+        except ProviderError:
+            raised = True
+
+        assert raised, "stream_response must re-raise as ProviderError"
+
+
+@pytest.mark.unit
+class TestOpenAIProviderError:
+    @pytest.fixture
+    def provider(self):
+        from providers.openai import OpenAIProvider
+
+        return OpenAIProvider(api_key="test", model="gpt-4o")
+
+    @pytest.mark.asyncio
+    async def test_generate_response_wraps(self, provider):
+        provider.client.responses.create = AsyncMock(
+            side_effect=_openai_status_error("Incorrect API key provided", 401)
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.generate_response("hello")
+
+        assert "Incorrect API key" in exc.value.message
+        assert exc.value.provider_type is ProviderType.OPENAI
+        assert exc.value.status_code == 401
+
+    @pytest.mark.asyncio
+    async def test_stream_response_wraps(self, provider):
+        provider.client.responses.create = AsyncMock(
+            side_effect=_openai_status_error("rate limited", 429)
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            async for _ in provider.stream_response("hello"):
+                pass
+
+        assert exc.value.status_code == 429
+        assert exc.value.provider_type is ProviderType.OPENAI
+
+
+@pytest.mark.unit
+class TestGeminiProviderError:
+    @pytest.fixture
+    def provider(self):
+        from providers.gemini import GeminiProvider
+
+        return GeminiProvider(api_key="test", model="gemini-2.5-flash")
+
+    @pytest.mark.asyncio
+    async def test_generate_response_wraps(self, provider):
+        provider.client.aio.models.generate_content = AsyncMock(
+            side_effect=_gemini_api_error("permission denied", 403)
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.generate_response("hello")
+
+        assert "permission denied" in exc.value.message
+        assert exc.value.provider_type is ProviderType.GEMINI
+        assert exc.value.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_stream_response_wraps(self, provider):
+        provider.client.aio.models.generate_content_stream = AsyncMock(
+            side_effect=_gemini_api_error("model not found", 404)
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            async for _ in provider.stream_response("hello"):
+                pass
+
+        assert "model not found" in exc.value.message
+        assert exc.value.provider_type is ProviderType.GEMINI
+        assert exc.value.status_code == 404
+
+
+@pytest.mark.unit
+class TestBedrockProviderError:
+    @pytest.fixture
+    def provider(self):
+        from providers.bedrock import BedrockProvider
+
+        # Anthropic-family path uses AnthropicBedrock which we'll mock per-test.
+        with patch("providers.bedrock.AnthropicBedrock") as mock_cls:
+            mock_cls.return_value = MagicMock()
+            return BedrockProvider(model_id="anthropic.claude-sonnet-4-20250514-v1:0")
+
+    @pytest.mark.asyncio
+    async def test_generate_response_wraps_anthropic_sdk_error(self, provider):
+        # Reproduces the exact failure mode from the user's report: a 404
+        # NotFoundError raised by the AnthropicBedrock client because the
+        # account hasn't filled out the model use case form yet.
+        provider.client.messages.create = MagicMock(
+            side_effect=_anthropic_status_error(
+                "Model use case details have not been submitted for this account.",
+                404,
+            )
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.generate_response("hello")
+
+        assert "Model use case details" in exc.value.message
+        assert exc.value.provider_type is ProviderType.BEDROCK
+        assert exc.value.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_generate_response_wraps_client_error_with_body(self, provider):
+        from botocore.exceptions import ClientError
+
+        client_error = ClientError(
+            error_response={
+                "Error": {
+                    "Code": "AccessDeniedException",
+                    "Message": "Your IAM user is not authorized.",
+                },
+                "ResponseMetadata": {"HTTPStatusCode": 403},
+            },
+            operation_name="InvokeModel",
+        )
+        provider.client.messages.create = MagicMock(side_effect=client_error)
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.generate_response("hello")
+
+        # AWS code AND human-readable body both preserved
+        assert "AccessDeniedException" in exc.value.message
+        assert "Your IAM user is not authorized" in exc.value.message
+        assert exc.value.status_code == 403
+        assert exc.value.provider_type is ProviderType.BEDROCK
+
+
+@pytest.mark.unit
+class TestOpenAICompatibleProviderError:
+    @pytest.fixture
+    def provider(self):
+        from providers.openai_compatible import OpenAICompatibleProvider
+
+        return OpenAICompatibleProvider(
+            base_url="http://llama-cpp:8000", api_key="x", model="llama-3"
+        )
+
+    @pytest.mark.asyncio
+    async def test_generate_response_wraps(self, provider):
+        provider.client.chat.completions.create = AsyncMock(
+            side_effect=_openai_status_error("connection refused", 503)
+        )
+
+        with pytest.raises(ProviderError) as exc:
+            await provider.generate_response("hello")
+
+        assert "connection refused" in exc.value.message
+        assert exc.value.provider_type is ProviderType.OPENAI_COMPATIBLE
+        assert exc.value.status_code == 503

--- a/web/src/lib/server/db/model-providers.ts
+++ b/web/src/lib/server/db/model-providers.ts
@@ -42,6 +42,11 @@ export interface CreateModelInput {
     isSecondary?: boolean
 }
 
+export interface ModelSeed {
+    modelId: string
+    displayName: string
+}
+
 export const PREDEFINED_MODELS: Record<
     ModelProviderType,
     { modelId: string; displayName: string }[]
@@ -160,6 +165,7 @@ export async function listAllActiveModels(): Promise<
             modelId: models.modelId,
             displayName: models.displayName,
             isDefault: models.isDefault,
+            isSecondary: models.isSecondary,
             isDeleted: models.isDeleted,
             createdAt: models.createdAt,
             updatedAt: models.updatedAt,
@@ -249,12 +255,11 @@ export async function setSecondaryModel(id: string): Promise<boolean> {
     return !!updated
 }
 
-export async function createPredefinedModels(
+export async function createModelSeeds(
     providerId: string,
-    providerType: ModelProviderType,
+    modelSeeds: ModelSeed[],
 ): Promise<Model[]> {
-    const predefined = PREDEFINED_MODELS[providerType]
-    if (!predefined || predefined.length === 0) return []
+    if (modelSeeds.length === 0) return []
 
     const hasExistingDefault = await db
         .select({ id: models.id })
@@ -263,16 +268,23 @@ export async function createPredefinedModels(
         .limit(1)
 
     const createdModels: Model[] = []
-    for (let i = 0; i < predefined.length; i++) {
+    for (let i = 0; i < modelSeeds.length; i++) {
         const isDefault = i === 0 && hasExistingDefault.length === 0
         const model = await createModel({
             modelProviderId: providerId,
-            modelId: predefined[i].modelId,
-            displayName: predefined[i].displayName,
+            modelId: modelSeeds[i].modelId,
+            displayName: modelSeeds[i].displayName,
             isDefault,
         })
         createdModels.push(model)
     }
 
     return createdModels
+}
+
+export async function createPredefinedModels(
+    providerId: string,
+    providerType: ModelProviderType,
+): Promise<Model[]> {
+    return await createModelSeeds(providerId, PREDEFINED_MODELS[providerType] ?? [])
 }

--- a/web/src/lib/types/model-provider.ts
+++ b/web/src/lib/types/model-provider.ts
@@ -1,0 +1,39 @@
+// Wire types for the web server -> AI service provider test endpoint,
+// plus chat stream error payloads.
+
+export type ProviderType =
+    | 'anthropic'
+    | 'openai'
+    | 'gemini'
+    | 'bedrock'
+    | 'vertex_ai'
+    | 'azure_foundry'
+    | 'openai_compatible'
+
+export interface TestModelRequest {
+    api_key?: string | null
+    model?: string | null
+    region_name?: string | null
+    model_id?: string | null
+    region?: string | null
+    project_id?: string | null
+    endpoint_url?: string | null
+    base_url?: string | null
+}
+
+export interface TestModelResponse {
+    ok: boolean
+    error: string | null
+    provider: ProviderType | null
+    status_code: number | null
+    model: string | null
+    latency_ms: number | null
+}
+
+// SSE `event: stream_error` payload from /chat/{id}/stream.
+export interface StreamErrorEvent {
+    message: string
+    provider?: ProviderType | null
+    model?: string | null
+    statusCode?: number | null
+}

--- a/web/src/lib/types/model-provider.ts
+++ b/web/src/lib/types/model-provider.ts
@@ -30,6 +30,15 @@ export interface TestModelResponse {
     latency_ms: number | null
 }
 
+export interface AvailableModel {
+    model_id: string
+    display_name: string
+}
+
+export interface ListProviderModelsResponse {
+    models: AvailableModel[]
+}
+
 // SSE `event: stream_error` payload from /chat/{id}/stream.
 export interface StreamErrorEvent {
     message: string

--- a/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
@@ -54,6 +54,40 @@ function rankDiscoveredModels(providerType: ModelProviderType, models: Available
     return [...preferred, ...remaining].slice(0, 3)
 }
 
+async function testProviderConnection(
+    providerType: ModelProviderType,
+    config: ModelProviderConfig,
+): Promise<{
+    error: string
+    provider?: string | null
+    statusCode?: number | null
+    model?: string | null
+} | null> {
+    const built = buildTestRequest(providerType, config, null)
+    if ('error' in built) return { error: built.error }
+
+    try {
+        const resp = await fetch(`${env.AI_SERVICE_URL}/admin/provider/${providerType}/test`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(built),
+        })
+        if (!resp.ok) return { error: 'Could not test provider connection' }
+
+        const body = (await resp.json()) as TestModelResponse
+        if (body.ok) return null
+        return {
+            error: body.error || 'Connection failed',
+            provider: body.provider,
+            statusCode: body.status_code,
+            model: body.model,
+        }
+    } catch (err) {
+        logger.error('Model test connection failed', err)
+        return { error: 'Could not reach AI service' }
+    }
+}
+
 async function listAvailableProviderModels(
     providerType: ModelProviderType,
     config: ModelProviderConfig,
@@ -124,6 +158,9 @@ export const actions: Actions = {
         if (validation) return fail(400, { error: validation })
 
         try {
+            const connectionError = await testProviderConnection(providerType, config)
+            if (connectionError) return fail(400, connectionError)
+
             const provider = await createProvider({ name, providerType, config })
             const discoveredModels = await listAvailableProviderModels(providerType, config)
             if (discoveredModels.length > 0) {
@@ -164,6 +201,9 @@ export const actions: Actions = {
         if (validation) return fail(400, { error: validation })
 
         try {
+            const connectionError = await testProviderConnection(providerType, config)
+            if (connectionError) return fail(400, connectionError)
+
             await updateProvider(id, { name, config })
             await reloadAIProviders()
             return { success: true, message: 'Provider updated' }

--- a/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
@@ -12,14 +12,21 @@ import {
     deleteModel,
     setDefaultModel,
     setSecondaryModel,
+    createModelSeeds,
     createPredefinedModels,
     MODEL_PROVIDER_TYPES,
+    PREDEFINED_MODELS,
     type ModelProviderConfig,
     type ModelProviderType,
 } from '$lib/server/db/model-providers'
 import { env } from '$env/dynamic/private'
 import { logger } from '$lib/server/logger'
-import type { TestModelRequest, TestModelResponse } from '$lib/types/model-provider'
+import type {
+    AvailableModel,
+    ListProviderModelsResponse,
+    TestModelRequest,
+    TestModelResponse,
+} from '$lib/types/model-provider'
 
 async function reloadAIProviders() {
     try {
@@ -32,6 +39,42 @@ async function reloadAIProviders() {
 function stripSecrets(config: Record<string, unknown>): Record<string, unknown> {
     const { apiKey, ...rest } = config
     return rest
+}
+
+function rankDiscoveredModels(providerType: ModelProviderType, models: AvailableModel[]) {
+    const predefined = PREDEFINED_MODELS[providerType] ?? []
+    const discoveredById = new Map(models.map((m) => [m.model_id, m]))
+    const preferred = predefined
+        .filter((m) => discoveredById.has(m.modelId))
+        .map((m) => ({ modelId: m.modelId, displayName: m.displayName }))
+    const preferredIds = new Set(preferred.map((m) => m.modelId))
+    const remaining = models
+        .filter((m) => !preferredIds.has(m.model_id))
+        .map((m) => ({ modelId: m.model_id, displayName: m.display_name }))
+    return [...preferred, ...remaining].slice(0, 3)
+}
+
+async function listAvailableProviderModels(
+    providerType: ModelProviderType,
+    config: ModelProviderConfig,
+) {
+    const built = buildTestRequest(providerType, config, null)
+    if ('error' in built) return []
+
+    try {
+        const resp = await fetch(`${env.AI_SERVICE_URL}/admin/provider/${providerType}/models`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(built),
+        })
+        if (!resp.ok) return []
+
+        const body = (await resp.json()) as ListProviderModelsResponse
+        return rankDiscoveredModels(providerType, body.models ?? [])
+    } catch (err) {
+        logger.warn('Failed to list provider models', { providerType, err })
+        return []
+    }
 }
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -82,7 +125,12 @@ export const actions: Actions = {
 
         try {
             const provider = await createProvider({ name, providerType, config })
-            await createPredefinedModels(provider.id, providerType)
+            const discoveredModels = await listAvailableProviderModels(providerType, config)
+            if (discoveredModels.length > 0) {
+                await createModelSeeds(provider.id, discoveredModels)
+            } else {
+                await createPredefinedModels(provider.id, providerType)
+            }
             await reloadAIProviders()
             return { success: true, message: 'Provider connected' }
         } catch (err) {

--- a/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.server.ts
@@ -18,6 +18,8 @@ import {
     type ModelProviderType,
 } from '$lib/server/db/model-providers'
 import { env } from '$env/dynamic/private'
+import { logger } from '$lib/server/logger'
+import type { TestModelRequest, TestModelResponse } from '$lib/types/model-provider'
 
 async function reloadAIProviders() {
     try {
@@ -218,6 +220,110 @@ export const actions: Actions = {
             return fail(500, { error: 'Failed to set secondary model' })
         }
     },
+
+    testConnection: async ({ request, locals }) => {
+        requireAdmin(locals)
+
+        const formData = await request.formData()
+        const id = (formData.get('id') as string) || null
+        const providerType = formData.get('providerType') as ModelProviderType
+
+        if (!providerType || !MODEL_PROVIDER_TYPES.includes(providerType))
+            return fail(400, { error: 'Invalid provider type' })
+
+        const config = parseConfig(formData, providerType)
+        let modelId = (formData.get('modelId') as string) || null
+
+        if (id) {
+            const existing = await getProvider(id)
+            if (!existing) return fail(404, { error: 'Provider not found' })
+            if (!config.apiKey) {
+                config.apiKey = (existing.config as ModelProviderConfig).apiKey ?? null
+            }
+            if (!modelId) {
+                const providerModels = await listModelsByProvider(id)
+                modelId =
+                    providerModels.find((m) => m.isDefault)?.modelId ??
+                    providerModels[0]?.modelId ??
+                    null
+            }
+        }
+
+        const built = buildTestRequest(providerType, config, modelId)
+        if ('error' in built) return fail(400, { error: built.error })
+
+        try {
+            const resp = await fetch(`${env.AI_SERVICE_URL}/admin/provider/${providerType}/test`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(built),
+            })
+            const body = (await resp.json()) as TestModelResponse
+            if (body.ok) {
+                const detail = [body.model, body.latency_ms ? `${body.latency_ms}ms` : null]
+                    .filter((p): p is string => !!p)
+                    .join(' · ')
+                return {
+                    success: true,
+                    message: detail ? `Connected (${detail})` : 'Connected',
+                }
+            }
+            return fail(400, {
+                error: body.error || 'Connection failed',
+                provider: body.provider,
+                statusCode: body.status_code,
+                model: body.model,
+            })
+        } catch (err) {
+            logger.error('Model test connection failed', err)
+            return fail(500, { error: 'Could not reach AI service' })
+        }
+    },
+}
+
+function buildTestRequest(
+    providerType: ModelProviderType,
+    config: ModelProviderConfig,
+    modelId: string | null,
+): TestModelRequest | { error: string } {
+    switch (providerType) {
+        case 'anthropic':
+            if (!config.apiKey) return { error: 'API key is required for Anthropic' }
+            return { api_key: config.apiKey, model: modelId }
+        case 'openai':
+            if (!config.apiKey) return { error: 'API key is required for OpenAI' }
+            return { api_key: config.apiKey, model: modelId }
+        case 'gemini':
+            if (!config.apiKey) return { error: 'API key is required for Gemini' }
+            return { api_key: config.apiKey, model: modelId }
+        case 'bedrock':
+            return {
+                region_name: config.regionName ?? null,
+                model_id: modelId,
+            }
+        case 'vertex_ai':
+            if (!config.regionName) return { error: 'GCP Region is required for Vertex AI' }
+            if (!config.projectId) return { error: 'GCP Project ID is required for Vertex AI' }
+            return {
+                region: config.regionName,
+                project_id: config.projectId,
+                model: modelId,
+            }
+        case 'azure_foundry':
+            if (!config.apiUrl) return { error: 'Endpoint URL is required for Azure AI Foundry' }
+            return {
+                endpoint_url: config.apiUrl,
+                model: modelId,
+            }
+        case 'openai_compatible':
+            if (!config.apiUrl)
+                return { error: 'Base URL is required for OpenAI-compatible provider' }
+            return {
+                base_url: config.apiUrl,
+                api_key: config.apiKey ?? null,
+                model: modelId,
+            }
+    }
 }
 
 function parseConfig(formData: FormData, providerType: string): ModelProviderConfig {

--- a/web/src/routes/(admin)/admin/settings/llm/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.svelte
@@ -9,6 +9,7 @@
     import * as Alert from '$lib/components/ui/alert'
     import * as AlertDialog from '$lib/components/ui/alert-dialog'
     import * as Dialog from '$lib/components/ui/dialog'
+    import * as Tooltip from '$lib/components/ui/tooltip'
     import { Loader2, Info, Pencil, Trash2, Server, CircleAlert, CircleCheck } from '@lucide/svelte'
     import { cn } from '$lib/utils'
     import { toast } from 'svelte-sonner'
@@ -707,9 +708,23 @@
                             <Alert.Title>{testResult.message}</Alert.Title>
                         </Alert.Root>
                     {:else}
+                        {@const errorMessage = testResult.message}
                         <Alert.Root variant="destructive">
                             <CircleAlert class="h-4 w-4" />
-                            <Alert.Title>{testResult.message}</Alert.Title>
+                            <Tooltip.Provider delayDuration={300}>
+                                <Tooltip.Root>
+                                    <Tooltip.Trigger>
+                                        {#snippet child({ props })}
+                                            <Alert.Title {...props} class="cursor-help">
+                                                {errorMessage}
+                                            </Alert.Title>
+                                        {/snippet}
+                                    </Tooltip.Trigger>
+                                    <Tooltip.Content class="max-w-sm text-left break-words">
+                                        {errorMessage}
+                                    </Tooltip.Content>
+                                </Tooltip.Root>
+                            </Tooltip.Provider>
                             {#if testResult.detail}
                                 <Alert.Description>{testResult.detail}</Alert.Description>
                             {/if}

--- a/web/src/routes/(admin)/admin/settings/llm/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import { enhance } from '$app/forms'
-    import type { SubmitFunction } from '@sveltejs/kit'
     import { Button } from '$lib/components/ui/button'
     import { Input } from '$lib/components/ui/input'
     import { Label } from '$lib/components/ui/label'
@@ -77,9 +76,7 @@
     type TestResult =
         | { ok: true; message: string }
         | { ok: false; message: string; detail: string | null }
-    let isTesting = $state(false)
     let testResult = $state<TestResult | null>(null)
-    let testConnectionFormRef = $state<HTMLFormElement | null>(null)
 
     let modelDialogOpen = $state(false)
     let modelFormState = $state<ModelFormState>({ ...emptyModelForm })
@@ -248,41 +245,23 @@
         testResult = null
     }
 
-    const enhanceTestConnection: SubmitFunction = () => {
-        isTesting = true
-        testResult = null
-        return async ({ result }) => {
-            isTesting = false
-            if (result.type === 'success') {
-                testResult = {
-                    ok: true,
-                    message: (result.data?.message as string) || 'Connection successful',
-                }
-            } else if (result.type === 'failure') {
-                const resultData = result.data as
-                    | {
-                          error?: string
-                          provider?: string | null
-                          statusCode?: number | null
-                          model?: string | null
-                      }
-                    | undefined
-                const detailParts: string[] = []
-                if (resultData?.provider) detailParts.push(resultData.provider)
-                if (resultData?.model) detailParts.push(resultData.model)
-                if (resultData?.statusCode) detailParts.push(`HTTP ${resultData.statusCode}`)
-                testResult = {
-                    ok: false,
-                    message: resultData?.error || 'Connection failed',
-                    detail: detailParts.length ? detailParts.join(' · ') : null,
-                }
-            } else {
-                testResult = {
-                    ok: false,
-                    message: 'Connection failed',
-                    detail: null,
-                }
-            }
+    function setConnectionError(resultData: unknown, fallback: string) {
+        const data = resultData as
+            | {
+                  error?: string
+                  provider?: string | null
+                  statusCode?: number | null
+                  model?: string | null
+              }
+            | undefined
+        const detailParts: string[] = []
+        if (data?.provider) detailParts.push(data.provider)
+        if (data?.model) detailParts.push(data.model)
+        if (data?.statusCode) detailParts.push(`HTTP ${data.statusCode}`)
+        testResult = {
+            ok: false,
+            message: data?.error || fallback,
+            detail: detailParts.length ? detailParts.join(' · ') : null,
         }
     }
 </script>
@@ -592,11 +571,12 @@
                     action={editMode ? '?/edit' : '?/add'}
                     use:enhance={() => {
                         isSubmitting = true
+                        testResult = null
                         return async ({ result, update }) => {
-                            await update()
                             isSubmitting = false
-                            dialogOpen = false
                             if (result.type === 'success') {
+                                await update()
+                                dialogOpen = false
                                 toast.success(
                                     actionMessage(
                                         result.data,
@@ -605,9 +585,9 @@
                                     ),
                                 )
                             } else if (result.type === 'failure') {
-                                toast.error(
-                                    actionMessage(result.data, 'error', 'Something went wrong'),
-                                )
+                                setConnectionError(result.data, 'Connection failed')
+                            } else {
+                                setConnectionError(null, 'Connection failed')
                             }
                         }
                     }}
@@ -747,78 +727,37 @@
                         </Alert.Root>
                     {/if}
 
-                    <div class="border-border bg-muted/20 space-y-3 rounded-lg border p-3">
-                        <div class="flex items-start justify-between gap-3">
-                            <div class="space-y-1">
-                                <p class="text-sm font-medium">Connection check</p>
-                                <p class="text-muted-foreground text-xs">
-                                    Verify these credentials before saving the provider.
-                                </p>
-                            </div>
-                            <Button
-                                type="button"
-                                variant="secondary"
-                                size="sm"
-                                disabled={isTesting || isSubmitting}
-                                class="cursor-pointer text-xs"
-                                onclick={() => testConnectionFormRef?.requestSubmit()}>
-                                {#if isTesting}
-                                    <Loader2 class="mr-1.5 h-3 w-3 animate-spin" />
-                                    Testing...
-                                {:else}
-                                    Test connection
+                    {#if testResult}
+                        {#if testResult.ok}
+                            <Alert.Root
+                                class="border-green-500/50 bg-green-50 text-green-900 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-100">
+                                <CircleCheck class="h-4 w-4" />
+                                <Alert.Title>{testResult.message}</Alert.Title>
+                            </Alert.Root>
+                        {:else}
+                            {@const errorMessage = testResult.message}
+                            <Alert.Root variant="destructive">
+                                <CircleAlert class="h-4 w-4" />
+                                <Tooltip.Provider delayDuration={300}>
+                                    <Tooltip.Root>
+                                        <Tooltip.Trigger>
+                                            {#snippet child({ props })}
+                                                <Alert.Title {...props} class="cursor-help">
+                                                    {errorMessage}
+                                                </Alert.Title>
+                                            {/snippet}
+                                        </Tooltip.Trigger>
+                                        <Tooltip.Content class="max-w-sm text-left break-words">
+                                            {errorMessage}
+                                        </Tooltip.Content>
+                                    </Tooltip.Root>
+                                </Tooltip.Provider>
+                                {#if testResult.detail}
+                                    <Alert.Description>{testResult.detail}</Alert.Description>
                                 {/if}
-                            </Button>
-                        </div>
-
-                        {#if testResult}
-                            {#if testResult.ok}
-                                <Alert.Root
-                                    class="border-green-500/50 bg-green-50 text-green-900 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-100">
-                                    <CircleCheck class="h-4 w-4" />
-                                    <Alert.Title>{testResult.message}</Alert.Title>
-                                </Alert.Root>
-                            {:else}
-                                {@const errorMessage = testResult.message}
-                                <Alert.Root variant="destructive">
-                                    <CircleAlert class="h-4 w-4" />
-                                    <Tooltip.Provider delayDuration={300}>
-                                        <Tooltip.Root>
-                                            <Tooltip.Trigger>
-                                                {#snippet child({ props })}
-                                                    <Alert.Title {...props} class="cursor-help">
-                                                        {errorMessage}
-                                                    </Alert.Title>
-                                                {/snippet}
-                                            </Tooltip.Trigger>
-                                            <Tooltip.Content class="max-w-sm text-left break-words">
-                                                {errorMessage}
-                                            </Tooltip.Content>
-                                        </Tooltip.Root>
-                                    </Tooltip.Provider>
-                                    {#if testResult.detail}
-                                        <Alert.Description>{testResult.detail}</Alert.Description>
-                                    {/if}
-                                </Alert.Root>
-                            {/if}
+                            </Alert.Root>
                         {/if}
-                    </div>
-                </form>
-
-                <form
-                    class="hidden"
-                    method="POST"
-                    action="?/testConnection"
-                    use:enhance={enhanceTestConnection}
-                    bind:this={testConnectionFormRef}>
-                    {#if editMode}
-                        <input type="hidden" name="id" value={formState.id} />
                     {/if}
-                    <input type="hidden" name="providerType" value={formState.providerType} />
-                    <input type="hidden" name="apiKey" value={formState.apiKey} />
-                    <input type="hidden" name="apiUrl" value={formState.apiUrl} />
-                    <input type="hidden" name="regionName" value={formState.regionName} />
-                    <input type="hidden" name="projectId" value={formState.projectId} />
                 </form>
 
                 <Dialog.Footer>
@@ -833,11 +772,11 @@
                     <Button
                         type="submit"
                         form="llm-provider-form"
-                        disabled={isSubmitting || isTesting}
+                        disabled={isSubmitting}
                         class="cursor-pointer">
                         {#if isSubmitting}
                             <Loader2 class="mr-2 h-4 w-4 animate-spin" />
-                            Saving...
+                            {editMode ? 'Updating...' : 'Connecting...'}
                         {:else}
                             {editMode ? 'Update' : 'Connect'}
                         {/if}

--- a/web/src/routes/(admin)/admin/settings/llm/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.svelte
@@ -9,7 +9,7 @@
     import * as Alert from '$lib/components/ui/alert'
     import * as AlertDialog from '$lib/components/ui/alert-dialog'
     import * as Dialog from '$lib/components/ui/dialog'
-    import { Loader2, Info, Pencil, Trash2, Server } from '@lucide/svelte'
+    import { Loader2, Info, Pencil, Trash2, Server, CircleAlert, CircleCheck } from '@lucide/svelte'
     import { cn } from '$lib/utils'
     import { toast } from 'svelte-sonner'
     import type { PageData } from './$types'
@@ -72,6 +72,12 @@
     let isSubmitting = $state(false)
     let editingHasApiKey = $state(false)
 
+    type TestResult =
+        | { ok: true; message: string }
+        | { ok: false; message: string; detail: string | null }
+    let isTesting = $state(false)
+    let testResult = $state<TestResult | null>(null)
+
     let modelDialogOpen = $state(false)
     let modelFormState = $state<ModelFormState>({ ...emptyModelForm })
     let isModelSubmitting = $state(false)
@@ -89,6 +95,20 @@
         confirmDescription = description
         confirmFormRef = formEl
         confirmDialogOpen = true
+    }
+
+    type ActionMessageData = { message?: string; error?: string }
+
+    function actionMessage(
+        resultData: unknown,
+        field: keyof ActionMessageData,
+        fallback: string,
+    ): string {
+        if (resultData && typeof resultData === 'object') {
+            const value = (resultData as ActionMessageData)[field]
+            if (typeof value === 'string') return value
+        }
+        return fallback
     }
 
     const showApiKey = (p: ProviderType) =>
@@ -176,6 +196,7 @@
     function openSetupDialog(type: ProviderType) {
         editMode = false
         editingHasApiKey = false
+        testResult = null
         formState = {
             ...emptyProviderForm,
             providerType: type,
@@ -187,6 +208,7 @@
     function openEditDialog(provider: (typeof data.providers)[0]) {
         editMode = true
         editingHasApiKey = provider.hasApiKey
+        testResult = null
         formState = {
             id: provider.id,
             name: provider.name,
@@ -520,6 +542,7 @@
                 </Dialog.Header>
 
                 <form
+                    id="llm-provider-form"
                     method="POST"
                     action={editMode ? '?/edit' : '?/add'}
                     use:enhance={() => {
@@ -530,10 +553,16 @@
                             dialogOpen = false
                             if (result.type === 'success') {
                                 toast.success(
-                                    result.data?.message || 'Operation completed successfully',
+                                    actionMessage(
+                                        result.data,
+                                        'message',
+                                        'Operation completed successfully',
+                                    ),
                                 )
                             } else if (result.type === 'failure') {
-                                toast.error(result.data?.error || 'Something went wrong')
+                                toast.error(
+                                    actionMessage(result.data, 'error', 'Something went wrong'),
+                                )
                             }
                         }
                     }}
@@ -668,25 +697,113 @@
                             </Alert.Description>
                         </Alert.Root>
                     {/if}
+                </form>
 
-                    <Dialog.Footer>
+                {#if testResult}
+                    {#if testResult.ok}
+                        <Alert.Root
+                            class="border-green-500/50 bg-green-50 text-green-900 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-100">
+                            <CircleCheck class="h-4 w-4" />
+                            <Alert.Title>{testResult.message}</Alert.Title>
+                        </Alert.Root>
+                    {:else}
+                        <Alert.Root variant="destructive">
+                            <CircleAlert class="h-4 w-4" />
+                            <Alert.Title>{testResult.message}</Alert.Title>
+                            {#if testResult.detail}
+                                <Alert.Description>{testResult.detail}</Alert.Description>
+                            {/if}
+                        </Alert.Root>
+                    {/if}
+                {/if}
+
+                <Dialog.Footer>
+                    <Button
+                        variant="outline"
+                        type="button"
+                        class="cursor-pointer"
+                        onclick={() => (dialogOpen = false)}>
+                        Cancel
+                    </Button>
+
+                    <form
+                        method="POST"
+                        action="?/testConnection"
+                        use:enhance={() => {
+                            isTesting = true
+                            testResult = null
+                            return async ({ result }) => {
+                                isTesting = false
+                                if (result.type === 'success') {
+                                    testResult = {
+                                        ok: true,
+                                        message:
+                                            (result.data?.message as string) ||
+                                            'Connection successful',
+                                    }
+                                } else if (result.type === 'failure') {
+                                    const data = result.data as
+                                        | {
+                                              error?: string
+                                              provider?: string | null
+                                              statusCode?: number | null
+                                              model?: string | null
+                                          }
+                                        | undefined
+                                    const detailParts: string[] = []
+                                    if (data?.provider) detailParts.push(data.provider)
+                                    if (data?.model) detailParts.push(data.model)
+                                    if (data?.statusCode)
+                                        detailParts.push(`HTTP ${data.statusCode}`)
+                                    testResult = {
+                                        ok: false,
+                                        message: data?.error || 'Connection failed',
+                                        detail: detailParts.length ? detailParts.join(' · ') : null,
+                                    }
+                                } else {
+                                    testResult = {
+                                        ok: false,
+                                        message: 'Connection failed',
+                                        detail: null,
+                                    }
+                                }
+                            }
+                        }}>
+                        {#if editMode}
+                            <input type="hidden" name="id" value={formState.id} />
+                        {/if}
+                        <input type="hidden" name="providerType" value={formState.providerType} />
+                        <input type="hidden" name="apiKey" value={formState.apiKey} />
+                        <input type="hidden" name="apiUrl" value={formState.apiUrl} />
+                        <input type="hidden" name="regionName" value={formState.regionName} />
+                        <input type="hidden" name="projectId" value={formState.projectId} />
                         <Button
-                            variant="outline"
-                            type="button"
-                            class="cursor-pointer"
-                            onclick={() => (dialogOpen = false)}>
-                            Cancel
-                        </Button>
-                        <Button type="submit" disabled={isSubmitting} class="cursor-pointer">
-                            {#if isSubmitting}
+                            type="submit"
+                            variant="secondary"
+                            disabled={isTesting || isSubmitting}
+                            class="cursor-pointer">
+                            {#if isTesting}
                                 <Loader2 class="mr-2 h-4 w-4 animate-spin" />
-                                Saving...
+                                Testing...
                             {:else}
-                                {editMode ? 'Update' : 'Connect'}
+                                Test connection
                             {/if}
                         </Button>
-                    </Dialog.Footer>
-                </form>
+                    </form>
+
+                    <Button
+                        type="submit"
+                        form="llm-provider-form"
+                        disabled={isSubmitting || isTesting}
+                        class="cursor-pointer">
+                        {#if isSubmitting}
+                            <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+                            Saving...
+                        {:else}
+                            {editMode ? 'Update' : 'Connect'}
+                        {/if}
+                    </Button>
+                </Dialog.Footer>
             </Dialog.Content>
         </Dialog.Root>
 
@@ -728,9 +845,17 @@
                             isModelSubmitting = false
                             modelDialogOpen = false
                             if (result.type === 'success') {
-                                toast.success(result.data?.message || 'Model added successfully')
+                                toast.success(
+                                    actionMessage(
+                                        result.data,
+                                        'message',
+                                        'Model added successfully',
+                                    ),
+                                )
                             } else if (result.type === 'failure') {
-                                toast.error(result.data?.error || 'Something went wrong')
+                                toast.error(
+                                    actionMessage(result.data, 'error', 'Something went wrong'),
+                                )
                             }
                         }
                     }}

--- a/web/src/routes/(admin)/admin/settings/llm/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.svelte
@@ -757,10 +757,10 @@
                             </div>
                             <Button
                                 type="button"
-                                variant="link"
+                                variant="secondary"
                                 size="sm"
                                 disabled={isTesting || isSubmitting}
-                                class="h-auto cursor-pointer px-0 py-0 text-xs"
+                                class="cursor-pointer text-xs"
                                 onclick={() => testConnectionFormRef?.requestSubmit()}>
                                 {#if isTesting}
                                     <Loader2 class="mr-1.5 h-3 w-3 animate-spin" />

--- a/web/src/routes/(admin)/admin/settings/llm/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/llm/+page.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import { enhance } from '$app/forms'
+    import type { SubmitFunction } from '@sveltejs/kit'
     import { Button } from '$lib/components/ui/button'
     import { Input } from '$lib/components/ui/input'
     import { Label } from '$lib/components/ui/label'
@@ -78,6 +79,7 @@
         | { ok: false; message: string; detail: string | null }
     let isTesting = $state(false)
     let testResult = $state<TestResult | null>(null)
+    let testConnectionFormRef = $state<HTMLFormElement | null>(null)
 
     let modelDialogOpen = $state(false)
     let modelFormState = $state<ModelFormState>({ ...emptyModelForm })
@@ -240,6 +242,48 @@
             providerId,
         }
         modelDialogOpen = true
+    }
+
+    function resetTestResult() {
+        testResult = null
+    }
+
+    const enhanceTestConnection: SubmitFunction = () => {
+        isTesting = true
+        testResult = null
+        return async ({ result }) => {
+            isTesting = false
+            if (result.type === 'success') {
+                testResult = {
+                    ok: true,
+                    message: (result.data?.message as string) || 'Connection successful',
+                }
+            } else if (result.type === 'failure') {
+                const resultData = result.data as
+                    | {
+                          error?: string
+                          provider?: string | null
+                          statusCode?: number | null
+                          model?: string | null
+                      }
+                    | undefined
+                const detailParts: string[] = []
+                if (resultData?.provider) detailParts.push(resultData.provider)
+                if (resultData?.model) detailParts.push(resultData.model)
+                if (resultData?.statusCode) detailParts.push(`HTTP ${resultData.statusCode}`)
+                testResult = {
+                    ok: false,
+                    message: resultData?.error || 'Connection failed',
+                    detail: detailParts.length ? detailParts.join(' · ') : null,
+                }
+            } else {
+                testResult = {
+                    ok: false,
+                    message: 'Connection failed',
+                    detail: null,
+                }
+            }
+        }
     }
 </script>
 
@@ -597,6 +641,7 @@
                                 name="apiKey"
                                 type="password"
                                 bind:value={formState.apiKey}
+                                oninput={resetTestResult}
                                 placeholder={editingHasApiKey && editMode
                                     ? 'Leave empty to keep current key'
                                     : formState.providerType === 'anthropic'
@@ -619,6 +664,7 @@
                                 id="apiUrl"
                                 name="apiUrl"
                                 bind:value={formState.apiUrl}
+                                oninput={resetTestResult}
                                 placeholder={formState.providerType === 'azure_foundry'
                                     ? 'https://<project>.services.ai.azure.com'
                                     : 'https://openrouter.ai/api/v1'}
@@ -658,6 +704,7 @@
                                 id="regionName"
                                 name="regionName"
                                 bind:value={formState.regionName}
+                                oninput={resetTestResult}
                                 placeholder={formState.providerType === 'vertex_ai'
                                     ? 'us-central1'
                                     : 'us-east-1 (auto-detected if empty)'}
@@ -672,6 +719,7 @@
                                 id="projectId"
                                 name="projectId"
                                 bind:value={formState.projectId}
+                                oninput={resetTestResult}
                                 placeholder="my-gcp-project"
                                 required />
                         </div>
@@ -698,39 +746,80 @@
                             </Alert.Description>
                         </Alert.Root>
                     {/if}
+
+                    <div class="border-border bg-muted/20 space-y-3 rounded-lg border p-3">
+                        <div class="flex items-start justify-between gap-3">
+                            <div class="space-y-1">
+                                <p class="text-sm font-medium">Connection check</p>
+                                <p class="text-muted-foreground text-xs">
+                                    Verify these credentials before saving the provider.
+                                </p>
+                            </div>
+                            <Button
+                                type="button"
+                                variant="link"
+                                size="sm"
+                                disabled={isTesting || isSubmitting}
+                                class="h-auto cursor-pointer px-0 py-0 text-xs"
+                                onclick={() => testConnectionFormRef?.requestSubmit()}>
+                                {#if isTesting}
+                                    <Loader2 class="mr-1.5 h-3 w-3 animate-spin" />
+                                    Testing...
+                                {:else}
+                                    Test connection
+                                {/if}
+                            </Button>
+                        </div>
+
+                        {#if testResult}
+                            {#if testResult.ok}
+                                <Alert.Root
+                                    class="border-green-500/50 bg-green-50 text-green-900 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-100">
+                                    <CircleCheck class="h-4 w-4" />
+                                    <Alert.Title>{testResult.message}</Alert.Title>
+                                </Alert.Root>
+                            {:else}
+                                {@const errorMessage = testResult.message}
+                                <Alert.Root variant="destructive">
+                                    <CircleAlert class="h-4 w-4" />
+                                    <Tooltip.Provider delayDuration={300}>
+                                        <Tooltip.Root>
+                                            <Tooltip.Trigger>
+                                                {#snippet child({ props })}
+                                                    <Alert.Title {...props} class="cursor-help">
+                                                        {errorMessage}
+                                                    </Alert.Title>
+                                                {/snippet}
+                                            </Tooltip.Trigger>
+                                            <Tooltip.Content class="max-w-sm text-left break-words">
+                                                {errorMessage}
+                                            </Tooltip.Content>
+                                        </Tooltip.Root>
+                                    </Tooltip.Provider>
+                                    {#if testResult.detail}
+                                        <Alert.Description>{testResult.detail}</Alert.Description>
+                                    {/if}
+                                </Alert.Root>
+                            {/if}
+                        {/if}
+                    </div>
                 </form>
 
-                {#if testResult}
-                    {#if testResult.ok}
-                        <Alert.Root
-                            class="border-green-500/50 bg-green-50 text-green-900 dark:border-green-500/40 dark:bg-green-950/40 dark:text-green-100">
-                            <CircleCheck class="h-4 w-4" />
-                            <Alert.Title>{testResult.message}</Alert.Title>
-                        </Alert.Root>
-                    {:else}
-                        {@const errorMessage = testResult.message}
-                        <Alert.Root variant="destructive">
-                            <CircleAlert class="h-4 w-4" />
-                            <Tooltip.Provider delayDuration={300}>
-                                <Tooltip.Root>
-                                    <Tooltip.Trigger>
-                                        {#snippet child({ props })}
-                                            <Alert.Title {...props} class="cursor-help">
-                                                {errorMessage}
-                                            </Alert.Title>
-                                        {/snippet}
-                                    </Tooltip.Trigger>
-                                    <Tooltip.Content class="max-w-sm text-left break-words">
-                                        {errorMessage}
-                                    </Tooltip.Content>
-                                </Tooltip.Root>
-                            </Tooltip.Provider>
-                            {#if testResult.detail}
-                                <Alert.Description>{testResult.detail}</Alert.Description>
-                            {/if}
-                        </Alert.Root>
+                <form
+                    class="hidden"
+                    method="POST"
+                    action="?/testConnection"
+                    use:enhance={enhanceTestConnection}
+                    bind:this={testConnectionFormRef}>
+                    {#if editMode}
+                        <input type="hidden" name="id" value={formState.id} />
                     {/if}
-                {/if}
+                    <input type="hidden" name="providerType" value={formState.providerType} />
+                    <input type="hidden" name="apiKey" value={formState.apiKey} />
+                    <input type="hidden" name="apiUrl" value={formState.apiUrl} />
+                    <input type="hidden" name="regionName" value={formState.regionName} />
+                    <input type="hidden" name="projectId" value={formState.projectId} />
+                </form>
 
                 <Dialog.Footer>
                     <Button
@@ -740,71 +829,6 @@
                         onclick={() => (dialogOpen = false)}>
                         Cancel
                     </Button>
-
-                    <form
-                        method="POST"
-                        action="?/testConnection"
-                        use:enhance={() => {
-                            isTesting = true
-                            testResult = null
-                            return async ({ result }) => {
-                                isTesting = false
-                                if (result.type === 'success') {
-                                    testResult = {
-                                        ok: true,
-                                        message:
-                                            (result.data?.message as string) ||
-                                            'Connection successful',
-                                    }
-                                } else if (result.type === 'failure') {
-                                    const data = result.data as
-                                        | {
-                                              error?: string
-                                              provider?: string | null
-                                              statusCode?: number | null
-                                              model?: string | null
-                                          }
-                                        | undefined
-                                    const detailParts: string[] = []
-                                    if (data?.provider) detailParts.push(data.provider)
-                                    if (data?.model) detailParts.push(data.model)
-                                    if (data?.statusCode)
-                                        detailParts.push(`HTTP ${data.statusCode}`)
-                                    testResult = {
-                                        ok: false,
-                                        message: data?.error || 'Connection failed',
-                                        detail: detailParts.length ? detailParts.join(' · ') : null,
-                                    }
-                                } else {
-                                    testResult = {
-                                        ok: false,
-                                        message: 'Connection failed',
-                                        detail: null,
-                                    }
-                                }
-                            }
-                        }}>
-                        {#if editMode}
-                            <input type="hidden" name="id" value={formState.id} />
-                        {/if}
-                        <input type="hidden" name="providerType" value={formState.providerType} />
-                        <input type="hidden" name="apiKey" value={formState.apiKey} />
-                        <input type="hidden" name="apiUrl" value={formState.apiUrl} />
-                        <input type="hidden" name="regionName" value={formState.regionName} />
-                        <input type="hidden" name="projectId" value={formState.projectId} />
-                        <Button
-                            type="submit"
-                            variant="secondary"
-                            disabled={isTesting || isSubmitting}
-                            class="cursor-pointer">
-                            {#if isTesting}
-                                <Loader2 class="mr-2 h-4 w-4 animate-spin" />
-                                Testing...
-                            {:else}
-                                Test connection
-                            {/if}
-                        </Button>
-                    </form>
 
                     <Button
                         type="submit"

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -102,6 +102,7 @@
             activeStreamChatId = null
             isStreaming = false
             error = null
+            errorDetail = null
             stopThinkingText()
             chatMessages = [...data.messages]
             branchSelections = {}
@@ -173,6 +174,7 @@
 
     let isStreaming = $state(false)
     let error = $state<string | null>(null)
+    let errorDetail = $state<string | null>(null)
     let eventSource: EventSource | null = $state(null)
     let activeStreamChatId: string | null = null
 
@@ -203,14 +205,33 @@
         }
     }
 
-    type StreamErrorPayload = { message: string }
+    type StreamErrorPayload = {
+        message: string
+        provider?: string | null
+        model?: string | null
+        statusCode?: number | null
+    }
 
-    function streamErrorMessage(event: MessageEvent<string>): string {
+    function streamErrorMessage(event: MessageEvent<string>): {
+        message: string
+        detail: string | null
+    } {
         try {
             const payload = JSON.parse(event.data) as StreamErrorPayload
-            return payload.message
+            const detailParts = [
+                payload.provider,
+                payload.model,
+                payload.statusCode ? `HTTP ${payload.statusCode}` : null,
+            ].filter((part): part is string => !!part)
+            return {
+                message: payload.message,
+                detail: detailParts.length ? detailParts.join(' · ') : null,
+            }
         } catch {
-            return event.data || 'Failed to generate response. Please try again.'
+            return {
+                message: event.data || 'Failed to generate response. Please try again.',
+                detail: null,
+            }
         }
     }
 
@@ -449,6 +470,7 @@
         // Reset all stream state so the input is immediately ready for a new message.
         isStreaming = false
         error = null
+        errorDetail = null
         activeStreamingMessageId = null
         stopThinkingText()
         refreshProcessedMessages()
@@ -1141,6 +1163,7 @@
         activeStreamChatId = chatId
         activeStreamingMessageId = null
         error = null
+        errorDetail = null
         startThinkingText()
 
         const toolUseStateByIndex = new Map<
@@ -1586,10 +1609,14 @@
 
         const handleStreamError = (event: Event) => {
             streamCompleted = true
-            error =
-                event instanceof MessageEvent
-                    ? streamErrorMessage(event as MessageEvent<string>)
-                    : 'Failed to generate response. Please try again.'
+            if (event instanceof MessageEvent) {
+                const streamError = streamErrorMessage(event as MessageEvent<string>)
+                error = streamError.message
+                errorDetail = streamError.detail
+            } else {
+                error = 'Failed to generate response. Please try again.'
+                errorDetail = null
+            }
             isStreaming = false
             activeStreamingMessageId = null
             refreshProcessedMessages()
@@ -1629,6 +1656,7 @@
                 messageEventsReceived > 0
                     ? 'Response stream disconnected before it finished. Please try again.'
                     : 'Failed to connect to the response stream. Please try again.'
+            errorDetail = null
             isStreaming = false
             activeStreamingMessageId = null
             refreshProcessedMessages()
@@ -2187,6 +2215,9 @@
                                     <Alert.Root variant="destructive" title={error}>
                                         <CircleAlert />
                                         <Alert.Title>{error}</Alert.Title>
+                                        {#if errorDetail}
+                                            <Alert.Description>{errorDetail}</Alert.Description>
+                                        {/if}
                                     </Alert.Root>
                                 </div>
                             {/if}
@@ -2292,6 +2323,9 @@
                             <Alert.Root variant="destructive" title={error}>
                                 <CircleAlert />
                                 <Alert.Title>{error}</Alert.Title>
+                                {#if errorDetail}
+                                    <Alert.Description>{errorDetail}</Alert.Description>
+                                {/if}
                             </Alert.Root>
                         {:else if isStreaming}
                             <span class="thinking-container mt-2 flex items-center gap-1.5">


### PR DESCRIPTION
- Add an AI endpoint and admin UI action to test LLM provider configs before saving.
- Wrap provider failures with structured error details for provider, model, and status code.
- Surface provider error details in chat stream failures and add focused tests.