### PR TITLE
refactor: rename Python SDK state to checkpoint

### DIFF
--- a/connectors/clickup/clickup_connector/connector.py
+++ b/connectors/clickup/clickup_connector/connector.py
@@ -71,7 +71,7 @@ class ClickUpConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         token = credentials.get("token")
@@ -97,8 +97,8 @@ class ClickUpConnector(Connector):
 
         logger.info("Starting ClickUp sync across %d workspace(s)", len(workspaces))
 
-        state = state or {}
-        workspace_states: dict[str, Any] = state.get("workspaces", {})
+        checkpoint = checkpoint or {}
+        workspace_states: dict[str, Any] = checkpoint.get("workspaces", {})
         new_workspace_states: dict[str, Any] = {}
         docs_since_checkpoint = 0
 
@@ -121,7 +121,7 @@ class ClickUpConnector(Connector):
                 # Sync group memberships before documents
                 await self._sync_group_memberships(workspace, spaces, ctx)
 
-                # Use previous timestamp for incremental sync (state-driven)
+                # Use previous timestamp for incremental sync (checkpoint-driven)
                 date_updated_gt: int | None = prev_state.get("last_updated_ts") or None
 
                 # Sync tasks
@@ -200,7 +200,7 @@ class ClickUpConnector(Connector):
                     await ctx.save_checkpoint({"workspaces": new_workspace_states})
                     docs_since_checkpoint = 0
 
