### PR TITLE
feat(google): improve drive sync

### DIFF
--- a/connectors/google/src/auth.rs
+++ b/connectors/google/src/auth.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{Context, Result, anyhow};
 use chrono::{Duration, Utc};
 use jsonwebtoken::{Algorithm, EncodingKey, Header, encode};
 use omni_connector_sdk::RateLimiter;
@@ -11,6 +11,26 @@ use std::sync::Arc;
 use std::time::Duration as StdDuration;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GoogleServiceAccountCredentials {
+    pub service_account_key: String,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct GoogleOAuthCredentials {
+    pub access_token: Option<String>,
+    pub refresh_token: String,
+    pub expires_at: Option<i64>,
+    pub user_email: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+#[serde(untagged)]
+pub enum GoogleCredentialPayload {
+    ServiceAccount(GoogleServiceAccountCredentials),
+    OAuth(GoogleOAuthCredentials),
+}
 
 #[derive(Debug, Serialize, Deserialize, Clone)]
 pub struct GoogleServiceAccountKey {
@@ -448,11 +468,9 @@ pub fn create_service_auth(
     creds: &ServiceCredential,
     source_type: SourceType,
 ) -> Result<ServiceAccountAuth> {
-    let service_account_json = creds
-        .credentials
-        .get("service_account_key")
-        .and_then(|v| v.as_str())
-        .ok_or_else(|| anyhow!("Missing service_account_key in credentials"))?;
+    let service_account_credentials: GoogleServiceAccountCredentials =
+        serde_json::from_value(creds.credentials.clone())
+            .context("Invalid Google service-account credentials")?;
 
     let scopes = creds
         .config
@@ -465,7 +483,7 @@ pub fn create_service_auth(
         })
         .unwrap_or_else(|| get_scopes_for_source_type(source_type));
 
-    ServiceAccountAuth::new(service_account_json, scopes)
+    ServiceAccountAuth::new(&service_account_credentials.service_account_key, scopes)
 }
 
 /// Read the workspace `domain` from a `ServiceCredential` config blob.

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -1,19 +1,23 @@
 use std::sync::Arc;
 
 use crate::admin::AdminClient;
-use crate::auth::{create_service_auth, get_domain_from_credentials};
+use crate::auth::{
+    GoogleCredentialPayload, GoogleOAuthCredentials, create_service_auth,
+    get_domain_from_credentials,
+};
 use crate::drive::DriveClient;
 use crate::gmail::{MessageFormat, MessagePart};
 use crate::models::{GoogleDirectoryUser, GoogleSyncCheckpoint, SearchUsersResponse};
 use crate::sync::SyncManager;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use axum::response::Response;
 use omni_connector_sdk::{
     ActionDefinition, ActionResponse, Connector, OAuthManifestConfig, OAuthScopeSet,
-    SearchOperator, ServiceCredential, Source, SourceType, SyncContext, SyncType,
+    SearchOperator, ServiceCredential, ServiceProvider, Source, SourceType, SyncContext,
+    SyncRequestValidationError, SyncType,
 };
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use std::collections::HashMap;
 use tracing::debug;
 
@@ -197,7 +201,7 @@ impl GoogleConnector {
             (bytes, mime_type.clone())
         };
 
-        let mut resp = Response::builder()
+        let resp = Response::builder()
             .status(200)
             .header("Content-Type", content_type)
             .header("Content-Length", bytes.len())
@@ -382,7 +386,7 @@ impl GoogleConnector {
 #[async_trait]
 impl Connector for GoogleConnector {
     type Config = JsonValue;
-    type Credentials = JsonValue;
+    type Credentials = GoogleCredentialPayload;
     type State = GoogleSyncCheckpoint;
 
     fn name(&self) -> &'static str {
@@ -426,7 +430,7 @@ impl Connector for GoogleConnector {
                     "properties": {
                         "file_id": {
                             "type": "string",
-                            "description": "Drive file ID, or a Gmail attachment composite ID (thread_id:att:message_id:attachment_id)"
+                            "description": "Drive file ID, or a Gmail attachment composite ID in the form urlencoded_rfc822_msgid:att:urlencoded_filename:size"
                         }
                     },
                     "required": ["file_id"]
@@ -521,6 +525,64 @@ impl Connector for GoogleConnector {
             scope_separator: " ".to_string(),
             enrich_endpoint: None,
         })
+    }
+
+    async fn validate_sync_request(
+        &self,
+        source: &Source,
+        credentials: Option<&ServiceCredential>,
+        _sync_type: SyncType,
+    ) -> std::result::Result<(), SyncRequestValidationError> {
+        let Some(creds) = credentials else {
+            return Err(SyncRequestValidationError::BadRequest(
+                "Google sync requires credentials".to_string(),
+            ));
+        };
+        if creds.provider != ServiceProvider::Google {
+            return Err(SyncRequestValidationError::BadRequest(format!(
+                "Expected Google credentials, found {:?}",
+                creds.provider
+            )));
+        }
+
+        match creds.auth_type {
+            omni_connector_sdk::AuthType::OAuth => {
+                let oauth_credentials: GoogleOAuthCredentials =
+                    serde_json::from_value(creds.credentials.clone()).map_err(|e| {
+                        SyncRequestValidationError::BadRequest(format!(
+                            "Invalid Google OAuth credentials: {}",
+                            e
+                        ))
+                    })?;
+                if oauth_credentials.refresh_token.is_empty()
+                    || oauth_credentials
+                        .user_email
+                        .as_deref()
+                        .or(creds.principal_email.as_deref())
+                        .is_none_or(|email| email.is_empty())
+                {
+                    return Err(SyncRequestValidationError::BadRequest(
+                        "OAuth Google credentials must include refresh_token and user_email/principal_email".to_string(),
+                    ));
+                }
+            }
+            _ => {
+                create_service_auth(creds, source.source_type).map_err(|e| {
+                    SyncRequestValidationError::BadRequest(format!(
+                        "Invalid Google service-account credentials: {}",
+                        e
+                    ))
+                })?;
+                get_domain_from_credentials(creds).map_err(|e| {
+                    SyncRequestValidationError::BadRequest(format!(
+                        "Invalid Google service-account config: {}",
+                        e
+                    ))
+                })?;
+            }
+        }
+
+        Ok(())
     }
 
     async fn sync(

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use reqwest::Client;
 use serde::Deserialize;
 use std::env;
@@ -9,7 +9,7 @@ use tracing::{debug, warn};
 use std::collections::HashMap;
 
 use crate::auth::{
-    ApiResult, GoogleAuth, classify_google_api_error, execute_with_auth_retry, google_max_retries,
+    classify_google_api_error, execute_with_auth_retry, google_max_retries, ApiResult, GoogleAuth,
 };
 use crate::models::{
     DriveChangesResponse, GoogleDriveFile, GooglePresentation, WebhookChannel,
@@ -34,6 +34,21 @@ const SHEETS_API_BASE: &str = "https://sheets.googleapis.com/v4";
 const SLIDES_API_BASE: &str = "https://slides.googleapis.com/v1";
 const DEFAULT_GOOGLE_SHEETS_MAX_INDEXED_ROWS: usize = 1000;
 const DEFAULT_GOOGLE_DRIVE_MAX_DOWNLOAD_BYTES: usize = 50 * 1024 * 1024;
+
+fn build_files_query(activity_after: Option<&str>) -> String {
+    let mut query_parts = vec!["trashed=false".to_string()];
+    if let Some(date) = activity_after {
+        // Drive preserves the source file's modifiedTime on upload, so a newly uploaded
+        // file can have modifiedTime older than createdTime. Use either timestamp for
+        // the full-sync cutoff to include both newly uploaded old files and old Drive
+        // files that were edited recently.
+        query_parts.push(format!(
+            "(modifiedTime > '{}' or createdTime > '{}')",
+            date, date
+        ));
+    }
+    query_parts.join(" and ")
+}
 
 fn drive_api_base() -> String {
     env::var("GOOGLE_DRIVE_API_BASE").unwrap_or_else(|_| DRIVE_API_BASE.to_string())
@@ -166,27 +181,22 @@ impl DriveClient {
         auth: &GoogleAuth,
         user_email: &str,
         page_token: Option<&str>,
-        created_after: Option<&str>,
+        modified_after: Option<&str>,
     ) -> Result<FilesListResponse> {
         let page_token = page_token.map(|s| s.to_string());
-        let created_after = created_after.map(|s| s.to_string());
+        let modified_after = modified_after.map(|s| s.to_string());
 
         execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
             let page_token = page_token.clone();
-            let created_after = created_after.clone();
+            let modified_after = modified_after.clone();
             async move {
             let url = format!("{}/files", drive_api_base().as_str());
 
-            // Build the query filter
-            let mut query_parts = vec!["trashed=false".to_string()];
-            if let Some(ref date) = created_after {
-                query_parts.push(format!("createdTime > '{}'", date));
-            }
-            let query = query_parts.join(" and ");
+            let query = build_files_query(modified_after.as_deref());
 
             let mut params = vec![
                 ("pageSize", "100"),
-                ("fields", "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,permissions(id,type,emailAddress,role),owners(emailAddress))"),
+                ("fields", "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))"),
                 ("q", query.as_str()),
                 ("orderBy", "modifiedTime desc"),
                 ("includeItemsFromAllDrives", "true"),
@@ -1329,6 +1339,15 @@ fn extract_text_from_presentation(presentation: &GooglePresentation) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn files_query_uses_modified_or_created_time_cutoff() {
+        let query = build_files_query(Some("2025-01-01T00:00:00Z"));
+        assert_eq!(
+            query,
+            "trashed=false and (modifiedTime > '2025-01-01T00:00:00Z' or createdTime > '2025-01-01T00:00:00Z')"
+        );
+    }
 
     #[test]
     fn spreadsheet_cell_textual_heuristic_filters_non_textual_values() {

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -108,7 +108,7 @@ pub struct GoogleDriveFile {
     pub size: Option<String>,
     pub parents: Option<Vec<String>>,
     pub shared: Option<bool>,
-    pub permissions: Option<Vec<Permission>>,
+    pub permissions: Option<Vec<GoogleDrivePermission>>,
     pub owners: Option<Vec<Owner>>,
 }
 
@@ -122,13 +122,18 @@ pub struct Owner {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct Permission {
+pub struct GoogleDrivePermission {
     pub id: String,
     #[serde(rename = "type")]
     pub permission_type: String,
     #[serde(rename = "emailAddress")]
     pub email_address: Option<String>,
+    pub domain: Option<String>,
     pub role: String,
+    #[serde(rename = "allowFileDiscovery")]
+    pub allow_file_discovery: Option<bool>,
+    #[serde(rename = "permissionDetails")]
+    pub permission_details: Option<Vec<serde_json::Value>>,
 }
 
 #[derive(Debug, Clone)]
@@ -212,7 +217,9 @@ impl GoogleDriveFile {
             for perm in file_permissions {
                 match perm.permission_type.as_str() {
                     "anyone" => {
-                        is_public = true;
+                        if perm.allow_file_discovery.unwrap_or(true) {
+                            is_public = true;
+                        }
                     }
                     "group" => {
                         if let Some(email) = &perm.email_address {
@@ -225,8 +232,12 @@ impl GoogleDriveFile {
                         }
                     }
                     "domain" => {
-                        if let Some(domain) = &perm.email_address {
-                            groups.push(domain.clone());
+                        if perm.allow_file_discovery.unwrap_or(true) {
+                            if let Some(domain) =
+                                perm.domain.as_ref().or(perm.email_address.as_ref())
+                            {
+                                groups.push(domain.clone());
+                            }
                         }
                     }
                     _ => {}
@@ -946,11 +957,14 @@ mod tests {
             size: Some("12345".to_string()),
             parents: Some(vec!["folder456".to_string()]),
             shared: Some(true),
-            permissions: Some(vec![Permission {
+            permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),
                 permission_type: "user".to_string(),
                 email_address: Some("user@example.com".to_string()),
+                domain: None,
                 role: "reader".to_string(),
+                allow_file_discovery: None,
+                permission_details: None,
             }]),
             owners: None,
         };
@@ -1175,29 +1189,41 @@ mod tests {
             parents: None,
             shared: Some(true),
             permissions: Some(vec![
-                Permission {
+                GoogleDrivePermission {
                     id: "perm1".to_string(),
                     permission_type: "user".to_string(),
                     email_address: Some("alice@example.com".to_string()),
+                    domain: None,
                     role: "writer".to_string(),
+                    allow_file_discovery: None,
+                    permission_details: None,
                 },
-                Permission {
+                GoogleDrivePermission {
                     id: "perm2".to_string(),
                     permission_type: "group".to_string(),
                     email_address: Some("team@example.com".to_string()),
+                    domain: None,
                     role: "reader".to_string(),
+                    allow_file_discovery: None,
+                    permission_details: None,
                 },
-                Permission {
+                GoogleDrivePermission {
                     id: "perm3".to_string(),
                     permission_type: "anyone".to_string(),
                     email_address: None,
+                    domain: None,
                     role: "reader".to_string(),
+                    allow_file_discovery: None,
+                    permission_details: None,
                 },
-                Permission {
+                GoogleDrivePermission {
                     id: "perm4".to_string(),
                     permission_type: "domain".to_string(),
                     email_address: Some("example.com".to_string()),
+                    domain: None,
                     role: "reader".to_string(),
+                    allow_file_discovery: None,
+                    permission_details: None,
                 },
             ]),
             owners: None,
@@ -1250,6 +1276,76 @@ mod tests {
             }
             _ => panic!("Expected DocumentCreated event"),
         }
+    }
+
+    #[test]
+    fn test_drive_file_link_only_permissions_do_not_overgrant() {
+        let file = GoogleDriveFile {
+            id: "file_link_only".to_string(),
+            name: "link-only.txt".to_string(),
+            mime_type: "text/plain".to_string(),
+            web_view_link: None,
+            created_time: None,
+            modified_time: None,
+            size: None,
+            parents: None,
+            shared: Some(true),
+            permissions: Some(vec![
+                GoogleDrivePermission {
+                    id: "perm_anyone_link".to_string(),
+                    permission_type: "anyone".to_string(),
+                    email_address: None,
+                    domain: None,
+                    role: "reader".to_string(),
+                    allow_file_discovery: Some(false),
+                    permission_details: None,
+                },
+                GoogleDrivePermission {
+                    id: "perm_domain_link".to_string(),
+                    permission_type: "domain".to_string(),
+                    email_address: None,
+                    domain: Some("example.com".to_string()),
+                    role: "reader".to_string(),
+                    allow_file_discovery: Some(false),
+                    permission_details: Some(vec![json!({"inherited": true})]),
+                },
+            ]),
+            owners: None,
+        };
+
+        let permissions = file.to_document_permissions(None);
+        assert!(!permissions.public);
+        assert!(permissions.groups.is_empty());
+        assert!(permissions.users.is_empty());
+    }
+
+    #[test]
+    fn test_drive_file_domain_permission_uses_domain_field() {
+        let file = GoogleDriveFile {
+            id: "file_domain".to_string(),
+            name: "domain.txt".to_string(),
+            mime_type: "text/plain".to_string(),
+            web_view_link: None,
+            created_time: None,
+            modified_time: None,
+            size: None,
+            parents: None,
+            shared: Some(true),
+            permissions: Some(vec![GoogleDrivePermission {
+                id: "perm_domain".to_string(),
+                permission_type: "domain".to_string(),
+                email_address: None,
+                domain: Some("example.com".to_string()),
+                role: "reader".to_string(),
+                allow_file_discovery: Some(true),
+                permission_details: None,
+            }]),
+            owners: None,
+        };
+
+        let permissions = file.to_document_permissions(None);
+        assert_eq!(permissions.groups, vec!["example.com".to_string()]);
+        assert!(!permissions.public);
     }
 
     #[test]
@@ -1340,11 +1436,14 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
-            permissions: Some(vec![Permission {
+            permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),
                 permission_type: "user".to_string(),
                 email_address: Some("owner@example.com".to_string()),
+                domain: None,
                 role: "owner".to_string(),
+                allow_file_discovery: None,
+                permission_details: None,
             }]),
             owners: Some(vec![Owner {
                 id: None,

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -1,11 +1,11 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use dashmap::DashMap;
-use futures::{stream, StreamExt};
+use futures::{StreamExt, stream};
 use omni_connector_sdk::SyncContext;
 use std::collections::{HashMap, HashSet};
 use std::future::Future;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use time::{self, OffsetDateTime};
 use tokio::sync::{Mutex, Notify, OwnedSemaphorePermit, Semaphore};
@@ -266,7 +266,7 @@ async fn emit_metadata_only_drive_event(
 }
 
 use crate::admin::AdminClient;
-use crate::auth::{google_max_retries, GoogleAuth, OAuthAuth};
+use crate::auth::{GoogleAuth, GoogleOAuthCredentials, OAuthAuth, google_max_retries};
 use crate::cache::LruFolderCache;
 use crate::chat::{
     ChatClient, GoogleChatAttachmentSource, GoogleChatMessage, GoogleChatSpace,
@@ -276,9 +276,9 @@ use crate::connector::build_attachment_doc_id;
 use crate::drive::{DriveClient, FileContent};
 use crate::gmail::{BatchThreadResult, ExtractedAttachment, GmailClient, MessageFormat};
 use crate::models::{
-    mime_type_to_content_type, AttachmentPointer, GmailThread, GoogleChatSegmentCheckpoint,
-    GoogleChatSpaceCheckpoint, GoogleConnectorState, GoogleSyncCheckpoint, UserFile,
-    WebhookChannel, WebhookChannelResponse, WebhookNotification,
+    AttachmentPointer, GmailThread, GoogleChatSegmentCheckpoint, GoogleChatSpaceCheckpoint,
+    GoogleConnectorState, GoogleSyncCheckpoint, UserFile, WebhookChannel, WebhookChannelResponse,
+    WebhookNotification, mime_type_to_content_type,
 };
 use omni_connector_sdk::RateLimiter;
 use omni_connector_sdk::SdkClient;
@@ -444,11 +444,12 @@ impl GoogleChatSegment {
         extra.insert("message_count".to_string(), json!(self.messages.len()));
         extra.insert(
             "message_names".to_string(),
-            json!(self
-                .messages
-                .iter()
-                .map(|m| m.name.clone())
-                .collect::<Vec<_>>()),
+            json!(
+                self.messages
+                    .iter()
+                    .map(|m| m.name.clone())
+                    .collect::<Vec<_>>()
+            ),
         );
         extra.insert("thread_names".to_string(), json!(self.thread_names()));
         extra.insert(
@@ -498,10 +499,11 @@ impl GoogleChatSegment {
         let mut attrs = HashMap::new();
         attrs.insert(
             "space".to_string(),
-            json!(self
-                .space_display_name
-                .as_deref()
-                .unwrap_or(&self.space_name)),
+            json!(
+                self.space_display_name
+                    .as_deref()
+                    .unwrap_or(&self.space_name)
+            ),
         );
         attrs.insert("space_id".to_string(), json!(self.space_name));
         attrs.insert("threads".to_string(), json!(self.thread_names()));
@@ -3196,33 +3198,16 @@ impl SyncManager {
     ) -> Result<GoogleAuth> {
         match creds.auth_type {
             AuthType::OAuth => {
-                let access_token = creds
-                    .credentials
-                    .get("access_token")
-                    .and_then(|v| v.as_str())
-                    .unwrap_or("")
-                    .to_string();
-
-                let refresh_token = creds
-                    .credentials
-                    .get("refresh_token")
-                    .and_then(|v| v.as_str())
-                    .ok_or_else(|| anyhow::anyhow!("Missing refresh_token in OAuth credentials"))?
-                    .to_string();
-
-                let expires_at = creds
-                    .credentials
-                    .get("expires_at")
-                    .and_then(|v| v.as_i64())
-                    .unwrap_or(0);
-
-                let user_email = creds
-                    .credentials
-                    .get("user_email")
-                    .and_then(|v| v.as_str())
-                    .or(creds.principal_email.as_deref())
-                    .ok_or_else(|| anyhow::anyhow!("Missing user_email in OAuth credentials"))?
-                    .to_string();
+                let oauth_credentials: GoogleOAuthCredentials =
+                    serde_json::from_value(creds.credentials.clone())
+                        .context("Invalid Google OAuth credentials")?;
+                let access_token = oauth_credentials.access_token.unwrap_or_default();
+                let refresh_token = oauth_credentials.refresh_token;
+                let expires_at = oauth_credentials.expires_at.unwrap_or(0);
+                let user_email = oauth_credentials
+                    .user_email
+                    .or_else(|| creds.principal_email.clone())
+                    .ok_or_else(|| anyhow::anyhow!("Missing user_email in OAuth credentials"))?;
 
                 // Fetch connector config for OAuth client_id/secret
                 let connector_config = self
@@ -3431,11 +3416,16 @@ impl SyncManager {
         };
 
         let service_creds = self.get_service_credentials(source_id).await?;
-        let service_auth =
-            crate::auth::create_service_auth(&service_creds, SourceType::GoogleDrive)?;
-        let user_email = self.get_user_email_from_source(source_id).await
-            .map_err(|e| anyhow::anyhow!("Failed to get user email for source {}: {}. Make sure the source has a valid creator.", source_id, e))?;
-        let access_token = service_auth.get_access_token(&user_email).await?;
+        let auth = self
+            .create_auth(&service_creds, SourceType::GoogleDrive)
+            .await?;
+        let user_email = if let Some(oauth_email) = auth.oauth_user_email() {
+            oauth_email.to_string()
+        } else {
+            self.get_user_email_from_source(source_id).await
+                .map_err(|e| anyhow::anyhow!("Failed to get user email for source {}: {}. Make sure the source has a valid creator.", source_id, e))?
+        };
+        let access_token = auth.get_access_token(&user_email).await?;
 
         let start_page_token = self
             .drive_client
@@ -3498,11 +3488,16 @@ impl SyncManager {
         resource_id: &str,
     ) -> Result<()> {
         let service_creds = self.get_service_credentials(source_id).await?;
-        let service_auth =
-            crate::auth::create_service_auth(&service_creds, SourceType::GoogleDrive)?;
-        let user_email = self.get_user_email_from_source(source_id).await
-            .map_err(|e| anyhow::anyhow!("Failed to get user email for source {}: {}. Make sure the source has a valid creator.", source_id, e))?;
-        let access_token = service_auth.get_access_token(&user_email).await?;
+        let auth = self
+            .create_auth(&service_creds, SourceType::GoogleDrive)
+            .await?;
+        let user_email = if let Some(oauth_email) = auth.oauth_user_email() {
+            oauth_email.to_string()
+        } else {
+            self.get_user_email_from_source(source_id).await
+                .map_err(|e| anyhow::anyhow!("Failed to get user email for source {}: {}. Make sure the source has a valid creator.", source_id, e))?
+        };
+        let access_token = auth.get_access_token(&user_email).await?;
 
         self.drive_client
             .stop_webhook_channel(&access_token, channel_id, resource_id)


### PR DESCRIPTION
 - Use Drive modifiedTime OR createdTime for full-sync cutoff to avoid missing recently edited old files or newly uploaded old-modified files.
 - Make Drive webhook registration/stop use auth-aware create_auth, so OAuth Drive sources are handled correctly.
 - Strongly type Google credential payloads for OAuth and service-account credentials.
 - Update Gmail attachment fetch_file schema description to the current composite ID format.
 - Fetch and handle Drive domain and allowFileDiscovery permission fields.
 - Avoid treating link-only anyone / domain Drive permissions as broadly public/domain-discoverable.
