### PR TITLE
fix(connector-manager): strip connector_state and checkpoint from /sources API response

### DIFF
--- a/connectors/imap/src/models.rs
+++ b/connectors/imap/src/models.rs
@@ -27,7 +27,10 @@ pub struct FolderSyncState {
     /// for deletion detection (`indexed_uids − server_uids`).
     #[serde(default)]
     pub indexed_uids: Vec<u32>,
-    /// Parsed message snapshots keyed by IMAP UID, used to rebuild thread docs.
+    /// Per-message metadata snapshots keyed by IMAP UID, used to rebuild thread
+    /// documents.  The message body (`ParsedEmail::body_text`) is intentionally
+    /// **not** persisted here; it is re-fetched from the IMAP server on demand
+    /// when a thread is rebuilt (see `SyncManager`'s `ensure_bodies_loaded`).
     #[serde(default)]
     pub messages: HashMap<u32, ParsedEmail>,
     /// UIDs that were intentionally skipped due to the `max_message_size` limit.
@@ -65,10 +68,18 @@ pub struct ParsedEmail {
     pub to: Vec<String>,
     pub cc: Vec<String>,
     pub date: Option<OffsetDateTime>,
+    /// The indexable message body.  Deliberately **not** persisted in the
+    /// connector checkpoint (`#[serde(skip)]`): bodies — especially once
+    /// extracted attachment text is appended — can be megabytes each, and
+    /// persisting one per indexed message blew `Source.connector_state` up to
+    /// >100 MB on large mailboxes.  Only lightweight metadata is checkpointed;
+    /// the body is re-fetched from the server when a thread document is rebuilt
+    /// (see `SyncManager`'s `ensure_bodies_loaded`).
+    #[serde(skip)]
     pub body_text: String,
     /// When true, `body_text` is raw HTML that must be converted via the
-    /// connector manager before indexing.
-    #[serde(default)]
+    /// connector manager before indexing.  Not persisted — see `body_text`.
+    #[serde(skip)]
     pub body_is_html: bool,
     #[serde(default)]
     pub flags: Vec<String>,

--- a/connectors/imap/src/sync.rs
+++ b/connectors/imap/src/sync.rs
@@ -35,6 +35,150 @@ fn is_connection_error(e: &anyhow::Error) -> bool {
     })
 }
 
