### PR TITLE
feat(chat): decouple LLM generation from browser connection via Redis stream

### DIFF
--- a/services/ai/db/messages.py
+++ b/services/ai/db/messages.py
@@ -9,6 +9,25 @@ from .models import ChatMessage
 from .connection import get_db_pool
 
 
+def _extract_content_text(message: Dict[str, Any]) -> Optional[str]:
+    """Plain-text projection of a message for search/title. Mirrors omni-web's
+    extractContentText so rows written here match those written by the web."""
+    if message.get("role") not in ("user", "assistant"):
+        return None
+    content = message.get("content")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            b.get("text", "")
+            for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        joined = "\n".join(p for p in parts if p)
+        return joined or None
+    return None
+
+
 class MessagesRepository:
     def __init__(self, pool: Optional[Pool] = None):
         self.pool = pool
@@ -46,17 +65,25 @@ class MessagesRepository:
             WHERE chat_id = $1
         """
 
+        content_text = _extract_content_text(message)
+
         async with pool.acquire() as conn:
             next_seq = await conn.fetchval(seq_query, chat_id)
 
             query = """
-                INSERT INTO chat_messages (id, chat_id, message_seq_num, message, parent_id, created_at)
-                VALUES ($1, $2, $3, $4, $5, NOW())
+                INSERT INTO chat_messages (id, chat_id, message_seq_num, message, parent_id, content_text, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, NOW())
                 RETURNING id, chat_id, message_seq_num, message, parent_id, created_at
             """
 
             row = await conn.fetchrow(
-                query, message_id, chat_id, next_seq, json.dumps(message), parent_id
+                query,
+                message_id,
+                chat_id,
+                next_seq,
+                json.dumps(message),
+                parent_id,
+                content_text,
             )
 
         return ChatMessage.from_row(dict(row))

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -108,7 +108,10 @@ def _sse_event(event_type: str, data: object) -> str:
 SSE_HEADERS = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
 
 _STREAM_HEARTBEAT_MS = 15000  # idle ping interval (keeps proxies from timing out)
-_RUN_LOCK_TTL = 300  # seconds; refreshed on every produced event
+_RUN_LOCK_TTL = 300  # seconds; refreshed on every produced event and by the heartbeat below
+_LOCK_REFRESH_INTERVAL = 60  # seconds; independent of event production, so a long
+# silent gap in the agent loop (e.g. a slow tool call with no intermediate SSE
+# events) can't let the lock expire while the producer is still running.
 _STREAM_TTL = 300  # seconds a finished stream stays replayable
 _STREAM_MAXLEN = 5000  # cap buffered events per run
 _CANCEL_TTL = 300
@@ -172,11 +175,22 @@ async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
         yield event_str
 
 
+async def _refresh_lock_periodically(redis_client, lock_key):
+    """Keep the run lock alive independently of event production, so a long
+    silent gap in the agent loop doesn't let it expire mid-run."""
+    while True:
+        await asyncio.sleep(_LOCK_REFRESH_INTERVAL)
+        await redis_client.expire(lock_key, _RUN_LOCK_TTL)
+
+
 async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
     """Background task: drive the agent loop to completion independently of any
     client connection, buffering every SSE event in a Redis Stream."""
     stream_key = _stream_key(chat_id)
     lock_key = _run_lock_key(chat_id)
