### PR TITLE
fix(connectors): hide nextcloud/imap actions from all chat tools

### DIFF
--- a/connectors/atlassian/src/connector.rs
+++ b/connectors/atlassian/src/connector.rs
@@ -77,6 +77,7 @@ impl Connector for AtlassianConnector {
             mode: ActionMode::Read,
             source_types: Vec::new(),
             admin_only: true,
+            hidden: false,
         }]
     }
 

--- a/connectors/filesystem/src/connector.rs
+++ b/connectors/filesystem/src/connector.rs
@@ -66,6 +66,7 @@ impl Connector for FileSystemConnector {
             }),
             source_types: Vec::new(),
             admin_only: false,
+            hidden: false,
         }]
     }
 

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -429,6 +429,7 @@ impl Connector for GoogleConnector {
                 }),
                 source_types: vec![SourceType::GoogleDrive, SourceType::Gmail],
                 admin_only: false,
+                hidden: false,
             },
             ActionDefinition {
                 name: "search_users".to_string(),
@@ -445,6 +446,7 @@ impl Connector for GoogleConnector {
                 }),
                 source_types: vec![SourceType::GoogleDrive],
                 admin_only: true,
+                hidden: false,
             },
         ]
     }

--- a/connectors/imap/src/connector.rs
+++ b/connectors/imap/src/connector.rs
@@ -92,16 +92,12 @@ impl Connector for ImapConnector {
                     },
                     "required": ["host"]
                 }),
-                // Hide this action from EVERY chat/MCP tool surface, admins included.
-                // The AI chat tool builder (connector_handler) and the
-                // connector-manager `list_actions` endpoint only surface an action
-                // when the source's type is listed in `source_types`. A sentinel type
-                // this connector never serves (any non-IMAP variant) drops it from
-                // every tool list for all users, before `admin_only` is consulted.
-                // It stays in the manifest (Read mode) and is still dispatchable by
-                // name; these are setup/util actions with no chat-facing use.
-                source_types: vec![SourceType::Linear],
+                // Setup/util action with no chat-facing use: hidden from every
+                // chat/MCP tool surface, admins included, but still in the
+                // manifest (Read mode) and dispatchable by name.
+                source_types: Vec::new(),
                 admin_only: false,
+                hidden: true,
             },
             ActionDefinition {
                 name: "list_folders".to_string(),
@@ -116,16 +112,12 @@ impl Connector for ImapConnector {
                     },
                     "required": ["host"]
                 }),
-                // Hide this action from EVERY chat/MCP tool surface, admins included.
-                // The AI chat tool builder (connector_handler) and the
-                // connector-manager `list_actions` endpoint only surface an action
-                // when the source's type is listed in `source_types`. A sentinel type
-                // this connector never serves (any non-IMAP variant) drops it from
-                // every tool list for all users, before `admin_only` is consulted.
-                // It stays in the manifest (Read mode) and is still dispatchable by
-                // name; these are setup/util actions with no chat-facing use.
-                source_types: vec![SourceType::Linear],
+                // Setup/util action with no chat-facing use: hidden from every
+                // chat/MCP tool surface, admins included, but still in the
+                // manifest (Read mode) and dispatchable by name.
+                source_types: Vec::new(),
                 admin_only: false,
+                hidden: true,
             },
         ]
     }

--- a/connectors/imap/src/connector.rs
+++ b/connectors/imap/src/connector.rs
@@ -92,7 +92,15 @@ impl Connector for ImapConnector {
                     },
                     "required": ["host"]
                 }),
-                source_types: Vec::new(),
+                // Hide this action from EVERY chat/MCP tool surface, admins included.
+                // The AI chat tool builder (connector_handler) and the
+                // connector-manager `list_actions` endpoint only surface an action
+                // when the source's type is listed in `source_types`. A sentinel type
+                // this connector never serves (any non-IMAP variant) drops it from
+                // every tool list for all users, before `admin_only` is consulted.
+                // It stays in the manifest (Read mode) and is still dispatchable by
+                // name; these are setup/util actions with no chat-facing use.
+                source_types: vec![SourceType::Linear],
                 admin_only: false,
             },
             ActionDefinition {
@@ -108,7 +116,15 @@ impl Connector for ImapConnector {
                     },
                     "required": ["host"]
                 }),
-                source_types: Vec::new(),
+                // Hide this action from EVERY chat/MCP tool surface, admins included.
+                // The AI chat tool builder (connector_handler) and the
+                // connector-manager `list_actions` endpoint only surface an action
+                // when the source's type is listed in `source_types`. A sentinel type
+                // this connector never serves (any non-IMAP variant) drops it from
+                // every tool list for all users, before `admin_only` is consulted.
+                // It stays in the manifest (Read mode) and is still dispatchable by
+                // name; these are setup/util actions with no chat-facing use.
+                source_types: vec![SourceType::Linear],
                 admin_only: false,
             },
         ]

