### PR TITLE
fix(ai): increase title generation token budget

### DIFF
--- a/services/ai/services/title_generation.py
+++ b/services/ai/services/title_generation.py
@@ -63,7 +63,7 @@ async def generate_title_for_conversation(
         try:
             generated_title, usage = await llm_provider.generate_response(
                 prompt=prompt,
-                max_tokens=20,
+                max_tokens=512,
                 temperature=0.7,
                 top_p=0.9,
             )


### PR DESCRIPTION
Increase chat title generation max_tokens from 20 to 512 so providers with hidden/reasoning token overhead can return usable titles.