### PR TITLE
Upgrade ParadeDB to 0.24.0

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -51,7 +51,7 @@ x-resources-connector: &resources-connector
 
 services:
   postgres:
-    image: paradedb/paradedb:0.23.1-pg17
+    image: paradedb/paradedb:0.24.0-pg17
     <<: *resources-critical
     cpus: ${OMNI_POSTGRES_CPUS:-1.0}
     mem_limit: ${OMNI_POSTGRES_MEMORY:-3g}

--- a/infra/aws/terraform/modules/database/README.md
+++ b/infra/aws/terraform/modules/database/README.md
@@ -27,7 +27,7 @@ module "database" {
   # ParadeDB configuration
   paradedb_instance_type   = "t3.small"
   paradedb_volume_size     = 50
-  paradedb_container_image = "paradedb/paradedb:0.20.6-pg17"
+  paradedb_container_image = "paradedb/paradedb:0.24.0-pg17"
 
   # Infrastructure dependencies
   vpc_id                         = module.networking.vpc_id
@@ -50,7 +50,7 @@ module "database" {
 | database_username | PostgreSQL master username | string | "omni" | no |
 | paradedb_instance_type | EC2 instance type for ParadeDB | string | "t3.small" | no |
 | paradedb_volume_size | EBS volume size in GB for ParadeDB data | number | 50 | no |
-| paradedb_container_image | Docker image for ParadeDB | string | "paradedb/paradedb:0.20.6-pg17" | no |
+| paradedb_container_image | Docker image for ParadeDB | string | "paradedb/paradedb:0.24.0-pg17" | no |
 | vpc_id | VPC ID for ParadeDB security group | string | - | yes |
 | ecs_security_group_id | ECS security group ID to allow connections to ParadeDB | string | - | yes |
 | ecs_cluster_name | ECS cluster name for ParadeDB service | string | - | yes |

--- a/infra/aws/terraform/modules/database/variables.tf
+++ b/infra/aws/terraform/modules/database/variables.tf
@@ -28,7 +28,7 @@ variable "paradedb_volume_size" {
 variable "paradedb_container_image" {
   description = "Docker image for ParadeDB"
   type        = string
-  default     = "paradedb/paradedb:0.20.6-pg17"
+  default     = "paradedb/paradedb:0.24.0-pg17"
 }
 
 variable "vpc_id" {

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -61,7 +61,7 @@ variable "paradedb_volume_size" {
 variable "paradedb_container_image" {
   description = "Docker image for ParadeDB"
   type        = string
-  default     = "paradedb/paradedb:0.20.6-pg17"
+  default     = "paradedb/paradedb:0.24.0-pg17"
 }
 
 # Cache Configuration

--- a/infra/gcp/terraform/modules/database/variables.tf
+++ b/infra/gcp/terraform/modules/database/variables.tf
@@ -35,7 +35,7 @@ variable "disk_size_gb" {
 variable "container_image" {
   description = "Docker image for ParadeDB"
   type        = string
-  default     = "paradedb/paradedb:0.20.6-pg17"
+  default     = "paradedb/paradedb:0.24.0-pg17"
 }
 
 variable "database_name" {

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -64,7 +64,7 @@ variable "paradedb_disk_size_gb" {
 variable "paradedb_container_image" {
   description = "Docker image for ParadeDB"
   type        = string
-  default     = "paradedb/paradedb:0.20.6-pg17"
+  default     = "paradedb/paradedb:0.24.0-pg17"
 }
 
 variable "redis_tier" {

--- a/sdk/python/omni_connector/testing/harness.py
+++ b/sdk/python/omni_connector/testing/harness.py
@@ -17,7 +17,7 @@ from .seed import SeedHelper
 
 logger = logging.getLogger(__name__)
 
-PARADEDB_IMAGE = "paradedb/paradedb:0.23.1-pg17"
+PARADEDB_IMAGE = "paradedb/paradedb:0.24.0-pg17"
 POSTGRES_USER = "omni"
 POSTGRES_PASSWORD = "omni_password"
 POSTGRES_DB = "omni_test"

--- a/services/ai/tests/conftest.py
+++ b/services/ai/tests/conftest.py
@@ -68,7 +68,7 @@ def postgres_container():
     import time
 
     container = (
-        DockerContainer("paradedb/paradedb:0.23.1-pg17")
+        DockerContainer("paradedb/paradedb:0.24.0-pg17")
         .with_exposed_ports(5432)
         .with_env("POSTGRES_USER", "test")
         .with_env("POSTGRES_PASSWORD", "test")

--- a/services/migrations/097_upgrade_paradedb_to_0.24.0.sql
+++ b/services/migrations/097_upgrade_paradedb_to_0.24.0.sql
@@ -1,0 +1,54 @@
+-- Upgrade ParadeDB pg_search extension from 0.23.1 to 0.24.0.
+--
+-- 0.24.0 adds WAL-backed crash recovery for pg_search buffers. Reindex
+-- BM25 indexes after the extension upgrade so existing indexes are rebuilt by
+-- the upgraded extension code.
+
+DO $$
+DECLARE
+    ext_ver TEXT;
+    ext_parts TEXT[];
+    ext_major INTEGER;
+    ext_minor INTEGER;
+    ext_patch INTEGER;
+    index_name TEXT;
+    bm25_indexes TEXT[] := ARRAY[
+        'document_search_idx',
+        'people_search_idx',
+        'chat_message_content_search_idx',
+        'chat_title_search_idx'
+    ];
+BEGIN
+    SELECT extversion INTO ext_ver FROM pg_extension WHERE extname = 'pg_search';
+
+    RAISE NOTICE 'pg_search current catalog version: %', ext_ver;
+
+    IF ext_ver IS NULL THEN
+        RAISE EXCEPTION 'pg_search extension is not installed';
+    END IF;
+
+    ext_parts := regexp_match(ext_ver, '^([0-9]+)\.([0-9]+)\.([0-9]+)');
+    IF ext_parts IS NULL THEN
+        RAISE EXCEPTION 'Unable to parse pg_search version %', ext_ver;
+    END IF;
+
+    ext_major := ext_parts[1]::INTEGER;
+    ext_minor := ext_parts[2]::INTEGER;
+    ext_patch := ext_parts[3]::INTEGER;
+
+    IF (ext_major, ext_minor, ext_patch) >= (0, 24, 0) THEN
+        RAISE NOTICE 'pg_search already at 0.24.0 or newer — nothing to upgrade';
+        RETURN;
+    END IF;
+
+    ALTER EXTENSION pg_search UPDATE TO '0.24.0';
+
+    FOREACH index_name IN ARRAY bm25_indexes LOOP
+        IF to_regclass(index_name) IS NOT NULL THEN
+            EXECUTE format('REINDEX INDEX %I', index_name);
+        END IF;
+    END LOOP;
+
+    RAISE NOTICE 'pg_search upgraded to 0.24.0 — BM25 indexes rebuilt';
+END;
+$$;

--- a/services/migrations/Dockerfile
+++ b/services/migrations/Dockerfile
@@ -13,12 +13,16 @@ RUN apt-get update && apt-get install -y \
     ca-certificates \
     libssl3 \
     jq \
+    postgresql-client \
     && rm -rf /var/lib/apt/lists/*
 
 COPY --from=builder /usr/local/cargo/bin/sqlx /usr/local/bin/sqlx
 
 RUN mkdir /migrations
 
-COPY services/migrations/*.sql ./migrations
+COPY services/migrations/*.sql ./migrations/
+COPY services/migrations/run-migrations.sh /usr/local/bin/run-migrations
 
-CMD ["bash", "-c", "ENCODED_PASSWORD=$(printf '%s' \"$DATABASE_PASSWORD\" | jq -sRr @uri) && SSL_PARAM=$([ \"$DATABASE_SSL\" = \"true\" ] && echo \"?sslmode=require\" || echo \"\") && export DATABASE_URL=\"postgresql://${DATABASE_USERNAME}:${ENCODED_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}${SSL_PARAM}\" && sqlx migrate run"]
+RUN chmod +x /usr/local/bin/run-migrations
+
+CMD ["run-migrations"]

--- a/services/migrations/run-migrations.sh
+++ b/services/migrations/run-migrations.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ENCODED_PASSWORD=$(printf '%s' "$DATABASE_PASSWORD" | jq -sRr @uri)
+SSL_PARAM=$([ "${DATABASE_SSL:-false}" = "true" ] && echo "?sslmode=require" || echo "")
+export DATABASE_URL="postgresql://${DATABASE_USERNAME}:${ENCODED_PASSWORD}@${DATABASE_HOST}:${DATABASE_PORT}/${DATABASE_NAME}${SSL_PARAM}"
+
+MIGRATIONS_DIR="/migrations"
+PARADEDB_023_MIGRATION="$MIGRATIONS_DIR/085_upgrade_paradedb_to_0.23.1.sql"
+
+version_ge() {
+    local actual=${1%%-*}
+    local minimum=${2%%-*}
+    local actual_major actual_minor actual_patch minimum_major minimum_minor minimum_patch
+
+    IFS=. read -r actual_major actual_minor actual_patch <<< "$actual"
+    IFS=. read -r minimum_major minimum_minor minimum_patch <<< "$minimum"
+
+    actual_major=${actual_major:-0}
+    actual_minor=${actual_minor:-0}
+    actual_patch=${actual_patch:-0}
+    minimum_major=${minimum_major:-0}
+    minimum_minor=${minimum_minor:-0}
+    minimum_patch=${minimum_patch:-0}
+
+    if (( actual_major != minimum_major )); then
+        (( actual_major > minimum_major ))
+        return
+    fi
+    if (( actual_minor != minimum_minor )); then
+        (( actual_minor > minimum_minor ))
+        return
+    fi
+    (( actual_patch >= minimum_patch ))
+}
+
+pg_search_version=$(psql "$DATABASE_URL" -Atc "SELECT extversion FROM pg_extension WHERE extname = 'pg_search'" | tr -d '[:space:]')
+
+migration_table_exists=$(psql "$DATABASE_URL" -Atc "SELECT to_regclass('public._sqlx_migrations') IS NOT NULL" | tr -d '[:space:]')
+if [[ "$migration_table_exists" == "t" ]]; then
+    migration_85_recorded=$(psql "$DATABASE_URL" -Atc "SELECT EXISTS(SELECT 1 FROM public._sqlx_migrations WHERE version = 85)" | tr -d '[:space:]')
+else
+    migration_85_recorded="f"
+fi
+
+# Fresh installs on the ParadeDB 0.24+ image start with pg_search already at
+# 0.24+. Historical migration 085 upgrades pg_search from 0.20.6 to 0.23.1 and
+# intentionally rejects any other version. We cannot edit that migration because
+# it may already be applied in existing deployments and sqlx validates migration
+# checksums. For brand-new databases only, baseline migrations through 084, then
+# record 085 with its real checksum so sqlx will skip that obsolete downgrade
+# path and continue with 086+. Existing deployments that already applied 085, or
+# older deployments that still need 085 to upgrade from 0.20.6, continue through
+# the normal sqlx path below.
+if [[ -n "$pg_search_version" ]] && version_ge "$pg_search_version" "0.24.0" && [[ "$migration_85_recorded" == "f" ]]; then
+    sqlx migrate run --source "$MIGRATIONS_DIR" --target-version 84
+
+    checksum=$(sha384sum "$PARADEDB_023_MIGRATION" | awk '{print $1}')
+    psql "$DATABASE_URL" -v ON_ERROR_STOP=1 -c "
+        INSERT INTO public._sqlx_migrations (version, description, installed_on, success, checksum, execution_time)
+        VALUES (85, 'upgrade paradedb to 0.23.1', now(), true, decode('$checksum', 'hex'), 0)
+        ON CONFLICT (version) DO NOTHING
+    "
+fi
+
+sqlx migrate run --source "$MIGRATIONS_DIR"

--- a/shared/src/test_environment.rs
+++ b/shared/src/test_environment.rs
@@ -5,12 +5,12 @@ use anyhow::Result;
 use redis::Client as RedisClient;
 use sqlx::PgPool;
 use testcontainers::{
-    ContainerAsync, GenericImage, ImageExt,
     core::{ContainerPort, WaitFor},
     runners::AsyncRunner,
+    ContainerAsync, GenericImage, ImageExt,
 };
 use testcontainers_modules::{localstack::LocalStack, redis::Redis};
-use tokio::time::{Duration, sleep};
+use tokio::time::{sleep, Duration};
 
 use crate::{
     config::{DatabaseConfig, RedisConfig},
@@ -35,7 +35,7 @@ impl TestEnvironment {
         tracing_subscriber::fmt::try_init().ok();
 
         // Start PostgreSQL with pgvector and pg_bm25 extensions (ParadeDB image)
-        let postgres_image = GenericImage::new("paradedb/paradedb", "0.23.1-pg17")
+        let postgres_image = GenericImage::new("paradedb/paradedb", "0.24.0-pg17")
             .with_wait_for(WaitFor::message_on_stderr(
                 "database system is ready to accept connections",
             ))
@@ -220,9 +220,9 @@ impl MockAIServer {
     /// Start the mock AI server
     pub async fn start() -> Result<Self> {
         use axum::{
-            Router,
             response::Json,
             routing::{get, post},
+            Router,
         };
         use serde::{Deserialize, Serialize};
         use tokio::net::TcpListener;

--- a/web/src/lib/server/db/test-setup.ts
+++ b/web/src/lib/server/db/test-setup.ts
@@ -11,7 +11,7 @@ let sql: ReturnType<typeof postgres>
 let db: PostgresJsDatabase<typeof schema>
 
 export async function startTestDb(): Promise<PostgresJsDatabase<typeof schema>> {
-    container = await new PostgreSqlContainer('paradedb/paradedb:0.20.6-pg17').start()
+    container = await new PostgreSqlContainer('paradedb/paradedb:0.24.0-pg17').start()
 
     sql = postgres(container.getConnectionUri(), { max: 5 })
     db = drizzle(sql, { schema })


### PR DESCRIPTION
ParadeDB 0.24.0 adds WAL-backed crash recovery for pg_search buffers. This should prevent BM25 index corruption and stale heap references after Postgres crashes/OOM events, which caused search latency degradation on some instances.