### PR TITLE
fix(chat): don't render non-navigable citation sources as clickable links

### DIFF
--- a/web/src/lib/components/reflink-hover-card.svelte
+++ b/web/src/lib/components/reflink-hover-card.svelte
@@ -73,12 +73,13 @@
         </div>
     </HoverCard.Content>
     <!-- Keep the trigger last and close Root inline so Svelte does not emit whitespace between the citation and following punctuation. -->
+    {@const isNavigable = href.startsWith('http://') || href.startsWith('https://')}
     <HoverCard.Trigger
-        {href}
+        href={isNavigable ? href : undefined}
         {title}
-        target="_blank"
-        rel="noreferrer noopener"
-        class="text-muted-foreground hover:text-foreground/80 inline-block max-w-36 items-center 
-        gap-1 truncate overflow-hidden border p-0.5 text-xs no-underline 
+        target={isNavigable ? '_blank' : undefined}
+        rel={isNavigable ? 'noreferrer noopener' : undefined}
+        class="text-muted-foreground hover:text-foreground/80 inline-block max-w-36 items-center
+        gap-1 truncate overflow-hidden border p-0.5 text-xs no-underline
         transition-colors">[{text}]</HoverCard.Trigger
     ></HoverCard.Root>


### PR DESCRIPTION
## Summary

- IMAP email citations carry an `imap:` prefixed source value (e.g. `imap:account / folder / date / subject`) because there is no webmail URL to link to
- Anthropic's citation feature embeds this value as the `href` in inline citation links, producing broken `imap://` links that browsers cannot open
- `reflink-hover-card.svelte` now checks whether the source URL is HTTP(S) navigable before passing `href`/`target`/`rel` to `HoverCard.Trigger` — the hover card tooltip continues to work for all citations regardless

This mirrors the same guard already present in the chat page's `sourcesSection` snippet (line 2097), which has always rendered IMAP citations as non-clickable `<div>` elements instead of anchors.

## Test plan

- [ ] Configure an IMAP connector and ask the chat about emails
- [ ] Verify that email citations appear as styled `[n]` indicators with a hover card tooltip but are **not** clickable links
- [ ] Verify that citations from HTTP-backed sources (Google Drive, Confluence, etc.) still open in a new tab when clicked