### PR TITLE
fix(searcher): improve home-screen suggestion quality

### DIFF
--- a/services/searcher/src/suggested_questions.rs
+++ b/services/searcher/src/suggested_questions.rs
@@ -6,23 +6,37 @@ use futures_util::StreamExt;
 use redis::AsyncCommands;
 use redis::Client as RedisClient;
 use shared::utils::safe_str_slice;
-use shared::{AIClient, DatabasePool, DocumentRepository, GroupRepository, ObjectStorage};
+use shared::{
+    AIClient, DatabasePool, DocumentRepository, GroupRepository, ObjectStorage, SourceType,
+};
+use std::collections::HashSet;
 use std::sync::Arc;
 use tracing::{debug, error, info, warn};
 
-const REDIS_CACHE_KEY: &str = "suggested_questions:v1";
-const CACHE_TTL_SECONDS: u64 = 86400; // 7 days
+// Bump the version suffix whenever the generation prompt or validation changes
+// so previously cached (and now undesirable) suggestions are invalidated.
+const REDIS_CACHE_KEY: &str = "suggested_questions:v2";
+const CACHE_TTL_SECONDS: u64 = 86400; // 24 hours
 const MAX_RETRIES: usize = 5;
-const QUESTION_PROMPT_TEMPLATE: &str = r#"You are helping generate example search queries for a workplace search tool that indexes company documents, emails, and files.
+/// Source types whose documents are predominantly code or technical material and
+/// therefore make poor "Try asking" suggestions (e.g. a GitHub repo yields queries
+/// like "Git repository object storage documentation"). They are excluded from the
+/// random document selection; per-document SKIP handling in the generator still
+/// filters technical content out of the remaining sources.
+const SUGGESTION_EXCLUDED_SOURCE_TYPES: &[SourceType] = &[SourceType::Github];
+const QUESTION_PROMPT_TEMPLATE: &str = r#"You are helping generate example search queries for a workplace search tool that indexes a company's documents, emails, and files. The result is shown as a clickable "Try asking" suggestion on the home screen, so it must read like something a real employee would naturally ask.
 
-Given the following document excerpt, generate ONE example search query that an employee might realistically type into a workplace search engine to find information related to this document's topic.
+You are given an excerpt from ONE indexed document. Based on the topic it covers, write ONE natural question that a colleague might ask to find this kind of information.
 
 Rules:
-- Write the query from the perspective of someone who does NOT have the document open — they are searching for information
-- Focus on the topic or knowledge area, not on specific metadata like URLs, file paths, modification dates, or technical properties
-- The query should be practical and useful (e.g. "How do we handle customer refunds?", "Onboarding steps for new engineers", "Q3 budget planning process")
-- Avoid questions that are only answerable by looking at a specific file's properties or raw structure
-- Write only the query itself, no quotes, no prefixes like "Question:" or "Query:"
+- Write a full, natural question, phrased the way a person actually speaks, and end it with a question mark. Examples: "How do we handle customer refunds?", "What are the onboarding steps for new engineers?", "Who is responsible for Q3 budget planning?"
+- Do NOT output keyword phrases, document titles, or noun phrases such as "Git repository object storage documentation". It must be a real question.
+- Ask from the perspective of someone who has NOT seen this document and is looking for the knowledge it contains.
+- Ignore document metadata and structure (URLs, file paths, IDs, timestamps, formatting, raw code, configuration values).
+
+If this document is not a good basis for a useful business question — for example it is source code, configuration, logs, build or CI output, auto-generated content, technical/system documentation, boilerplate, or has no clear business topic an employee would search for — then respond with exactly the single word SKIP and nothing else.
+
+Output only the question itself (or SKIP), with no quotes and no prefix like "Question:" or "Query:".
 
 Document excerpt:
 {content}"#;
