### PR TITLE
feat(agents): harden agent run queue

### DIFF
--- a/services/ai/agents/__init__.py
+++ b/services/ai/agents/__init__.py
@@ -1,13 +1,18 @@
-from .models import Agent, AgentRun
+from .models import Agent, AgentRun, AgentRunLog
 from .repository import AgentRepository, AgentRunRepository
-from .executor import execute_agent
-from .scheduler import run_agent_scheduler
+from .executor import execute_agent, execute_claimed_agent
+from .queue_worker import run_agent_queue_worker
+from .scheduler import run_agent_schedule_materializer, run_agent_scheduler
 
 __all__ = [
     "Agent",
     "AgentRun",
+    "AgentRunLog",
     "AgentRepository",
     "AgentRunRepository",
     "execute_agent",
+    "execute_claimed_agent",
+    "run_agent_queue_worker",
+    "run_agent_schedule_materializer",
     "run_agent_scheduler",
 ]

--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -4,30 +4,48 @@ import asyncio
 import json
 import logging
 from dataclasses import dataclass
-from datetime import UTC, datetime
+from datetime import timedelta
 from pathlib import Path
 from typing import cast
 
 import httpx
 from anthropic.types import (
+    BashCodeExecutionToolResultBlockParam,
+    CodeExecutionToolResultBlockParam,
+    ContainerUploadBlockParam,
+    ContentBlock,
+    DocumentBlockParam,
+    ImageBlockParam,
     MessageParam,
+    RedactedThinkingBlockParam,
+    SearchResultBlockParam,
+    ServerToolUseBlockParam,
     TextBlockParam,
+    TextEditorCodeExecutionToolResultBlockParam,
+    ThinkingBlockParam,
     ToolParam,
     ToolResultBlockParam,
+    ToolSearchToolResultBlockParam,
     ToolUseBlockParam,
+    WebFetchToolResultBlockParam,
+    WebSearchToolResultBlockParam,
 )
 
 from config import (
+    AGENT_MAX_CONCURRENT_RUNS,
     AGENT_MAX_ITERATIONS,
+    AGENT_RUN_BACKOFF_SECONDS,
+    AGENT_RUN_LEASE_SECONDS,
+    AGENT_RUN_MAX_ATTEMPTS,
     CONNECTOR_MANAGER_URL,
     DEFAULT_MAX_TOKENS,
     DEFAULT_TEMPERATURE,
     DEFAULT_TOP_P,
     SANDBOX_URL,
 )
-from db.documents import DocumentsRepository
-from db.models import UserConfiguration, Source
 from db.configuration import ConfigurationRepository
+from db.documents import DocumentsRepository
+from db.models import Source, UserConfiguration
 from db.usage import UsageRepository
 from db.users import UsersRepository
 from memory import MemoryMode, agent_key, resolve_memory_mode
@@ -37,7 +55,6 @@ from services.compaction import ConversationCompactor
 from services.usage import UsageContext, UsagePurpose, UsageTracker, track_usage
 from state import AppState
 from tools import (
-    ConnectorToolHandler,
     DocumentToolHandler,
     PeopleSearchHandler,
     SearchToolHandler,
@@ -58,12 +75,38 @@ from tools.search_handler import fetch_operator_values
 from tools.skill_handler import SkillHandler
 from tools.turn_builder import build_turn_tools
 
-from .models import Agent, AgentRun
+from .models import (
+    Agent,
+    AgentExecutionResult,
+    AgentRun,
+    AgentRunAlreadyActive,
+    AgentRunLogMessage,
+    AgentRunRetryPolicy,
+    AgentRunTriggerType,
+)
 from .repository import AgentRunRepository
 
 logger = logging.getLogger(__name__)
 
-MAX_RETRIES = 3
+AgentContentBlock = (
+    TextBlockParam
+    | ImageBlockParam
+    | DocumentBlockParam
+    | SearchResultBlockParam
+    | ThinkingBlockParam
+    | RedactedThinkingBlockParam
+    | ToolUseBlockParam
+    | ToolResultBlockParam
+    | ServerToolUseBlockParam
+    | WebSearchToolResultBlockParam
+    | WebFetchToolResultBlockParam
+    | CodeExecutionToolResultBlockParam
+    | BashCodeExecutionToolResultBlockParam
+    | TextEditorCodeExecutionToolResultBlockParam
+    | ToolSearchToolResultBlockParam
+    | ContainerUploadBlockParam
+    | ContentBlock
+)
 
 
 def _resolve_llm_provider(state: AppState, agent: Agent) -> LLMProvider:
@@ -255,20 +298,139 @@ async def _noop_on_load(_: set[str]) -> None:
     return None
 
 
+def _content_blocks(message: MessageParam) -> list[AgentContentBlock]:
+    content = message.get("content")
+    return list(content) if isinstance(content, list) else []
+
+
+def _tool_use_id(block: AgentContentBlock) -> str | None:
+    if block.get("type") == "tool_use":
+        tool_id = block.get("id")
+        return str(tool_id) if tool_id is not None else None
+    return None
+
+
+def _tool_result_id(block: AgentContentBlock) -> str | None:
+    if block.get("type") == "tool_result":
+        tool_id = block.get("tool_use_id")
+        return str(tool_id) if tool_id is not None else None
+    return None
+
+
+def _find_unanswered_tool_calls(messages: list[AgentRunLogMessage]) -> list[ToolUseBlockParam]:
+    pending: dict[str, ToolUseBlockParam] = {}
+    for message in messages:
+        for block in _content_blocks(message):
+            tool_use_id = _tool_use_id(block)
+            if tool_use_id is not None:
+                pending[tool_use_id] = cast(ToolUseBlockParam, block)
+                continue
+            tool_result_id = _tool_result_id(block)
+            if tool_result_id is not None:
+                pending.pop(tool_result_id, None)
+    return list(pending.values())
+
+
+def _synthetic_interrupted_results(
+    tool_calls: list[ToolUseBlockParam],
+) -> MessageParam | None:
+    if not tool_calls:
+        return None
+    results: list[ToolResultBlockParam] = []
+    for tool_call in tool_calls:
+        results.append(
+            ToolResultBlockParam(
+                type="tool_result",
+                tool_use_id=tool_call["id"],
+                content=[
+                    {
+                        "type": "text",
+                        "text": (
+                            "A previous attempt was interrupted after this tool call was "
+                            "requested, before a tool result was durably recorded. Inspect "
+                            "the prior context and retry or reconcile as appropriate."
+                        ),
+                    }
+                ],
+                is_error=True,
+            )
+        )
+    return MessageParam(role="user", content=results)
+
+
+def _is_tool_result_only_user_message(message: AgentRunLogMessage) -> bool:
+    if message.get("role") != "user":
+        return False
+    blocks = _content_blocks(message)
+    return bool(blocks) and all(_tool_result_id(block) is not None for block in blocks)
+
+
+def _conversation_from_log_messages(
+    messages: list[AgentRunLogMessage],
+) -> list[MessageParam]:
+    """Build provider conversation, coalescing adjacent persisted tool-result rows."""
+    conversation: list[MessageParam] = []
+    pending_tool_results: list[ToolResultBlockParam] = []
+
+    def flush_tool_results() -> None:
+        nonlocal pending_tool_results
+        if pending_tool_results:
+            conversation.append(MessageParam(role="user", content=pending_tool_results))
+            pending_tool_results = []
+
+    for message in messages:
+        if _is_tool_result_only_user_message(message):
+            pending_tool_results.extend(cast(list[ToolResultBlockParam], _content_blocks(message)))
+        else:
+            flush_tool_results()
+            conversation.append(cast(MessageParam, message))
+    flush_tool_results()
+    return conversation
+
+
+async def _load_or_initialize_conversation(
+    run: AgentRun,
+    run_repo: AgentRunRepository,
+    claim_token: str,
+) -> list[AgentRunLogMessage]:
+    logs = await run_repo.list_run_logs(run.id)
+    messages = [log.message for log in logs]
+    if not messages:
+        initial = MessageParam(role="user", content="Execute your scheduled task now.")
+        await run_repo.append_run_log_messages(run.id, claim_token, [initial])
+        messages.append(initial)
+        return messages
+
+    interrupted = _synthetic_interrupted_results(_find_unanswered_tool_calls(messages))
+    if interrupted is not None:
+        await run_repo.append_run_log_messages(run.id, claim_token, [interrupted])
+        messages.append(interrupted)
+    return messages
+
+
+async def _append_log_message(
+    run: AgentRun,
+    run_repo: AgentRunRepository,
+    claim_token: str,
+    messages: list[AgentRunLogMessage],
+    message: MessageParam,
+) -> None:
+    rows = await run_repo.append_run_log_messages(run.id, claim_token, [message])
+    if not rows:
+        raise RuntimeError("Lost agent run claim while appending conversation log")
+    messages.append(message)
+
+
 async def _run_agent_loop(
     agent: Agent,
     app_state: AppState,
     run: AgentRun,
     run_repo: AgentRunRepository,
-    status_queue: asyncio.Queue | None,
-) -> AgentRun:
-    """Core agent loop. Separated from execute_agent to allow retries."""
+    claim_token: str,
+) -> AgentExecutionResult:
+    """Core agent loop. Queue lifecycle finalization is handled by the worker."""
 
-    async def emit_status(message: str):
-        if status_queue:
-            await status_queue.put({"type": "status", "message": message})
-
-    await emit_status("Initializing...")
+    logger.info("Agent %s run %s: initializing", agent.id, run.id)
 
     llm_provider = _resolve_llm_provider(app_state, agent)
     sources = await _fetch_sources()
@@ -332,11 +494,9 @@ async def _run_agent_loop(
         user_configuration=agent_user_configuration,
     )
 