+    refresh_task = asyncio.create_task(
+        _refresh_lock_periodically(redis_client, lock_key)
+    )
     try:
         async for event_str in _persist_and_transform(
             gen, chat_id, messages_repo, parent_id
@@ -198,6 +212,11 @@ async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
         except Exception:
             pass
     finally:
+        refresh_task.cancel()
+        try:
+            await refresh_task
+        except asyncio.CancelledError:
+            pass
         for coro in (
             redis_client.expire(stream_key, _STREAM_TTL),
             redis_client.delete(lock_key),

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -97,6 +97,155 @@ def _sse_event(event_type: str, data: object) -> str:
     return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
 
 
+# --- Decoupled streaming run (survives client disconnect; supports resume) ---
+# The agent loop runs as a background "producer" that writes each SSE event into
+# a per-chat Redis Stream. HTTP requests are thin "consumers" that tail that
+# stream from an offset (SSE Last-Event-ID), so a client that backgrounds/
+# reconnects resumes without interrupting generation. The producer is the single
+# DB writer of the streaming path (persists messages, then emits `message_id`),
+# which keeps replays free of duplicate writes.
+
+SSE_HEADERS = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
+
+_STREAM_HEARTBEAT_MS = 15000  # idle ping interval (keeps proxies from timing out)
+_RUN_LOCK_TTL = 300  # seconds; refreshed on every produced event
+_STREAM_TTL = 300  # seconds a finished stream stays replayable
+_STREAM_MAXLEN = 5000  # cap buffered events per run
+_CANCEL_TTL = 300
+
+_background_run_tasks: set[asyncio.Task] = set()
+
+
+def _stream_key(chat_id: str) -> str:
+    return f"chat:stream:{chat_id}"
+
+
+def _run_lock_key(chat_id: str) -> str:
+    return f"chat:runlock:{chat_id}"
+
+
+def _cancel_key(chat_id: str) -> str:
+    return f"chat:cancel:{chat_id}"
+
+
+async def _is_run_cancelled(redis_client, chat_id: str) -> bool:
+    if redis_client is None:
+        return False
+    try:
+        return bool(await redis_client.exists(_cancel_key(chat_id)))
+    except Exception:
+        return False
+
+
+def _sse_event_type(event_str: str) -> str:
+    for line in event_str.split("\n"):
+        if line.startswith("event:"):
+            return line[len("event:") :].strip()
+    return "message"
+
+
+def _sse_event_data(event_str: str) -> str:
+    for line in event_str.split("\n"):
+        if line.startswith("data:"):
+            return line[len("data:") :].strip()
+    return ""
+
+
+async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
+    """Persist assistant/tool_result messages (single writer of the streaming
+    path) and replace each internal `save_message` event with a client-facing
+    `message_id` event. Deterministic parent_id chaining makes replays safe."""
+    async for event_str in gen:
+        if _sse_event_type(event_str) == "save_message":
+            try:
+                message = json.loads(_sse_event_data(event_str))
+                created = await messages_repo.create(
+                    chat_id, message, parent_id=parent_id
+                )
+                parent_id = created.id
+                yield f"event: message_id\ndata: {created.id}\n\n"
+            except Exception as e:
+                logger.error(
+                    f"Failed to persist streamed message for chat {chat_id}: {e}"
+                )
+            continue
+        yield event_str
+
+
+async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
+    """Background task: drive the agent loop to completion independently of any
+    client connection, buffering every SSE event in a Redis Stream."""
+    stream_key = _stream_key(chat_id)
+    lock_key = _run_lock_key(chat_id)
+    try:
+        async for event_str in _persist_and_transform(
+            gen, chat_id, messages_repo, parent_id
+        ):
+            await redis_client.xadd(
+                stream_key,
+                {"e": event_str},
+                maxlen=_STREAM_MAXLEN,
+                approximate=True,
+            )
+            await redis_client.expire(lock_key, _RUN_LOCK_TTL)
+    except Exception as e:
+        logger.error(f"Producer failed for chat {chat_id}: {e}", exc_info=True)
+        try:
+            await redis_client.xadd(
+                stream_key,
+                {"e": _sse_event("stream_error", {"message": _chat_error_message(e)})},
+            )
+        except Exception:
+            pass
+    finally:
+        for coro in (
+            redis_client.expire(stream_key, _STREAM_TTL),
+            redis_client.delete(lock_key),
+            redis_client.delete(_cancel_key(chat_id)),
+        ):
+            try:
+                await coro
+            except Exception:
+                pass
+
+
+async def _consume_run(redis_client, chat_id, start_id):
+    """Thin consumer: tail the Redis Stream from `start_id`, prefixing each event
+    with its Redis id (SSE `id:`) for Last-Event-ID resume. Emits heartbeats
+    while idle and a terminal event if the producer vanished."""
+    stream_key = _stream_key(chat_id)
+    lock_key = _run_lock_key(chat_id)
+    last = start_id or "0"
+    while True:
+        resp = await redis_client.xread(
+            {stream_key: last}, block=_STREAM_HEARTBEAT_MS, count=200
+        )
+        if resp:
+            for _key, entries in resp:
+                for entry_id, fields in entries:
+                    last = entry_id
+                    event_str = fields.get("e", "")
+                    yield f"id: {entry_id}\n{event_str}"
+                    if _sse_event_type(event_str) in ("end_of_stream", "stream_error"):
+                        return
+            continue
+        # Idle: no new events within the heartbeat window.
+        if not await redis_client.exists(stream_key):
+            if await redis_client.exists(lock_key):
+                # Producer just started and hasn't written its first event yet.
+                yield ": ping\n\n"
+                continue
+            yield "event: not_resumable\ndata: \n\n"
+            return
+        if not await redis_client.exists(lock_key):
+            # Producer is gone but never wrote a terminal event we forwarded.
+            yield _sse_event(
+                "stream_error", {"message": "Generation ended unexpectedly."}
+            )
+            return
+        yield ": ping\n\n"
+
+
 def _resolve_provider(state: AppState, model_id: str | None) -> LLMProvider:
     """Resolve a model by ID, returning the provider.
     Priority: requested model -> default model -> first available.
@@ -490,6 +639,24 @@ async def stream_chat(
 
     llm_provider = _resolve_llm_provider(request.app.state, chat)
     redis_client = getattr(request.app.state, "redis_client", None)
+
+    # Reconnect/resume fast path: if a buffered run already exists for this chat,
+    # attach to it (tail from the client's offset) and skip all (re)setup so we
+    # never re-run registry build / compaction / tools on a reconnect.
+    last_event_id = request.headers.get("last-event-id") or request.query_params.get(
+        "last_event_id"
+    )
+    if (
+        redis_client is not None
+        and last_event_id is not None
+        and await redis_client.exists(_stream_key(chat_id))
+    ):
+        return StreamingResponse(
+            _consume_run(redis_client, chat_id, last_event_id),
+            media_type="text/event-stream",
+            headers=SSE_HEADERS,
+        )
+
     messages_repo = MessagesRepository()
     chat_messages = await messages_repo.get_active_path(chat_id)
 
@@ -937,11 +1104,11 @@ async def stream_chat(
             usage_repo = UsageRepository()
 
             for iteration in range(AGENT_MAX_ITERATIONS):
-                # Check if client disconnected before starting expensive operations
-                if await request.is_disconnected():
-                    logger.info(
-                        f"Client disconnected, stopping stream for chat {chat_id}"
-                    )
+                # Stop only on an explicit user cancel (Stop button). The run is
+                # decoupled from the client connection, so a backgrounded tab no
+                # longer aborts generation.
+                if await _is_run_cancelled(redis_client, chat_id):
+                    logger.info(f"Run cancelled, stopping stream for chat {chat_id}")
                     break
 
                 logger.info(f"Iteration {iteration + 1}/{AGENT_MAX_ITERATIONS}")
@@ -982,9 +1149,18 @@ async def stream_chat(
 
                 event_index = 0
                 message_stop_received = False
+                cancelled = False
                 async for event in stream:
                     logger.debug(f"Received event: {event} (index: {event_index})")
                     event_index += 1
+
+                    # Responsive Stop: poll the cancel flag periodically so an
+                    # explicit user Stop interrupts a long in-progress message.
+                    if event_index % 32 == 0 and await _is_run_cancelled(
+                        redis_client, chat_id
+                    ):
+                        cancelled = True
+                        break
 
                     if event.type == "message_start":
                         logger.info("Message start received.")
@@ -1080,6 +1256,9 @@ async def stream_chat(
                     if message_stop_received:
                         break
 
+                if cancelled:
+                    break
+
                 tracker.save()
 
                 # Parse tool call inputs. Convert to JSON.
@@ -1110,10 +1289,10 @@ async def stream_chat(
 
                 logger.info(f"Processing {len(tool_calls)} tool calls")
 
-                # Check for disconnection before expensive tool execution
-                if await request.is_disconnected():
+                # Stop before expensive tool execution if the user cancelled.
+                if await _is_run_cancelled(redis_client, chat_id):
                     logger.info(
-                        f"Client disconnected before tool execution, stopping stream for chat {chat_id}"
+                        f"Run cancelled before tool execution for chat {chat_id}"
                     )
                     break
 
@@ -1278,11 +1457,60 @@ async def stream_chat(
             )
             yield _sse_event("stream_error", {"message": _chat_error_message(e)})
 
-    return StreamingResponse(
-        stream_generator(),
-        media_type="text/event-stream",
-        headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+    # First new message persisted by omni-web is the parent of the run's output.
+    parent_id = chat_messages[-1].id if chat_messages else None
+
+    if redis_client is None:
+        # No Redis: run inline (no resume), still persisting via the producer wrapper.
+        return StreamingResponse(
+            _persist_and_transform(
+                stream_generator(), chat_id, messages_repo, parent_id
+            ),
+            media_type="text/event-stream",
+            headers=SSE_HEADERS,
+        )
+
+    # Single producer per chat: the lock winner starts the background run; a
+    # racing connect attaches to it instead of starting a duplicate.
+    got_lock = await redis_client.set(
+        _run_lock_key(chat_id), "1", nx=True, ex=_RUN_LOCK_TTL
     )
+    if not got_lock:
+        return StreamingResponse(
+            _consume_run(redis_client, chat_id, last_event_id or "0"),
+            media_type="text/event-stream",
+            headers=SSE_HEADERS,
+        )
+
+    await redis_client.delete(_stream_key(chat_id))
+    await redis_client.delete(_cancel_key(chat_id))
+    task = asyncio.create_task(
+        _run_producer(
+            redis_client, chat_id, stream_generator(), messages_repo, parent_id
+        )
+    )
+    _background_run_tasks.add(task)
+    task.add_done_callback(_background_run_tasks.discard)
+
+    return StreamingResponse(
+        _consume_run(redis_client, chat_id, "0"),
+        media_type="text/event-stream",
+        headers=SSE_HEADERS,
+    )
+
+
+@router.post("/chat/{chat_id}/cancel")
+async def cancel_chat_stream(
+    request: Request, chat_id: str = Path(..., description="Chat thread ID")
+):
+    """Explicit Stop: signal the background run to stop at its next checkpoint."""
+    redis_client = getattr(request.app.state, "redis_client", None)
+    if redis_client is not None:
+        try:
+            await redis_client.set(_cancel_key(chat_id), "1", ex=_CANCEL_TTL)
+        except Exception as e:
+            logger.error(f"Failed to set cancel flag for chat {chat_id}: {e}")
+    return {"status": "cancelling"}
 
 
 @router.post("/chat/{chat_id}/generate_title")

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -646,13 +646,20 @@ async def stream_chat(
     last_event_id = request.headers.get("last-event-id") or request.query_params.get(
         "last_event_id"
     )
-    if (
-        redis_client is not None
-        and last_event_id is not None
-        and await redis_client.exists(_stream_key(chat_id))
-    ):
+    if redis_client is not None and last_event_id is not None:
+        if await redis_client.exists(_stream_key(chat_id)):
+            return StreamingResponse(
+                _consume_run(redis_client, chat_id, last_event_id),
+                media_type="text/event-stream",
+                headers=SSE_HEADERS,
+            )
+        # Stream expired (TTL elapsed). Starting a new generation would produce a
+        # duplicate response — tell the client to reload from the database instead.
+        async def _not_resumable_response():
+            yield "event: not_resumable\ndata: \n\n"
+
         return StreamingResponse(
-            _consume_run(redis_client, chat_id, last_event_id),
+            _not_resumable_response(),
             media_type="text/event-stream",
             headers=SSE_HEADERS,
         )

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -54,7 +54,7 @@
         CitationSearchResultLocationParam,
         ContentBlockParam,
     } from '@anthropic-ai/sdk/resources.js'
-    import { afterNavigate, invalidate } from '$app/navigation'
+    import { afterNavigate, invalidate, invalidateAll } from '$app/navigation'
     import { page } from '$app/state'
     import UserInput from '$lib/components/user-input.svelte'
     import UploadChip from '$lib/components/upload-chip.svelte'
@@ -82,6 +82,7 @@
         eventSource?.close()
         eventSource = null
         activeStreamChatId = null
+        clearReconnectState()
     })
 
     afterNavigate(() => {
@@ -96,6 +97,7 @@
                 eventSource.close()
                 eventSource = null
             }
+            clearReconnectState()
             activeStreamChatId = null
             isStreaming = false
             error = null
@@ -172,6 +174,33 @@
     let error = $state<string | null>(null)
     let eventSource: EventSource | null = $state(null)
     let activeStreamChatId: string | null = null
+
+    // --- Stream resilience (reconnect after a backgrounded tab / transient drop) ---
+    // The server keeps the run alive and buffered, so we reconnect from the last
+    // received offset (SSE Last-Event-ID) and resume seamlessly instead of failing.
+    let streamLastEventId: string | null = null
+    let reconnectAttempts = 0
+    let reconnectTimer: ReturnType<typeof setTimeout> | null = null
+    let streamWatchdog: ReturnType<typeof setInterval> | null = null
+    let lastStreamEventAt = 0
+    // Re-opens the active chat's stream from streamLastEventId; set by streamResponse.
+    let reconnectStream: (() => void) | null = null
+    const MAX_RECONNECT_ATTEMPTS = 6
+    const STREAM_STALL_MS = 20000
+
+    function clearReconnectState() {
+        reconnectAttempts = 0
+        streamLastEventId = null
+        reconnectStream = null
+        if (reconnectTimer) {
+            clearTimeout(reconnectTimer)
+            reconnectTimer = null
+        }
+        if (streamWatchdog) {
+            clearInterval(streamWatchdog)
+            streamWatchdog = null
+        }
+    }
 
     type StreamErrorPayload = { message: string }
 
@@ -397,11 +426,18 @@
     }
 
     function handleStop() {
+        // The run is decoupled from this connection, so closing the EventSource
+        // is no longer enough — tell the server to actually stop generating.
+        const stopChatId = activeStreamChatId ?? data.chat.id
+        fetch(`/api/chat/${stopChatId}/stop`, { method: 'POST' }).catch((err) =>
+            console.error('Failed to stop stream:', err),
+        )
         if (eventSource) {
             eventSource.close()
             eventSource = null
             activeStreamChatId = null
         }
+        clearReconnectState()
         // Reset all stream state so the input is immediately ready for a new message.
         isStreaming = false
         error = null
@@ -1071,9 +1107,26 @@
         const resizeObserver = new ResizeObserver(() => recalcBottomPadding())
         if (chatContentRef) resizeObserver.observe(chatContentRef)
 
+        // When returning to a backgrounded/frozen tab, the SSE connection is
+        // often dead without an 'error' event firing. If we're still streaming,
+        // reconnect from the last offset and resume.
+        const handleVisibility = () => {
+            if (
+                document.visibilityState === 'visible' &&
+                isStreaming &&
+                activeStreamChatId === data.chat.id &&
+                (!eventSource || eventSource.readyState === EventSource.CLOSED) &&
+                !reconnectTimer
+            ) {
+                reconnectStream?.()
+            }
+        }
+        document.addEventListener('visibilitychange', handleVisibility)
+
         return () => {
             chatContainerRef?.removeEventListener('scroll', handleScroll)
             resizeObserver.disconnect()
+            document.removeEventListener('visibilitychange', handleVisibility)
         }
     })
 
@@ -1092,10 +1145,9 @@
         const pendingPersistedMessageIds: string[] = []
         let tempMessageCounter = 0
 
-        eventSource = new EventSource(`/api/chat/${chatId}/stream`, { withCredentials: true })
-
         let streamCompleted = false
         let messageEventsReceived = 0
+        reconnectAttempts = 0
 
         const nextTempMessageId = () => `temp-${Date.now()}-${tempMessageCounter++}`
 
@@ -1311,9 +1363,36 @@
             })
         }
 
-        eventSource.addEventListener('message_id', (event) => {
-            applyPersistedMessageId(event.data)
-        })
+        const openStream = (resumeFromId: string | null) => {
+            const base = `/api/chat/${chatId}/stream`
+            eventSource = new EventSource(
+                resumeFromId
+                    ? `${base}?last_event_id=${encodeURIComponent(resumeFromId)}`
+                    : base,
+                { withCredentials: true },
+            )
+
+            eventSource.addEventListener('message_id', (event) => {
+                streamLastEventId = event.lastEventId || streamLastEventId
+                lastStreamEventAt = Date.now()
+                reconnectAttempts = 0
+                applyPersistedMessageId(event.data)
+            })
+
+            eventSource.addEventListener('not_resumable', () => {
+                // The buffered run is gone (expired or never existed). Reload the
+                // persisted messages from the server and clear streaming state.
+                streamCompleted = true
+                isStreaming = false
+                activeStreamingMessageId = null
+                refreshProcessedMessages()
+                stopThinkingText()
+                eventSource?.close()
+                eventSource = null
+                activeStreamChatId = null
+                clearReconnectState()
+                invalidateAll()
+            })
 
         eventSource.addEventListener('title', () => {
             invalidate('app:recent_chats') // This will force a re-fetch of recent chats and update the title in the sidebar
@@ -1325,6 +1404,9 @@
         })
 
         eventSource.addEventListener('message', (event) => {
+            streamLastEventId = event.lastEventId || streamLastEventId
+            lastStreamEventAt = Date.now()
+            reconnectAttempts = 0
             try {
                 const data: MessageStreamEvent | ToolResultBlockParam = JSON.parse(event.data)
                 if (data.type === 'message_start') {
@@ -1482,6 +1564,7 @@
             eventSource?.close()
             eventSource = null
             activeStreamChatId = null
+            clearReconnectState()
 
             if (messageEventsReceived === 0 && !error) {
                 error = 'Failed to generate response. Please try again.'
@@ -1489,6 +1572,7 @@
         })
 
         const handleStreamError = (event: Event) => {
+            streamCompleted = true
             error =
                 event instanceof MessageEvent
                     ? streamErrorMessage(event as MessageEvent<string>)
@@ -1502,6 +1586,7 @@
             eventSource?.close()
             eventSource = null
             activeStreamChatId = null
+            clearReconnectState()
         }
 
         const handleConnectionError = () => {
@@ -1509,6 +1594,24 @@
             // handleStop() sets isStreaming = false before the EventSource fires its
             // error event, so we can use that as a signal to skip cleanup here.
             if (streamCompleted || !isStreaming) return
+
+            // Transient drop (e.g. backgrounded tab): the server keeps the run
+            // alive and buffered, so reconnect from our last offset with backoff
+            // instead of failing. Only surface an error once the budget is spent.
+            eventSource?.close()
+            eventSource = null
+            if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+                reconnectAttempts += 1
+                const delay = Math.min(1000 * 2 ** (reconnectAttempts - 1), 15000)
+                if (reconnectTimer) clearTimeout(reconnectTimer)
+                reconnectTimer = setTimeout(() => {
+                    reconnectTimer = null
+                    if (!isStreaming || streamCompleted || activeStreamChatId !== chatId) return
+                    reconnectStream?.()
+                }, delay)
+                return
+            }
+
             error =
                 messageEventsReceived > 0
                     ? 'Response stream disconnected before it finished. Please try again.'
@@ -1519,13 +1622,29 @@
             stopThinkingText()
             requestAnimationFrame(() => recalcBottomPadding())
             userInputRef?.focus()
-            eventSource?.close()
-            eventSource = null
             activeStreamChatId = null
+            clearReconnectState()
         }
 
-        eventSource.addEventListener('stream_error', handleStreamError)
-        eventSource.addEventListener('error', handleConnectionError)
+            eventSource.addEventListener('stream_error', handleStreamError)
+            eventSource.addEventListener('error', handleConnectionError)
+        }
+
+        streamLastEventId = null
+        lastStreamEventAt = Date.now()
+        reconnectStream = () => openStream(streamLastEventId)
+        openStream(null)
+
+        // Safety net for the case where the browser never fires an 'error' event
+        // after a freeze: if the stream stalls while its connection is not open,
+        // reconnect from the last offset.
+        if (streamWatchdog) clearInterval(streamWatchdog)
+        streamWatchdog = setInterval(() => {
+            if (!isStreaming || streamCompleted || activeStreamChatId !== chatId) return
+            const stalled = Date.now() - lastStreamEventAt > STREAM_STALL_MS
+            const notOpen = !eventSource || eventSource.readyState !== EventSource.OPEN
+            if (stalled && notOpen && !reconnectTimer) reconnectStream?.()
+        }, 5000)
     }
 
     async function handleApproval(decision: 'approved' | 'denied') {

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -1364,6 +1364,14 @@
         }
 
         const openStream = (resumeFromId: string | null) => {
+            // Close any stale EventSource before opening a new one. Without this,
+            // the old connection's error event fires after openStream returns, calls
+            // handleConnectionError which closes the *new* eventSource, and triggers
+            // another reconnect loop.
+            if (eventSource) {
+                eventSource.close()
+                eventSource = null
+            }
             const base = `/api/chat/${chatId}/stream`
             eventSource = new EventSource(
                 resumeFromId

--- a/web/src/routes/api/chat/[chatId]/stop/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stop/+server.ts
@@ -1,0 +1,41 @@
+import { json } from '@sveltejs/kit'
+import { env } from '$env/dynamic/private'
+import type { RequestHandler } from './$types.js'
+import { chatRepository } from '$lib/server/db/chats.js'
+
+export const POST: RequestHandler = async ({ params, locals }) => {
+    const logger = locals.logger.child('chat-stop')
+
+    const chatId = params.chatId
+    if (!chatId) {
+        return json({ error: 'chatId parameter is required' }, { status: 400 })
+    }
+
+    const chat = await chatRepository.get(chatId)
+    if (!chat) {
+        return json({ error: 'Chat not found' }, { status: 404 })
+    }
+
+    // Validate user owns the chat
+    if (chat.userId !== locals.user.id) {
+        return json({ error: 'Forbidden' }, { status: 403 })
+    }
+
+    try {
+        const response = await fetch(`${env.AI_SERVICE_URL}/chat/${chatId}/cancel`, {
+            method: 'POST',
+        })
+        if (!response.ok) {
+            logger.warn('AI service cancel returned non-OK', undefined, {
+                chatId,
+                status: response.status,
+            })
+        }
+    } catch (err) {
+        logger.error('Failed to cancel chat stream', err, { chatId })
+    }
+
+    // Best-effort: report success even if the AI service is unreachable, since
+    // the client also tears down its own stream state on Stop.
+    return json({ status: 'ok' })
+}

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -3,17 +3,12 @@ import { relative, resolve } from 'node:path'
 import { json, error } from '@sveltejs/kit'
 import { env } from '$env/dynamic/private'
 import type { RequestHandler } from './$types.js'
-import { chatRepository, chatMessageRepository } from '$lib/server/db/chats.js'
+import { chatRepository } from '$lib/server/db/chats.js'
 import { getAgent } from '$lib/server/db/agents.js'
 import { isProviderConfigured } from '$lib/server/oauth/connectorOAuth.js'
 import { getSourceDisplayName } from '$lib/utils/icons.js'
 import { SourceType } from '$lib/types.js'
 import type { OAuthRequiredAIEvent } from '$lib/types/message.js'
-import type {
-    ContentBlockParam,
-    ToolResultBlockParam,
-    ToolUseBlockParam,
-} from '@anthropic-ai/sdk/resources/messages'
 
 function sseEvent(eventType: string, data: object): string {
     return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`
@@ -167,7 +162,7 @@ async function triggerTitleGeneration(chatId: string, logger: any): Promise<Titl
     }
 }
 
-export const GET: RequestHandler = async ({ params, locals, cookies }) => {
+export const GET: RequestHandler = async ({ params, locals, cookies, request, url }) => {
     const replayPath = replayStreamFixturePath(cookies)
     if (replayPath) {
         const sampleStream = await readFile(replayPath, 'utf-8')
@@ -201,11 +196,20 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
     const abortController = new AbortController()
 
     try {
-        const streamUrl = chat.agentId
+        // Resume offset: native EventSource reconnects send the Last-Event-ID
+        // header; our manual reconnects pass ?last_event_id=. Forward either to
+        // the AI service so it can resume the buffered run from that point.
+        const lastEventId =
+            request.headers.get('last-event-id') ?? url.searchParams.get('last_event_id')
+        let streamUrl = chat.agentId
             ? `${env.AI_SERVICE_URL}/chat/${chatId}/stream?auto_start=true`
             : `${env.AI_SERVICE_URL}/chat/${chatId}/stream`
+        if (lastEventId) {
+            streamUrl += `${streamUrl.includes('?') ? '&' : '?'}last_event_id=${encodeURIComponent(lastEventId)}`
+        }
         const response = await fetch(streamUrl, {
             signal: abortController.signal,
+            headers: lastEventId ? { 'Last-Event-ID': lastEventId } : undefined,
         })
 
         if (!response.ok) {
@@ -228,10 +232,6 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
         if (!reader) {
             throw new Error('Response body is null')
         }
-
-        // Track the last saved message ID to chain parent_id during streaming
-        const lastActiveMessage = await chatMessageRepository.getLastMessageInActivePath(chatId)
-        let lastSavedMessageId: string | undefined = lastActiveMessage?.id
 
         const decoder = new TextDecoder()
         const encoder = new TextEncoder()
@@ -286,43 +286,20 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
                             const lines = event.split('\n')
                             let eventType = 'message' // default event type
                             let data = ''
+                            let id = '' // Redis stream offset for Last-Event-ID resume
 
                             for (const line of lines) {
                                 if (line.startsWith('event:')) {
                                     eventType = line.substring(6).trim()
                                 } else if (line.startsWith('data:')) {
                                     data = line.substring(5).trim()
+                                } else if (line.startsWith('id:')) {
+                                    id = line.substring(3).trim()
                                 }
                             }
-
-                            // If this is a save_message event, save it immediately to database
-                            if (eventType === 'save_message' && data) {
-                                try {
-                                    const message = JSON.parse(data)
-                                    const { id: messageId } = await chatMessageRepository.create(
-                                        chatId,
-                                        message,
-                                        lastSavedMessageId,
-                                    )
-                                    lastSavedMessageId = messageId
-                                    logger.debug('Saved message to database', {
-                                        chatId,
-                                        role: message.role,
-                                        messageId,
-                                    })
-
-                                    // Send message ID to client
-                                    const event = `event: message_id\ndata: ${messageId}\n\n`
-                                    controller.enqueue(encoder.encode(event))
-                                } catch (error) {
-                                    logger.error('Failed to save message to database', error, {
-                                        chatId,
-                                        data,
-                                    })
-                                }
-                                // Don't forward save_message events to client (internal only)
-                                continue
-                            }
+                            // Preserve the offset on every reconstructed event below
+                            // so the browser advances Last-Event-ID correctly.
+                            const idPrefix = id ? `id: ${id}\n` : ''
 
                             // Forward approval_required events to client
                             if (eventType === 'approval_required' && data) {
@@ -343,7 +320,7 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
                                         chatId,
                                     })
                                 }
-                                const approvalEvent = `event: approval_required\ndata: ${data}\n\n`
+                                const approvalEvent = `${idPrefix}event: approval_required\ndata: ${data}\n\n`
                                 controller.enqueue(encoder.encode(approvalEvent))
                                 continue
                             }
@@ -367,7 +344,7 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
                                         provider_configured: providerConfigured,
                                         source_display_name: sourceDisplayName,
                                     }
-                                    const enrichedEvent = `event: oauth_required\ndata: ${JSON.stringify(enriched)}\n\n`
+                                    const enrichedEvent = `${idPrefix}event: oauth_required\ndata: ${JSON.stringify(enriched)}\n\n`
                                     controller.enqueue(encoder.encode(enrichedEvent))
                                 } catch (err) {
                                     logger.error('Failed to enrich oauth_required event', err, {
@@ -375,7 +352,7 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
                                     })
                                     // Fall back to forwarding the raw event so the
                                     // client at least sees something actionable.
-                                    const fallback = `event: oauth_required\ndata: ${data}\n\n`
+                                    const fallback = `${idPrefix}event: oauth_required\ndata: ${data}\n\n`
                                     controller.enqueue(encoder.encode(fallback))
                                 }
                                 continue
@@ -436,7 +413,7 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
                                             content: redactedContent,
                                         }
 
-                                        const redactedEvent = `event: message\ndata: ${JSON.stringify(redactedData)}\n\n`
+                                        const redactedEvent = `${idPrefix}event: message\ndata: ${JSON.stringify(redactedData)}\n\n`
                                         controller.enqueue(encoder.encode(redactedEvent))
                                         continue
                                     }
@@ -459,63 +436,13 @@ export const GET: RequestHandler = async ({ params, locals, cookies }) => {
                 }
             },
             async cancel() {
-                logger.info('Client disconnected, cancelling stream', { chatId })
+                // The browser disconnected (e.g. backgrounded tab). Stop proxying
+                // by aborting our upstream read, but do NOT touch the run — it
+                // continues server-side so the client can reconnect and resume.
+                // Generation is ended only via the explicit Stop endpoint.
+                logger.info('Client disconnected from stream proxy', { chatId })
                 reader.cancel()
                 abortController.abort()
-
-                // Clean up any incomplete tool uses from the interrupted stream
-                try {
-                    const lastMessage =
-                        await chatMessageRepository.getLastMessageInActivePath(chatId)
-                    if (!lastMessage || lastMessage.message.role !== 'assistant') return
-
-                    const content = lastMessage.message.content
-                    const contentBlocks: ContentBlockParam[] = Array.isArray(content) ? content : []
-                    const toolUseBlocks = contentBlocks.filter(
-                        (b): b is ToolUseBlockParam => b.type === 'tool_use',
-                    )
-                    if (toolUseBlocks.length === 0) return
-
-                    const allMessages = await chatMessageRepository.getByChatId(chatId)
-                    const toolResultMsgs = allMessages.filter((m) => m.parentId === lastMessage.id)
-                    const existingToolUseIds = new Set<string>()
-                    for (const msg of toolResultMsgs) {
-                        if (msg.message.role === 'user' && Array.isArray(msg.message.content)) {
-                            for (const block of msg.message.content) {
-                                if (block.type === 'tool_result') {
-                                    existingToolUseIds.add(block.tool_use_id)
-                                }
-                            }
-                        }
-                    }
-
-                    const missingToolUses = toolUseBlocks.filter(
-                        (tu) => !existingToolUseIds.has(tu.id),
-                    )
-                    if (missingToolUses.length === 0) return
-
-                    const syntheticToolResults: ToolResultBlockParam[] = missingToolUses.map(
-                        (tu) => ({
-                            type: 'tool_result',
-                            tool_use_id: tu.id,
-                            content: [{ type: 'text', text: 'Tool response was interrupted' }],
-                            is_error: true,
-                        }),
-                    )
-
-                    await chatMessageRepository.create(
-                        chatId,
-                        { role: 'user', content: syntheticToolResults },
-                        lastMessage.id,
-                    )
-
-                    logger.info('Cleaned up interrupted stream', {
-                        chatId,
-                        missingToolCount: missingToolUses.length,
-                    })
-                } catch (err) {
-                    logger.error('Error cleaning up interrupted stream', err, { chatId })
-                }
             },
         })
 


### PR DESCRIPTION
## Summary

- **Producer/Consumer split**: LLM generation runs as a background asyncio task writing events to a Redis Stream (`XADD`). The HTTP consumer tails the stream by offset, so browser disconnects (tab switch, minimize, network blip) no longer abort generation.
- **Resumable streams**: Every SSE event carries a Redis stream ID as `id:`. Native `EventSource` reconnects and manual reconnects both forward `Last-Event-ID` / `?last_event_id` to resume from the last seen offset with no duplicate events.
- **Explicit Stop**: New `POST /api/chat/[chatId]/stop` (web) → `POST /chat/{id}/cancel` (AI) sets a Redis cancel flag; the producer checks it at iteration boundaries instead of relying on `is_disconnected()`.
- **Single DB writer**: The producer is now the sole writer of chat messages (including `content_text`), eliminating any idempotency/upsert concern on reconnect.
- **Client resilience**: Exponential-backoff reconnect on error (up to 6 attempts), `visibilitychange` reconnect when tab returns to foreground, 20 s stall watchdog, and a Stop button that terminates server-side generation.
- **No duplicate runs on reconnect**: a follow-up commit closes a race where reconnecting after the stream's TTL had expired could fall through and start a second generation; the consumer now returns an explicit `not_resumable` event instead.
- **Lock kept alive during silent gaps**: the per-chat run lock was only refreshed when an SSE event was produced, so a long silent stretch in the agent loop (e.g. a slow tool call with no intermediate output) could let the lock expire while generation was still running, opening a window for a duplicate producer. A periodic 60 s heartbeat now refreshes the lock independently of event production.

## Test plan

- [ ] Start a long generation, switch tabs for >30 s, return — stream resumes seamlessly
- [ ] Start a generation, minimize the browser, restore — no duplicate messages, continues where it left off
- [ ] Reload mid-stream — page reconnects with last offset and renders remaining tokens
- [ ] Click Stop — generation ends server-side (no further tool calls or tokens)
- [ ] Two rapid reconnects — only one producer runs (lock prevents duplicate run)
- [ ] A generation with a long silent gap (slow tool call) past the old 300 s lock TTL — no duplicate producer spawned
- [ ] `npm run check` (web TypeScript) passes