-            await ctx.complete(new_state={"workspaces": new_workspace_states})
+            await ctx.complete(checkpoint={"workspaces": new_workspace_states})
             logger.info(
                 "Sync completed: %d scanned, %d emitted",
                 ctx.documents_scanned,

--- a/connectors/clickup/tests/test_full_sync.py
+++ b/connectors/clickup/tests/test_full_sync.py
@@ -92,7 +92,7 @@ async def test_full_sync_includes_comments_in_content(
     assert n_events >= 1
 
 
-async def test_full_sync_saves_connector_state(
+async def test_full_sync_saves_checkpoint(
     harness, seed, source_id, mock_clickup_api, cm_client: httpx.AsyncClient
 ):
     mock_clickup_api.add_workspace("team_1", "Test Workspace")
@@ -109,10 +109,10 @@ async def test_full_sync_saves_connector_state(
     sync_run_id = resp.json()["sync_run_id"]
     await wait_for_sync(harness.db_pool, sync_run_id, timeout=30)
 
-    state = await seed.get_connector_state(source_id)
-    assert state is not None, "connector_state should be saved after sync"
-    assert "workspaces" in state
-    assert "team_1" in state["workspaces"]
+    checkpoint = await seed.get_checkpoint(source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
+    assert "workspaces" in checkpoint
+    assert "team_1" in checkpoint["workspaces"]
 
 
 async def test_full_sync_scanned_count(

--- a/connectors/github/github_connector/connector.py
+++ b/connectors/github/github_connector/connector.py
@@ -106,7 +106,7 @@ class GitHubConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         try:
@@ -129,9 +129,9 @@ class GitHubConnector(Connector):
 
         logger.info("Starting GitHub sync as user '%s'", username)
 
-        state = state or {}
-        repo_states: dict[str, Any] = state.get("repos", {})
-        new_repo_states: dict[str, Any] = {}
+        checkpoint = checkpoint or {}
+        repo_checkpoints: dict[str, Any] = checkpoint.get("repos", {})
+        new_repo_checkpoints: dict[str, Any] = {}
         docs_since_checkpoint = 0
 
         try:
@@ -146,10 +146,10 @@ class GitHubConnector(Connector):
 
                 full_name = repo.full_name
                 is_private = repo.private
-                prev = repo_states.get(full_name, {})
+                prev = repo_checkpoints.get(full_name, {})
                 owner, name = full_name.split("/", 1)
 
-                new_state_entry: dict[str, str] = {}
+                new_checkpoint_entry: dict[str, str] = {}
 
                 # Sync repo document
                 docs_since_checkpoint = await self._sync_repo(
@@ -159,7 +159,7 @@ class GitHubConnector(Connector):
                     name,
                     ctx,
                     docs_since_checkpoint,
-                    new_repo_states,
+                    new_repo_checkpoints,
                 )
 
                 # Sync issues
@@ -198,7 +198,7 @@ class GitHubConnector(Connector):
                     await ctx.emit_error(f"github:issue:{full_name}:*", str(e))
 
                 if latest_issue_ts:
-                    new_state_entry["issues_updated_at"] = latest_issue_ts
+                    new_checkpoint_entry["issues_updated_at"] = latest_issue_ts
 
                 # Sync pull requests
                 since_prs = prev.get("prs_updated_at")
@@ -246,7 +246,7 @@ class GitHubConnector(Connector):
                     await ctx.emit_error(f"github:pr:{full_name}:*", str(e))
 
                 if latest_pr_ts:
-                    new_state_entry["prs_updated_at"] = latest_pr_ts
+                    new_checkpoint_entry["prs_updated_at"] = latest_pr_ts
 
                 # Sync discussions
                 if config.include_discussions:
@@ -285,16 +285,16 @@ class GitHubConnector(Connector):
                         await ctx.emit_error(f"github:discussion:{full_name}:*", str(e))
 
                     if latest_disc_ts:
-                        new_state_entry["discussions_updated_at"] = latest_disc_ts
+                        new_checkpoint_entry["discussions_updated_at"] = latest_disc_ts
 
-                if new_state_entry:
-                    new_repo_states[full_name] = new_state_entry
+                if new_checkpoint_entry:
+                    new_repo_checkpoints[full_name] = new_checkpoint_entry
 
                 if docs_since_checkpoint >= CHECKPOINT_INTERVAL:
-                    await ctx.save_checkpoint({"repos": new_repo_states})
+                    await ctx.save_checkpoint({"repos": new_repo_checkpoints})
                     docs_since_checkpoint = 0
 
-            await ctx.complete(new_state={"repos": new_repo_states})
+            await ctx.complete(checkpoint={"repos": new_repo_checkpoints})
             logger.info(
                 "Sync completed: %d scanned, %d emitted",
                 ctx.documents_scanned,
@@ -317,7 +317,7 @@ class GitHubConnector(Connector):
         name: str,
         ctx: SyncContext,
         docs_since_checkpoint: int,
-        new_repo_states: dict[str, Any],
+        new_repo_checkpoints: dict[str, Any],
     ) -> int:
         """Sync a single repository document. Returns updated docs_since_checkpoint."""
         await ctx.increment_scanned()

--- a/connectors/github/tests/test_full_sync.py
+++ b/connectors/github/tests/test_full_sync.py
@@ -33,7 +33,7 @@ async def test_full_sync_creates_all_documents(
     assert n_events >= 4, f"Expected >=4 document_created events, got {n_events}"
 
 
-async def test_full_sync_saves_connector_state(
+async def test_full_sync_saves_checkpoint(
     harness, seed, source_id, mock_github_api, cm_client: httpx.AsyncClient
 ):
     mock_github_api.add_repo("octocat", "Hello-World")
@@ -46,10 +46,10 @@ async def test_full_sync_saves_connector_state(
     sync_run_id = resp.json()["sync_run_id"]
     await wait_for_sync(harness.db_pool, sync_run_id, timeout=30)
 
-    state = await seed.get_connector_state(source_id)
-    assert state is not None, "connector_state should be saved after sync"
-    assert "repos" in state
-    assert "octocat/Hello-World" in state["repos"]
+    checkpoint = await seed.get_checkpoint(source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
+    assert "repos" in checkpoint
+    assert "octocat/Hello-World" in checkpoint["repos"]
 
 
 async def test_full_sync_scanned_count(

--- a/connectors/google_ads/google_ads_connector/connector.py
+++ b/connectors/google_ads/google_ads_connector/connector.py
@@ -409,7 +409,7 @@ class GoogleAdsConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         try:
@@ -421,15 +421,17 @@ class GoogleAdsConnector(Connector):
             )
             creds = GoogleAdsCredentials.parse(merged_creds)
             config = GoogleAdsSourceConfig.parse(source_config, merged_creds)
-            checkpoint = _parse_checkpoint(state)
+            parsed_checkpoint = _parse_checkpoint(checkpoint)
         except ValueError as exc:
             await ctx.fail(str(exc))
             return
 
         if not config.sync_enabled:
             await ctx.complete(
-                new_state=_checkpoint(
-                    last_successful_sync_at=_last_successful_sync_time(checkpoint),
+                checkpoint=_checkpoint(
+                    last_successful_sync_at=_last_successful_sync_time(
+                        parsed_checkpoint
+                    ),
                     last_completed_unit=None,
                 )
             )
@@ -439,9 +441,9 @@ class GoogleAdsConnector(Connector):
 
         try:
             if ctx.sync_mode == SyncMode.INCREMENTAL:
-                await self._incremental_sync(client, config, checkpoint, ctx)
+                await self._incremental_sync(client, config, parsed_checkpoint, ctx)
             else:
-                await self._full_sync(client, config, checkpoint, ctx)
+                await self._full_sync(client, config, parsed_checkpoint, ctx)
         except GoogleAdsConnectorError as exc:
             logger.exception("Google Ads sync failed")
             await ctx.fail(str(exc))
@@ -501,7 +503,7 @@ class GoogleAdsConnector(Connector):
             )
 
         await ctx.complete(
-            new_state=_checkpoint(
+            checkpoint=_checkpoint(
                 last_successful_sync_at=run_started_at,
                 last_completed_unit=None,
             )
@@ -595,7 +597,7 @@ class GoogleAdsConnector(Connector):
             )
 
         await ctx.complete(
-            new_state=_checkpoint(
+            checkpoint=_checkpoint(
                 last_successful_sync_at=run_started_at,
                 last_completed_unit=None,
             )

--- a/connectors/google_ads/tests/test_connector.py
+++ b/connectors/google_ads/tests/test_connector.py
@@ -50,11 +50,11 @@ class FakeContext:
     async def save_checkpoint(self, checkpoint):
         self.checkpoints.append(checkpoint)
 
-    async def save_connector_state(self, state):
-        self.connector_states.append(state)
+    async def save_connector_state(self, connector_state):
+        self.connector_states.append(connector_state)
 
-    async def complete(self, new_state=None):
-        self.completed = new_state or {}
+    async def complete(self, checkpoint=None):
+        self.completed = checkpoint or {}
 
     async def fail(self, error):
         self.failed = error

--- a/connectors/hubspot/hubspot_connector/connector.py
+++ b/connectors/hubspot/hubspot_connector/connector.py
@@ -40,7 +40,7 @@ class HubSpotConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         """
@@ -49,7 +49,7 @@ class HubSpotConnector(Connector):
         Args:
             source_config: Source configuration (may contain portal_id)
             credentials: Must contain 'access_token'
-            state: Previous sync state (unused for full sync)
+            checkpoint: Previous checkpoint (unused for full sync)
             ctx: Sync context with emit(), complete(), etc.
         """
         access_token = credentials.get("access_token")
@@ -83,7 +83,7 @@ class HubSpotConnector(Connector):
 
                 await self._sync_object_type(client, object_type, portal_id, ctx)
 
-            await ctx.complete(new_state={})
+            await ctx.complete(checkpoint={})
             logger.info(
                 "Sync completed: %d scanned, %d emitted",
                 ctx.documents_scanned,

--- a/connectors/microsoft/ms_connector/connector.py
+++ b/connectors/microsoft/ms_connector/connector.py
@@ -253,7 +253,7 @@ class MicrosoftConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         try:
@@ -303,20 +303,20 @@ class MicrosoftConnector(Connector):
         }
 
         syncer = self._create_syncer(syncer_key, source_config)
-        state = state or {}
+        checkpoint = checkpoint or {}
 
         logger.info("Starting Microsoft sync (syncer=%s)", syncer_key)
 
         try:
-            result_state = await syncer.sync(
+            result_checkpoint = await syncer.sync(
                 client,
                 ctx,
-                state,
+                checkpoint,
                 source_config=source_config,
                 user_cache=user_cache,
                 group_cache=group_cache,
             )
-            await ctx.complete(new_state=result_state)
+            await ctx.complete(checkpoint=result_checkpoint)
             logger.info(
                 "Sync completed: %d scanned, %d emitted",
                 ctx.documents_scanned,

--- a/connectors/microsoft/ms_connector/syncers/base.py
+++ b/connectors/microsoft/ms_connector/syncers/base.py
@@ -56,14 +56,14 @@ class BaseSyncer(abc.ABC):
         self,
         client: GraphClient,
         ctx: SyncContext,
-        state: dict[str, Any],
+        checkpoint: dict[str, Any],
         source_config: dict[str, Any] | None = None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
     ) -> dict[str, Any]:
-        """Run sync across all users. Returns updated state dict."""
+        """Run sync across all users. Returns updated checkpoint dict."""
         source_config = source_config or {}
-        delta_tokens: dict[str, str] = state.get("delta_tokens", {})
+        delta_tokens: dict[str, str] = checkpoint.get("delta_tokens", {})
         # Seed with existing tokens so users not processed this run retain theirs.
         new_tokens: dict[str, str] = dict(delta_tokens)
 

--- a/connectors/microsoft/ms_connector/syncers/mail.py
+++ b/connectors/microsoft/ms_connector/syncers/mail.py
@@ -32,14 +32,14 @@ class MailSyncer(BaseSyncer):
         self,
         client: GraphClient,
         ctx: SyncContext,
-        state: dict[str, Any],
+        checkpoint: dict[str, Any],
         source_config: dict[str, Any] | None = None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
     ) -> dict[str, Any]:
         """Run mail sync across all users and mail folders."""
         source_config = source_config or {}
-        delta_tokens: dict[str, str] = state.get("delta_tokens", {})
+        delta_tokens: dict[str, str] = checkpoint.get("delta_tokens", {})
         new_tokens: dict[str, str] = dict(delta_tokens)
 
         users = await client.list_users()

--- a/connectors/microsoft/ms_connector/syncers/sharepoint.py
+++ b/connectors/microsoft/ms_connector/syncers/sharepoint.py
@@ -142,7 +142,7 @@ class SharePointSyncer:
         self,
         client: GraphClient,
         ctx: SyncContext,
-        state: dict[str, Any],
+        checkpoint: dict[str, Any],
         source_config: dict[str, Any] | None = None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
@@ -152,7 +152,7 @@ class SharePointSyncer:
         self._drive_permissions: dict[DriveId, list[GraphPermission]] = {}
         self._site_members: dict[SiteId, list[Email]] = {}
 
-        delta_tokens: dict[str, str] = dict(state.get(DRIVE_DELTA_TOKENS_KEY, {}))
+        delta_tokens: dict[str, str] = dict(checkpoint.get(DRIVE_DELTA_TOKENS_KEY, {}))
         skip_classifications: Counter[str] = Counter()
 
         sites = await self._list_sites(client)

--- a/connectors/microsoft/ms_connector/syncers/teams.py
+++ b/connectors/microsoft/ms_connector/syncers/teams.py
@@ -317,7 +317,7 @@ class TeamsSyncer:
         self,
         client: GraphClient,
         ctx: SyncContext,
-        state: dict[str, Any],
+        checkpoint: dict[str, Any],
         source_config: dict[str, Any] | None = None,
         user_cache: dict[str, str] | None = None,
         group_cache: dict[str, str] | None = None,
@@ -325,9 +325,9 @@ class TeamsSyncer:
         source_config = source_config or {}
         user_cache = user_cache or {}
         group_cache = group_cache or {}
-        delta_tokens: dict[str, str] = state.get("delta_tokens", {})
-        last_sync_ts: dict[str, str] = state.get("last_sync_ts", {})
-        chat_last_sync_ts: dict[str, str] = state.get("chat_last_sync_ts", {})
+        delta_tokens: dict[str, str] = checkpoint.get("delta_tokens", {})
+        last_sync_ts: dict[str, str] = checkpoint.get("last_sync_ts", {})
+        chat_last_sync_ts: dict[str, str] = checkpoint.get("chat_last_sync_ts", {})
         new_tokens: dict[str, str] = dict(delta_tokens)
         new_sync_ts: dict[str, str] = dict(last_sync_ts)
         new_chat_sync_ts: dict[str, str] = dict(chat_last_sync_ts)

--- a/connectors/microsoft/tests/test_full_sync.py
+++ b/connectors/microsoft/tests/test_full_sync.py
@@ -81,8 +81,8 @@ async def test_onedrive_sync(
         did.startswith("onedrive:") for did in doc_ids
     ), f"No onedrive doc in {doc_ids}"
 
-    state = await seed.get_connector_state(onedrive_source_id)
-    assert state is not None, "connector_state should be saved after sync"
+    checkpoint = await seed.get_checkpoint(onedrive_source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
 
 
 async def test_onedrive_paged_delta_sync(
@@ -134,8 +134,8 @@ async def test_onedrive_paged_delta_sync(
     }
     assert f"onedrive:{DRIVE_ID}:paged-file" in doc_ids
 
-    state = await seed.get_connector_state(source_id)
-    token = state.get("delta_tokens", {}).get(USER_ID, "")
+    checkpoint = await seed.get_checkpoint(source_id)
+    token = checkpoint.get("delta_tokens", {}).get(USER_ID, "")
     assert "deltatoken=latest" in token
 
 
@@ -198,8 +198,8 @@ async def test_outlook_sync(
     }
     assert any(did.startswith("mail:") for did in doc_ids), f"No mail doc in {doc_ids}"
 
-    state = await seed.get_connector_state(outlook_source_id)
-    assert state is not None, "connector_state should be saved after sync"
+    checkpoint = await seed.get_checkpoint(outlook_source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
 
 
 async def test_outlook_deleted_delta_emits_document_deleted(
@@ -314,8 +314,8 @@ async def test_outlook_calendar_sync(
         did.startswith("calendar:") for did in doc_ids
     ), f"No calendar doc in {doc_ids}"
 
-    state = await seed.get_connector_state(outlook_calendar_source_id)
-    assert state is not None, "connector_state should be saved after sync"
+    checkpoint = await seed.get_checkpoint(outlook_calendar_source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
 
 
 async def test_sharepoint_sync(
@@ -375,8 +375,8 @@ async def test_sharepoint_sync(
         did.startswith("sharepoint:") for did in doc_ids
     ), f"No sharepoint doc in {doc_ids}"
 
-    state = await seed.get_connector_state(sharepoint_source_id)
-    assert state is not None, "connector_state should be saved after sync"
+    checkpoint = await seed.get_checkpoint(sharepoint_source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
 
 
 async def test_sharepoint_multi_drive_and_folder_sync(
@@ -465,8 +465,8 @@ async def test_sharepoint_multi_drive_and_folder_sync(
     assert f"sharepoint:{site_id}:{drive_a}:file-a" in doc_ids, doc_ids
     assert f"sharepoint:{site_id}:{drive_b}:file-b" in doc_ids, doc_ids
 
-    state = await seed.get_connector_state(sharepoint_source_id)
-    tokens = state.get("delta_tokens", {})
+    checkpoint = await seed.get_checkpoint(sharepoint_source_id)
+    tokens = checkpoint.get("delta_tokens", {})
     assert drive_a in tokens and drive_b in tokens, tokens
 
 
@@ -512,8 +512,8 @@ async def test_sharepoint_delta_resync_on_410(
     row = await wait_for_sync(harness.db_pool, sync_run_id, timeout=60)
     assert row["status"] == "completed"
 
-    state = await seed.get_connector_state(sharepoint_source_id)
-    assert drive_id in state.get("delta_tokens", {})
+    checkpoint = await seed.get_checkpoint(sharepoint_source_id)
+    assert drive_id in checkpoint.get("delta_tokens", {})
 
     # Second sync — first delta call returns 410, retry should succeed.
     mock_graph_api.queue_drive_delta_error(
@@ -730,9 +730,9 @@ async def test_teams_basic_sync(
         did.startswith("teams:") for did in doc_ids
     ), f"No teams doc in {doc_ids}"
 
-    state = await seed.get_connector_state(ms_teams_source_id)
-    assert state is not None, "connector_state should be saved after sync"
-    assert "delta_tokens" in state
+    checkpoint = await seed.get_checkpoint(ms_teams_source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
+    assert "delta_tokens" in checkpoint
 
 
 async def test_teams_thread_sync(

--- a/connectors/microsoft/tests/test_syncers.py
+++ b/connectors/microsoft/tests/test_syncers.py
@@ -1,4 +1,4 @@
-"""Focused tests for Microsoft syncer state and delta edge cases."""
+"""Focused tests for Microsoft syncer checkpoint and delta edge cases."""
 
 import copy
 from typing import Any
@@ -20,7 +20,7 @@ class FakeContentStorage:
 class FakeContext:
     def __init__(self) -> None:
         self.deleted: list[str] = []
-        self.saved_states: list[dict[str, Any]] = []
+        self.saved_checkpoints: list[dict[str, Any]] = []
         self.scanned = 0
         self.content_storage = FakeContentStorage()
 
@@ -30,8 +30,8 @@ class FakeContext:
     def should_index_user(self, email: str) -> bool:
         return True
 
-    async def save_state(self, state: dict[str, Any]) -> None:
-        self.saved_states.append(copy.deepcopy(state))
+    async def save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
+        self.saved_checkpoints.append(copy.deepcopy(checkpoint))
 
     async def emit_deleted(self, external_id: str) -> None:
         self.deleted.append(external_id)
@@ -76,7 +76,9 @@ async def test_onedrive_checkpoints_each_completed_delta_page() -> None:
         token_key="u1",
     )
 
-    saved_tokens = [state["delta_tokens"]["u1"] for state in ctx.saved_states]
+    saved_tokens = [
+        checkpoint["delta_tokens"]["u1"] for checkpoint in ctx.saved_checkpoints
+    ]
     assert saved_tokens == ["next-token", "delta-token"]
     assert token == "delta-token"
 
@@ -138,13 +140,13 @@ async def test_mail_preserves_existing_tokens_when_folder_has_no_new_token() -> 
         async def get_delta(self, *args: Any, **kwargs: Any):
             return ([], None)
 
-    state = {"delta_tokens": {"u1:inbox": "old-inbox", "u1:archive": "old-archive"}}
-    result = await MailSyncer().sync(Client(), ctx, state)
+    checkpoint = {"delta_tokens": {"u1:inbox": "old-inbox", "u1:archive": "old-archive"}}
+    result = await MailSyncer().sync(Client(), ctx, checkpoint)
 
-    assert result["delta_tokens"] == state["delta_tokens"]
+    assert result["delta_tokens"] == checkpoint["delta_tokens"]
 
 
-async def test_teams_preserves_existing_channel_and_chat_state() -> None:
+async def test_teams_preserves_existing_channel_and_chat_checkpoint() -> None:
     ctx = FakeContext()
 
     class Client:
@@ -154,14 +156,14 @@ async def test_teams_preserves_existing_channel_and_chat_state() -> None:
         async def list_users(self) -> list[dict[str, Any]]:
             return []
 
-    state = {
+    checkpoint = {
         "delta_tokens": {"team:channel": "delta-token"},
         "last_sync_ts": {"team:channel": "2026-01-01T00:00:00+00:00"},
         "chat_last_sync_ts": {"chat-1": "2026-01-01T00:00:00+00:00"},
     }
-    result = await TeamsSyncer().sync(Client(), ctx, state)
+    result = await TeamsSyncer().sync(Client(), ctx, checkpoint)
 
-    assert result == state
+    assert result == checkpoint
 
 
 async def test_base_syncer_fails_when_all_users_fail() -> None:

--- a/connectors/notion/notion_connector/connector.py
+++ b/connectors/notion/notion_connector/connector.py
@@ -108,7 +108,7 @@ class NotionConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         token = _extract_token(credentials)
@@ -146,11 +146,11 @@ class NotionConnector(Connector):
             client, permission_group, workspace_name, ctx
         )
 
-        state = state or {}
+        checkpoint = checkpoint or {}
 
         try:
-            if ctx.sync_mode == SyncMode.INCREMENTAL and state.get("last_sync_at"):
-                await self._incremental_sync(client, state, permission_group, ctx)
+            if ctx.sync_mode == SyncMode.INCREMENTAL and checkpoint.get("last_sync_at"):
+                await self._incremental_sync(client, checkpoint, permission_group, ctx)
             else:
                 await self._full_sync(client, permission_group, ctx)
         except AuthenticationError as e:
@@ -254,7 +254,7 @@ class NotionConnector(Connector):
                     data_source_entry_ids.update(entries)
 
                     if docs_emitted >= CHECKPOINT_INTERVAL:
-                        await ctx.save_checkpoint(ctx.state)
+                        await ctx.save_checkpoint(ctx.checkpoint)
                         docs_emitted = 0
                 except NotionError as e:
                     logger.error("Error syncing data source %s: %s", ds_id, e)
@@ -299,14 +299,14 @@ class NotionConnector(Connector):
                     await ctx.emit_error(eid, str(e))
 
                 if docs_emitted >= CHECKPOINT_INTERVAL:
-                    await ctx.save_checkpoint(ctx.state)
+                    await ctx.save_checkpoint(ctx.checkpoint)
                     docs_emitted = 0
 
             if not response.get("has_more"):
                 break
             cursor = response.get("next_cursor")
 
-        await ctx.complete(new_state={"last_sync_at": sync_started_at})
+        await ctx.complete(checkpoint={"last_sync_at": sync_started_at})
         logger.info(
             "Full sync completed: %d scanned, %d emitted",
             ctx.documents_scanned,
@@ -316,12 +316,12 @@ class NotionConnector(Connector):
     async def _incremental_sync(
         self,
         client: NotionClient,
-        state: dict[str, Any],
+        checkpoint: dict[str, Any],
         permission_group: str,
         ctx: SyncContext,
     ) -> None:
         """Incremental sync: re-index pages/data sources modified since last sync."""
-        last_sync_at = state["last_sync_at"]
+        last_sync_at = checkpoint["last_sync_at"]
         sync_started_at = datetime.now(UTC).isoformat()
         docs_emitted = 0
 
@@ -409,7 +409,7 @@ class NotionConnector(Connector):
                 break
             cursor = response.get("next_cursor")
 
-        await ctx.complete(new_state={"last_sync_at": sync_started_at})
+        await ctx.complete(checkpoint={"last_sync_at": sync_started_at})
         logger.info(
             "Incremental sync completed: %d scanned, %d emitted",
             ctx.documents_scanned,
@@ -528,7 +528,7 @@ class NotionConnector(Connector):
                     await ctx.emit_error(eid, str(e))
 
                 if docs_emitted >= CHECKPOINT_INTERVAL:
-                    await ctx.save_checkpoint(ctx.state)
+                    await ctx.save_checkpoint(ctx.checkpoint)
                     docs_emitted = 0
 
             if not response.get("has_more"):

--- a/connectors/notion/tests/test_full_sync.py
+++ b/connectors/notion/tests/test_full_sync.py
@@ -144,9 +144,9 @@ async def test_full_sync_indexes_pages_and_data_sources(
         ), f"document {event['payload']['document_id']} missing workspace group"
         assert perms["public"] is False
 
-    state = await seed.get_connector_state(source_id)
-    assert state is not None, "connector_state should be saved after sync"
-    assert "last_sync_at" in state
+    checkpoint = await seed.get_checkpoint(source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
+    assert "last_sync_at" in checkpoint
 
     assert (
         row["documents_scanned"] >= 3
@@ -156,9 +156,9 @@ async def test_full_sync_indexes_pages_and_data_sources(
 async def test_full_sync_honors_requested_mode_when_state_exists(
     harness, seed, source_id, mock_notion_api, cm_client: httpx.AsyncClient
 ):
-    """A requested full sync must not be demoted to incremental by connector state."""
+    """A requested full sync must not be demoted to incremental by checkpoint."""
     cutoff = "2024-06-01T00:00:00.000Z"
-    await seed.set_connector_state(source_id, {"last_sync_at": cutoff})
+    await seed.set_checkpoint(source_id, {"last_sync_at": cutoff})
 
     mock_notion_api.add_page(
         OLD_FULL_SYNC_PAGE_ID,

--- a/connectors/notion/tests/test_incremental_sync.py
+++ b/connectors/notion/tests/test_incremental_sync.py
@@ -45,10 +45,10 @@ async def test_incremental_sync_only_emits_modified_items(
         last_edited_time="2024-08-01T12:00:00.000Z",
     )
 
-    # Seed connector_state to simulate a prior successful sync. The cutoff
+    # Seed checkpoint to simulate a prior successful sync. The cutoff
     # falls between the stale page and the two recent ones.
     cutoff = "2024-06-01T00:00:00.000Z"
-    await seed.set_connector_state(source_id, {"last_sync_at": cutoff})
+    await seed.set_checkpoint(source_id, {"last_sync_at": cutoff})
 
     resp = await cm_client.post(
         "/sync",
@@ -78,8 +78,8 @@ async def test_incremental_sync_only_emits_modified_items(
     assert f"notion:page:{NEWER_PAGE_ID}" in doc_ids
     assert f"notion:page:{OLD_PAGE_ID}" not in doc_ids
 
-    state = await seed.get_connector_state(source_id)
-    assert state is not None
+    checkpoint = await seed.get_checkpoint(source_id)
+    assert checkpoint is not None
     assert (
-        state["last_sync_at"] > cutoff
+        checkpoint["last_sync_at"] > cutoff
     ), "last_sync_at should advance to the new run's timestamp"

--- a/connectors/paperless/paperless_connector/connector.py
+++ b/connectors/paperless/paperless_connector/connector.py
@@ -53,7 +53,7 @@ class PaperlessConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         base_url = source_config.get("base_url", "").strip().rstrip("/")
@@ -78,13 +78,11 @@ class PaperlessConnector(Connector):
                 await ctx.fail(f"Connection to paperless-ngx failed: {e}")
                 return
 
-            # Incremental sync: if we have state with a last_sync_at timestamp,
-            # only fetch documents modified after that time. This is state-driven
-            # (like the ClickUp connector) rather than relying on ctx.sync_mode,
-            # because SyncContext does not expose sync_mode.
+            # Incremental sync: if we have a checkpoint with a last_sync_at timestamp,
+            # only fetch documents modified after that time.
             modified_after: datetime | None = None
-            if state:
-                last_sync_ts = state.get("last_sync_at")
+            if checkpoint:
+                last_sync_ts = checkpoint.get("last_sync_at")
                 if last_sync_ts:
                     try:
                         modified_after = datetime.fromisoformat(last_sync_ts)
@@ -128,7 +126,7 @@ class PaperlessConnector(Connector):
                     docs_since_checkpoint = 0
 
             await ctx.complete(
-                new_state={"last_sync_at": sync_started_at.isoformat()}
+                checkpoint={"last_sync_at": sync_started_at.isoformat()}
             )
             logger.info(
                 "Sync completed: %d scanned, %d emitted",

--- a/connectors/paperless/tests/test_connector.py
+++ b/connectors/paperless/tests/test_connector.py
@@ -35,7 +35,7 @@ def _make_ctx(
     ctx._errors = errors
     ctx._failed: list[str] = []
     ctx._completed: list[dict | None] = []
-    ctx._saved_states: list[dict] = []
+    ctx._saved_checkpoints: list[dict] = []
 
     async def _emit(doc: Any) -> None:
         emitted.append(doc)
@@ -50,11 +50,11 @@ def _make_ctx(
     async def _fail(msg: str) -> None:
         ctx._failed.append(msg)
 
-    async def _complete(new_state: dict | None = None) -> None:
-        ctx._completed.append(new_state)
+    async def _complete(checkpoint: dict | None = None) -> None:
+        ctx._completed.append(checkpoint)
 
-    async def _save_state(state: dict) -> None:
-        ctx._saved_states.append(state)
+    async def _save_checkpoint(checkpoint: dict) -> None:
+        ctx._saved_checkpoints.append(checkpoint)
 
     # Content storage returns a predictable content_id
     ctx.content_storage = MagicMock()
@@ -65,7 +65,7 @@ def _make_ctx(
     ctx.emit_error = AsyncMock(side_effect=_emit_error)
     ctx.fail = AsyncMock(side_effect=_fail)
     ctx.complete = AsyncMock(side_effect=_complete)
-    ctx.save_state = AsyncMock(side_effect=_save_state)
+    ctx.save_checkpoint = AsyncMock(side_effect=_save_checkpoint)
 
     return ctx
 
@@ -200,8 +200,8 @@ class TestFullSync:
         assert len(ctx._emitted) == 2
         assert ctx._completed, "sync should complete successfully"
 
-    async def test_first_sync_without_state_fetches_all(self) -> None:
-        """First sync (no prior state) should fetch all documents (modified_after=None)."""
+    async def test_first_sync_without_checkpoint_fetches_all(self) -> None:
+        """First sync (no prior checkpoint) should fetch all documents (modified_after=None)."""
         connector = PaperlessConnector()
         ctx = _make_ctx()
 
@@ -221,7 +221,7 @@ class TestFullSync:
         ):
             await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, None, ctx)
 
-        # Without state, modified_after should be None
+        # Without checkpoint, modified_after should be None
         mock_list.assert_called_once_with(modified_after=None)
 
     async def test_documents_scanned_count_incremented(self) -> None:
@@ -248,7 +248,7 @@ class TestFullSync:
 
         assert ctx.documents_scanned == 3
 
-    async def test_state_saved_after_completion(self) -> None:
+    async def test_checkpoint_saved_after_completion(self) -> None:
         connector = PaperlessConnector()
         ctx = _make_ctx()
 
@@ -270,9 +270,9 @@ class TestFullSync:
             await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, None, ctx)
 
         assert ctx._completed
-        final_state = ctx._completed[0]
-        assert final_state is not None
-        assert "last_sync_at" in final_state
+        final_checkpoint = ctx._completed[0]
+        assert final_checkpoint is not None
+        assert "last_sync_at" in final_checkpoint
 
     async def test_document_processing_error_continues_sync(self) -> None:
         """A single bad document should not abort the entire sync."""
@@ -356,10 +356,10 @@ class TestFullSync:
 
 
 class TestIncrementalSync:
-    async def test_state_driven_incremental_passes_modified_after(self) -> None:
-        """When state has last_sync_at, list_documents is called with modified_after."""
+    async def test_checkpoint_driven_incremental_passes_modified_after(self) -> None:
+        """When checkpoint has last_sync_at, list_documents is called with modified_after."""
         connector = PaperlessConnector()
-        state = {"last_sync_at": "2024-06-01T00:00:00+00:00"}
+        checkpoint = {"last_sync_at": "2024-06-01T00:00:00+00:00"}
         ctx = _make_ctx()
 
         with (
@@ -376,7 +376,7 @@ class TestIncrementalSync:
                 new_callable=AsyncMock,
             ),
         ):
-            await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, state, ctx)
+            await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, checkpoint, ctx)
 
         call_kwargs = mock_list.call_args
         modified_after = call_kwargs.kwargs.get("modified_after")
@@ -384,8 +384,8 @@ class TestIncrementalSync:
         assert modified_after.year == 2024
         assert modified_after.month == 6
 
-    async def test_no_state_fetches_all(self) -> None:
-        """Without prior state, all documents are fetched (modified_after=None)."""
+    async def test_no_checkpoint_fetches_all(self) -> None:
+        """Without prior checkpoint, all documents are fetched (modified_after=None)."""
         connector = PaperlessConnector()
         ctx = _make_ctx()
 
@@ -407,8 +407,8 @@ class TestIncrementalSync:
 
         mock_list.assert_called_once_with(modified_after=None)
 
-    async def test_empty_state_fetches_all(self) -> None:
-        """Empty state dict should also fetch all."""
+    async def test_empty_checkpoint_fetches_all(self) -> None:
+        """Empty checkpoint dict should also fetch all."""
         connector = PaperlessConnector()
         ctx = _make_ctx()
 
@@ -431,9 +431,9 @@ class TestIncrementalSync:
         mock_list.assert_called_once_with(modified_after=None)
 
     async def test_malformed_last_sync_at_fetches_all(self) -> None:
-        """Malformed timestamp in state should fall back to full sync."""
+        """Malformed timestamp in checkpoint should fall back to full sync."""
         connector = PaperlessConnector()
-        state = {"last_sync_at": "not-a-timestamp"}
+        checkpoint = {"last_sync_at": "not-a-timestamp"}
         ctx = _make_ctx()
 
         with (
@@ -450,14 +450,14 @@ class TestIncrementalSync:
                 new_callable=AsyncMock,
             ),
         ):
-            await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, state, ctx)
+            await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, checkpoint, ctx)
 
         mock_list.assert_called_once_with(modified_after=None)
 
-    async def test_incremental_updates_state_after_completion(self) -> None:
+    async def test_incremental_updates_checkpoint_after_completion(self) -> None:
         """Incremental sync should save a new last_sync_at timestamp."""
         connector = PaperlessConnector()
-        state = {"last_sync_at": "2024-01-01T00:00:00+00:00"}
+        checkpoint = {"last_sync_at": "2024-01-01T00:00:00+00:00"}
         ctx = _make_ctx()
 
         with (
@@ -475,14 +475,14 @@ class TestIncrementalSync:
                 return_value=_parsed_doc(1),
             ),
         ):
-            await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, state, ctx)
+            await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, checkpoint, ctx)
 
         assert ctx._completed
-        new_state = ctx._completed[0]
-        assert new_state is not None
-        assert "last_sync_at" in new_state
+        checkpoint = ctx._completed[0]
+        assert checkpoint is not None
+        assert "last_sync_at" in checkpoint
         # New timestamp should be different from the old one
-        assert new_state["last_sync_at"] != "2024-01-01T00:00:00+00:00"
+        assert checkpoint["last_sync_at"] != "2024-01-01T00:00:00+00:00"
 
 
 class TestAuthFailures:
@@ -590,8 +590,8 @@ class TestCancellation:
 
 
 class TestCheckpointing:
-    async def test_checkpoint_interval_triggers_state_save(self) -> None:
-        """State should be saved every CHECKPOINT_INTERVAL documents."""
+    async def test_checkpoint_interval_triggers_checkpoint_save(self) -> None:
+        """Checkpoint should be saved every CHECKPOINT_INTERVAL documents."""
         from paperless_connector.config import CHECKPOINT_INTERVAL
 
         connector = PaperlessConnector()
@@ -617,5 +617,5 @@ class TestCheckpointing:
             await connector.sync(VALID_CONFIG, VALID_CREDENTIALS, None, ctx)
 
         # At least one checkpoint should have been saved
-        assert len(ctx._saved_states) >= 1
-        assert "last_sync_at" in ctx._saved_states[0]
+        assert len(ctx._saved_checkpoints) >= 1
+        assert "last_sync_at" in ctx._saved_checkpoints[0]

--- a/connectors/paperless/tests/test_integration.py
+++ b/connectors/paperless/tests/test_integration.py
@@ -52,9 +52,9 @@ async def test_full_sync_indexes_documents(
     assert f"paperless:{source_id}:1" in doc_ids
     assert f"paperless:{source_id}:2" in doc_ids
 
-    state = await seed.get_connector_state(source_id)
-    assert state is not None, "connector_state should be saved after sync"
-    assert "last_sync_at" in state
+    checkpoint = await seed.get_checkpoint(source_id)
+    assert checkpoint is not None, "checkpoint should be saved after sync"
+    assert "last_sync_at" in checkpoint
 
     assert (
         row["documents_scanned"] >= 2

--- a/sdk/python/README.md
+++ b/sdk/python/README.md
@@ -38,10 +38,10 @@ class MyConnector(Connector):
         self,
         source_config: dict,
         credentials: dict,
-        state: dict | None,
+        checkpoint: dict | None,
         ctx: SyncContext,
     ) -> None:
-        cursor = state.get("cursor") if state else None
+        cursor = checkpoint.get("cursor") if checkpoint else None
 
         async for item in fetch_items(credentials, cursor):
             if ctx.is_cancelled():
@@ -63,7 +63,7 @@ class MyConnector(Connector):
             await ctx.increment_scanned()
             cursor = item["cursor"]
 
-        await ctx.complete(new_state={"cursor": cursor})
+        await ctx.complete(checkpoint={"cursor": cursor})
 
 if __name__ == "__main__":
     MyConnector().serve(port=8000)
@@ -82,8 +82,11 @@ The `SyncContext` object is passed to your `sync()` method and provides:
 - `ctx.emit_updated(doc)` - Emit a document update
 - `ctx.emit_deleted(external_id)` - Mark a document as deleted
 - `ctx.increment_scanned()` - Increment the scanned counter
-- `ctx.save_state(state)` - Checkpoint state for resumability
-- `ctx.complete(new_state)` - Mark sync as completed
+- `ctx.checkpoint` - Current sync checkpoint for resumability
+- `ctx.connector_state` - Durable source-level metadata outside the checkpoint
+- `ctx.save_checkpoint(checkpoint)` - Persist a resumability checkpoint
+- `ctx.save_connector_state(connector_state)` - Persist non-checkpoint source metadata
+- `ctx.complete(checkpoint)` - Mark sync as completed, optionally saving a final checkpoint
 - `ctx.fail(error)` - Mark sync as failed
 - `ctx.is_cancelled()` - Check if sync was cancelled
 - `ctx.content_storage.save(content)` - Store content and get content_id

--- a/sdk/python/examples/rss_connector.py
+++ b/sdk/python/examples/rss_connector.py
@@ -83,7 +83,7 @@ class RSSConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         """Sync articles from an RSS feed."""
@@ -93,8 +93,8 @@ class RSSConnector(Connector):
             return
 
         last_sync_time = None
-        if state:
-            last_sync_str = state.get("last_sync_time")
+        if checkpoint:
+            last_sync_str = checkpoint.get("last_sync_time")
             if last_sync_str:
                 last_sync_time = datetime.fromisoformat(last_sync_str)
 
@@ -167,7 +167,7 @@ class RSSConnector(Connector):
                 await ctx.save_checkpoint({"last_sync_time": current_time.isoformat()})
                 docs_since_checkpoint = 0
 
-        await ctx.complete(new_state={"last_sync_time": current_time.isoformat()})
+        await ctx.complete(checkpoint={"last_sync_time": current_time.isoformat()})
         logger.info(
             "Sync completed: %d scanned, %d emitted",
             ctx.documents_scanned,

--- a/sdk/python/omni_connector/client.py
+++ b/sdk/python/omni_connector/client.py
@@ -34,7 +34,7 @@ class SdkClient:
         return self._client
 
     async def fetch_source_sync_data(self, source_id: str) -> SdkSourceSyncData:
-        """Fetch source sync data (config, credentials, state, filters) from connector-manager."""
+        """Fetch source sync data from connector-manager."""
         client = await self._get_client()
         response = await client.get(
             f"{self.base_url}/sdk/source/{source_id}/sync-config"
@@ -263,7 +263,7 @@ class SdkClient:
             )
 
     async def update_connector_state(
-        self, source_id: str, state: dict[str, Any]
+        self, source_id: str, connector_state: dict[str, Any]
     ) -> None:
         """Persist non-checkpoint connector metadata to the manager."""
         logger.debug("SDK: Updating connector state for source=%s", source_id)
@@ -271,7 +271,7 @@ class SdkClient:
         client = await self._get_client()
         response = await client.put(
             f"{self.base_url}/sdk/source/{source_id}/connector-state",
-            json=state,
+            json=connector_state,
         )
 
         if not response.is_success:
@@ -313,7 +313,7 @@ class SdkClient:
         sync_run_id: str,
         documents_scanned: int,
         documents_updated: int,
-        new_state: dict[str, Any] | None = None,
+        checkpoint: dict[str, Any] | None = None,
     ) -> None:
         """Mark sync as completed."""
         logger.info("SDK: Completing sync_run=%s", sync_run_id)
@@ -322,8 +322,8 @@ class SdkClient:
             "documents_scanned": documents_scanned,
             "documents_updated": documents_updated,
         }
-        if new_state is not None:
-            await self.update_checkpoint(sync_run_id, new_state)
+        if checkpoint is not None:
+            await self.update_checkpoint(sync_run_id, checkpoint)
 
         client = await self._get_client()
         response = await client.post(

--- a/sdk/python/omni_connector/connector.py
+++ b/sdk/python/omni_connector/connector.py
@@ -205,7 +205,7 @@ class Connector(ABC):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         """
@@ -214,7 +214,7 @@ class Connector(ABC):
         Args:
             source_config: Source configuration from database
             credentials: Authentication credentials
-            state: Previous sync state for incremental syncs
+            checkpoint: Previous successful checkpoint for incremental/resumed syncs
             ctx: Sync context with emit(), complete(), etc.
         """
         pass

--- a/sdk/python/omni_connector/context.py
+++ b/sdk/python/omni_connector/context.py
@@ -41,7 +41,7 @@ class SyncContext:
         sync_run_id: str,
         source_id: str,
         source_type: str | None = None,
-        state: dict[str, Any] | None = None,
+        checkpoint: dict[str, Any] | None = None,
         connector_state: dict[str, Any] | None = None,
         user_filter_mode: UserFilterMode = UserFilterMode.ALL,
         user_whitelist: list[str] | None = None,
@@ -50,15 +50,13 @@ class SyncContext:
         documents_scanned: int = 0,
         documents_updated: int = 0,
         is_resume: bool = False,
-        checkpoint: dict[str, Any] | None = None,
     ):
         self._client = sdk_client
         self._sync_run_id = sync_run_id
         self._source_id = source_id
         self._source_type = source_type
         # checkpoint is the run/source cursor used for resumability.
-        # `state` remains as a deprecated constructor alias for older SDK callers.
-        self._checkpoint = checkpoint if checkpoint is not None else (state or {})
+        self._checkpoint = checkpoint or {}
         # connector_state is durable source-level metadata, not a resume cursor.
         self._connector_state = connector_state or {}
         self._cancelled = asyncio.Event()
@@ -93,11 +91,6 @@ class SyncContext:
 
     @property
     def checkpoint(self) -> dict[str, Any]:
-        return self._checkpoint
-
-    @property
-    def state(self) -> dict[str, Any]:
-        """Deprecated alias for checkpoint."""
         return self._checkpoint
 
     @property
@@ -242,7 +235,7 @@ class SyncContext:
         await self._client.increment_scanned(self._sync_run_id)
 
     async def save_checkpoint(self, checkpoint: dict[str, Any]) -> None:
-        """Checkpoint state for resumability. Call periodically for long syncs.
+        """Checkpoint progress for resumability. Call periodically for long syncs.
 
         Persists `checkpoint` to the manager so an interrupted sync can resume
         from this point. Flushes buffered events first — without this, a crash
@@ -254,21 +247,17 @@ class SyncContext:
         await self._client.update_checkpoint(self._sync_run_id, checkpoint)
         await self._client.heartbeat(self._sync_run_id)
 
-    async def save_state(self, state: dict[str, Any]) -> None:
-        """Deprecated alias for save_checkpoint."""
-        await self.save_checkpoint(state)
-
-    async def save_connector_state(self, state: dict[str, Any]) -> None:
+    async def save_connector_state(self, connector_state: dict[str, Any]) -> None:
         """Persist source-level connector state outside the sync checkpoint."""
-        self._connector_state = state
-        await self._client.update_connector_state(self._source_id, state)
+        self._connector_state = connector_state
+        await self._client.update_connector_state(self._source_id, connector_state)
 
-    async def complete(self, new_state: dict[str, Any] | None = None) -> None:
+    async def complete(self, checkpoint: dict[str, Any] | None = None) -> None:
         """Mark sync as successfully completed. Saves final checkpoint first."""
         await self.flush()
-        if new_state is not None:
-            self._checkpoint = new_state
-            await self._client.update_checkpoint(self._sync_run_id, new_state)
+        if checkpoint is not None:
+            self._checkpoint = checkpoint
+            await self._client.update_checkpoint(self._sync_run_id, checkpoint)
         await self._client.complete(
             self._sync_run_id,
             self._documents_scanned,

--- a/sdk/python/omni_connector/testing/seed.py
+++ b/sdk/python/omni_connector/testing/seed.py
@@ -134,14 +134,6 @@ class SeedHelper:
             source_id,
         )
 
-    async def get_connector_state(self, source_id: str) -> Any:
-        """Deprecated alias for tests that historically asserted checkpoint state."""
-        return await self.get_checkpoint(source_id)
-
-    async def set_connector_state(self, source_id: str, state: dict[str, Any]) -> None:
-        """Deprecated alias for tests that historically seeded checkpoint state."""
-        await self.set_checkpoint(source_id, state)
-
     async def get_sync_run(self, sync_run_id: str) -> asyncpg.Record | None:
         return await self._pool.fetchrow(
             "SELECT * FROM sync_runs WHERE id = $1::char(26)",

--- a/sdk/python/tests/test_client.py
+++ b/sdk/python/tests/test_client.py
@@ -98,36 +98,46 @@ async def test_store_content_sends_correct_payload(sdk_client, mock_connector_ma
 
 
 @pytest.mark.asyncio
-async def test_complete_sends_correct_payload(sdk_client, mock_connector_manager):
-    """Verify sync completion request includes all fields."""
+async def test_complete_saves_checkpoint_before_completion(
+    sdk_client, mock_connector_manager
+):
+    """Verify sync completion can save a final checkpoint first."""
     await sdk_client.complete(
         sync_run_id="sync-123",
         documents_scanned=150,
         documents_updated=42,
-        new_state={"cursor": "abc123", "page": 5},
+        checkpoint={"cursor": "abc123", "page": 5},
     )
 
-    call = mock_connector_manager.calls[0]
-    assert "/sdk/sync/sync-123/complete" in str(call.request.url)
+    checkpoint_call = mock_connector_manager.calls[0]
+    assert "/sdk/sync/sync-123/checkpoint" in str(checkpoint_call.request.url)
+    assert json.loads(checkpoint_call.request.content) == {
+        "cursor": "abc123",
+        "page": 5,
+    }
 
-    payload = json.loads(call.request.content)
+    complete_call = mock_connector_manager.calls[1]
+    assert "/sdk/sync/sync-123/complete" in str(complete_call.request.url)
+
+    payload = json.loads(complete_call.request.content)
     assert payload["documents_scanned"] == 150
     assert payload["documents_updated"] == 42
-    assert payload["new_state"] == {"cursor": "abc123", "page": 5}
 
 
 @pytest.mark.asyncio
-async def test_complete_without_state(sdk_client, mock_connector_manager):
-    """Verify completion works without new_state."""
+async def test_complete_without_checkpoint(sdk_client, mock_connector_manager):
+    """Verify completion works without a checkpoint."""
     await sdk_client.complete(
         sync_run_id="sync-123",
         documents_scanned=10,
         documents_updated=5,
-        new_state=None,
+        checkpoint=None,
     )
 
-    payload = json.loads(mock_connector_manager.calls[0].request.content)
-    assert "new_state" not in payload
+    assert len(mock_connector_manager.calls) == 1
+    assert "/sdk/sync/sync-123/complete" in str(
+        mock_connector_manager.calls[0].request.url
+    )
 
 
 @pytest.mark.asyncio

--- a/sdk/python/tests/test_context.py
+++ b/sdk/python/tests/test_context.py
@@ -123,7 +123,7 @@ async def test_complete_sends_correct_counts(sdk_client, mock_connector_manager)
     await ctx.emit(doc)
     await ctx.emit(doc)
 
-    await ctx.complete(new_state={"cursor": "final"})
+    await ctx.complete(checkpoint={"cursor": "final"})
 
     # Find the complete call (last one)
     complete_calls = [
@@ -134,7 +134,13 @@ async def test_complete_sends_correct_counts(sdk_client, mock_connector_manager)
     payload = json.loads(complete_calls[0].request.content)
     assert payload["documents_scanned"] == 5
     assert payload["documents_updated"] == 3  # 3 emits
-    assert payload["new_state"] == {"cursor": "final"}
+
+    checkpoint_calls = [
+        c
+        for c in mock_connector_manager.calls
+        if "checkpoint" in str(c.request.url)
+    ]
+    assert json.loads(checkpoint_calls[0].request.content) == {"cursor": "final"}
 
 
 @pytest.mark.asyncio
@@ -156,26 +162,31 @@ async def test_fail_sends_error_message(sdk_client, mock_connector_manager):
 
 
 @pytest.mark.asyncio
-async def test_save_state_persists_and_heartbeats(sdk_client, mock_connector_manager):
-    """Verify save_state() persists state to manager and triggers a heartbeat."""
+async def test_save_checkpoint_persists_and_heartbeats(
+    sdk_client, mock_connector_manager
+):
+    """Verify save_checkpoint() persists checkpoint and triggers a heartbeat."""
     ctx = SyncContext(
         sdk_client=sdk_client,
         sync_run_id="sync-123",
         source_id="source-456",
-        state={"page": 1},
+        checkpoint={"page": 1},
     )
 
-    await ctx.save_state({"page": 2, "cursor": "abc"})
+    await ctx.save_checkpoint({"page": 2, "cursor": "abc"})
 
-    state_calls = [
+    checkpoint_calls = [
         c
         for c in mock_connector_manager.calls
         if "checkpoint" in str(c.request.url)
     ]
-    assert len(state_calls) == 1
-    assert "sync-123" in str(state_calls[0].request.url)
-    assert state_calls[0].request.method == "PUT"
-    assert json.loads(state_calls[0].request.content) == {"page": 2, "cursor": "abc"}
+    assert len(checkpoint_calls) == 1
+    assert "sync-123" in str(checkpoint_calls[0].request.url)
+    assert checkpoint_calls[0].request.method == "PUT"
+    assert json.loads(checkpoint_calls[0].request.content) == {
+        "page": 2,
+        "cursor": "abc",
+    }
 
     heartbeat_calls = [
         c for c in mock_connector_manager.calls if "heartbeat" in str(c.request.url)
@@ -183,8 +194,8 @@ async def test_save_state_persists_and_heartbeats(sdk_client, mock_connector_man
     assert len(heartbeat_calls) == 1
     assert "sync-123" in str(heartbeat_calls[0].request.url)
 
-    # State should be updated locally
-    assert ctx.state == {"page": 2, "cursor": "abc"}
+    # Checkpoint should be updated locally
+    assert ctx.checkpoint == {"page": 2, "cursor": "abc"}
 
 
 @pytest.mark.asyncio
@@ -267,12 +278,12 @@ def test_context_exposes_properties():
         sdk_client=MockClient(),  # type: ignore
         sync_run_id="sync-run-id",
         source_id="source-id",
-        state={"existing": "state"},
+        checkpoint={"existing": "checkpoint"},
     )
 
     assert ctx.sync_run_id == "sync-run-id"
     assert ctx.source_id == "source-id"
-    assert ctx.state == {"existing": "state"}
+    assert ctx.checkpoint == {"existing": "checkpoint"}
     assert ctx.documents_emitted == 0
     assert ctx.documents_scanned == 0
     assert ctx.content_storage is not None

--- a/sdk/python/tests/test_mcp_adapter.py
+++ b/sdk/python/tests/test_mcp_adapter.py
@@ -233,7 +233,7 @@ class TestConnectorMcpIntegration:
                 self,
                 source_config: dict[str, Any],
                 credentials: dict[str, Any],
-                state: dict[str, Any] | None,
+                checkpoint: dict[str, Any] | None,
                 ctx: Any,
             ) -> None:
                 pass

--- a/sdk/python/tests/test_server.py
+++ b/sdk/python/tests/test_server.py
@@ -67,11 +67,11 @@ class MockConnector(Connector):
         self,
         source_config: dict[str, Any],
         credentials: dict[str, Any],
-        state: dict[str, Any] | None,
+        checkpoint: dict[str, Any] | None,
         ctx: SyncContext,
     ) -> None:
         self.sync_called = True
-        self.sync_args = (source_config, credentials, state)
+        self.sync_args = (source_config, credentials, checkpoint)
         # Simulate emitting a document
         await ctx.emit(
             Document(
@@ -80,7 +80,7 @@ class MockConnector(Connector):
                 content_id="content-123",
             )
         )
-        await ctx.complete(new_state={"synced": True})
+        await ctx.complete(checkpoint={"synced": True})
 
     async def execute_action(
         self,
@@ -182,7 +182,7 @@ class TestCancelEndpoint:
             def source_types(self) -> list[str]:
                 return ["stuck"]
 
-            async def sync(self, source_config, credentials, state, ctx):
+            async def sync(self, source_config, credentials, checkpoint, ctx):
                 self.sync_calls += 1
                 if self.sync_calls == 1:
                     sync_started.set()
@@ -288,7 +288,7 @@ class TestSyncStatusEndpoint:
             def source_types(self) -> list[str]:
                 return ["blocking"]
 
-            async def sync(self, source_config, credentials, state, ctx):
+            async def sync(self, source_config, credentials, checkpoint, ctx):
                 sync_started.set()
                 while not sync_can_finish.is_set():
                     await asyncio.sleep(0.01)
@@ -423,7 +423,7 @@ class TestSyncEndpoint:
             def source_types(self) -> list[str]:
                 return ["blocking"]
 
-            async def sync(self, source_config, credentials, state, ctx):
+            async def sync(self, source_config, credentials, checkpoint, ctx):
                 sync_started.set()
                 while not sync_can_finish.is_set():
                     await asyncio.sleep(0.01)


### PR DESCRIPTION
- Remove deprecated SyncContext state aliases in favor of checkpoint
- Update Python connectors, examples, and tests to use checkpoint naming
- Keep connector_state reserved for non-checkpoint source metadata