+/// Run the HTML→text conversion and attachment-text extraction that turn a
+/// freshly parsed message into its final indexable body.  Shared by the
+/// new-message indexing pass and the on-demand body re-fetch used when
+/// rebuilding a thread document, so a re-fetched body is byte-for-byte
+/// identical to the one produced at first index time.
+async fn finalize_email_content(
+    ctx: &SyncContext,
+    sync_run_id: &str,
+    email: &mut ParsedEmail,
+    raw_attachments: Vec<crate::attachment::RawAttachment>,
+) {
+    // If the email body is HTML (no plain-text alternative), convert it via the
+    // connector manager so Docling is used when enabled.  On failure, fall back
+    // to the built-in HTML-to-text extractor so we never index raw HTML tags.
+    if email.body_is_html && !email.body_text.is_empty() {
+        match ctx
+            .sdk_client()
+            .extract_text(
+                sync_run_id,
+                email.body_text.as_bytes().to_vec(),
+                "text/html",
+                None,
+            )
+            .await
+        {
+            Ok(text) => {
+                email.body_text = text;
+                email.body_is_html = false;
+            }
+            Err(e) => {
+                warn!(
+                    "Failed to convert HTML body for UID {}: {}, using built-in fallback",
+                    email.imap_uid, e
+                );
+                let html_bytes = email.body_text.as_bytes();
+                email.body_text = omni_connector_sdk::content_extractor::extract_content(
+                    html_bytes,
+                    "text/html",
+                    None,
+                )
+                .unwrap_or_default();
+                email.body_is_html = false;
+            }
+        }
+    }
+
+    // Extract attachment text via the connector manager (supports Docling when
+    // enabled) and append to the email body.
+    for att in raw_attachments {
+        match ctx
+            .sdk_client()
+            .extract_text(sync_run_id, att.data, &att.mime_type, Some(&att.filename))
+            .await
+        {
+            Ok(text) if !text.trim().is_empty() => {
+                email.body_text.push_str("\n\n");
+                email
+                    .body_text
+                    .push_str(&format!("[Attachment: {}]\n", att.filename));
+                email.body_text.push_str(&text);
+            }
+            Ok(_) => {}
+            Err(e) => {
+                warn!(
+                    "Failed to extract attachment '{}' for UID {}: {}",
+                    att.filename, email.imap_uid, e
+                );
+            }
+        }
+    }
+}
+
+/// Ensure every UID in `uids` has its indexable body available in `messages`,
+/// re-fetching and re-processing it from the IMAP server when the stored
+/// snapshot only carries metadata (bodies are not persisted in the checkpoint).
+///
+/// `loaded` is a per-sync-run cache of UIDs whose body is already in memory, so
+/// a message is fetched at most once regardless of how many thread rebuilds
+/// reference it.  Connection-level fetch failures are propagated so the caller
+/// can abort and reconnect rather than emit a thread document with missing
+/// content; other failures (e.g. an individual message the server will not
+/// return) are logged and that message is left body-less, degrading it to
+/// headers only.
+async fn ensure_bodies_loaded(
+    session: &mut ImapSession,
+    ctx: &SyncContext,
+    folder: &str,
+    messages: &mut HashMap<u32, ParsedEmail>,
+    loaded: &mut HashSet<u32>,
+    uids: &[u32],
+) -> Result<()> {
+    let missing: Vec<u32> = uids
+        .iter()
+        .copied()
+        .filter(|uid| !loaded.contains(uid) && messages.contains_key(uid))
+        .collect();
+    if missing.is_empty() {
+        return Ok(());
+    }
+
+    let sync_run_id = ctx.sync_run_id();
+    for chunk in missing.chunks(FETCH_BATCH_SIZE) {
+        let raw_messages = match session.fetch_messages(chunk).await {
+            Ok(msgs) => msgs,
+            Err(e) => {
+                if is_connection_error(&e) {
+                    return Err(e.context(format!(
+                        "Connection lost while loading message bodies in folder '{}'",
+                        folder
+                    )));
+                }
+                warn!(
+                    "Failed to load bodies for thread rebuild in '{}': {}",
+                    folder, e
+                );
+                continue;
+            }
+        };
+
+        for raw in &raw_messages {
+            let (mut email, raw_attachments) = match parse_raw_email(&raw.data, raw.uid, folder) {
+                Ok(parsed) => parsed,
+                Err(e) => {
+                    warn!(
+                        "Failed to re-parse message UID {} in '{}' for thread rebuild: {}",
+                        raw.uid, folder, e
+                    );
+                    continue;
+                }
+            };
+            finalize_email_content(ctx, sync_run_id, &mut email, raw_attachments).await;
+            // Restore only the body onto the existing snapshot; its metadata
+            // (flags, threading headers) remains authoritative.
+            if let Some(existing) = messages.get_mut(&raw.uid) {
+                existing.body_text = email.body_text;
+                existing.body_is_html = email.body_is_html;
+            }
+            loaded.insert(raw.uid);
+        }
+    }
+
+    Ok(())
+}
+
 pub struct SyncManager;
 
 impl SyncManager {
@@ -334,6 +478,12 @@ impl SyncManager {
         let mut scanned = 0usize;
         let mut processed = 0usize;
 
+        // Per-folder cache of UIDs whose body is currently loaded in
+        // `folder_state.messages`.  Bodies are not persisted in the checkpoint,
+        // so this set ensures each message is re-fetched at most once per sync
+        // run while assembling thread documents.
+        let mut bodies_loaded: HashSet<u32> = HashSet::new();
+
         // Build message_id → UID index for thread root chain-walking.
         // Maintained incrementally as new messages are indexed.
         let mut by_message_id: HashMap<String, u32> = folder_state
@@ -419,67 +569,11 @@ impl SyncManager {
                 };
                 email.flags = raw.flags.clone();
 
-                // If the email body is HTML (no plain-text alternative), convert
-                // it via the connector manager so Docling is used when enabled.
-                // On failure, fall back to the built-in HTML-to-text extractor
-                // so we never index raw HTML tags.
-                if email.body_is_html && !email.body_text.is_empty() {
-                    match ctx
-                        .sdk_client()
-                        .extract_text(
-                            sync_run_id,
-                            email.body_text.as_bytes().to_vec(),
-                            "text/html",
-                            None,
-                        )
-                        .await
-                    {
-                        Ok(text) => {
-                            email.body_text = text;
-                            email.body_is_html = false;
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to convert HTML body for UID {}: {}, using built-in fallback",
-                                raw.uid, e
-                            );
-                            let html_bytes = email.body_text.as_bytes();
-                            email.body_text =
-                                omni_connector_sdk::content_extractor::extract_content(
-                                    html_bytes,
-                                    "text/html",
-                                    None,
-                                )
-                                .unwrap_or_default();
-                            email.body_is_html = false;
-                        }
-                    }
-                }
-
-                // Extract attachment text via the connector manager (supports
-                // Docling when enabled) and append to the email body.
-                for att in raw_attachments {
-                    match ctx
-                        .sdk_client()
-                        .extract_text(sync_run_id, att.data, &att.mime_type, Some(&att.filename))
-                        .await
-                    {
-                        Ok(text) if !text.trim().is_empty() => {
-                            email.body_text.push_str("\n\n");
-                            email
-                                .body_text
-                                .push_str(&format!("[Attachment: {}]\n", att.filename));
-                            email.body_text.push_str(&text);
-                        }
-                        Ok(_) => {}
-                        Err(e) => {
-                            warn!(
-                                "Failed to extract attachment '{}' for UID {}: {}",
-                                att.filename, raw.uid, e
-                            );
-                        }
-                    }
-                }
+                // Convert the HTML body (Docling-aware, via the connector
+                // manager) and append extracted attachment text.  Shared with
+                // the on-demand body re-fetch path so a re-fetched body matches
+                // what is produced here.
+                finalize_email_content(ctx, sync_run_id, &mut email, raw_attachments).await;
 
                 // Resolve canonical thread root with full chain-walking so that
                 // replies-to-replies without a References header are grouped
@@ -488,20 +582,37 @@ impl SyncManager {
                     resolve_new_email_thread_root(&email, &folder_state.messages, &by_message_id);
                 let thread_existed = thread_root_map.values().any(|r| r == &thread_root);
 
-                let mut thread_messages: Vec<ParsedEmail> = folder_state
+                // Already-indexed siblings of this thread, excluding the new
+                // message itself and any UID known to be deleted on the server
+                // (so the emitted document never includes stale content from
+                // messages about to be removed).
+                let sibling_uids: Vec<u32> = folder_state
                     .messages
                     .values()
                     .filter(|m| {
                         thread_root_map.get(&m.imap_uid) == Some(&thread_root)
-                            // Exclude UIDs already known to be deleted on the
-                            // server so the emitted document never includes
-                            // stale content from messages about to be removed.
                             && !deleted_uid_set.contains(&m.imap_uid)
+                            && m.imap_uid != email.imap_uid
                     })
-                    .cloned()
+                    .map(|m| m.imap_uid)
                     .collect();
-                // Defensive: ensure the new email's UID is not already in the slice.
-                thread_messages.retain(|m| m.imap_uid != email.imap_uid);
+                // Bodies are not persisted in the checkpoint, so re-load any
+                // sibling whose snapshot is metadata-only before assembling the
+                // thread document.
+                ensure_bodies_loaded(
+                    session,
+                    ctx,
+                    folder,
+                    &mut folder_state.messages,
+                    &mut bodies_loaded,
+                    &sibling_uids,
+                )
+                .await?;
+
+                let mut thread_messages: Vec<ParsedEmail> = sibling_uids
+                    .iter()
+                    .filter_map(|uid| folder_state.messages.get(uid).cloned())
+                    .collect();
                 thread_messages.push(email.clone());
 
                 let content = generate_thread_content(&thread_messages);
@@ -545,6 +656,9 @@ impl SyncManager {
                 // On full syncs, indexed_uids was cleared before this pass; no duplicate can exist.
                 folder_state.indexed_uids.push(raw.uid);
                 folder_state.messages.insert(raw.uid, email);
+                // The freshly indexed message's body is in memory; record it so
+                // a later thread rebuild this run does not re-fetch it.
+                bodies_loaded.insert(raw.uid);
                 processed += 1;
             }
 
@@ -617,14 +731,32 @@ impl SyncManager {
                         if ctx.is_cancelled() {
                             break;
                         }
-                        let thread_messages: Vec<ParsedEmail> = folder_state
+                        let member_uids: Vec<u32> = folder_state
                             .messages
                             .values()
                             .filter(|m| {
                                 thread_root_map.get(&m.imap_uid).map(String::as_str)
                                     == Some(&thread_root)
                             })
-                            .cloned()
+                            .map(|m| m.imap_uid)
+                            .collect();
+                        if member_uids.is_empty() {
+                            continue;
+                        }
+                        // Re-load bodies (metadata-only in the checkpoint) before
+                        // rebuilding the thread document.
+                        ensure_bodies_loaded(
+                            session,
+                            ctx,
+                            folder,
+                            &mut folder_state.messages,
+                            &mut bodies_loaded,
+                            &member_uids,
+                        )
+                        .await?;
+                        let thread_messages: Vec<ParsedEmail> = member_uids
+                            .iter()
+                            .filter_map(|uid| folder_state.messages.get(uid).cloned())
                             .collect();
                         if thread_messages.is_empty() {
                             continue;
@@ -698,23 +830,38 @@ impl SyncManager {
                     deleted_message.thread_id()
                 }
             };
-            let remaining_messages: Vec<ParsedEmail> = folder_state
+            let remaining_uids: Vec<u32> = folder_state
                 .messages
                 .values()
                 .filter(|m| {
                     thread_root_map.get(&m.imap_uid).map(String::as_str) == Some(&thread_root)
                         && m.imap_uid != uid
                 })
-                .cloned()
+                .map(|m| m.imap_uid)
                 .collect();
 
-            let event = if remaining_messages.is_empty() {
+            let event = if remaining_uids.is_empty() {
                 ConnectorEvent::DocumentDeleted {
                     sync_run_id: sync_run_id.to_string(),
                     source_id: source_id.to_string(),
                     document_id: make_thread_document_id(folder, &thread_root),
                 }
             } else {
+                // Re-load bodies (metadata-only in the checkpoint) for the
+                // surviving thread members before rebuilding the document.
+                ensure_bodies_loaded(
+                    session,
+                    ctx,
+                    folder,
+                    &mut folder_state.messages,
+                    &mut bodies_loaded,
+                    &remaining_uids,
+                )
+                .await?;
+                let remaining_messages: Vec<ParsedEmail> = remaining_uids
+                    .iter()
+                    .filter_map(|member_uid| folder_state.messages.get(member_uid).cloned())
+                    .collect();
                 let content = generate_thread_content(&remaining_messages);
                 let content_id = match ctx.store_content(&content).await {
                     Ok(id) => id,

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -9,7 +9,7 @@ use crate::models::{
 use anyhow::{Context, Result};
 use axum::{
     Router,
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Path, State},
     http::StatusCode,
     middleware,
     response::{IntoResponse, Json, Response},
@@ -171,6 +171,7 @@ where
         .route("/prompt", post(get_prompt::<C>));
 
     router
+        .layer(DefaultBodyLimit::disable())
         .layer(
             ServiceBuilder::new()
                 .layer(middleware::from_fn(telemetry::middleware::trace_layer))

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -231,7 +231,7 @@ pub async fn list_sources(
 ) -> Result<Json<Vec<SourceSyncOverview>>, ApiError> {
     let source_repo = SourceRepository::new(state.db_pool.pool());
     let sources = source_repo
-        .find_all_sources()
+        .find_all_sources_without_state()
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 
@@ -299,11 +299,19 @@ async fn build_source_sync_overviews(
                 } else {
                     SourceHealth::Healthy
                 };
-            let sync_runs = sync_runs.into_iter().take(10).collect();
+            let sync_runs: Vec<SyncRun> = sync_runs
+                .into_iter()
+                .take(10)
+                .map(|run| SyncRun { checkpoint: None, ..run })
+                .collect();
 
             SourceSyncOverview {
                 sync_runs,
-                source,
+                source: Source {
+                    connector_state: None,
+                    checkpoint: None,
+                    ..source
+                },
                 health,
             }
         })

--- a/shared/src/db/repositories/source.rs
+++ b/shared/src/db/repositories/source.rs
@@ -48,6 +48,27 @@ impl SourceRepository {
         Ok(sources)
     }
 
+    /// Like `find_all_sources` but skips `connector_state` and `checkpoint`,
+    /// which can be tens of MB per source. Use this for list/overview endpoints
+    /// that strip those fields before responding.
+    pub async fn find_all_sources_without_state(&self) -> Result<Vec<Source>, DatabaseError> {
+        let sources = sqlx::query_as::<_, Source>(
+            r#"
+            SELECT id, name, source_type, config, is_active, is_deleted, scope,
+                   user_filter_mode, user_whitelist, user_blacklist,
+                   NULL::jsonb AS connector_state, NULL::jsonb AS checkpoint,
+                   sync_interval_seconds, created_at, updated_at, created_by
+            FROM sources
+            WHERE is_deleted = false
+            ORDER BY created_at DESC
+            "#,
+        )
+        .fetch_all(&self.pool)
+        .await?;
+
+        Ok(sources)
+    }
+
     pub async fn find_active_sources(&self) -> Result<Vec<Source>, DatabaseError> {
         let sources = sqlx::query_as::<_, Source>(
             r#"

--- a/shared/src/db/repositories/sync_run.rs
+++ b/shared/src/db/repositories/sync_run.rs
@@ -523,9 +523,11 @@ impl SyncRunRepository {
             r#"
             SELECT id, source_id, sync_type, started_at, completed_at, status, trigger_type,
                    documents_scanned, documents_processed, documents_updated, error_message,
-                   checkpoint, created_at, updated_at
+                   NULL::jsonb AS checkpoint, created_at, updated_at
             FROM (
-                SELECT sr.*,
+                SELECT sr.id, sr.source_id, sr.sync_type, sr.started_at, sr.completed_at,
+                       sr.status, sr.trigger_type, sr.documents_scanned, sr.documents_processed,
+                       sr.documents_updated, sr.error_message, sr.created_at, sr.updated_at,
                        ROW_NUMBER() OVER (
                            PARTITION BY source_id
                            ORDER BY started_at DESC, created_at DESC


### PR DESCRIPTION
## Problem

Visiting `/admin/settings/integrations` caused multiple compounding failures:

1. **Node.js heap OOM crash** — `GET /sources` on the connector manager returned ~127 MB. IMAP `connector_state` fields (42 MB + 15 MB) and `SyncRun.checkpoint` fields (970 KB × 10 runs for Nextcloud) were serialized verbatim into the API response, exhausting the SvelteKit SSR heap.

2. **6–10 second page load** — Even after fixing the response size, the endpoint still took 4+ seconds because `find_all_sources()` selected `connector_state` and `checkpoint` from the sources table. PostgreSQL decompresses TOAST values before transfer; sqlx then JSON-parses them into `serde_json::Value`. This transferred and parsed ~116 MB on every request.

3. **IMAP connectors permanently unhealthy** — The connector manager embeds `source.checkpoint` (42 MB) in the `SyncRequest` body it POSTs to each connector's `/sync` endpoint. Axum's default 2 MB body limit in the SDK server rejected every IMAP sync with HTTP 413.

4. **120 MB Postgres → connector-manager transfer per request** — `list_runs_for_sync_types` used `SELECT sr.*` inside a window-function subquery, pulling `checkpoint` (~970 KB/run × 700 runs) even though neither the health evaluator nor the response uses it.

5. **Root cause of the IMAP checkpoint bloat** — the IMAP connector was using `connector_state` as a message-body cache: each indexed message's fully-processed body (inline text + extracted attachment text) was persisted in `FolderSyncState.messages`, which is what produced the 42 MB checkpoints in (1)/(3) on large mailboxes.

## Fix

| Location | Change |
|---|---|
| `shared/src/db/repositories/source.rs` | Add `find_all_sources_without_state()` — returns `NULL::jsonb` for `connector_state` and `checkpoint`, avoiding TOAST decompression |
| `services/connector-manager/src/handlers.rs` | `list_sources` uses the new lightweight query; `build_source_sync_overviews` strips `connector_state`/`checkpoint` from both `Source` and `SyncRun` before serializing |
| `shared/src/db/repositories/sync_run.rs` | `list_runs_for_sync_types` replaces `SELECT sr.*` with an explicit column list and `NULL::jsonb AS checkpoint` |
| `sdk/rust/src/server.rs` | Add `DefaultBodyLimit::disable()` to the connector SDK router — consistent with the connector manager's own server |
| `connectors/imap/src/models.rs`, `connectors/imap/src/sync.rs` | Stop persisting message bodies in the checkpoint at all (root-cause fix for #1/#3, not just a symptom workaround): `ParsedEmail.body_text`/`body_is_html` are now `#[serde(skip)]`, so `connector_state` only stores lightweight per-message metadata. When a thread document needs rebuilding (new message in the thread, a flag change, or a deletion), the bodies of the thread's other messages are re-fetched from the IMAP server via a new `ensure_bodies_loaded`, with a per-sync-run cache so each message is fetched at most once. A connection error during a re-fetch aborts the folder (retried next run); a single message the server won't return degrades to headers-only and self-heals later. |

## Test plan

- [ ] Visit `/admin/settings/integrations`
- [ ] `GET /sources` response is under 20 KB
- [ ] IMAP sync runs to completion and existing oversized checkpoints shrink on the next save
- [ ] A thread with a new reply, a flag change, or a deletion still rebuilds with full body content for all thread members