--- a/connectors/nextcloud/src/connector.rs
+++ b/connectors/nextcloud/src/connector.rs
@@ -116,6 +116,7 @@ impl Connector for NextcloudConnector {
                 mode: omni_connector_sdk::ActionMode::Read,
                 source_types: Vec::new(),
                 admin_only: false,
+                hidden: false,
             },
             ActionDefinition {
                 name: "fetch_file".into(),
@@ -131,17 +132,12 @@ impl Connector for NextcloudConnector {
                     "required": ["file_id"]
                 }),
                 mode: omni_connector_sdk::ActionMode::Read,
-                // Hide this action from EVERY chat/MCP tool surface, admins included.
-                // The AI chat tool builder (connector_handler) and the
-                // connector-manager `list_actions` endpoint only surface an action
-                // when the source's type is listed in `source_types`. Pointing it at
-                // a type this connector never serves (a sentinel — any non-Nextcloud
-                // variant works) drops it from every tool list for all users, before
-                // `admin_only` is ever consulted, so admins cannot see it either.
-                // The action still lives in the manifest with Read mode, so
-                // connector-manager keeps dispatching it BY NAME for setup and the
-                // internal read_document binary fetch, and the read-only guard passes.
-                source_types: vec![SourceType::Linear],
+                source_types: Vec::new(),
+                // Internal action with no chat-facing use: hidden from every
+                // chat/MCP tool surface, admins included, but still in the
+                // manifest (Read mode) and dispatchable by name for the
+                // internal read_document binary fetch.
+                hidden: true,
                 // Route /action dispatch to the org credential so the internal
                 // read_document binary fetch keeps working for org-level agents and
                 // non-admin users (Nextcloud has only an org basic-auth credential;

--- a/connectors/nextcloud/src/connector.rs
+++ b/connectors/nextcloud/src/connector.rs
@@ -131,8 +131,22 @@ impl Connector for NextcloudConnector {
                     "required": ["file_id"]
                 }),
                 mode: omni_connector_sdk::ActionMode::Read,
-                source_types: Vec::new(),
-                admin_only: false,
+                // Hide this action from EVERY chat/MCP tool surface, admins included.
+                // The AI chat tool builder (connector_handler) and the
+                // connector-manager `list_actions` endpoint only surface an action
+                // when the source's type is listed in `source_types`. Pointing it at
+                // a type this connector never serves (a sentinel — any non-Nextcloud
+                // variant works) drops it from every tool list for all users, before
+                // `admin_only` is ever consulted, so admins cannot see it either.
+                // The action still lives in the manifest with Read mode, so
+                // connector-manager keeps dispatching it BY NAME for setup and the
+                // internal read_document binary fetch, and the read-only guard passes.
+                source_types: vec![SourceType::Linear],
+                // Route /action dispatch to the org credential so the internal
+                // read_document binary fetch keeps working for org-level agents and
+                // non-admin users (Nextcloud has only an org basic-auth credential;
+                // there is no per-user OAuth flow to satisfy).
+                admin_only: true,
             },
         ]
     }

--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -142,6 +142,9 @@ class ActionDefinition(BaseModel):
     # Revisit if/when we generate Python types from the Rust models.
     source_types: list[str] = Field(default_factory=list)
     admin_only: bool = False
+    # Hidden from every chat/agent tool surface, admins included (unlike
+    # admin_only, not bypassed for admin users). Still dispatchable by name.
+    hidden: bool = False
 
 
 class SearchOperator(BaseModel):

--- a/sdk/rust/src/mcp_adapter.rs
+++ b/sdk/rust/src/mcp_adapter.rs
@@ -474,6 +474,7 @@ async fn fetch_actions(client: &RmcpClient) -> Result<Vec<ActionDefinition>> {
             },
             source_types: Vec::new(),
             admin_only: false,
+            hidden: false,
         });
     }
     Ok(actions)

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -49,6 +49,7 @@ class ConnectorAction:
     input_schema: dict
     mode: SourceMode
     admin_only: bool = False
+    hidden: bool = False
 
 
 class ConnectorToolHandler:
@@ -204,6 +205,7 @@ class ConnectorToolHandler:
                             ),
                             mode=action_def.get("mode", "write"),
                             admin_only=action_def.get("admin_only", False),
+                            hidden=action_def.get("hidden", False),
                         )
                     )
 