-    # Initialize conversation with a single trigger message
-    conversation_messages: list[MessageParam] = [
-        MessageParam(role="user", content="Execute your scheduled task now.")
-    ]
-    execution_log: list[MessageParam] = list(conversation_messages)
+    # Load durable conversation/action WAL, or initialize it before the first LLM call.
+    log_messages = await _load_or_initialize_conversation(run, run_repo, claim_token)
+    conversation_messages = _conversation_from_log_messages(log_messages)
 
     context = ToolContext(
         chat_id=run.id,
@@ -438,14 +598,11 @@ async def _run_agent_loop(
                     if event.index < len(content_blocks):
                         text_block = cast(TextBlockParam, content_blocks[event.index])
                         text_block["text"] += event.delta.text
-                elif event.delta.type == "input_json_delta":
-                    if event.index < len(content_blocks):
-                        tool_block = cast(
-                            ToolUseBlockParam, content_blocks[event.index]
-                        )
-                        tool_block["input"] = (
-                            cast(str, tool_block["input"]) + event.delta.partial_json
-                        )
+                elif event.delta.type == "input_json_delta" and event.index < len(content_blocks):
+                    tool_block = cast(ToolUseBlockParam, content_blocks[event.index])
+                    tool_block["input"] = (
+                        cast(str, tool_block["input"]) + event.delta.partial_json
+                    )
             elif event.type == "message_stop":
                 break
 
@@ -478,14 +635,18 @@ async def _run_agent_loop(
                 )
 
         assistant_message = MessageParam(role="assistant", content=content_blocks)
-        conversation_messages.append(assistant_message)
-        execution_log.append(assistant_message)
+        await _append_log_message(
+            run, run_repo, claim_token, log_messages, assistant_message
+        )
+        conversation_messages = _conversation_from_log_messages(log_messages)
 
         # If there were parse errors, feed them back to the LLM and continue the loop
         if parse_errors:
             error_message = MessageParam(role="user", content=parse_errors)
-            conversation_messages.append(error_message)
-            execution_log.append(error_message)
+            await _append_log_message(
+                run, run_repo, claim_token, log_messages, error_message
+            )
+            conversation_messages = _conversation_from_log_messages(log_messages)
             continue
 
         # No tool calls — done
@@ -493,28 +654,27 @@ async def _run_agent_loop(
             logger.info(f"Agent {agent.id} run {run.id}: no tool calls, completing")
             break
 
-        # Execute tool calls — no approval needed
-        tool_results: list[ToolResultBlockParam] = []
+        # Execute tool calls — no approval needed. Persist each result immediately.
         for tool_call in tool_calls:
             tool_name = tool_call["name"]
-            await emit_status(f"Executing: {tool_name}")
+            logger.info("Agent %s run %s: executing tool %s", agent.id, run.id, tool_name)
 
             result = await registry.execute(tool_name, tool_call["input"], context)
-            tool_results.append(
-                ToolResultBlockParam(
-                    type="tool_result",
-                    tool_use_id=tool_call["id"],
-                    content=result.content,
-                    is_error=result.is_error,
-                )
+            tool_result = ToolResultBlockParam(
+                type="tool_result",
+                tool_use_id=tool_call["id"],
+                content=result.content,
+                is_error=result.is_error,
+            )
+            tool_result_message = MessageParam(role="user", content=[tool_result])
+            await _append_log_message(
+                run, run_repo, claim_token, log_messages, tool_result_message
             )
 
-        tool_result_message = MessageParam(role="user", content=tool_results)
-        conversation_messages.append(tool_result_message)
-        execution_log.append(tool_result_message)
+        conversation_messages = _conversation_from_log_messages(log_messages)
 
     # Generate summary using one final LLM turn
-    await emit_status("Generating summary...")
+    logger.info("Agent %s run %s: generating summary", agent.id, run.id)
     summary_prompt_message = MessageParam(
         role="user",
         content=(
@@ -522,7 +682,10 @@ async def _run_agent_loop(
             "Be factual and concise."
         ),
     )
-    conversation_messages.append(summary_prompt_message)
+    await _append_log_message(
+        run, run_repo, claim_token, log_messages, summary_prompt_message
+    )
+    conversation_messages = _conversation_from_log_messages(log_messages)
 
     summary_blocks: list = []
     summary_tracker = UsageTracker(
@@ -580,70 +743,61 @@ async def _run_agent_loop(
         except Exception as e:
             logger.warning(f"Memory write setup failed for agent {agent.id}: {e}")
 
-    completed_at = datetime.now(UTC)
-    run = await run_repo.update_run(
-        run.id,
-        status="completed",
-        completed_at=completed_at,
-        execution_log=execution_log,
-        summary=summary,
-    )
-
-    if status_queue:
-        await status_queue.put({"type": "completed", "summary": summary})
-
     logger.info(f"Agent {agent.id} run {run.id} completed successfully")
-    return run
+    return AgentExecutionResult(summary=summary)
+
+
+async def execute_claimed_agent(
+    agent: Agent,
+    app_state: AppState,
+    run: AgentRun,
+    claim_token: str,
+    run_repo: AgentRunRepository,
+) -> AgentExecutionResult:
+    """Execute an already-claimed agent run and return its summary result."""
+    return await _run_agent_loop(agent, app_state, run, run_repo, claim_token)
 
 
 async def execute_agent(
     agent: Agent,
     app_state: AppState,
-    status_queue: asyncio.Queue | None = None,
-    run: AgentRun | None = None,
 ) -> AgentRun:
-    """Execute a background agent run with retry support.
-
-    Args:
-        run: Optional pre-created AgentRun. If None, a new one is created.
-    Retries up to MAX_RETRIES times on failure before giving up.
-    """
+    """Synchronous helper for tests/manual callers: enqueue, claim, execute, finalize."""
     run_repo = AgentRunRepository()
-    if run is None:
-        run = await run_repo.create_run(agent.id)
-
-    now = datetime.now(UTC)
-    run = await run_repo.update_run(run.id, status="running", started_at=now)
-
-    last_error: Exception | None = None
-
-    for attempt in range(1, MAX_RETRIES + 1):
-        try:
-            if attempt > 1:
-                logger.info(
-                    f"Agent {agent.id} run {run.id}: retry attempt {attempt}/{MAX_RETRIES}"
-                )
-            return await _run_agent_loop(agent, app_state, run, run_repo, status_queue)
-        except Exception as e:
-            last_error = e
-            logger.error(
-                f"Agent {agent.id} run {run.id} attempt {attempt} failed: {e}",
-                exc_info=True,
-            )
-            if attempt < MAX_RETRIES:
-                await asyncio.sleep(2**attempt)
-
-    # All retries exhausted
-    completed_at = datetime.now(UTC)
-    run = await run_repo.update_run(
-        run.id,
-        status="failed",
-        completed_at=completed_at,
-        execution_log=[],
-        error_message=f"Failed after {MAX_RETRIES} attempts: {last_error}",
+    retry_policy = AgentRunRetryPolicy(
+        max_attempts=AGENT_RUN_MAX_ATTEMPTS,
+        backoff_delays=tuple(timedelta(seconds=s) for s in AGENT_RUN_BACKOFF_SECONDS),
     )
+    created = await run_repo.create_run(
+        agent.id,
+        trigger_type=AgentRunTriggerType.MANUAL,
+        max_attempts=AGENT_RUN_MAX_ATTEMPTS,
+    )
+    run = created.run if isinstance(created, AgentRunAlreadyActive) else created
 
-    if status_queue:
-        await status_queue.put({"type": "failed", "error": str(last_error)})
+    claim = await run_repo.claim_next_run(
+        max_concurrent_runs=AGENT_MAX_CONCURRENT_RUNS,
+        lease_duration=timedelta(seconds=AGENT_RUN_LEASE_SECONDS),
+        retry_policy=retry_policy,
+    )
+    if claim is None or claim.run.id != run.id:
+        raise RuntimeError(f"Unable to claim agent run {run.id}")
 
-    return run
+    try:
+        result = await execute_claimed_agent(
+            agent, app_state, claim.run, claim.claim_token, run_repo
+        )
+        completed = await run_repo.complete_run(
+            claim.run.id, claim.claim_token, result.summary
+        )
+        if completed is None:
+            raise RuntimeError(f"Lost claim before completing run {claim.run.id}")
+        return completed
+    except Exception as e:
+        logger.error("Agent %s run %s failed: %s", agent.id, claim.run.id, e, exc_info=True)
+        failed = await run_repo.fail_run(
+            claim.run.id, claim.claim_token, str(e), retry_policy
+        )
+        if failed is None:
+            raise
+        return failed

--- a/services/ai/agents/models.py
+++ b/services/ai/agents/models.py
@@ -1,16 +1,32 @@
-"""Dataclasses for the agents and agent_runs tables."""
+"""Typed models for agents, durable agent runs, and agent run logs."""
 
 import json
-from dataclasses import dataclass, field
-from datetime import datetime
-from typing import Literal, Optional
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from enum import StrEnum
+from typing import Literal, TypeAlias, Optional
+
+from anthropic.types import MessageParam
 
 AgentType = Literal["user", "org"]
 ScheduleType = Literal["cron", "interval"]
-RunStatus = Literal["pending", "running", "completed", "failed"]
+AgentRunLogMessage: TypeAlias = MessageParam
+AgentRunConversation: TypeAlias = list[AgentRunLogMessage]
 
 
-@dataclass
+class RunStatus(StrEnum):
+    PENDING = "pending"
+    RUNNING = "running"
+    COMPLETED = "completed"
+    FAILED = "failed"
+
+
+class AgentRunTriggerType(StrEnum):
+    MANUAL = "manual"
+    SCHEDULED = "scheduled"
+
+
+@dataclass(frozen=True)
 class Agent:
     id: str
     user_id: str
@@ -20,7 +36,7 @@ class Agent:
     schedule_type: ScheduleType
     schedule_value: str
     model_id: Optional[str]
-    allowed_sources: list[dict]  # [{source_id, modes: ["read","write"]}]
+    allowed_sources: list[dict[str, object]]  # [{source_id, modes: ["read","write"]}]
     allowed_actions: list[str]  # tool name whitelist for org agents
     is_enabled: bool
     is_deleted: bool
@@ -28,37 +44,47 @@ class Agent:
     updated_at: datetime
 
     @classmethod
-    def from_row(cls, row: dict) -> "Agent":
-        allowed_sources = row.get("allowed_sources", [])
-        if isinstance(allowed_sources, str):
-            allowed_sources = json.loads(allowed_sources)
+    def from_row(cls, row: dict[str, object]) -> "Agent":
+        allowed_sources_raw = row.get("allowed_sources", [])
+        if isinstance(allowed_sources_raw, str):
+            allowed_sources = json.loads(allowed_sources_raw)
+        elif isinstance(allowed_sources_raw, list):
+            allowed_sources = allowed_sources_raw
+        else:
+            allowed_sources = []
 
-        allowed_actions = row.get("allowed_actions", [])
-        if isinstance(allowed_actions, str):
-            allowed_actions = json.loads(allowed_actions)
+        allowed_actions_raw = row.get("allowed_actions", [])
+        if isinstance(allowed_actions_raw, str):
+            allowed_actions = json.loads(allowed_actions_raw)
+        elif isinstance(allowed_actions_raw, list):
+            allowed_actions = [str(action) for action in allowed_actions_raw]
+        else:
+            allowed_actions = []
 
-        model_id = row.get("model_id")
-        if model_id:
-            model_id = model_id.strip()
+        model_id_raw = row.get("model_id")
+        model_id = model_id_raw.strip() if isinstance(model_id_raw, str) else None
+
+        agent_type = str(row["agent_type"])
+        schedule_type = str(row["schedule_type"])
 
         return cls(
-            id=row["id"].strip(),
-            user_id=row["user_id"].strip(),
-            name=row["name"],
-            instructions=row["instructions"],
-            agent_type=row["agent_type"],
-            schedule_type=row["schedule_type"],
-            schedule_value=row["schedule_value"],
+            id=str(row["id"]).strip(),
+            user_id=str(row["user_id"]).strip(),
+            name=str(row["name"]),
+            instructions=str(row["instructions"]),
+            agent_type="org" if agent_type == "org" else "user",
+            schedule_type="cron" if schedule_type == "cron" else "interval",
+            schedule_value=str(row["schedule_value"]),
             model_id=model_id,
             allowed_sources=allowed_sources,
             allowed_actions=allowed_actions,
-            is_enabled=row["is_enabled"],
-            is_deleted=row["is_deleted"],
-            created_at=row["created_at"],
-            updated_at=row["updated_at"],
+            is_enabled=bool(row["is_enabled"]),
+            is_deleted=bool(row["is_deleted"]),
+            created_at=row["created_at"],  # type: ignore[assignment]
+            updated_at=row["updated_at"],  # type: ignore[assignment]
         )
 
-    def to_dict(self) -> dict:
+    def to_dict(self) -> dict[str, object]:
         return {
             "id": self.id,
             "user_id": self.user_id,
@@ -77,49 +103,117 @@ class Agent:
         }
 
 
-@dataclass
+@dataclass(frozen=True)
 class AgentRun:
     id: str
     agent_id: str
     status: RunStatus
-    started_at: Optional[datetime]
-    completed_at: Optional[datetime]
-    execution_log: list[dict] = field(default_factory=list)
-    summary: Optional[str] = None
-    error_message: Optional[str] = None
-    created_at: Optional[datetime] = None
+    trigger_type: AgentRunTriggerType
+    started_at: datetime | None
+    completed_at: datetime | None
+    claim_token: str | None
+    lease_expires_at: datetime | None
+    heartbeat_at: datetime | None
+    attempt_count: int
+    max_attempts: int
+    summary: str | None = None
+    error_message: str | None = None
+    created_at: datetime | None = None
 
     @classmethod
-    def from_row(cls, row: dict) -> "AgentRun":
-        execution_log = row.get("execution_log", [])
-        if isinstance(execution_log, str):
-            execution_log = json.loads(execution_log)
-
+    def from_row(cls, row: dict[str, object]) -> "AgentRun":
+        claim_token_raw = row.get("claim_token")
         return cls(
-            id=row["id"].strip(),
-            agent_id=row["agent_id"].strip(),
-            status=row["status"],
-            started_at=row.get("started_at"),
-            completed_at=row.get("completed_at"),
-            execution_log=execution_log,
-            summary=row.get("summary"),
-            error_message=row.get("error_message"),
-            created_at=row.get("created_at"),
+            id=str(row["id"]).strip(),
+            agent_id=str(row["agent_id"]).strip(),
+            status=RunStatus(str(row["status"])),
+            trigger_type=AgentRunTriggerType(str(row.get("trigger_type", "manual"))),
+            started_at=row.get("started_at"),  # type: ignore[arg-type]
+            completed_at=row.get("completed_at"),  # type: ignore[arg-type]
+            claim_token=str(claim_token_raw).strip() if claim_token_raw else None,
+            lease_expires_at=row.get("lease_expires_at"),  # type: ignore[arg-type]
+            heartbeat_at=row.get("heartbeat_at"),  # type: ignore[arg-type]
+            attempt_count=int(row.get("attempt_count", 0)),
+            max_attempts=int(row.get("max_attempts", 3)),
+            summary=row.get("summary") if isinstance(row.get("summary"), str) else None,
+            error_message=(
+                row.get("error_message") if isinstance(row.get("error_message"), str) else None
+            ),
+            created_at=row.get("created_at"),  # type: ignore[arg-type]
         )
 
-    def to_dict(self, include_execution_log: bool = True) -> dict:
-        d = {
+    def to_dict(self) -> dict[str, object]:
+        return {
             "id": self.id,
             "agent_id": self.agent_id,
-            "status": self.status,
+            "status": self.status.value,
+            "trigger_type": self.trigger_type.value,
             "started_at": self.started_at.isoformat() if self.started_at else None,
-            "completed_at": (
-                self.completed_at.isoformat() if self.completed_at else None
-            ),
+            "completed_at": self.completed_at.isoformat() if self.completed_at else None,
+            "lease_expires_at": self.lease_expires_at.isoformat()
+            if self.lease_expires_at
+            else None,
+            "heartbeat_at": self.heartbeat_at.isoformat() if self.heartbeat_at else None,
+            "attempt_count": self.attempt_count,
+            "max_attempts": self.max_attempts,
             "summary": self.summary,
             "error_message": self.error_message,
             "created_at": self.created_at.isoformat() if self.created_at else None,
         }
-        if include_execution_log:
-            d["execution_log"] = self.execution_log
-        return d
+
+
+@dataclass(frozen=True)
+class AgentRunLog:
+    id: str
+    run_id: str
+    message_seq_num: int
+    message: AgentRunLogMessage
+    created_at: datetime
+
+    @classmethod
+    def from_row(cls, row: dict[str, object]) -> "AgentRunLog":
+        message_raw = row["message"]
+        if isinstance(message_raw, str):
+            message = json.loads(message_raw)
+        else:
+            message = message_raw
+        return cls(
+            id=str(row["id"]).strip(),
+            run_id=str(row["run_id"]).strip(),
+            message_seq_num=int(row["message_seq_num"]),
+            message=message,  # type: ignore[arg-type]
+            created_at=row["created_at"],  # type: ignore[assignment]
+        )
+
+
+@dataclass(frozen=True)
+class AgentRunClaim:
+    run: AgentRun
+    claim_token: str
+
+
+@dataclass(frozen=True)
+class AgentRunAlreadyActive:
+    run: AgentRun
+
+
+AgentRunCreateResult: TypeAlias = AgentRun | AgentRunAlreadyActive
+
+
+@dataclass(frozen=True)
+class AgentRunRetryPolicy:
+    max_attempts: int
+    backoff_delays: tuple[timedelta, ...]
+
+    def delay_for_attempt(self, attempt_count: int) -> timedelta:
+        if attempt_count <= 0:
+            return timedelta(seconds=0)
+        if not self.backoff_delays:
+            return timedelta(seconds=0)
+        idx = min(attempt_count - 1, len(self.backoff_delays) - 1)
+        return self.backoff_delays[idx]
+
+
+@dataclass(frozen=True)
+class AgentExecutionResult:
+    summary: str | None

--- a/services/ai/agents/queue_worker.py
+++ b/services/ai/agents/queue_worker.py
@@ -1,0 +1,200 @@
+"""Durable queue worker for agent_runs.
+
+Lease contract:
+- `agent_runs` rows in `pending` are durable work.
+- Claiming sets `running`, a fresh ULID `claim_token`, heartbeat timestamps, and a
+  lease expiry. The token is held only in memory by the active asyncio task.
+- Heartbeat, completion, failure, and agent_run_logs WAL writes are fenced by
+  `(run_id, claim_token)`, so stale tasks cannot finalize after lease recovery.
+- `AGENT_MAX_CONCURRENT_RUNS` limits both local asyncio run tasks in this process
+  and the cluster-wide count enforced inside the Postgres claim transaction.
+- Agent conversation/action history is written incrementally to `agent_run_logs`:
+  assistant tool-use messages are inserted before tool execution, and tool
+  results are inserted immediately after each tool returns.
+- Delivery is at-least-once. A crash can happen after an external side effect but
+  before its result is logged; recovery records an interrupted tool result so the
+  next LLM turn has durable context to reconcile.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import timedelta
+
+from config import (
+    AGENT_MAX_CONCURRENT_RUNS,
+    AGENT_RUN_BACKOFF_SECONDS,
+    AGENT_RUN_CLAIM_POLL_INTERVAL_SECONDS,
+    AGENT_RUN_HEARTBEAT_INTERVAL_SECONDS,
+    AGENT_RUN_LEASE_SECONDS,
+    AGENT_RUN_MAX_ATTEMPTS,
+    AGENT_RUN_STALE_RECOVERY_INTERVAL_SECONDS,
+)
+from state import AppState
+
+from .executor import execute_claimed_agent
+from .models import AgentRunClaim, AgentRunRetryPolicy
+from .repository import AgentRepository, AgentRunRepository
+
+logger = logging.getLogger(__name__)
+
+
+def _retry_policy() -> AgentRunRetryPolicy:
+    return AgentRunRetryPolicy(
+        max_attempts=AGENT_RUN_MAX_ATTEMPTS,
+        backoff_delays=tuple(timedelta(seconds=s) for s in AGENT_RUN_BACKOFF_SECONDS),
+    )
+
+
+def _lease_duration() -> timedelta:
+    return timedelta(seconds=AGENT_RUN_LEASE_SECONDS)
+
+
+async def run_agent_queue_worker(app_state: AppState) -> None:
+    """Run stale recovery and the durable claim loop forever."""
+    run_repo = AgentRunRepository()
+    retry_policy = _retry_policy()
+
+    logger.info(
+        "Agent queue worker started (max_concurrent=%s, lease=%ss, heartbeat=%ss)",
+        AGENT_MAX_CONCURRENT_RUNS,
+        AGENT_RUN_LEASE_SECONDS,
+        AGENT_RUN_HEARTBEAT_INTERVAL_SECONDS,
+    )
+
+    await run_repo.recover_stale_runs()
+    recovery_task = asyncio.create_task(_recovery_loop(run_repo), name="agent-run-recovery")
+
+    active_tasks: set[asyncio.Task[None]] = set()
+    try:
+        while True:
+            active_tasks = {task for task in active_tasks if not task.done()}
+
+            while len(active_tasks) < AGENT_MAX_CONCURRENT_RUNS:
+                claim = await run_repo.claim_next_run(
+                    max_concurrent_runs=AGENT_MAX_CONCURRENT_RUNS,
+                    lease_duration=_lease_duration(),
+                    retry_policy=retry_policy,
+                )
+                if claim is None:
+                    break
+
+                task = asyncio.create_task(
+                    _execute_claimed_run(app_state, claim, retry_policy),
+                    name=f"agent-run-{claim.run.id}",
+                )
+                task.add_done_callback(_log_task_result)
+                active_tasks.add(task)
+
+            await asyncio.sleep(AGENT_RUN_CLAIM_POLL_INTERVAL_SECONDS)
+    finally:
+        recovery_task.cancel()
+        for task in active_tasks:
+            task.cancel()
+        await asyncio.gather(recovery_task, *active_tasks, return_exceptions=True)
+
+
+async def _recovery_loop(run_repo: AgentRunRepository) -> None:
+    while True:
+        try:
+            await asyncio.sleep(AGENT_RUN_STALE_RECOVERY_INTERVAL_SECONDS)
+            await run_repo.recover_stale_runs()
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("Agent stale-run recovery failed: %s", e, exc_info=True)
+
+
+def _log_task_result(task: asyncio.Task[None]) -> None:
+    if task.cancelled():
+        return
+    exc = task.exception()
+    if exc is not None:
+        logger.error(
+            "Agent run task failed unexpectedly: %s",
+            exc,
+            exc_info=(type(exc), exc, exc.__traceback__),
+        )
+
+
+async def _execute_claimed_run(
+    app_state: AppState,
+    claim: AgentRunClaim,
+    retry_policy: AgentRunRetryPolicy,
+) -> None:
+    run_repo = AgentRunRepository()
+    agent_repo = AgentRepository()
+    current_task = asyncio.current_task()
+    heartbeat_task = asyncio.create_task(
+        _heartbeat_loop(run_repo, claim, current_task),
+        name=f"agent-run-heartbeat-{claim.run.id}",
+    )
+
+    try:
+        agent = await agent_repo.get_agent(claim.run.agent_id)
+        if agent is None or agent.is_deleted or not agent.is_enabled:
+            failed = await run_repo.fail_run(
+                claim.run.id,
+                claim.claim_token,
+                "Agent is disabled, deleted, or no longer exists",
+                AgentRunRetryPolicy(max_attempts=0, backoff_delays=()),
+            )
+            if failed is None:
+                logger.warning("Lost claim while failing unavailable agent run %s", claim.run.id)
+            return
+
+        result = await execute_claimed_agent(
+            agent,
+            app_state,
+            claim.run,
+            claim.claim_token,
+            run_repo,
+        )
+        completed = await run_repo.complete_run(
+            claim.run.id,
+            claim.claim_token,
+            result.summary,
+        )
+        if completed is None:
+            logger.warning("Lost claim before completing agent run %s", claim.run.id)
+    except asyncio.CancelledError:
+        logger.warning("Agent run %s task cancelled", claim.run.id)
+        raise
+    except Exception as e:
+        logger.error("Agent run %s failed: %s", claim.run.id, e, exc_info=True)
+        failed = await run_repo.fail_run(
+            claim.run.id,
+            claim.claim_token,
+            str(e),
+            retry_policy,
+        )
+        if failed is None:
+            logger.warning("Lost claim before failing agent run %s", claim.run.id)
+    finally:
+        heartbeat_task.cancel()
+        await asyncio.gather(heartbeat_task, return_exceptions=True)
+
+
+async def _heartbeat_loop(
+    run_repo: AgentRunRepository,
+    claim: AgentRunClaim,
+    run_task: asyncio.Task[None] | None,
+) -> None:
+    while True:
+        try:
+            await asyncio.sleep(AGENT_RUN_HEARTBEAT_INTERVAL_SECONDS)
+            ok = await run_repo.heartbeat_run(
+                claim.run.id,
+                claim.claim_token,
+                _lease_duration(),
+            )
+            if not ok:
+                logger.warning("Agent run %s lost its claim; cancelling task", claim.run.id)
+                if run_task is not None:
+                    run_task.cancel()
+                return
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            logger.error("Heartbeat for agent run %s failed: %s", claim.run.id, e, exc_info=True)

--- a/services/ai/agents/repository.py
+++ b/services/ai/agents/repository.py
@@ -1,17 +1,51 @@
-"""Database access for agents (read-only) and agent_runs (read-write)."""
+"""Database access for agents and the durable agent_runs queue."""
 
+from __future__ import annotations
+
+import hashlib
 import json
 import logging
-from datetime import datetime
-from typing import Optional
+from datetime import datetime, timedelta
+from typing import Optional, Sequence
 
 from asyncpg import Pool
 from ulid import ULID
 
+from config import AGENT_RUN_MAX_ATTEMPTS
 from db.connection import get_db_pool
-from .models import Agent, AgentRun
+from .models import (
+    Agent,
+    AgentRun,
+    AgentRunAlreadyActive,
+    AgentRunClaim,
+    AgentRunCreateResult,
+    AgentRunLog,
+    AgentRunLogMessage,
+    AgentRunRetryPolicy,
+    AgentRunTriggerType,
+    RunStatus,
+)
 
 logger = logging.getLogger(__name__)
+
+_AGENT_RUN_COLUMNS = """
+    id, agent_id, status, trigger_type, started_at, completed_at,
+    claim_token, lease_expires_at, heartbeat_at, attempt_count, max_attempts,
+    summary, error_message, created_at
+"""
+
+_AGENT_RUN_CLAIM_LOCK_KEY = 0x0A6E7A5F001  # arbitrary stable advisory-lock key
+
+
+def _advisory_lock_key(value: str) -> int:
+    digest = hashlib.sha256(value.encode("utf-8")).digest()[:8]
+    return int.from_bytes(digest, byteorder="big", signed=True)
+
+
+def _backoff_seconds(policy: AgentRunRetryPolicy) -> list[int]:
+    if not policy.backoff_delays:
+        return [0]
+    return [max(0, int(delay.total_seconds())) for delay in policy.backoff_delays]
 
 
 class AgentRepository:
@@ -55,12 +89,7 @@ class AgentRepository:
         return [Agent.from_row(dict(r)) for r in rows]
 
     async def find_due_agents(self, now: datetime) -> list[Agent]:
-        """Find agents that are due for execution.
-
-        Computes next_run_at by looking at the latest completed agent_run
-        for each agent (or agents.created_at if no runs exist), then applying
-        the schedule. Returns agents where next_run_at <= now.
-        """
+        """Find enabled agents whose schedule is due and that have no active run."""
         pool = await self._get_pool()
         query = """
             WITH latest_runs AS (
@@ -69,7 +98,7 @@ class AgentRepository:
                     completed_at
                 FROM agent_runs
                 WHERE status IN ('completed', 'failed')
-                ORDER BY agent_id, completed_at DESC
+                ORDER BY agent_id, completed_at DESC NULLS LAST, created_at DESC
             )
             SELECT a.id, a.user_id, a.name, a.instructions, a.agent_type,
                    a.schedule_type, a.schedule_value, a.model_id,
@@ -78,36 +107,36 @@ class AgentRepository:
                    COALESCE(lr.completed_at, a.created_at) AS last_run_time
             FROM agents a
             LEFT JOIN latest_runs lr ON lr.agent_id = a.id
-            LEFT JOIN agent_runs active ON active.agent_id = a.id
-                AND active.status IN ('pending', 'running')
             WHERE a.is_enabled = TRUE
               AND a.is_deleted = FALSE
-              AND active.id IS NULL
+              AND NOT EXISTS (
+                  SELECT 1
+                  FROM agent_runs active
+                  WHERE active.agent_id = a.id
+                    AND active.status IN ('pending', 'running')
+              )
         """
         async with pool.acquire() as conn:
             rows = await conn.fetch(query)
 
-        # Filter in Python using croniter/interval logic
         from .cron_utils import is_due
 
-        due_agents = []
+        due_agents: list[Agent] = []
         for row in rows:
             row_dict = dict(row)
             last_run_time = row_dict.pop("last_run_time")
             agent = Agent.from_row(row_dict)
             try:
-                if is_due(
-                    agent.schedule_type, agent.schedule_value, last_run_time, now
-                ):
+                if is_due(agent.schedule_type, agent.schedule_value, last_run_time, now):
                     due_agents.append(agent)
             except Exception as e:
-                logger.warning(f"Failed to compute schedule for agent {agent.id}: {e}")
+                logger.warning("Failed to compute schedule for agent %s: %s", agent.id, e)
 
         return due_agents
 
 
 class AgentRunRepository:
-    """Read-write access to the agent_runs table (owned by omni-ai)."""
+    """Read-write access to the agent_runs durable queue."""
 
     def __init__(self, pool: Optional[Pool] = None):
         self.pool = pool
@@ -117,38 +146,69 @@ class AgentRunRepository:
             return self.pool
         return await get_db_pool()
 
-    async def create_run(self, agent_id: str) -> AgentRun:
+    async def create_run(
+        self,
+        agent_id: str,
+        trigger_type: AgentRunTriggerType = AgentRunTriggerType.MANUAL,
+        max_attempts: int = AGENT_RUN_MAX_ATTEMPTS,
+    ) -> AgentRunCreateResult:
+        """Create a pending run if the agent is idle; otherwise return the active run."""
         pool = await self._get_pool()
         run_id = str(ULID())
-        query = """
-            INSERT INTO agent_runs (id, agent_id, status, created_at)
-            VALUES ($1, $2, 'pending', NOW())
-            RETURNING id, agent_id, status, started_at, completed_at,
-                      execution_log, summary, error_message, created_at
-        """
         async with pool.acquire() as conn:
-            row = await conn.fetchrow(query, run_id, agent_id)
+            async with conn.transaction():
+                await conn.execute("SELECT pg_advisory_xact_lock($1::bigint)", _advisory_lock_key(agent_id))
+                active_row = await conn.fetchrow(
+                    f"""
+                    SELECT {_AGENT_RUN_COLUMNS}
+                    FROM agent_runs
+                    WHERE agent_id = $1
+                      AND status IN ('pending', 'running')
+                    ORDER BY created_at ASC
+                    LIMIT 1
+                    """,
+                    agent_id,
+                )
+                if active_row:
+                    return AgentRunAlreadyActive(AgentRun.from_row(dict(active_row)))
+
+                row = await conn.fetchrow(
+                    f"""
+                    INSERT INTO agent_runs (
+                        id, agent_id, status, trigger_type, max_attempts, created_at
+                    )
+                    VALUES ($1, $2, 'pending', $3, $4, NOW())
+                    RETURNING {_AGENT_RUN_COLUMNS}
+                    """,
+                    run_id,
+                    agent_id,
+                    trigger_type.value,
+                    max_attempts,
+                )
+        if row is None:
+            raise RuntimeError("agent run insert did not return a row")
         return AgentRun.from_row(dict(row))
 
     async def update_run(
         self,
         run_id: str,
-        status: Optional[str] = None,
+        status: Optional[RunStatus | str] = None,
         started_at: Optional[datetime] = None,
         completed_at: Optional[datetime] = None,
-        execution_log: Optional[list[dict]] = None,
         summary: Optional[str] = None,
         error_message: Optional[str] = None,
     ) -> Optional[AgentRun]:
+        """Legacy narrow updater for non-queue callers. Queue code should not use it."""
         pool = await self._get_pool()
 
-        set_clauses = []
-        params = [run_id]
+        set_clauses: list[str] = []
+        params: list[object] = [run_id]
         idx = 2
 
         if status is not None:
+            status_value = status.value if isinstance(status, RunStatus) else status
             set_clauses.append(f"status = ${idx}")
-            params.append(status)
+            params.append(status_value)
             idx += 1
         if started_at is not None:
             set_clauses.append(f"started_at = ${idx}")
@@ -157,10 +217,6 @@ class AgentRunRepository:
         if completed_at is not None:
             set_clauses.append(f"completed_at = ${idx}")
             params.append(completed_at)
-            idx += 1
-        if execution_log is not None:
-            set_clauses.append(f"execution_log = ${idx}")
-            params.append(json.dumps(execution_log, default=str))
             idx += 1
         if summary is not None:
             set_clauses.append(f"summary = ${idx}")
@@ -178,8 +234,7 @@ class AgentRunRepository:
             UPDATE agent_runs
             SET {', '.join(set_clauses)}
             WHERE id = $1
-            RETURNING id, agent_id, status, started_at, completed_at,
-                      execution_log, summary, error_message, created_at
+            RETURNING {_AGENT_RUN_COLUMNS}
         """
         async with pool.acquire() as conn:
             row = await conn.fetchrow(query, *params)
@@ -189,9 +244,8 @@ class AgentRunRepository:
 
     async def get_run(self, run_id: str) -> Optional[AgentRun]:
         pool = await self._get_pool()
-        query = """
-            SELECT id, agent_id, status, started_at, completed_at,
-                   execution_log, summary, error_message, created_at
+        query = f"""
+            SELECT {_AGENT_RUN_COLUMNS}
             FROM agent_runs
             WHERE id = $1
         """
@@ -205,9 +259,8 @@ class AgentRunRepository:
         self, agent_id: str, limit: int = 50, offset: int = 0
     ) -> list[AgentRun]:
         pool = await self._get_pool()
-        query = """
-            SELECT id, agent_id, status, started_at, completed_at,
-                   execution_log, summary, error_message, created_at
+        query = f"""
+            SELECT {_AGENT_RUN_COLUMNS}
             FROM agent_runs
             WHERE agent_id = $1
             ORDER BY created_at DESC
@@ -216,3 +269,285 @@ class AgentRunRepository:
         async with pool.acquire() as conn:
             rows = await conn.fetch(query, agent_id, limit, offset)
         return [AgentRun.from_row(dict(r)) for r in rows]
+
+    async def get_active_run_for_agent(
+        self, agent_id: str, *, include_stale_running: bool = False
+    ) -> AgentRun | None:
+        pool = await self._get_pool()
+        running_clause = (
+            "status = 'running'"
+            if include_stale_running
+            else "(status = 'running' AND lease_expires_at > NOW())"
+        )
+        query = f"""
+            SELECT {_AGENT_RUN_COLUMNS}
+            FROM agent_runs
+            WHERE agent_id = $1
+              AND (status = 'pending' OR {running_clause})
+            ORDER BY created_at ASC
+            LIMIT 1
+        """
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(query, agent_id)
+        return AgentRun.from_row(dict(row)) if row else None
+
+    async def recover_stale_runs(self) -> int:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            retry_result = await conn.execute(
+                """
+                UPDATE agent_runs
+                SET status = 'pending',
+                    claim_token = NULL,
+                    lease_expires_at = NULL,
+                    heartbeat_at = NULL
+                WHERE status = 'running'
+                  AND lease_expires_at <= NOW()
+                  AND attempt_count < max_attempts
+                """
+            )
+            failed_result = await conn.execute(
+                """
+                UPDATE agent_runs
+                SET status = 'failed',
+                    completed_at = NOW(),
+                    claim_token = NULL,
+                    lease_expires_at = NULL,
+                    heartbeat_at = NULL,
+                    error_message = COALESCE(error_message, 'Agent run lease expired and retry attempts were exhausted')
+                WHERE status = 'running'
+                  AND lease_expires_at <= NOW()
+                  AND attempt_count >= max_attempts
+                """
+            )
+        recovered = int(retry_result.split()[-1]) + int(failed_result.split()[-1])
+        if recovered:
+            logger.info("Recovered %d stale agent run(s)", recovered)
+        return recovered
+
+    async def claim_next_run(
+        self,
+        max_concurrent_runs: int,
+        lease_duration: timedelta,
+        retry_policy: AgentRunRetryPolicy,
+    ) -> AgentRunClaim | None:
+        pool = await self._get_pool()
+        claim_token = str(ULID())
+        lease_seconds = int(lease_duration.total_seconds())
+        backoff_seconds = _backoff_seconds(retry_policy)
+
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await conn.execute("SELECT pg_advisory_xact_lock($1::bigint)", _AGENT_RUN_CLAIM_LOCK_KEY)
+                active_count = await conn.fetchval(
+                    """
+                    SELECT COUNT(*)
+                    FROM agent_runs
+                    WHERE status = 'running'
+                      AND lease_expires_at > NOW()
+                    """
+                )
+                if int(active_count or 0) >= max_concurrent_runs:
+                    return None
+
+                row = await conn.fetchrow(
+                    f"""
+                    WITH candidate AS (
+                        SELECT r.id
+                        FROM agent_runs r
+                        WHERE r.status = 'pending'
+                          AND r.attempt_count < r.max_attempts
+                          AND (
+                              r.attempt_count = 0
+                              OR r.started_at IS NULL
+                              OR r.started_at
+                                  + (
+                                      INTERVAL '1 second'
+                                      * (($3::int[])[LEAST(r.attempt_count, array_length($3::int[], 1))])
+                                    ) <= NOW()
+                          )
+                          AND NOT EXISTS (
+                              SELECT 1
+                              FROM agent_runs active
+                              WHERE active.agent_id = r.agent_id
+                                AND active.status = 'running'
+                                AND active.lease_expires_at > NOW()
+                          )
+                        ORDER BY r.created_at ASC
+                        LIMIT 1
+                        FOR UPDATE SKIP LOCKED
+                    )
+                    UPDATE agent_runs r
+                    SET status = 'running',
+                        started_at = NOW(),
+                        completed_at = NULL,
+                        claim_token = $1,
+                        lease_expires_at = NOW() + (INTERVAL '1 second' * $2),
+                        heartbeat_at = NOW(),
+                        attempt_count = r.attempt_count + 1
+                    FROM candidate
+                    WHERE r.id = candidate.id
+                    RETURNING r.id, r.agent_id, r.status, r.trigger_type, r.started_at,
+                              r.completed_at, r.claim_token, r.lease_expires_at,
+                              r.heartbeat_at, r.attempt_count, r.max_attempts,
+                              r.summary, r.error_message, r.created_at
+                    """,
+                    claim_token,
+                    lease_seconds,
+                    backoff_seconds,
+                )
+        if row is None:
+            return None
+        return AgentRunClaim(run=AgentRun.from_row(dict(row)), claim_token=claim_token)
+
+    async def heartbeat_run(
+        self, run_id: str, claim_token: str, lease_duration: timedelta
+    ) -> bool:
+        pool = await self._get_pool()
+        lease_seconds = int(lease_duration.total_seconds())
+        async with pool.acquire() as conn:
+            result = await conn.execute(
+                """
+                UPDATE agent_runs
+                SET lease_expires_at = NOW() + (INTERVAL '1 second' * $3),
+                    heartbeat_at = NOW()
+                WHERE id = $1
+                  AND claim_token = $2
+                  AND status = 'running'
+                """,
+                run_id,
+                claim_token,
+                lease_seconds,
+            )
+        return int(result.split()[-1]) == 1
+
+    async def list_run_logs(self, run_id: str) -> list[AgentRunLog]:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(
+                """
+                SELECT id, run_id, message_seq_num, message, created_at
+                FROM agent_run_logs
+                WHERE run_id = $1
+                ORDER BY message_seq_num ASC
+                """,
+                run_id,
+            )
+        return [AgentRunLog.from_row(dict(row)) for row in rows]
+
+    async def append_run_log_messages(
+        self,
+        run_id: str,
+        claim_token: str,
+        messages: Sequence[AgentRunLogMessage],
+    ) -> list[AgentRunLog]:
+        if not messages:
+            return []
+
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                run_row = await conn.fetchrow(
+                    """
+                    SELECT id
+                    FROM agent_runs
+                    WHERE id = $1
+                      AND claim_token = $2
+                      AND status = 'running'
+                    FOR UPDATE
+                    """,
+                    run_id,
+                    claim_token,
+                )
+                if not run_row:
+                    return []
+
+                next_seq = await conn.fetchval(
+                    """
+                    SELECT COALESCE(MAX(message_seq_num) + 1, 0)
+                    FROM agent_run_logs
+                    WHERE run_id = $1
+                    """,
+                    run_id,
+                )
+
+                rows: list[AgentRunLog] = []
+                for offset, message in enumerate(messages):
+                    row = await conn.fetchrow(
+                        """
+                        INSERT INTO agent_run_logs (id, run_id, message_seq_num, message)
+                        VALUES ($1, $2, $3, $4::jsonb)
+                        RETURNING id, run_id, message_seq_num, message, created_at
+                        """,
+                        str(ULID()),
+                        run_id,
+                        int(next_seq) + offset,
+                        json.dumps(message, default=str),
+                    )
+                    rows.append(AgentRunLog.from_row(dict(row)))
+        return rows
+
+    async def complete_run(
+        self, run_id: str, claim_token: str, summary: str | None
+    ) -> AgentRun | None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"""
+                UPDATE agent_runs
+                SET status = 'completed',
+                    completed_at = NOW(),
+                    claim_token = NULL,
+                    lease_expires_at = NULL,
+                    heartbeat_at = NULL,
+                    summary = $3,
+                    error_message = NULL
+                WHERE id = $1
+                  AND claim_token = $2
+                  AND status = 'running'
+                RETURNING {_AGENT_RUN_COLUMNS}
+                """,
+                run_id,
+                claim_token,
+                summary,
+            )
+        return AgentRun.from_row(dict(row)) if row else None
+
+    async def fail_run(
+        self,
+        run_id: str,
+        claim_token: str,
+        error: str,
+        retry_policy: AgentRunRetryPolicy,
+    ) -> AgentRun | None:
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"""
+                UPDATE agent_runs
+                SET status = CASE
+                        WHEN attempt_count < LEAST(max_attempts, $3) THEN 'pending'
+                        ELSE 'failed'
+                    END,
+                    completed_at = CASE
+                        WHEN attempt_count < LEAST(max_attempts, $3) THEN NULL
+                        ELSE NOW()
+                    END,
+                    claim_token = NULL,
+                    lease_expires_at = NULL,
+                    heartbeat_at = NULL,
+                    error_message = CASE
+                        WHEN attempt_count < LEAST(max_attempts, $3) THEN error_message
+                        ELSE $4
+                    END
+                WHERE id = $1
+                  AND claim_token = $2
+                  AND status = 'running'
+                RETURNING {_AGENT_RUN_COLUMNS}
+                """,
+                run_id,
+                claim_token,
+                retry_policy.max_attempts,
+                error,
+            )
+        return AgentRun.from_row(dict(row)) if row else None

--- a/services/ai/agents/scheduler.py
+++ b/services/ai/agents/scheduler.py
@@ -1,56 +1,77 @@
-"""Background scheduler that polls for due agents and executes them."""
+"""Background materializer for scheduled agent runs."""
 
 import asyncio
 import logging
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 
-from config import AGENT_SCHEDULER_POLL_INTERVAL, AGENT_MAX_CONCURRENT_RUNS
+from config import AGENT_MAX_CONCURRENT_RUNS, AGENT_SCHEDULER_POLL_INTERVAL
 from state import AppState
-from .executor import execute_agent
-from .repository import AgentRepository
+
+from .models import AgentRunAlreadyActive, AgentRunTriggerType
+from .repository import AgentRepository, AgentRunRepository
 
 logger = logging.getLogger(__name__)
 
 
-async def run_agent_scheduler(app_state: AppState):
-    """Long-running scheduler loop. Launched as asyncio.create_task from main.py startup."""
+async def materialize_due_agent_runs(
+    agent_repo: AgentRepository,
+    run_repo: AgentRunRepository,
+    now: datetime,
+) -> int:
+    """Insert pending scheduled runs for due agents and return created count."""
+    due_agents = await agent_repo.find_due_agents(now)
+
+    if due_agents:
+        logger.info("Found %d due agent(s)", len(due_agents))
+
+    created_count = 0
+    for agent in due_agents:
+        result = await run_repo.create_run(
+            agent.id, trigger_type=AgentRunTriggerType.SCHEDULED
+        )
+        if isinstance(result, AgentRunAlreadyActive):
+            logger.debug(
+                "Skipped scheduled run for agent %s because run %s is %s",
+                agent.id,
+                result.run.id,
+                result.run.status.value,
+            )
+        else:
+            created_count += 1
+            logger.info(
+                "Materialized scheduled run %s for agent %s",
+                result.id,
+                agent.id,
+            )
+    return created_count
+
+
+async def run_agent_schedule_materializer(app_state: AppState) -> None:
+    """Poll due agents and insert pending scheduled runs only.
+
+    Execution is handled by the durable queue worker; the scheduler never starts
+    agent execution directly.
+    """
     logger.info(
-        f"Agent scheduler started (poll_interval={AGENT_SCHEDULER_POLL_INTERVAL}s, "
-        f"max_concurrent={AGENT_MAX_CONCURRENT_RUNS})"
+        "Agent schedule materializer started (poll_interval=%ss, max_concurrent=%s)",
+        AGENT_SCHEDULER_POLL_INTERVAL,
+        AGENT_MAX_CONCURRENT_RUNS,
     )
 
-    semaphore = asyncio.Semaphore(AGENT_MAX_CONCURRENT_RUNS)
     agent_repo = AgentRepository()
+    run_repo = AgentRunRepository()
 
     while True:
         try:
-            now = datetime.now(timezone.utc)
-            due_agents = await agent_repo.find_due_agents(now)
-
-            if due_agents:
-                logger.info(f"Found {len(due_agents)} due agent(s)")
-
-            for agent in due_agents:
-                # Spawn bounded task
-                asyncio.create_task(_run_with_semaphore(semaphore, agent, app_state))
+            now = datetime.now(UTC)
+            await materialize_due_agent_runs(agent_repo, run_repo, now)
 
         except Exception as e:
-            logger.error(f"Agent scheduler tick failed: {e}", exc_info=True)
+            logger.error("Agent schedule materializer tick failed: %s", e, exc_info=True)
 
         await asyncio.sleep(AGENT_SCHEDULER_POLL_INTERVAL)
 
 
-async def _run_with_semaphore(semaphore: asyncio.Semaphore, agent, app_state: AppState):
-    """Execute an agent run with concurrency limiting."""
-    async with semaphore:
-        try:
-            logger.info(f"Starting scheduled run for agent {agent.id} ({agent.name})")
-
-            # Create a status queue for this run
-            status_queue = asyncio.Queue()
-            await execute_agent(agent, app_state, status_queue=status_queue)
-
-        except Exception as e:
-            logger.error(
-                f"Scheduled run for agent {agent.id} failed: {e}", exc_info=True
-            )
+async def run_agent_scheduler(app_state: AppState) -> None:
+    """Backward-compatible entrypoint for the schedule materializer."""
+    await run_agent_schedule_materializer(app_state)

--- a/services/ai/config.py
+++ b/services/ai/config.py
@@ -99,3 +99,19 @@ AGENT_SCHEDULER_POLL_INTERVAL = int(
     get_optional_env("AGENT_SCHEDULER_POLL_INTERVAL", "30")
 )  # seconds
 AGENT_MAX_CONCURRENT_RUNS = int(get_optional_env("AGENT_MAX_CONCURRENT_RUNS", "3"))
+AGENT_RUN_LEASE_SECONDS = int(get_optional_env("AGENT_RUN_LEASE_SECONDS", "300"))
+AGENT_RUN_HEARTBEAT_INTERVAL_SECONDS = int(
+    get_optional_env("AGENT_RUN_HEARTBEAT_INTERVAL_SECONDS", "30")
+)
+AGENT_RUN_CLAIM_POLL_INTERVAL_SECONDS = int(
+    get_optional_env("AGENT_RUN_CLAIM_POLL_INTERVAL_SECONDS", "5")
+)
+AGENT_RUN_STALE_RECOVERY_INTERVAL_SECONDS = int(
+    get_optional_env("AGENT_RUN_STALE_RECOVERY_INTERVAL_SECONDS", "30")
+)
+AGENT_RUN_MAX_ATTEMPTS = int(get_optional_env("AGENT_RUN_MAX_ATTEMPTS", "3"))
+AGENT_RUN_BACKOFF_SECONDS = tuple(
+    int(part.strip())
+    for part in get_optional_env("AGENT_RUN_BACKOFF_SECONDS", "30,120,300").split(",")
+    if part.strip()
+)

--- a/services/ai/main.py
+++ b/services/ai/main.py
@@ -67,9 +67,11 @@ async def startup_event():
         await start_batch_processor(app.state)
 
         if os.getenv("AGENTS_ENABLED", "false").lower() == "true":
-            from agents.scheduler import run_agent_scheduler
+            from agents.queue_worker import run_agent_queue_worker
+            from agents.scheduler import run_agent_schedule_materializer
 
-            asyncio.create_task(run_agent_scheduler(app.state))
+            asyncio.create_task(run_agent_schedule_materializer(app.state))
+            asyncio.create_task(run_agent_queue_worker(app.state))
 
         if MEMORY_ENABLED:
             try:

--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -469,9 +469,10 @@ def format_run_history(
         if run.error_message:
             header += f"\n- Error: {run.error_message}"
 
-        if i < max_detailed and run.execution_log:
+        execution_log = getattr(run, "execution_log", None)
+        if i < max_detailed and execution_log:
             header += "\n- Execution details:\n"
-            header += _format_execution_log(run.execution_log)
+            header += _format_execution_log(execution_log)
 
         sections.append(header)
         total_chars += len(header)

--- a/services/ai/routers/agents.py
+++ b/services/ai/routers/agents.py
@@ -8,11 +8,10 @@ import json
 import logging
 
 from fastapi import APIRouter, HTTPException, Path, Request
-from fastapi.responses import StreamingResponse
+from fastapi.responses import JSONResponse, StreamingResponse
 
-from agents.models import Agent
+from agents.models import Agent, AgentRunAlreadyActive, AgentRunTriggerType
 from agents.repository import AgentRepository, AgentRunRepository
-from agents.executor import execute_agent
 from db import UsersRepository
 from state import AppState
 
@@ -49,25 +48,25 @@ async def trigger_agent(
     if not user_id:
         raise HTTPException(status_code=401, detail="User ID required")
 
-    agent = await _get_agent_with_auth(request, agent_id, user_id)
+    await _get_agent_with_auth(request, agent_id, user_id)
 
-    app_state: AppState = request.app.state
-
-    # Create the run upfront so we can return its ID immediately
     run_repo = AgentRunRepository()
-    run = await run_repo.create_run(agent_id)
+    result = await run_repo.create_run(agent_id, trigger_type=AgentRunTriggerType.MANUAL)
 
-    status_queue: asyncio.Queue = asyncio.Queue()
+    if isinstance(result, AgentRunAlreadyActive):
+        return JSONResponse(
+            status_code=409,
+            content={
+                "error": "agent_already_active",
+                "run_id": result.run.id,
+                "run_status": result.run.status.value,
+            },
+        )
 
-    async def _run():
-        try:
-            await execute_agent(agent, app_state, status_queue=status_queue, run=run)
-        except Exception as e:
-            logger.error(f"Triggered run for agent {agent_id} failed: {e}")
-
-    asyncio.create_task(_run())
-
-    return {"status": "started", "run_id": run.id}
+    return JSONResponse(
+        status_code=202,
+        content={"status": "queued", "run_id": result.id},
+    )
 
 
 @router.get("/{agent_id}/runs/{run_id}/stream")

--- a/services/ai/tests/integration/test_agent_run_queue.py
+++ b/services/ai/tests/integration/test_agent_run_queue.py
@@ -1,0 +1,268 @@
+"""Integration tests for durable agent_runs queue semantics."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+
+import pytest
+from anthropic.types import MessageParam, ToolUseBlockParam
+from ulid import ULID
+
+import db.connection
+from agents.models import AgentRunAlreadyActive, AgentRunRetryPolicy, AgentRunTriggerType
+from agents.queue_worker import _execute_claimed_run
+from agents.repository import AgentRepository, AgentRunRepository
+from agents.scheduler import materialize_due_agent_runs
+from state import AppState
+from tests.helpers import create_mock_llm_multi, create_test_user
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def _patch_db_pool(db_pool, monkeypatch):
+    monkeypatch.setattr(db.connection, "_db_pool", db_pool)
+    async with db_pool.acquire() as conn:
+        await conn.execute("DELETE FROM agent_run_logs")
+        await conn.execute("DELETE FROM agent_runs")
+        await conn.execute("DELETE FROM agents")
+
+
+async def _create_agent(db_pool, user_id: str) -> str:
+    agent_id = str(ULID())
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            """INSERT INTO agents (id, user_id, name, instructions, agent_type,
+                                   schedule_type, schedule_value,
+                                   allowed_sources, allowed_actions,
+                                   is_enabled, is_deleted,
+                                   created_at, updated_at)
+               VALUES ($1, $2, 'Queue Test Agent', 'Do queue test work', 'user',
+                       'interval', '60', '[]'::jsonb, '[]'::jsonb,
+                       true, false, NOW() - INTERVAL '2 minutes', NOW() - INTERVAL '2 minutes')""",
+            agent_id,
+            user_id,
+        )
+    return agent_id
+
+
+def _policy(max_attempts: int = 3) -> AgentRunRetryPolicy:
+    return AgentRunRetryPolicy(
+        max_attempts=max_attempts,
+        backoff_delays=(timedelta(seconds=0), timedelta(seconds=0), timedelta(seconds=0)),
+    )
+
+
+def _app_state_with_llm(mock_llm) -> AppState:
+    app_state = AppState()
+    app_state.models = {"mock-model": mock_llm}
+    app_state.default_model_id = "mock-model"
+    app_state.searcher_tool = AsyncMock()
+    app_state.content_storage = AsyncMock()
+    app_state.redis_client = None
+    return app_state
+
+
+@pytest.mark.asyncio
+async def test_create_run_if_idle_returns_conflict_for_active_run(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    repo = AgentRunRepository(pool=db_pool)
+
+    first = await repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+    assert not isinstance(first, AgentRunAlreadyActive)
+    assert first.status == "pending"
+
+    second = await repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+    assert isinstance(second, AgentRunAlreadyActive)
+    assert second.run.id == first.id
+
+
+@pytest.mark.asyncio
+async def test_concurrent_claimers_do_not_claim_same_run(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    repo = AgentRunRepository(pool=db_pool)
+    await repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+
+    results = await asyncio.gather(
+        repo.claim_next_run(10, timedelta(minutes=5), _policy()),
+        repo.claim_next_run(10, timedelta(minutes=5), _policy()),
+    )
+    claimed = [result for result in results if result is not None]
+    assert len(claimed) == 1
+    assert claimed[0].run.status == "running"
+    assert claimed[0].run.claim_token == claimed[0].claim_token
+    assert claimed[0].run.attempt_count == 1
+
+
+@pytest.mark.asyncio
+async def test_cluster_concurrency_cap_blocks_claims(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_a = await _create_agent(db_pool, user_id)
+    agent_b = await _create_agent(db_pool, user_id)
+    repo = AgentRunRepository(pool=db_pool)
+    await repo.create_run(agent_a, AgentRunTriggerType.MANUAL)
+    await repo.create_run(agent_b, AgentRunTriggerType.MANUAL)
+
+    first = await repo.claim_next_run(1, timedelta(minutes=5), _policy())
+    assert first is not None
+    second = await repo.claim_next_run(1, timedelta(minutes=5), _policy())
+    assert second is None
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_and_completion_are_fenced_by_claim_token(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    repo = AgentRunRepository(pool=db_pool)
+    await repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+    claim = await repo.claim_next_run(10, timedelta(minutes=5), _policy())
+    assert claim is not None
+
+    assert not await repo.heartbeat_run(claim.run.id, "0" * 26, timedelta(minutes=5))
+    assert await repo.heartbeat_run(claim.run.id, claim.claim_token, timedelta(minutes=5))
+
+    assert await repo.complete_run(claim.run.id, "0" * 26, "bad") is None
+    completed = await repo.complete_run(claim.run.id, claim.claim_token, "done")
+    assert completed is not None
+    assert completed.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_stale_lease_recovery_and_old_token_cannot_complete(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    repo = AgentRunRepository(pool=db_pool)
+    await repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+    first = await repo.claim_next_run(10, timedelta(minutes=5), _policy())
+    assert first is not None
+
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            "UPDATE agent_runs SET lease_expires_at = NOW() - INTERVAL '1 second' WHERE id = $1",
+            first.run.id,
+        )
+
+    assert await repo.recover_stale_runs() == 1
+    second = await repo.claim_next_run(10, timedelta(minutes=5), _policy())
+    assert second is not None
+    assert second.run.id == first.run.id
+    assert second.claim_token != first.claim_token
+
+    assert await repo.complete_run(first.run.id, first.claim_token, "old") is None
+    completed = await repo.complete_run(second.run.id, second.claim_token, "new")
+    assert completed is not None
+    assert completed.status == "completed"
+
+
+@pytest.mark.asyncio
+async def test_run_logs_are_fenced_and_ordered(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    repo = AgentRunRepository(pool=db_pool)
+    await repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+    claim = await repo.claim_next_run(10, timedelta(minutes=5), _policy())
+    assert claim is not None
+
+    tool_use = MessageParam(
+        role="assistant",
+        content=[ToolUseBlockParam(type="tool_use", id="toolu_1", name="search", input={})],
+    )
+    assert await repo.append_run_log_messages(claim.run.id, "0" * 26, [tool_use]) == []
+    rows = await repo.append_run_log_messages(claim.run.id, claim.claim_token, [tool_use])
+    assert len(rows) == 1
+    assert rows[0].message_seq_num == 0
+
+    logs = await repo.list_run_logs(claim.run.id)
+    assert [log.message_seq_num for log in logs] == [0]
+    assert logs[0].message["role"] == "assistant"
+
+
+@pytest.mark.asyncio
+async def test_scheduler_materializes_due_run_without_duplicate(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    agent_repo = AgentRepository(pool=db_pool)
+    run_repo = AgentRunRepository(pool=db_pool)
+
+    created = await materialize_due_agent_runs(
+        agent_repo,
+        run_repo,
+        datetime.now(UTC),
+    )
+    assert created == 1
+    runs = await run_repo.list_runs(agent_id)
+    assert len(runs) == 1
+    assert runs[0].status == "pending"
+    assert runs[0].trigger_type == "scheduled"
+
+    created_again = await materialize_due_agent_runs(
+        agent_repo,
+        run_repo,
+        datetime.now(UTC),
+    )
+    assert created_again == 0
+    assert len(await run_repo.list_runs(agent_id)) == 1
+
+
+@pytest.mark.asyncio
+async def test_queue_worker_executes_claimed_run_through_executor(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    run_repo = AgentRunRepository(pool=db_pool)
+    await run_repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+    claim = await run_repo.claim_next_run(10, timedelta(minutes=5), _policy())
+    assert claim is not None
+
+    mock_llm = create_mock_llm_multi([
+        ("text", "The queued agent run completed."),
+        ("text", "Queued run summary."),
+    ])
+    await _execute_claimed_run(_app_state_with_llm(mock_llm), claim, _policy())
+
+    completed = await run_repo.get_run(claim.run.id)
+    assert completed is not None
+    assert completed.status == "completed"
+    assert completed.summary == "Queued run summary."
+    logs = await run_repo.list_run_logs(claim.run.id)
+    assert [log.message["role"] for log in logs] == ["user", "assistant", "user"]
+
+
+@pytest.mark.asyncio
+async def test_executor_recovers_interrupted_tool_call_from_run_logs(db_pool, _patch_db_pool):
+    user_id, _ = await create_test_user(db_pool)
+    agent_id = await _create_agent(db_pool, user_id)
+    run_repo = AgentRunRepository(pool=db_pool)
+    await run_repo.create_run(agent_id, AgentRunTriggerType.MANUAL)
+    claim = await run_repo.claim_next_run(10, timedelta(minutes=5), _policy())
+    assert claim is not None
+
+    initial = MessageParam(role="user", content="Execute your scheduled task now.")
+    interrupted_tool_use = MessageParam(
+        role="assistant",
+        content=[
+            ToolUseBlockParam(
+                type="tool_use",
+                id="toolu_interrupted",
+                name="search_documents",
+                input={"query": "quarterly report"},
+            )
+        ],
+    )
+    await run_repo.append_run_log_messages(
+        claim.run.id, claim.claim_token, [initial, interrupted_tool_use]
+    )
+
+    mock_llm = create_mock_llm_multi([
+        ("text", "I saw the interrupted tool call and reconciled it."),
+        ("text", "Recovered interrupted run."),
+    ])
+    await _execute_claimed_run(_app_state_with_llm(mock_llm), claim, _policy())
+
+    logs = await run_repo.list_run_logs(claim.run.id)
+    log_text = str([log.message for log in logs])
+    assert "previous attempt was interrupted" in log_text
+    assert (await run_repo.get_run(claim.run.id)).summary == "Recovered interrupted run."

--- a/services/ai/tests/integration/test_background_agents.py
+++ b/services/ai/tests/integration/test_background_agents.py
@@ -223,7 +223,8 @@ async def test_background_agent_end_to_end(db_pool, _patch_db_pool, _patch_env):
     assert run.started_at is not None
     assert run.completed_at is not None
     assert run.error_message is None
-    assert len(run.execution_log) >= 3
+    run_logs = await run_repo.list_run_logs(run.id)
+    assert len(run_logs) >= 3
     assert run.summary is not None
     assert SUMMARY_TEXT in run.summary
 
@@ -277,7 +278,8 @@ async def test_personal_agent_search_scoped_to_user(
     run = await execute_agent(agent, app_state)
     assert run.status == "completed"
 
-    log_text = json.dumps(run.execution_log)
+    run_logs = await AgentRunRepository(pool=db_pool).list_run_logs(run.id)
+    log_text = json.dumps([log.message for log in run_logs])
     assert (
         "Quarterly Report for User A" in log_text
     ), "Personal agent should see user A's document"
@@ -327,7 +329,8 @@ async def test_org_agent_search_sees_all_documents(
     run = await execute_agent(agent, app_state)
     assert run.status == "completed"
 
-    log_text = json.dumps(run.execution_log)
+    run_logs = await AgentRunRepository(pool=db_pool).list_run_logs(run.id)
+    log_text = json.dumps([log.message for log in run_logs])
     assert "Admin Visible Report" in log_text, "Org agent should see admin's document"
     assert (
         "Other User Private Doc" in log_text

--- a/services/migrations/102_harden_agent_runs_queue.sql
+++ b/services/migrations/102_harden_agent_runs_queue.sql
@@ -1,0 +1,51 @@
+-- Harden agent_runs into a durable DB-backed queue for background agents.
+-- agent_runs is the queue; agent_run_logs is the durable conversation/action WAL.
+
+ALTER TABLE agent_runs
+    ADD COLUMN IF NOT EXISTS trigger_type TEXT NOT NULL DEFAULT 'manual',
+    ADD COLUMN IF NOT EXISTS claim_token CHAR(26),
+    ADD COLUMN IF NOT EXISTS lease_expires_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS heartbeat_at TIMESTAMPTZ,
+    ADD COLUMN IF NOT EXISTS attempt_count INTEGER NOT NULL DEFAULT 0,
+    ADD COLUMN IF NOT EXISTS max_attempts INTEGER NOT NULL DEFAULT 3;
+
+ALTER TABLE agent_runs
+    DROP COLUMN IF EXISTS execution_log;
+
+ALTER TABLE agent_runs
+    ADD CONSTRAINT agent_runs_trigger_type_check
+        CHECK (trigger_type IN ('manual', 'scheduled')),
+    ADD CONSTRAINT agent_runs_attempt_count_check
+        CHECK (attempt_count >= 0),
+    ADD CONSTRAINT agent_runs_max_attempts_check
+        CHECK (max_attempts >= 1),
+    ADD CONSTRAINT agent_runs_running_lease_check
+        CHECK (
+            status <> 'running'
+            OR (claim_token IS NOT NULL AND lease_expires_at IS NOT NULL AND heartbeat_at IS NOT NULL)
+        );
+
+CREATE TABLE IF NOT EXISTS agent_run_logs (
+    id CHAR(26) PRIMARY KEY,
+    run_id CHAR(26) NOT NULL REFERENCES agent_runs(id) ON DELETE CASCADE,
+    message_seq_num INTEGER NOT NULL,
+    message JSONB NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT agent_run_logs_seq_num_check CHECK (message_seq_num >= 0),
+    CONSTRAINT agent_run_logs_run_seq_unique UNIQUE (run_id, message_seq_num)
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_pending_created
+    ON agent_runs(created_at)
+    WHERE status = 'pending';
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_active_by_agent
+    ON agent_runs(agent_id, status, lease_expires_at)
+    WHERE status IN ('pending', 'running');
+
+CREATE INDEX IF NOT EXISTS idx_agent_runs_stale_running
+    ON agent_runs(lease_expires_at)
+    WHERE status = 'running';
+
+CREATE INDEX IF NOT EXISTS idx_agent_run_logs_run_seq
+    ON agent_run_logs(run_id, message_seq_num);

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -53,7 +53,7 @@
                 "eslint-plugin-svelte": "^3.0.0",
                 "globals": "^16.0.0",
                 "mode-watcher": "^1.0.8",
-                "prettier": "^3.8.1",
+                "prettier": "^3.8.4",
                 "prettier-plugin-svelte": "^3.5.2",
                 "prettier-plugin-tailwindcss": "^0.7.2",
                 "svelte": "^5.55.7",
@@ -8829,9 +8829,9 @@
             }
         },
         "node_modules/prettier": {
-            "version": "3.8.1",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.1.tgz",
-            "integrity": "sha512-UOnG6LftzbdaHZcKoPFtOcCKztrQ57WkHDeRD9t/PTQtmT0NHSeWWepj6pS0z/N7+08BHFDQVUrfmfMRcZwbMg==",
+            "version": "3.8.4",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.8.4.tgz",
+            "integrity": "sha512-N2MylSdi48+5N/6S5j+maeHbUSIzzZ5uOcX5Hm4QpV8Dkb1HFjfAKTKX6yNPJQD9AhcT3ifHNB66tWTTJDi11Q==",
             "license": "MIT",
             "bin": {
                 "prettier": "bin/prettier.cjs"

--- a/web/package.json
+++ b/web/package.json
@@ -43,7 +43,7 @@
         "eslint-plugin-svelte": "^3.0.0",
         "globals": "^16.0.0",
         "mode-watcher": "^1.0.8",
-        "prettier": "^3.8.1",
+        "prettier": "^3.8.4",
         "prettier-plugin-svelte": "^3.5.2",
         "prettier-plugin-tailwindcss": "^0.7.2",
         "svelte": "^5.55.7",

--- a/web/src/lib/server/db/agents.ts
+++ b/web/src/lib/server/db/agents.ts
@@ -1,6 +1,6 @@
 import { db } from './index.js'
-import { agents, agentRuns } from './schema.js'
-import { eq, and, desc } from 'drizzle-orm'
+import { agents, agentRuns, agentRunLogs } from './schema.js'
+import { eq, and, desc, gt, inArray, or } from 'drizzle-orm'
 import { ulid } from 'ulid'
 import { error } from '@sveltejs/kit'
 import type { Agent } from './schema.js'
@@ -185,7 +185,62 @@ export async function listAgentRuns(agentId: string, limit = 50) {
         .limit(limit)
 }
 
+export async function getActiveAgentRun(agentId: string) {
+    const [run] = await db
+        .select()
+        .from(agentRuns)
+        .where(
+            and(
+                eq(agentRuns.agentId, agentId),
+                or(
+                    eq(agentRuns.status, 'pending'),
+                    and(eq(agentRuns.status, 'running'), gt(agentRuns.leaseExpiresAt, new Date())),
+                ),
+            ),
+        )
+        .orderBy(agentRuns.createdAt)
+        .limit(1)
+    return run || null
+}
+
+export async function listActiveRunsForAgents(agentIds: string[]) {
+    if (agentIds.length === 0) return new Map<string, typeof agentRuns.$inferSelect>()
+
+    const runs = await db
+        .select()
+        .from(agentRuns)
+        .where(
+            and(
+                inArray(agentRuns.agentId, agentIds),
+                or(
+                    eq(agentRuns.status, 'pending'),
+                    and(eq(agentRuns.status, 'running'), gt(agentRuns.leaseExpiresAt, new Date())),
+                ),
+            ),
+        )
+        .orderBy(agentRuns.createdAt)
+
+    const byAgent = new Map<string, typeof agentRuns.$inferSelect>()
+    for (const run of runs) {
+        if (!byAgent.has(run.agentId)) byAgent.set(run.agentId, run)
+    }
+    return byAgent
+}
+
+export async function listAgentRunLogs(runId: string) {
+    return db
+        .select()
+        .from(agentRunLogs)
+        .where(eq(agentRunLogs.runId, runId))
+        .orderBy(agentRunLogs.messageSeqNum)
+}
+
 export async function getAgentRun(runId: string) {
     const [run] = await db.select().from(agentRuns).where(eq(agentRuns.id, runId)).limit(1)
-    return run || null
+    if (!run) return null
+    const logs = await listAgentRunLogs(runId)
+    return {
+        ...run,
+        executionLog: logs.map((log) => log.message),
+    }
 }

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -290,11 +290,26 @@ export const agentRuns = pgTable('agent_runs', {
         .notNull()
         .references(() => agents.id, { onDelete: 'cascade' }),
     status: text('status').notNull().default('pending'),
+    triggerType: text('trigger_type').notNull().default('manual'),
     startedAt: timestamp('started_at', { withTimezone: true, mode: 'date' }),
     completedAt: timestamp('completed_at', { withTimezone: true, mode: 'date' }),
-    executionLog: jsonb('execution_log').notNull().default([]),
+    claimToken: text('claim_token'),
+    leaseExpiresAt: timestamp('lease_expires_at', { withTimezone: true, mode: 'date' }),
+    heartbeatAt: timestamp('heartbeat_at', { withTimezone: true, mode: 'date' }),
+    attemptCount: integer('attempt_count').notNull().default(0),
+    maxAttempts: integer('max_attempts').notNull().default(3),
     summary: text('summary'),
     errorMessage: text('error_message'),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+})
+
+export const agentRunLogs = pgTable('agent_run_logs', {
+    id: text('id').primaryKey(),
+    runId: text('run_id')
+        .notNull()
+        .references(() => agentRuns.id, { onDelete: 'cascade' }),
+    messageSeqNum: integer('message_seq_num').notNull(),
+    message: jsonb('message').$type<MessageParam>().notNull(),
     createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 })
 
@@ -336,4 +351,5 @@ export type ToolApproval = typeof toolApprovals.$inferSelect
 export type EmailProvider = typeof emailProviders.$inferSelect
 export type Agent = typeof agents.$inferSelect
 export type AgentRun = typeof agentRuns.$inferSelect
+export type AgentRunLog = typeof agentRunLogs.$inferSelect
 export type ApiKey = typeof apiKeys.$inferSelect

--- a/web/src/routes/(admin)/admin/settings/agents/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/agents/+page.server.ts
@@ -1,10 +1,11 @@
 import type { PageServerLoad } from './$types.js'
 import { requireAdmin, requireActiveUser } from '$lib/server/authHelpers.js'
-import { listOrgAgents } from '$lib/server/db/agents.js'
+import { listActiveRunsForAgents, listOrgAgents } from '$lib/server/db/agents.js'
 
 export const load: PageServerLoad = async ({ locals }) => {
     requireActiveUser(locals)
     const { user } = requireAdmin(locals)
     const agents = await listOrgAgents()
-    return { user, agents }
+    const activeRuns = await listActiveRunsForAgents(agents.map((agent) => agent.id))
+    return { user, agents, activeRuns: Object.fromEntries(activeRuns) }
 }

--- a/web/src/routes/(admin)/admin/settings/agents/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/agents/+page.svelte
@@ -162,6 +162,13 @@
 
     async function triggerAgent(agentId: string) {
         await fetch(`/api/agents/${agentId}/trigger`, { method: 'POST' })
+        invalidateAll()
+    }
+
+    function activeLabel(agentId: string): string | null {
+        const run = data.activeRuns?.[agentId]
+        if (!run) return null
+        return run.status === 'pending' ? 'Queued' : 'Running'
     }
 
     async function startChat(agentId: string) {
@@ -343,6 +350,7 @@
     {:else}
         <div class="space-y-3">
             {#each data.agents as agent (agent.id)}
+                {@const label = activeLabel(agent.id)}
                 <div
                     class="hover:bg-muted/50 flex items-center justify-between rounded-lg border p-4 transition-colors">
                     <button
@@ -372,11 +380,16 @@
                         </Button>
                         <Button
                             variant="ghost"
-                            size="icon"
+                            size={label ? 'sm' : 'icon'}
                             class="cursor-pointer"
-                            title="Run now"
+                            title={label ?? 'Run now'}
+                            disabled={!!label}
                             onclick={() => triggerAgent(agent.id)}>
-                            <Play class="h-4 w-4" />
+                            {#if label}
+                                {label}
+                            {:else}
+                                <Play class="h-4 w-4" />
+                            {/if}
                         </Button>
                     </div>
                 </div>

--- a/web/src/routes/(app)/agents/+page.server.ts
+++ b/web/src/routes/(app)/agents/+page.server.ts
@@ -1,9 +1,10 @@
 import type { PageServerLoad } from './$types.js'
 import { requireAuth, requireActiveUser } from '$lib/server/authHelpers.js'
-import { listAgents } from '$lib/server/db/agents.js'
+import { listAgents, listActiveRunsForAgents } from '$lib/server/db/agents.js'
 
 export const load: PageServerLoad = async ({ locals }) => {
     const { user } = requireActiveUser(locals)
     const agents = await listAgents(user.id)
-    return { user, agents }
+    const activeRuns = await listActiveRunsForAgents(agents.map((agent) => agent.id))
+    return { user, agents, activeRuns: Object.fromEntries(activeRuns) }
 }

--- a/web/src/routes/(app)/agents/+page.svelte
+++ b/web/src/routes/(app)/agents/+page.svelte
@@ -20,6 +20,13 @@
 
     async function triggerAgent(agentId: string) {
         await fetch(`/api/agents/${agentId}/trigger`, { method: 'POST' })
+        invalidateAll()
+    }
+
+    function activeLabel(agentId: string): string | null {
+        const run = data.activeRuns?.[agentId]
+        if (!run) return null
+        return run.status === 'pending' ? 'Queued' : 'Running'
     }
 </script>
 
@@ -54,6 +61,7 @@
     {:else}
         <div class="space-y-3">
             {#each data.agents as agent (agent.id)}
+                {@const label = activeLabel(agent.id)}
                 <div
                     class="hover:bg-muted/50 flex items-center justify-between rounded-lg border p-4 transition-colors">
                     <a href="/agents/{agent.id}" class="min-w-0 flex-1 cursor-pointer">
@@ -83,10 +91,15 @@
                     <div class="ml-4 flex items-center gap-2">
                         <Button
                             variant="ghost"
-                            size="icon"
+                            size={label ? 'sm' : 'icon'}
                             class="cursor-pointer"
+                            disabled={!!label}
                             onclick={() => triggerAgent(agent.id)}>
-                            <Play class="h-4 w-4" />
+                            {#if label}
+                                {label}
+                            {:else}
+                                <Play class="h-4 w-4" />
+                            {/if}
                         </Button>
                         <Switch.Root
                             checked={agent.isEnabled}

--- a/web/src/routes/(app)/agents/[agentId]/+page.server.ts
+++ b/web/src/routes/(app)/agents/[agentId]/+page.server.ts
@@ -1,13 +1,17 @@
 import type { PageServerLoad } from './$types.js'
 import { requireActiveUser } from '$lib/server/authHelpers.js'
-import { requireAgentAccess, listAgentRuns } from '$lib/server/db/agents.js'
+import { requireAgentAccess, listAgentRuns, getActiveAgentRun } from '$lib/server/db/agents.js'
 import { listAllActiveModels } from '$lib/server/db/model-providers.js'
 
 export const load: PageServerLoad = async ({ locals, params }) => {
     const { user } = requireActiveUser(locals)
     const agent = await requireAgentAccess(params.agentId, user)
 
-    const [runs, models] = await Promise.all([listAgentRuns(params.agentId), listAllActiveModels()])
+    const [runs, models, activeRun] = await Promise.all([
+        listAgentRuns(params.agentId),
+        listAllActiveModels(),
+        getActiveAgentRun(params.agentId),
+    ])
 
-    return { user, agent, runs, models }
+    return { user, agent, runs, models, activeRun }
 }

--- a/web/src/routes/(app)/agents/[agentId]/+page.svelte
+++ b/web/src/routes/(app)/agents/[agentId]/+page.svelte
@@ -76,6 +76,10 @@
         invalidateAll()
     }
 
+    let activeRunLabel = $derived(
+        data.activeRun ? (data.activeRun.status === 'pending' ? 'Queued' : 'Running') : null,
+    )
+
     async function confirmDelete() {
         await fetch(`/api/agents/${data.agent.id}`, { method: 'DELETE' })
         goto('/agents')
@@ -139,8 +143,13 @@
                 <MessageSquare class="mr-1 h-3 w-3" />
                 {startingChat ? 'Starting...' : 'Chat with Agent'}
             </Button>
-            <Button variant="outline" size="sm" class="cursor-pointer" onclick={triggerRun}>
-                <Play class="mr-1 h-3 w-3" /> Run Now
+            <Button
+                variant="outline"
+                size="sm"
+                class="cursor-pointer"
+                onclick={triggerRun}
+                disabled={!!activeRunLabel}>
+                <Play class="mr-1 h-3 w-3" /> {activeRunLabel ?? 'Run Now'}
             </Button>
             <Switch.Root
                 checked={data.agent.isEnabled}

--- a/web/src/routes/api/agents/[agentId]/trigger/+server.ts
+++ b/web/src/routes/api/agents/[agentId]/trigger/+server.ts
@@ -22,10 +22,11 @@ export const POST: RequestHandler = async ({ params, locals }) => {
         },
     )
 
+    const body = await response.json().catch(() => ({ error: 'Failed to trigger agent' }))
+
     if (!response.ok) {
-        return json({ error: 'Failed to trigger agent' }, { status: response.status })
+        return json(body, { status: response.status })
     }
 
-    const result = await response.json()
-    return json(result)
+    return json(body, { status: response.status })
 }


### PR DESCRIPTION
- Makes `agent_runs` the durable Postgres-backed queue for manual and scheduled agent execution.
- Adds lease-based claiming, heartbeat recovery, retries, and claim-token fencing to prevent duplicate/stale finalization.
- Persists agent conversation/tool-call history in `agent_run_logs` before tool execution so crashed runs can resume with durable context.
- Updates agent UI/API behavior to show active queued/running runs and reject duplicate manual triggers.
- Adds integration coverage for queue claims, stale recovery, scheduler materialization, worker execution, and durable run logs.