@@ -138,6 +152,11 @@ impl SuggestedQuestionsGenerator {
         user_email: &str,
     ) -> Result<usize> {
         let mut questions = Vec::new();
+        // Random fetches across retry attempts can re-draw the same document, and
+        // distinct documents can yield identical questions. Track both so the
+        // suggestions we return stay unique.
+        let mut seen_doc_ids: HashSet<String> = HashSet::new();
+        let mut seen_questions: HashSet<String> = HashSet::new();
         let mut attempts = 0;
 
         let num_questions = 9;
@@ -161,7 +180,12 @@ impl SuggestedQuestionsGenerator {
                 .await
                 .unwrap_or_default();
             match doc_repo
-                .fetch_random_documents(user_email, &user_groups, needed)
+                .fetch_random_documents(
+                    user_email,
+                    &user_groups,
+                    needed,
+                    SUGGESTION_EXCLUDED_SOURCE_TYPES,
+                )
                 .await
             {
                 Ok(docs) => {
@@ -196,6 +220,12 @@ impl SuggestedQuestionsGenerator {
                         .collect::<Result<Vec<_>>>()?;
 
                     for (doc, content) in docs.into_iter().zip(contents) {
+                        // Skip documents already handled in an earlier attempt so we
+                        // neither spend an AI call nor surface a duplicate suggestion.
+                        if !seen_doc_ids.insert(doc.id.clone()) {
+                            continue;
+                        }
+
                         debug!(
                             "Processing document {} [id={}] (content length: {} chars)",
                             doc.title,
@@ -207,6 +237,15 @@ impl SuggestedQuestionsGenerator {
                             .await
                         {
                             Ok(question) => {
+                                // Two different documents can produce the same generic
+                                // question; keep the displayed suggestions distinct.
+                                if !seen_questions.insert(question.to_lowercase()) {
+                                    debug!(
+                                        "Skipping duplicate suggestion text from document {}",
+                                        doc.id
+                                    );
+                                    continue;
+                                }
                                 questions.push(SuggestedQuestion {
                                     question: question.clone(),
                                     document_id: doc.id.clone(),
@@ -360,7 +399,7 @@ impl SuggestedQuestionsGenerator {
             question.len()
         );
 
-        let question = question.trim().to_string();
+        let question = question.trim().trim_matches('"').trim().to_string();
 
         if question.is_empty() {
             warn!(
@@ -368,6 +407,31 @@ impl SuggestedQuestionsGenerator {
                 document_id
             );
             return Err(anyhow!("AI service returned empty question"));
+        }
+
+        // The model is instructed to return the literal word SKIP for documents
+        // that are not a good basis for a workplace question (code, config, logs,
+        // auto-generated/technical docs, etc.). Treat that as "no question" so the
+        // caller fetches and tries a different random document.
+        let normalized =
+            question.trim_end_matches(|c: char| c == '.' || c == '!' || c.is_whitespace());
+        if normalized.eq_ignore_ascii_case("skip") {
+            info!(
+                "Document {} deemed unsuitable for a suggested question (model returned SKIP)",
+                document_id
+            );
+            return Err(anyhow!("Document unsuitable for question generation (SKIP)"));
+        }
+
+        // Guard against keyword/noun-phrase output slipping through despite the
+        // prompt (e.g. "Git repository object storage documentation"): a real
+        // suggestion is a question and must contain a question mark.
+        if !question.contains('?') {
+            warn!(
+                "Discarding non-question suggestion for document {}: \"{}\"",
+                document_id, question
+            );
+            return Err(anyhow!("Generated suggestion was not a question"));
         }
 
         info!(

--- a/services/searcher/src/suggested_questions.rs
+++ b/services/searcher/src/suggested_questions.rs
@@ -179,12 +179,17 @@ impl SuggestedQuestionsGenerator {
                 .find_groups_for_user(user_email)
                 .await
                 .unwrap_or_default();
+            // Exclude documents already consumed in earlier attempts at the query
+            // level, so every fetched document is new and attempts don't spin on
+            // re-drawn rows (the seen_doc_ids guard below stays as a safety net).
+            let already_seen: Vec<String> = seen_doc_ids.iter().cloned().collect();
             match doc_repo
                 .fetch_random_documents(
                     user_email,
                     &user_groups,
                     needed,
                     SUGGESTION_EXCLUDED_SOURCE_TYPES,
+                    &already_seen,
                 )
                 .await
             {

--- a/services/searcher/src/suggested_questions.rs
+++ b/services/searcher/src/suggested_questions.rs
@@ -15,7 +15,7 @@ use tracing::{debug, error, info, warn};
 
 // Bump the version suffix whenever the generation prompt or validation changes
 // so previously cached (and now undesirable) suggestions are invalidated.
-const REDIS_CACHE_KEY: &str = "suggested_questions:v2";
+const REDIS_CACHE_KEY: &str = "suggested_questions:v3";
 const CACHE_TTL_SECONDS: u64 = 86400; // 24 hours
 const MAX_RETRIES: usize = 5;
 /// Source types whose documents are predominantly code or technical material and
@@ -37,6 +37,24 @@ Rules:
 If this document is not a good basis for a useful business question — for example it is source code, configuration, logs, build or CI output, auto-generated content, technical/system documentation, boilerplate, or has no clear business topic an employee would search for — then respond with exactly the single word SKIP and nothing else.
 
 Output only the question itself (or SKIP), with no quotes and no prefix like "Question:" or "Query:".
+
+Document excerpt:
+{content}"#;
+
+const TASK_PROMPT_TEMPLATE: &str = r#"You are helping generate example task prompts for a workplace AI tool that can answer questions and also perform tasks like running analyses, summarizing content, or creating charts. The result is shown as a clickable suggestion on the home screen.
+
+You are given an excerpt from ONE indexed document. Based on what it covers, write ONE natural task instruction that a colleague might give the AI — something actionable it could do with this kind of content.
+
+Rules:
+- Write a concise imperative instruction in the style of "Summarize the key takeaways from the Q3 board meeting", "Show a chart of sales by region from the Q4 report", or "List the action items from the last sprint retro".
+- Do NOT write a question — the output must be an instruction, not an inquiry.
+- Do NOT output keyword phrases, document titles, or noun phrases.
+- Phrase it from the perspective of someone who wants the AI to do something useful with this content.
+- Ignore document metadata and structure (URLs, file paths, IDs, timestamps, formatting, raw code, configuration values).
+
+If this document is not a good basis for a useful task instruction — for example it is source code, configuration, logs, build or CI output, auto-generated content, technical/system documentation, boilerplate, or has no clear business action an employee would want performed — then respond with exactly the single word SKIP and nothing else.
+
+Output only the task instruction itself (or SKIP), with no quotes and no prefix like "Task:" or "Instruction:".
 
 Document excerpt:
 {content}"#;
@@ -161,7 +179,7 @@ impl SuggestedQuestionsGenerator {
 
         let num_questions = 9;
         info!(
-            "Beginning question generation loop (target: {} questions, max attempts: {})",
+            "Beginning suggestion generation loop (target: {} suggestions, max attempts: {})",
             num_questions, MAX_RETRIES
         );
 
@@ -196,7 +214,7 @@ impl SuggestedQuestionsGenerator {
                 Ok(docs) => {
                     let num_docs_fetched = docs.len();
                     info!(
-                        "Fetched {} random document(s) for question generation",
+                        "Fetched {} random document(s) for suggestion generation",
                         num_docs_fetched
                     );
 
@@ -238,12 +256,18 @@ impl SuggestedQuestionsGenerator {
                             content.len()
                         );
 
-                        match Self::generate_question_from_document(&ai_client, &doc.id, &content)
-                            .await
-                        {
+                        // Every third suggestion is a task instruction; the rest are questions.
+                        let use_task_prompt = questions.len() % 3 == 2;
+                        let result = if use_task_prompt {
+                            Self::generate_task_from_document(&ai_client, &doc.id, &content).await
+                        } else {
+                            Self::generate_question_from_document(&ai_client, &doc.id, &content)
+                                .await
+                        };
+                        match result {
                             Ok(question) => {
                                 // Two different documents can produce the same generic
-                                // question; keep the displayed suggestions distinct.
+                                // suggestion; keep the displayed suggestions distinct.
                                 if !seen_questions.insert(question.to_lowercase()) {
                                     debug!(
                                         "Skipping duplicate suggestion text from document {}",
@@ -256,7 +280,7 @@ impl SuggestedQuestionsGenerator {
                                     document_id: doc.id.clone(),
                                 });
                                 info!(
-                                    "Generated question {}/{}: \"{}\" (from document: {})",
+                                    "Generated suggestion {}/{}: \"{}\" (from document: {})",
                                     questions.len(),
                                     num_questions,
                                     question,
@@ -288,19 +312,19 @@ impl SuggestedQuestionsGenerator {
                                     .context("Failed to cache questions in Redis")?;
 
                                 info!(
-                                    "Successfully cached {} suggested question(s) in Redis (TTL: {} hours)",
+                                    "Successfully cached {} suggested suggestion(s) in Redis (TTL: {} hours)",
                                     response.questions.len(),
                                     CACHE_TTL_SECONDS / 3600
                                 );
                             }
                             Err(e) => {
-                                warn!("Failed to generate question for document {}: {}", doc.id, e);
+                                warn!("Failed to generate suggestion for document {}: {}", doc.id, e);
                             }
                         }
 
                         if questions.len() >= num_questions {
                             info!(
-                                "Target of {} questions reached, stopping generation",
+                                "Target of {} suggestions reached, stopping generation",
                                 num_questions
                             );
                             break;
@@ -326,17 +350,17 @@ impl SuggestedQuestionsGenerator {
 
         if questions.is_empty() {
             error!(
-                "Failed to generate any questions after {} attempts",
+                "Failed to generate any suggestions after {} attempts",
                 attempts
             );
             return Err(anyhow!(
-                "Failed to generate any questions after {} attempts",
+                "Failed to generate any suggestions after {} attempts",
                 attempts
             ));
         }
 
         info!(
-            "Question generation complete: {} question(s) generated after {} attempt(s)",
+            "Suggestion generation complete: {} suggestion(s) generated after {} attempt(s)",
             questions.len(),
             attempts
         );
@@ -344,12 +368,13 @@ impl SuggestedQuestionsGenerator {
         Ok(questions.len())
     }
 
-    async fn generate_question_from_document(
+    async fn generate_suggestion_from_document(
         ai_client: &AIClient,
         document_id: &str,
         content: &str,
+        prompt_template: &str,
+        expect_question_mark: bool,
     ) -> Result<String> {
-        // Take first 2000 characters of content
         let excerpt = if content.len() > 2000 {
             debug!(
                 "Truncating content from {} to 2000 chars for document {}",
@@ -361,89 +386,80 @@ impl SuggestedQuestionsGenerator {
             content
         };
 
-        let prompt = QUESTION_PROMPT_TEMPLATE.replace("{content}", excerpt);
-        debug!(
-            "Generated prompt for document {} (length: {} chars)",
-            document_id,
-            prompt.len()
-        );
+        let prompt = prompt_template.replace("{content}", excerpt);
 
-        info!(
-            "Calling AI service to generate question for document {}",
-            document_id
-        );
-
-        // Call AI service using stream_prompt and collect the full response
         let mut stream = ai_client
             .stream_prompt(&prompt)
             .await
             .context("Failed to start AI stream")?;
 
-        debug!("AI stream started, collecting response chunks");
-        let mut question = String::new();
-        let mut chunk_count = 0;
-
+        let mut output = String::new();
         while let Some(chunk_result) = stream.next().await {
             match chunk_result {
-                Ok(chunk) => {
-                    chunk_count += 1;
-                    debug!("Received chunk {} ({} bytes)", chunk_count, chunk.len());
-                    question.push_str(&chunk);
-                }
-                Err(e) => {
-                    error!("Error in AI stream for document {}: {}", document_id, e);
-                    return Err(anyhow!("Error in AI stream: {}", e));
-                }
+                Ok(chunk) => output.push_str(&chunk),
+                Err(e) => return Err(anyhow!("Error in AI stream: {}", e)),
             }
         }
 
-        debug!(
-            "AI stream complete for document {}: received {} chunks, total {} chars",
-            document_id,
-            chunk_count,
-            question.len()
-        );
+        let output = output.trim().trim_matches('"').trim().to_string();
 
-        let question = question.trim().trim_matches('"').trim().to_string();
-
-        if question.is_empty() {
-            warn!(
-                "AI service returned empty question for document {}",
-                document_id
-            );
-            return Err(anyhow!("AI service returned empty question"));
+        if output.is_empty() {
+            return Err(anyhow!("AI service returned empty output"));
         }
 
-        // The model is instructed to return the literal word SKIP for documents
-        // that are not a good basis for a workplace question (code, config, logs,
-        // auto-generated/technical docs, etc.). Treat that as "no question" so the
-        // caller fetches and tries a different random document.
         let normalized =
-            question.trim_end_matches(|c: char| c == '.' || c == '!' || c.is_whitespace());
+            output.trim_end_matches(|c: char| c == '.' || c == '!' || c.is_whitespace());
         if normalized.eq_ignore_ascii_case("skip") {
             info!(
-                "Document {} deemed unsuitable for a suggested question (model returned SKIP)",
+                "Document {} deemed unsuitable for suggestion (model returned SKIP)",
                 document_id
             );
-            return Err(anyhow!("Document unsuitable for question generation (SKIP)"));
+            return Err(anyhow!("Document unsuitable for suggestion generation (SKIP)"));
         }
 
-        // Guard against keyword/noun-phrase output slipping through despite the
-        // prompt (e.g. "Git repository object storage documentation"): a real
-        // suggestion is a question and must contain a question mark.
-        if !question.contains('?') {
+        if expect_question_mark && !output.contains('?') {
             warn!(
                 "Discarding non-question suggestion for document {}: \"{}\"",
-                document_id, question
+                document_id, output
             );
             return Err(anyhow!("Generated suggestion was not a question"));
         }
 
         info!(
-            "Successfully generated question for document {}: \"{}\"",
-            document_id, question
+            "Successfully generated suggestion for document {}: \"{}\"",
+            document_id, output
         );
 
-        Ok(question)
+        Ok(output)
+    }
+
+    async fn generate_question_from_document(
+        ai_client: &AIClient,
+        document_id: &str,
+        content: &str,
+    ) -> Result<String> {
+        Self::generate_suggestion_from_document(
+            ai_client,
+            document_id,
+            content,
+            QUESTION_PROMPT_TEMPLATE,
+            true,
+        )
+        .await
+    }
+
+    async fn generate_task_from_document(
+        ai_client: &AIClient,
+        document_id: &str,
+        content: &str,
+    ) -> Result<String> {
+        Self::generate_suggestion_from_document(
+            ai_client,
+            document_id,
+            content,
+            TASK_PROMPT_TEMPLATE,
+            false,
+        )
+        .await
     }
 }

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -116,17 +116,21 @@ impl DocumentRepository {
         user_groups: &[String],
         count: usize,
         excluded_source_types: &[SourceType],
+        excluded_document_ids: &[String],
     ) -> Result<Vec<Document>, DatabaseError> {
         let permission_filter = &self.generate_permission_filter(user_email, user_groups);
 
         // `excluded_source_types` lets the caller drop whole source categories (e.g.
-        // code repositories) that produce poor results. An empty slice excludes
-        // nothing, since `ANY('{}')` never matches.
+        // code repositories) that produce poor results. `excluded_document_ids` skips
+        // documents the caller has already consumed, so repeated random draws don't
+        // return duplicates. An empty slice excludes nothing, since `ANY('{}')` never
+        // matches and `<> ALL('{}')` is always true.
         let query = format!(
             r#"
             SELECT *
             FROM documents d
             WHERE d.content_id IS NOT NULL
+                AND d.id <> ALL($3)
                 AND NOT EXISTS (
                     SELECT 1
                     FROM sources s
@@ -143,6 +147,7 @@ impl DocumentRepository {
         let documents = sqlx::query_as::<_, Document>(&query)
             .bind(count as i32)
             .bind(excluded_source_types)
+            .bind(excluded_document_ids)
             .fetch_all(&self.pool)
             .await?;
 

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -115,14 +115,24 @@ impl DocumentRepository {
         user_email: &str,
         user_groups: &[String],
         count: usize,
+        excluded_source_types: &[SourceType],
     ) -> Result<Vec<Document>, DatabaseError> {
         let permission_filter = &self.generate_permission_filter(user_email, user_groups);
 
+        // `excluded_source_types` lets the caller drop whole source categories (e.g.
+        // code repositories) that produce poor results. An empty slice excludes
+        // nothing, since `ANY('{}')` never matches.
         let query = format!(
             r#"
             SELECT *
             FROM documents d
             WHERE d.content_id IS NOT NULL
+                AND NOT EXISTS (
+                    SELECT 1
+                    FROM sources s
+                    WHERE s.id = d.source_id
+                        AND s.source_type = ANY($2)
+                )
                 AND {}
             ORDER BY RANDOM()
             LIMIT $1
@@ -132,6 +142,7 @@ impl DocumentRepository {
 
         let documents = sqlx::query_as::<_, Document>(&query)
             .bind(count as i32)
+            .bind(excluded_source_types)
             .fetch_all(&self.pool)
             .await?;
 


### PR DESCRIPTION
## Problem

The "Try asking" suggestion chips on the home screen (new chat) sometimes surface nonsensical keyword phrases instead of real questions — e.g. **"Git repository object storage documentation"**. The follow-up to #286 improved phrasing in general, but two gaps remained: technical/code documents are still eligible for selection, and keyword-style output is never rejected.

## Root cause

`SuggestedQuestionsGenerator` picks **completely random** documents (`fetch_random_documents`, `ORDER BY RANDOM()`) across *all* indexed sources, sends a 2000-char excerpt to the model, and only validates that the result is non-empty. When the random pick lands on a technical document (e.g. a GitHub repo), the model dutifully produces a topic keyword phrase rather than a question, and nothing filters it out.

## Changes

1. **Exclude code/technical sources from selection.** `fetch_random_documents` now takes an `excluded_source_types: &[SourceType]` list; the generator excludes `Github`. The exclusion is a `NOT EXISTS` sub-filter, so an empty list excludes nothing.

2. **Sharper prompt.** It now requires a *natural question* and explicitly forbids noun-phrase/keyword output. For documents that aren't a good basis for a business question (source code, config, logs, CI output, auto-generated/technical docs), the model is told to return the sentinel `SKIP`.

3. **Output validation.** The generated text is rejected when it is `SKIP` or when it isn't a question (no `?`). A rejected document is skipped and the loop fetches another random document (existing `MAX_RETRIES` retry path).

4. **Deduplicate suggestions.** Rejected documents cause more retry rounds, and each round re-draws documents at random, so the same document — or an identical generic question from two documents — could be surfaced twice. Generation now deduplicates by document id and by question text so the chips stay distinct. On top of that application-level guard, `fetch_random_documents` takes an `excluded_document_ids` list and filters already-consumed documents in SQL (`d.id <> ALL(...)`), so each random draw returns only new documents instead of spinning on re-drawn rows — which also keeps the `num_docs_fetched < needed` termination signal accurate.

5. **Cache invalidation.** Redis cache key bumped `v1` -> `v2` so previously cached low-quality suggestions disappear immediately instead of lingering for the 24h TTL. (Also corrected the stale `// 7 days` comment on the 86400s TTL.)

## Testing notes

Per the repo's build constraints this was developed via static analysis only — no Rust build/test and no live DB were run. The one aspect that warrants a runtime sanity check is the new SQL in `fetch_random_documents` — the `NOT EXISTS` source-type sub-filter and the `d.id <> ALL($3)` exclusion, combined with the ParadeDB `@@@` permission predicate; the change is standard SQL and `@@@` already coexists with other predicates there, but it has not been executed against a real database.

Known residual limitation: the `?` guard rejects output with no question mark, but a noun phrase with a trailing `?` would still pass — the prompt is the primary defense against that, the guard is a cheap backstop.