@@ -219,6 +221,11 @@ class ConnectorToolHandler:
 
         seen_tools: set[str] = set()
         for action in actions:
+            # Hidden actions (e.g. internal setup actions) never appear in
+            # chat/agent tool lists, admins included.
+            if action.hidden:
+                continue
+
             # Hide admin-only actions (e.g. admin-directory ops) from non-admins.
             if action.admin_only and not self._is_admin:
                 continue

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -684,6 +684,9 @@ pub async fn list_actions(
                 if !action.source_types.is_empty() && !action.source_types.contains(source_type) {
                     continue;
                 }
+                if action.hidden {
+                    continue;
+                }
                 all_actions.push(json!({
                     "source_type": source_type,
                     "name": action.name,
@@ -2245,6 +2248,7 @@ mod tests {
                 mode: ActionMode::Read,
                 source_types: Vec::new(),
                 admin_only: false,
+                hidden: false,
             }],
             search_operators: Vec::new(),
             read_only: false,

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -381,8 +381,16 @@ pub struct ActionDefinition {
     pub source_types: Vec<SourceType>,
     /// Hide this action from non-admin users in LLM tool exposure (e.g.
     /// admin-directory ops that require a service-account credential).
+    /// Also consulted at dispatch time to resolve credentials (see
+    /// `resolve_credentials` in connector-manager), independent of `hidden`.
     #[serde(default)]
     pub admin_only: bool,
+    /// Exclude this action from every chat/agent tool surface, admins
+    /// included (e.g. setup/internal actions with no chat-facing use).
+    /// Unlike `admin_only`, this is not bypassed for admin users. The
+    /// action remains in the manifest and dispatchable by name.
+    #[serde(default)]
+    pub hidden: bool,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]


### PR DESCRIPTION
## Problem

Nextcloud and IMAP authenticate with a single **org-level basic-auth credential** and have **no per-user OAuth flow**. Their connector actions (`nextcloud__fetch_file`, `imap__validate_credentials`, `imap__list_folders`) were advertised as chat tools.

When the chat model invoked one, the call ran user-scoped and dead-ended in the connector-manager credential gate: `resolve_credentials` found no per-user credential, saw the org row, and returned `NeedsUserAuth` → the UI rendered a **"Connection required"** card that can never be satisfied (there is no OAuth app client for these sources). The model wasted turns trying to "open" files whose content was already in context via search/`read_document`.

## Fix

Added a dedicated `ActionDefinition.hidden: bool` field (`shared/src/models.rs`) that excludes an action from **every** chat/agent tool surface unconditionally, admins included — checked in both chat-tool-list-building surfaces, the AI service's `connector_handler` (`_build_tools`) and the connector-manager `list_actions` endpoint.

This replaces an earlier approach (pointing `source_types` at a sentinel type the connector never serves) that a reviewer correctly flagged as fragile and indirect. `hidden` is a separate concern from `admin_only`, which keeps its existing meaning — visible to admins in chat, hidden from non-admins — and its separate role in dispatch-time credential resolution (org vs per-user) in connector-manager. The two concerns (chat visibility vs. credential routing) are now cleanly orthogonal booleans rather than overloading one field.

The actions stay in the manifest with `Read` mode and real `source_types`, so connector-manager still **dispatches them by name** for setup (`validate_credentials`) and the internal `read_document` binary fetch (`fetch_file`), and passes the read-only guard.

Nextcloud `fetch_file` is additionally marked `admin_only: true` so `/action` dispatch resolves the **org credential**, keeping `read_document`'s internal binary fetch working for org-level agents and non-admin users.

## Scope

- `shared/src/models.rs`: new `ActionDefinition.hidden` field
- `connectors/nextcloud/src/connector.rs`: `fetch_file` → `hidden: true`
- `connectors/imap/src/connector.rs`: `validate_credentials`, `list_folders` → `hidden: true`
- `connectors/google/src/connector.rs`, `connectors/atlassian/src/connector.rs`, `connectors/filesystem/src/connector.rs`, `sdk/rust/src/mcp_adapter.rs`: add `hidden: false` to existing `ActionDefinition` literals (new required field)
- `sdk/python/omni_connector/models.py`: `ActionDefinition.hidden: bool = False`
- `services/ai/tools/connector_handler.py`: `ConnectorAction.hidden`, checked first (and unconditionally) in `_build_tools`
- `services/connector-manager/src/handlers.rs`: `list_actions` excludes `hidden` actions from the response

## Notes

- Hides the actions for all chat users, including admins.
- Takes effect once connectors are re-registered (new manifest) and the per-user `actions:{user_id}` Redis cache expires.