### PR TITLE
fix(web): persist stopped chat streams

### DIFF
--- a/services/ai/db/messages.py
+++ b/services/ai/db/messages.py
@@ -142,3 +142,30 @@ class MessagesRepository:
             rows = await conn.fetch(query, chat_id)
 
         return [ChatMessage.from_row(dict(row)) for row in rows]
+
+    async def get_path_to_message(
+        self, chat_id: str, message_id: str
+    ) -> List[ChatMessage]:
+        """Get the branch path from root through a specific message."""
+        pool = await self._get_pool()
+
+        query = """
+            WITH RECURSIVE walk_up AS (
+                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.created_at
+                FROM chat_messages cm
+                WHERE cm.chat_id = $1 AND cm.id = $2
+
+                UNION ALL
+
+                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.created_at
+                FROM chat_messages cm
+                JOIN walk_up wu ON cm.id = wu.parent_id
+                WHERE cm.chat_id = $1
+            )
+            SELECT * FROM walk_up ORDER BY message_seq_num
+        """
+
+        async with pool.acquire() as conn:
+            rows = await conn.fetch(query, chat_id, message_id)
+
+        return [ChatMessage.from_row(dict(row)) for row in rows]

--- a/services/ai/db/messages.py
+++ b/services/ai/db/messages.py
@@ -142,30 +142,3 @@ class MessagesRepository:
             rows = await conn.fetch(query, chat_id)
 
         return [ChatMessage.from_row(dict(row)) for row in rows]
-
-    async def get_path_to_message(
-        self, chat_id: str, message_id: str
-    ) -> List[ChatMessage]:
-        """Get the branch path from root through a specific message."""
-        pool = await self._get_pool()
-
-        query = """
-            WITH RECURSIVE walk_up AS (
-                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.created_at
-                FROM chat_messages cm
-                WHERE cm.chat_id = $1 AND cm.id = $2
-
-                UNION ALL
-
-                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.created_at
-                FROM chat_messages cm
-                JOIN walk_up wu ON cm.id = wu.parent_id
-                WHERE cm.chat_id = $1
-            )
-            SELECT * FROM walk_up ORDER BY message_seq_num
-        """
-
-        async with pool.acquire() as conn:
-            rows = await conn.fetch(query, chat_id, message_id)
-
-        return [ChatMessage.from_row(dict(row)) for row in rows]

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -847,6 +847,10 @@ async def stream_chat(
     auto_start: bool = Query(
         False, description="Auto-inject initial message for agent chats"
     ),
+    parent_message_id: str | None = Query(
+        None,
+        description="Generate from the branch ending at this user message",
+    ),
 ):
     """Stream AI response for a chat thread using Server-Sent Events"""
     if not request.app.state.searcher_tool:
@@ -886,7 +890,18 @@ async def stream_chat(
         )
 
     messages_repo = MessagesRepository()
-    chat_messages = await messages_repo.get_active_path(chat_id)
+    if parent_message_id is not None:
+        chat_messages = await messages_repo.get_path_to_message(
+            chat_id, parent_message_id
+        )
+        if not chat_messages:
+            raise HTTPException(status_code=404, detail="Parent message not found")
+        if chat_messages[-1].message.get("role") != "user":
+            raise HTTPException(
+                status_code=400, detail="Parent message must be a user message"
+            )
+    else:
+        chat_messages = await messages_repo.get_active_path(chat_id)
 
     # Memory state — populated in both agent and regular chat branches
     memory_provider = None

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -847,10 +847,6 @@ async def stream_chat(
     auto_start: bool = Query(
         False, description="Auto-inject initial message for agent chats"
     ),
-    parent_message_id: str | None = Query(
-        None,
-        description="Generate from the branch ending at this user message",
-    ),
 ):
     """Stream AI response for a chat thread using Server-Sent Events"""
     if not request.app.state.searcher_tool:
@@ -890,18 +886,7 @@ async def stream_chat(
         )
 
     messages_repo = MessagesRepository()
-    if parent_message_id is not None:
-        chat_messages = await messages_repo.get_path_to_message(
-            chat_id, parent_message_id
-        )
-        if not chat_messages:
-            raise HTTPException(status_code=404, detail="Parent message not found")
-        if chat_messages[-1].message.get("role") != "user":
-            raise HTTPException(
-                status_code=400, detail="Parent message must be a user message"
-            )
-    else:
-        chat_messages = await messages_repo.get_active_path(chat_id)
+    chat_messages = await messages_repo.get_active_path(chat_id)
 
     # Memory state — populated in both agent and regular chat branches
     memory_provider = None

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -168,6 +168,24 @@ def _sse_event_data(event_str: str) -> str:
     return ""
 
 
+def _partial_assistant_message(
+    content_blocks: list[TextBlockParam | ToolUseBlockParam],
+) -> MessageParam | None:
+    text_blocks: list[TextBlockParam] = []
+    for block in content_blocks:
+        if block["type"] != "text":
+            continue
+        text_block = cast(TextBlockParam, block)
+        if not text_block["text"].strip():
+            continue
+        text_blocks.append(cast(TextBlockParam, dict(text_block)))
+
+    if not text_blocks:
+        return None
+
+    return MessageParam(role="assistant", content=text_blocks)
+
+
 async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
     """Persist assistant/tool_result messages (single writer of the streaming
     path) and replace each internal `save_message` event with a client-facing
@@ -1341,6 +1359,7 @@ async def stream_chat(
             )
 
             usage_repo = UsageRepository()
+            assistant_message: MessageParam | None = None
 
             for iteration in range(AGENT_MAX_ITERATIONS):
                 # Stop only on an explicit user cancel (Stop button). The run is
@@ -1404,11 +1423,7 @@ async def stream_chat(
                     logger.debug(f"Received event: {event} (index: {event_index})")
                     event_index += 1
 
-                    # Responsive Stop: poll the cancel flag periodically so an
-                    # explicit user Stop interrupts a long in-progress message.
-                    if event_index % 32 == 0 and await _is_run_cancelled(
-                        redis_client, chat_id
-                    ):
+                    if await _is_run_cancelled(redis_client, chat_id):
                         cancelled = True
                         break
 
@@ -1507,6 +1522,10 @@ async def stream_chat(
                         break
 
                 if cancelled:
+                    assistant_message = _partial_assistant_message(content_blocks)
+                    if assistant_message is not None:
+                        conversation_messages.append(assistant_message)
+                        yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
                     break
 
                 tracker.save()

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -129,6 +129,7 @@ _LOCK_REFRESH_INTERVAL = 60  # seconds; independent of event production, so a lo
 _STREAM_TTL = 300  # seconds a finished stream stays replayable
 _STREAM_MAXLEN = 5000  # cap buffered events per run
 _CANCEL_TTL = 300
+_CANCEL_CHECK_INTERVAL_SECONDS = 1.0
 
 _background_run_tasks: set[asyncio.Task] = set()
 
@@ -1419,13 +1420,17 @@ async def stream_chat(
                 event_index = 0
                 message_stop_received = False
                 cancelled = False
+                last_cancel_check_at = 0.0
                 async for event in stream:
                     logger.debug(f"Received event: {event} (index: {event_index})")
                     event_index += 1
 
-                    if await _is_run_cancelled(redis_client, chat_id):
-                        cancelled = True
-                        break
+                    now = asyncio.get_running_loop().time()
+                    if now - last_cancel_check_at >= _CANCEL_CHECK_INTERVAL_SECONDS:
+                        last_cancel_check_at = now
+                        if await _is_run_cancelled(redis_client, chat_id):
+                            cancelled = True
+                            break
 
                     if event.type == "message_start":
                         logger.info("Message start received.")

--- a/web/e2e/chat-branching.spec.ts
+++ b/web/e2e/chat-branching.spec.ts
@@ -124,6 +124,24 @@ async function seedBranchChat(messages: BranchMessage[]): Promise<SeededChat> {
     return { userId, chatId, sessionToken, sessionKey, messages: Object.fromEntries(idByKey) }
 }
 
+async function countMessagesContaining(
+    chatId: string,
+    role: 'user' | 'assistant',
+    text: string,
+): Promise<number> {
+    const sql = postgres(dbConfig)
+    const [row] = await sql<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count
+        FROM chat_messages
+        WHERE chat_id = ${chatId}
+          AND message->>'role' = ${role}
+          AND message::text LIKE ${`%${text}%`}
+    `
+    await sql.end()
+
+    return row.count
+}
+
 async function cleanupChat(seeded: SeededChat | null): Promise<void> {
     if (!seeded) return
 
@@ -283,6 +301,46 @@ test('branching chat clears downstream branch selection when changing parent bra
         await expect(page.getByText('assistant A latest answer')).toBeVisible()
         await expect(page.getByText('user A older follow-up')).toHaveCount(0)
         await expect(page.getByText('assistant A older answer')).toHaveCount(0)
+    } finally {
+        await cleanupChat(seeded)
+    }
+})
+
+test('retrying a user message regenerates without duplicating the user message', async ({
+    page,
+}) => {
+    let seeded: SeededChat | null = null
+    try {
+        seeded = await openSeededChat(page, [
+            { key: 'root', parentKey: null, role: 'user', content: 'retry prompt' },
+            { key: 'oldAssistant', parentKey: 'root', role: 'assistant', content: 'old answer' },
+        ])
+        await page.route(`**/api/chat/${seeded.chatId}/stream**`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                headers: {
+                    'content-type': 'text/event-stream',
+                    'cache-control': 'no-cache',
+                    connection: 'keep-alive',
+                },
+                body: textStream(ulid(), 'retried answer'),
+            })
+        })
+
+        await expect(page.getByText('retry prompt')).toBeVisible()
+        await expect(page.getByText('old answer')).toBeVisible()
+
+        await page.getByText('retry prompt').hover()
+        await page.getByTestId(`retry-message-${seeded.messages.root}`).click({ force: true })
+
+        await expect(page.getByText('retried answer')).toBeVisible()
+        await expect(page.getByText('retry prompt')).toHaveCount(1)
+        await expect(page.getByText('old answer')).toHaveCount(0)
+        await expect
+            .poll(() => countMessagesContaining(seeded!.chatId, 'user', 'retry prompt'), {
+                message: 'retry should not create a duplicate user message row',
+            })
+            .toBe(1)
     } finally {
         await cleanupChat(seeded)
     }

--- a/web/e2e/chat-branching.spec.ts
+++ b/web/e2e/chat-branching.spec.ts
@@ -288,6 +288,41 @@ test('branching chat clears downstream branch selection when changing parent bra
     }
 })
 
+test('retrying a user message creates a new sibling branch without showing duplicate user bubbles', async ({
+    page,
+}) => {
+    let seeded: SeededChat | null = null
+    try {
+        seeded = await openSeededChat(page, [
+            { key: 'root', parentKey: null, role: 'user', content: 'retry prompt' },
+            { key: 'oldAssistant', parentKey: 'root', role: 'assistant', content: 'old answer' },
+        ])
+        await page.route(`**/api/chat/${seeded.chatId}/stream`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                headers: {
+                    'content-type': 'text/event-stream',
+                    'cache-control': 'no-cache',
+                    connection: 'keep-alive',
+                },
+                body: textStream(ulid(), 'retried answer'),
+            })
+        })
+
+        await expect(page.getByText('retry prompt')).toBeVisible()
+        await expect(page.getByText('old answer')).toBeVisible()
+
+        await page.getByText('retry prompt').hover()
+        await page.getByTestId(`retry-message-${seeded.messages.root}`).click({ force: true })
+
+        await expect(page.getByText('retried answer')).toBeVisible()
+        await expect(page.getByText('retry prompt')).toHaveCount(1)
+        await expect(page.getByText('old answer')).toHaveCount(0)
+    } finally {
+        await cleanupChat(seeded)
+    }
+})
+
 test('branching chat streams follow-up on the selected non-latest branch', async ({ page }) => {
     let seeded: SeededChat | null = null
     try {

--- a/web/e2e/chat-branching.spec.ts
+++ b/web/e2e/chat-branching.spec.ts
@@ -124,24 +124,6 @@ async function seedBranchChat(messages: BranchMessage[]): Promise<SeededChat> {
     return { userId, chatId, sessionToken, sessionKey, messages: Object.fromEntries(idByKey) }
 }
 
-async function countMessagesContaining(
-    chatId: string,
-    role: 'user' | 'assistant',
-    text: string,
-): Promise<number> {
-    const sql = postgres(dbConfig)
-    const [row] = await sql<{ count: number }[]>`
-        SELECT COUNT(*)::int AS count
-        FROM chat_messages
-        WHERE chat_id = ${chatId}
-          AND message->>'role' = ${role}
-          AND message::text LIKE ${`%${text}%`}
-    `
-    await sql.end()
-
-    return row.count
-}
-
 async function cleanupChat(seeded: SeededChat | null): Promise<void> {
     if (!seeded) return
 
@@ -301,46 +283,6 @@ test('branching chat clears downstream branch selection when changing parent bra
         await expect(page.getByText('assistant A latest answer')).toBeVisible()
         await expect(page.getByText('user A older follow-up')).toHaveCount(0)
         await expect(page.getByText('assistant A older answer')).toHaveCount(0)
-    } finally {
-        await cleanupChat(seeded)
-    }
-})
-
-test('retrying a user message regenerates without duplicating the user message', async ({
-    page,
-}) => {
-    let seeded: SeededChat | null = null
-    try {
-        seeded = await openSeededChat(page, [
-            { key: 'root', parentKey: null, role: 'user', content: 'retry prompt' },
-            { key: 'oldAssistant', parentKey: 'root', role: 'assistant', content: 'old answer' },
-        ])
-        await page.route(`**/api/chat/${seeded.chatId}/stream**`, async (route) => {
-            await route.fulfill({
-                status: 200,
-                headers: {
-                    'content-type': 'text/event-stream',
-                    'cache-control': 'no-cache',
-                    connection: 'keep-alive',
-                },
-                body: textStream(ulid(), 'retried answer'),
-            })
-        })
-
-        await expect(page.getByText('retry prompt')).toBeVisible()
-        await expect(page.getByText('old answer')).toBeVisible()
-
-        await page.getByText('retry prompt').hover()
-        await page.getByTestId(`retry-message-${seeded.messages.root}`).click({ force: true })
-
-        await expect(page.getByText('retried answer')).toBeVisible()
-        await expect(page.getByText('retry prompt')).toHaveCount(1)
-        await expect(page.getByText('old answer')).toHaveCount(0)
-        await expect
-            .poll(() => countMessagesContaining(seeded!.chatId, 'user', 'retry prompt'), {
-                message: 'retry should not create a duplicate user message row',
-            })
-            .toBe(1)
     } finally {
         await cleanupChat(seeded)
     }

--- a/web/e2e/chat-stream.spec.ts
+++ b/web/e2e/chat-stream.spec.ts
@@ -583,8 +583,8 @@ test('chat renders a captured stream from a seeded chat fixture', async ({ page 
         !capturedSeedChatPath ||
             !capturedExpectedText ||
             !capturedSubmitText ||
-            !process.env.OMNI_CHAT_STREAM_REPLAY_PATH,
-        'Set OMNI_CAPTURE_SEED_CHAT_PATH, OMNI_CAPTURE_SUBMIT_TEXT, OMNI_CAPTURE_EXPECT_TEXT, and OMNI_CHAT_STREAM_REPLAY_PATH to run this capture replay test.',
+            !process.env.OMNI_TEST_CHAT_STREAM_REPLAY_PATH,
+        'Set OMNI_CAPTURE_SEED_CHAT_PATH, OMNI_CAPTURE_SUBMIT_TEXT, OMNI_CAPTURE_EXPECT_TEXT, and OMNI_TEST_CHAT_STREAM_REPLAY_PATH to run this capture replay test.',
     )
 
     let seeded: SeededChat | null = null

--- a/web/e2e/chat-stream.spec.ts
+++ b/web/e2e/chat-stream.spec.ts
@@ -320,6 +320,24 @@ async function seedCitationRenderingChat(): Promise<SeededCitationChat> {
     return { ...seeded, assistantMessageId: assistantMessage.id }
 }
 
+async function countMessagesContaining(
+    chatId: string,
+    role: 'user' | 'assistant',
+    text: string,
+): Promise<number> {
+    const sql = postgres(dbConfig)
+    const [row] = await sql<{ count: number }[]>`
+        SELECT COUNT(*)::int AS count
+        FROM chat_messages
+        WHERE chat_id = ${chatId}
+          AND message->>'role' = ${role}
+          AND message::text LIKE ${`%${text}%`}
+    `
+    await sql.end()
+
+    return row.count
+}
+
 async function cleanupChat(seeded: SeededChat | null): Promise<void> {
     if (!seeded) return
 
@@ -584,6 +602,80 @@ test('chat renders a captured stream from a seeded chat fixture', async ({ page 
     }
 })
 
+test('stopping a partial assistant stream allows a follow-up message to be submitted', async ({
+    page,
+}) => {
+    let seeded: SeededChat | null = null
+    try {
+        seeded = await seedChat()
+        await authenticate(page, seeded)
+        await selectReplayFixture(page, 'cancel-partial-stream.sse')
+
+        await page.goto(`/chat/${seeded.chatId}`)
+        await page.getByRole('main').getByRole('textbox').fill('Start the partial stream')
+        await page.keyboard.press('Enter')
+
+        await expect(page.getByText('Start the partial stream')).toBeVisible()
+        await expect(page.getByText('Partial answer before stop.')).toBeVisible()
+
+        const stopButton = page.locator('.omni-composer-send.rounded-full')
+        await expect(stopButton).toBeVisible()
+        await stopButton.click()
+        await expect(stopButton).not.toBeVisible()
+
+        const textbox = page.getByRole('main').getByRole('textbox')
+        await textbox.fill('Follow-up after stop')
+        await page.keyboard.press('Enter')
+
+        await expect
+            .poll(() => countMessagesContaining(seeded!.chatId, 'user', 'Follow-up after stop'), {
+                message: 'follow-up user message should be persisted after stopping',
+            })
+            .toBe(1)
+    } finally {
+        await cleanupChat(seeded)
+    }
+})
+
+test('stopping a partial assistant stream persists the partial content across reload', async ({
+    page,
+}) => {
+    let seeded: SeededChat | null = null
+    try {
+        seeded = await seedChat()
+        await authenticate(page, seeded)
+        await selectReplayFixture(page, 'cancel-partial-stream.sse')
+
+        await page.goto(`/chat/${seeded.chatId}`)
+        await page.getByRole('main').getByRole('textbox').fill('Start a persisted partial stream')
+        await page.keyboard.press('Enter')
+
+        await expect(page.getByText('Partial answer before stop.')).toBeVisible()
+
+        const stopButton = page.locator('.omni-composer-send.rounded-full')
+        await expect(stopButton).toBeVisible()
+        await stopButton.click()
+        await expect(stopButton).not.toBeVisible()
+
+        await expect
+            .poll(
+                () =>
+                    countMessagesContaining(
+                        seeded!.chatId,
+                        'assistant',
+                        'Partial answer before stop.',
+                    ),
+                { message: 'partial assistant content should be persisted to chat_messages' },
+            )
+            .toBe(1)
+
+        await page.reload()
+        await expect(page.getByText('Partial answer before stop.')).toBeVisible()
+    } finally {
+        await cleanupChat(seeded)
+    }
+})
+
 test('stop button during streaming resets state so the input is ready for a new message', async ({
     page,
 }) => {
@@ -609,7 +701,7 @@ test('stop button during streaming resets state so the input is ready for a new 
             await route.fulfill({
                 status: 200,
                 headers: { 'content-type': 'text/event-stream', 'cache-control': 'no-cache' },
-                body: '',
+                body: 'event: end_of_stream\ndata: Stream stopped\n\n',
             })
         })
 

--- a/web/e2e/fixtures/cancel-partial-stream.sse
+++ b/web/e2e/fixtures/cancel-partial-stream.sse
@@ -1,0 +1,214 @@
+event: message
+data: {"type": "message_start", "message": {"id": "msg_cancel_partial", "type": "message", "role": "assistant", "content": [], "model": "playwright-model", "stop_reason": null, "stop_sequence": null, "usage": {"input_tokens": 1, "output_tokens": 1}}}
+
+event: message
+data: {"type": "content_block_start", "index": 0, "content_block": {"type": "text", "text": ""}}
+
+event: message
+data: {"type": "content_block_delta", "index": 0, "delta": {"type": "text_delta", "text": "Partial answer before stop."}}
+
+: keepalive 0
+
+: keepalive 1
+
+: keepalive 2
+
+: keepalive 3
+
+: keepalive 4
+
+: keepalive 5
+
+: keepalive 6
+
+: keepalive 7
+
+: keepalive 8
+
+: keepalive 9
+
+: keepalive 10
+
+: keepalive 11
+
+: keepalive 12
+
+: keepalive 13
+
+: keepalive 14
+
+: keepalive 15
+
+: keepalive 16
+
+: keepalive 17
+
+: keepalive 18
+
+: keepalive 19
+
+: keepalive 20
+
+: keepalive 21
+
+: keepalive 22
+
+: keepalive 23
+
+: keepalive 24
+
+: keepalive 25
+
+: keepalive 26
+
+: keepalive 27
+
+: keepalive 28
+
+: keepalive 29
+
+: keepalive 30
+
+: keepalive 31
+
+: keepalive 32
+
+: keepalive 33
+
+: keepalive 34
+
+: keepalive 35
+
+: keepalive 36
+
+: keepalive 37
+
+: keepalive 38
+
+: keepalive 39
+
+: keepalive 40
+
+: keepalive 41
+
+: keepalive 42
+
+: keepalive 43
+
+: keepalive 44
+
+: keepalive 45
+
+: keepalive 46
+
+: keepalive 47
+
+: keepalive 48
+
+: keepalive 49
+
+: keepalive 50
+
+: keepalive 51
+
+: keepalive 52
+
+: keepalive 53
+
+: keepalive 54
+
+: keepalive 55
+
+: keepalive 56
+
+: keepalive 57
+
+: keepalive 58
+
+: keepalive 59
+
+: keepalive 60
+
+: keepalive 61
+
+: keepalive 62
+
+: keepalive 63
+
+: keepalive 64
+
+: keepalive 65
+
+: keepalive 66
+
+: keepalive 67
+
+: keepalive 68
+
+: keepalive 69
+
+: keepalive 70
+
+: keepalive 71
+
+: keepalive 72
+
+: keepalive 73
+
+: keepalive 74
+
+: keepalive 75
+
+: keepalive 76
+
+: keepalive 77
+
+: keepalive 78
+
+: keepalive 79
+
+: keepalive 80
+
+: keepalive 81
+
+: keepalive 82
+
+: keepalive 83
+
+: keepalive 84
+
+: keepalive 85
+
+: keepalive 86
+
+: keepalive 87
+
+: keepalive 88
+
+: keepalive 89
+
+: keepalive 90
+
+: keepalive 91
+
+: keepalive 92
+
+: keepalive 93
+
+: keepalive 94
+
+: keepalive 95
+
+: keepalive 96
+
+: keepalive 97
+
+: keepalive 98
+
+: keepalive 99
+
+event: save_message
+data: {"role": "assistant", "content": [{"type": "text", "text": "Partial answer before stop."}]}
+
+event: end_of_stream
+data: Stream stopped

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -17,10 +17,11 @@ export default defineConfig({
             AI_SERVICE_URL: process.env.AI_SERVICE_URL ?? 'http://localhost:1',
             CONNECTOR_MANAGER_URL: process.env.CONNECTOR_MANAGER_URL ?? 'http://localhost:1',
             APP_URL: process.env.APP_URL ?? 'http://localhost:4173',
-            OMNI_CHAT_STREAM_REPLAY_PATH:
-                process.env.OMNI_CHAT_STREAM_REPLAY_PATH ?? 'e2e/fixtures/branched-chat-stream.sse',
-            OMNI_CHAT_STREAM_REPLAY_FIXTURE_DIR:
-                process.env.OMNI_CHAT_STREAM_REPLAY_FIXTURE_DIR ?? 'e2e/fixtures',
+            OMNI_TEST_CHAT_STREAM_REPLAY_PATH:
+                process.env.OMNI_TEST_CHAT_STREAM_REPLAY_PATH ??
+                'e2e/fixtures/branched-chat-stream.sse',
+            OMNI_TEST_CHAT_STREAM_REPLAY_FIXTURE_DIR:
+                process.env.OMNI_TEST_CHAT_STREAM_REPLAY_FIXTURE_DIR ?? 'e2e/fixtures',
         },
     },
     testDir: 'e2e',

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -1970,6 +1970,8 @@
                         size="icon"
                         variant="ghost"
                         class="h-7 w-7 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100"
+                        aria-label="Retry message"
+                        data-testid={`retry-message-${message.origMessageId}`}
                         onclick={() => handleEdit(message.origMessageId, firstText?.text ?? '')}>
                         <RotateCcw class="h-3.5 w-3.5" />
                     </Button>

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -690,23 +690,6 @@
         }
     }
 
-    async function handleRetry(origMessageId: string) {
-        if (isStreaming || stopInProgress) return
-
-        const origMsg = chatMessages.find((message) => message.id === origMessageId)
-        if (!origMsg || origMsg.message.role !== 'user') return
-
-        selectBranch(origMsg.parentId, origMsg.id)
-        clearDownstreamSelections(origMsg.id)
-        activeStreamingMessageId = origMsg.id
-        markChatMessagesChanged()
-        refreshProcessedMessages()
-
-        userHasScrolled = false
-        scrollUserMessageToTop()
-        streamResponse(data.chat.id, { parentMessageId: origMsg.id })
-    }
-
     async function handleEdit(origMessageId: string, newContent: string) {
         editingMessageId = null
         const response = await fetch(`/api/chat/${data.chat.id}/messages/${origMessageId}/edit`, {
@@ -1180,10 +1163,10 @@
         }
     })
 
-    function streamResponse(chatId: string, options?: { parentMessageId?: string }) {
+    function streamResponse(chatId: string) {
         isStreaming = true
         activeStreamChatId = chatId
-        activeStreamingMessageId = options?.parentMessageId ?? null
+        activeStreamingMessageId = null
         error = null
         errorDetail = null
         startThinkingText()
@@ -1423,15 +1406,11 @@
                 eventSource.close()
                 eventSource = null
             }
-            const streamParams = new URLSearchParams()
-            if (options?.parentMessageId)
-                streamParams.set('parent_message_id', options.parentMessageId)
-            if (resumeFromId) streamParams.set('last_event_id', resumeFromId)
-            const query = streamParams.toString()
             const base = `/api/chat/${chatId}/stream`
-            eventSource = new EventSource(query ? `${base}?${query}` : base, {
-                withCredentials: true,
-            })
+            eventSource = new EventSource(
+                resumeFromId ? `${base}?last_event_id=${encodeURIComponent(resumeFromId)}` : base,
+                { withCredentials: true },
+            )
 
             eventSource.addEventListener('message_id', (event) => {
                 streamLastEventId = event.lastEventId || streamLastEventId
@@ -1991,9 +1970,7 @@
                         size="icon"
                         variant="ghost"
                         class="h-7 w-7 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100"
-                        aria-label="Retry message"
-                        data-testid={`retry-message-${message.origMessageId}`}
-                        onclick={() => handleRetry(message.origMessageId)}>
+                        onclick={() => handleEdit(message.origMessageId, firstText?.text ?? '')}>
                         <RotateCcw class="h-3.5 w-3.5" />
                     </Button>
                     <Button

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -690,6 +690,23 @@
         }
     }
 
+    async function handleRetry(origMessageId: string) {
+        if (isStreaming || stopInProgress) return
+
+        const origMsg = chatMessages.find((message) => message.id === origMessageId)
+        if (!origMsg || origMsg.message.role !== 'user') return
+
+        selectBranch(origMsg.parentId, origMsg.id)
+        clearDownstreamSelections(origMsg.id)
+        activeStreamingMessageId = origMsg.id
+        markChatMessagesChanged()
+        refreshProcessedMessages()
+
+        userHasScrolled = false
+        scrollUserMessageToTop()
+        streamResponse(data.chat.id, { parentMessageId: origMsg.id })
+    }
+
     async function handleEdit(origMessageId: string, newContent: string) {
         editingMessageId = null
         const response = await fetch(`/api/chat/${data.chat.id}/messages/${origMessageId}/edit`, {
@@ -1163,10 +1180,10 @@
         }
     })
 
-    function streamResponse(chatId: string) {
+    function streamResponse(chatId: string, options?: { parentMessageId?: string }) {
         isStreaming = true
         activeStreamChatId = chatId
-        activeStreamingMessageId = null
+        activeStreamingMessageId = options?.parentMessageId ?? null
         error = null
         errorDetail = null
         startThinkingText()
@@ -1406,11 +1423,15 @@
                 eventSource.close()
                 eventSource = null
             }
+            const streamParams = new URLSearchParams()
+            if (options?.parentMessageId)
+                streamParams.set('parent_message_id', options.parentMessageId)
+            if (resumeFromId) streamParams.set('last_event_id', resumeFromId)
+            const query = streamParams.toString()
             const base = `/api/chat/${chatId}/stream`
-            eventSource = new EventSource(
-                resumeFromId ? `${base}?last_event_id=${encodeURIComponent(resumeFromId)}` : base,
-                { withCredentials: true },
-            )
+            eventSource = new EventSource(query ? `${base}?${query}` : base, {
+                withCredentials: true,
+            })
 
             eventSource.addEventListener('message_id', (event) => {
                 streamLastEventId = event.lastEventId || streamLastEventId
@@ -1970,7 +1991,9 @@
                         size="icon"
                         variant="ghost"
                         class="h-7 w-7 cursor-pointer opacity-0 transition-opacity group-hover:opacity-100"
-                        onclick={() => handleEdit(message.origMessageId, firstText?.text ?? '')}>
+                        aria-label="Retry message"
+                        data-testid={`retry-message-${message.origMessageId}`}
+                        onclick={() => handleRetry(message.origMessageId)}>
                         <RotateCcw class="h-3.5 w-3.5" />
                     </Button>
                     <Button

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -101,6 +101,7 @@
             clearReconnectState()
             activeStreamChatId = null
             isStreaming = false
+            stopInProgress = false
             error = null
             errorDetail = null
             stopThinkingText()
@@ -173,6 +174,7 @@
     let userInputRef: ReturnType<typeof UserInput>
 
     let isStreaming = $state(false)
+    let stopInProgress = $state(false)
     let error = $state<string | null>(null)
     let errorDetail = $state<string | null>(null)
     let eventSource: EventSource | null = $state(null)
@@ -456,28 +458,29 @@
         }
     }
 
-    function handleStop() {
+    async function handleStop() {
+        if (stopInProgress) return
+
         // The run is decoupled from this connection, so closing the EventSource
         // is no longer enough — tell the server to actually stop generating.
+        // Keep the stream open until omni-ai emits message_id/end_of_stream for
+        // the partial assistant message it persisted on cancellation.
         const stopChatId = activeStreamChatId ?? data.chat.id
-        fetch(`/api/chat/${stopChatId}/stop`, { method: 'POST' }).catch((err) =>
-            console.error('Failed to stop stream:', err),
-        )
-        if (eventSource) {
-            eventSource.close()
-            eventSource = null
-            activeStreamChatId = null
-        }
-        clearReconnectState()
-        // Reset all stream state so the input is immediately ready for a new message.
-        isStreaming = false
+        stopInProgress = true
         error = null
         errorDetail = null
-        activeStreamingMessageId = null
         stopThinkingText()
-        refreshProcessedMessages()
-        requestAnimationFrame(() => recalcBottomPadding())
-        userInputRef?.focus()
+
+        try {
+            const response = await fetch(`/api/chat/${stopChatId}/stop`, { method: 'POST' })
+            if (!response.ok) {
+                console.error('Failed to stop stream')
+                stopInProgress = false
+            }
+        } catch (err) {
+            console.error('Failed to stop stream:', err)
+            stopInProgress = false
+        }
     }
 
     async function handleFeedback(messageId: string, feedbackType: 'upvote' | 'downvote') {
@@ -1405,9 +1408,7 @@
             }
             const base = `/api/chat/${chatId}/stream`
             eventSource = new EventSource(
-                resumeFromId
-                    ? `${base}?last_event_id=${encodeURIComponent(resumeFromId)}`
-                    : base,
+                resumeFromId ? `${base}?last_event_id=${encodeURIComponent(resumeFromId)}` : base,
                 { withCredentials: true },
             )
 
@@ -1423,6 +1424,7 @@
                 // persisted messages from the server and clear streaming state.
                 streamCompleted = true
                 isStreaming = false
+                stopInProgress = false
                 activeStreamingMessageId = null
                 refreshProcessedMessages()
                 stopThinkingText()
@@ -1433,241 +1435,245 @@
                 invalidateAll()
             })
 
-        eventSource.addEventListener('title', () => {
-            invalidate('app:recent_chats') // This will force a re-fetch of recent chats and update the title in the sidebar
-        })
+            eventSource.addEventListener('title', () => {
+                invalidate('app:recent_chats') // This will force a re-fetch of recent chats and update the title in the sidebar
+            })
 
-        eventSource.addEventListener('title_error', () => {
-            // Title generation is best-effort; answer streaming should not surface its failures.
-        })
+            eventSource.addEventListener('title_error', () => {
+                // Title generation is best-effort; answer streaming should not surface its failures.
+            })
 
-        eventSource.addEventListener('message', (event) => {
-            streamLastEventId = event.lastEventId || streamLastEventId
-            lastStreamEventAt = Date.now()
-            reconnectAttempts = 0
-            try {
-                const data: MessageStreamEvent | ToolResultBlockParam = JSON.parse(event.data)
-                if (data.type === 'message_start') {
-                    // Find the last message in current display path to use as parent
-                    const displayPath = getDisplayPath(chatMessages)
-                    const streamParentId =
-                        displayPath.length > 0 ? displayPath[displayPath.length - 1].id : undefined
-                    const startedMessage: ChatMessage = {
-                        id: nextTempMessageId(),
-                        chatId,
-                        parentId: streamParentId ?? null,
-                        message: {
-                            role: data.message.role,
-                            content: data.message.content,
-                        },
-                        contentText: null,
-                        messageSeqNum: nextMessageSeqNum(chatMessages),
-                        createdAt: new Date(),
-                    }
-                    chatMessages = [...chatMessages, startedMessage]
-                    activeStreamingMessageId = startedMessage.id
-                    selectBranch(startedMessage.parentId, startedMessage.id)
-                    trackTempMessage(startedMessage.id)
-                    markChatMessagesChanged()
-                } else if (data.type === 'content_block_start') {
-                    if (data.content_block.type === 'tool_use') {
-                        collectStreamingResponse(data.content_block, data.index)
-                        toolUseStateByIndex.set(data.index, {
-                            id: data.content_block.id,
-                            name: data.content_block.name,
-                            inputJson: '',
-                        })
-                        updateThinkingForTool(data.content_block.name)
-                    } else if (data.content_block.type === 'text') {
-                        collectStreamingResponse(data.content_block, data.index)
-                    }
-                } else if (data.type === 'content_block_delta') {
-                    if (data.delta.type === 'text_delta' && data.delta.text) {
-                        updateThinkingForText()
-                        collectStreamingResponse(data.delta, data.index)
-                    } else if (data.delta.type === 'citations_delta') {
-                        collectStreamingResponse(data.delta, data.index)
-                    } else if (data.delta.type === 'input_json_delta') {
-                        const toolUseState = toolUseStateByIndex.get(data.index)
-                        if (!toolUseState) {
-                            console.warn(
-                                `Received input JSON delta for unknown tool block index ${data.index}`,
-                            )
-                            return
+            eventSource.addEventListener('message', (event) => {
+                streamLastEventId = event.lastEventId || streamLastEventId
+                lastStreamEventAt = Date.now()
+                reconnectAttempts = 0
+                try {
+                    const data: MessageStreamEvent | ToolResultBlockParam = JSON.parse(event.data)
+                    if (data.type === 'message_start') {
+                        // Find the last message in current display path to use as parent
+                        const displayPath = getDisplayPath(chatMessages)
+                        const streamParentId =
+                            displayPath.length > 0
+                                ? displayPath[displayPath.length - 1].id
+                                : undefined
+                        const startedMessage: ChatMessage = {
+                            id: nextTempMessageId(),
+                            chatId,
+                            parentId: streamParentId ?? null,
+                            message: {
+                                role: data.message.role,
+                                content: data.message.content,
+                            },
+                            contentText: null,
+                            messageSeqNum: nextMessageSeqNum(chatMessages),
+                            createdAt: new Date(),
                         }
-
-                        // Parse partial JSON to show search query if possible
-                        toolUseState.inputJson += data.delta.partial_json
-                        try {
-                            const parsedInput = JSON.parse(toolUseState.inputJson)
-                            collectStreamingResponse(
-                                {
-                                    type: 'tool_use',
-                                    id: toolUseState.id,
-                                    name: toolUseState.name,
-                                    input: parsedInput,
-                                },
-                                data.index,
-                            )
-                        } catch (err) {
-                            // Ignore JSON parse errors for partial input
-                        }
-                    }
-                } else if (data.type == 'tool_result') {
-                    collectStreamingResponse(data)
-                }
-
-                if (!userHasScrolled) scrollToBottom()
-            } catch (err) {
-                console.error('Failed to parse SSE data:', event.data, err)
-            } finally {
-                messageEventsReceived += 1
-            }
-        })
-
-        eventSource.addEventListener('approval_required', (event) => {
-            try {
-                const approvalData: ApprovalRequiredEvent = JSON.parse(event.data)
-                pendingApproval = approvalData
-                isStreaming = false
-                activeStreamingMessageId = null
-                refreshProcessedMessages()
-                stopThinkingText()
-                requestAnimationFrame(() => recalcBottomPadding())
-            } catch (err) {
-                console.error('Failed to parse approval_required event:', err)
-            }
-        })
-
-        eventSource.addEventListener('oauth_required', (event) => {
-            try {
-                const oauthData: OAuthRequiredEvent = JSON.parse(event.data)
-                oauthEventByToolCallId[oauthData.tool_call_id] = oauthData
-                isStreaming = false
-                activeStreamingMessageId = null
-                refreshProcessedMessages()
-                stopThinkingText()
-                requestAnimationFrame(() => recalcBottomPadding())
-            } catch (err) {
-                console.error('Failed to parse oauth_required event:', err)
-            }
-        })
-
-        eventSource.addEventListener('tool_result_replaced', (event) => {
-            try {
-                const data: ToolResultReplacedEvent = JSON.parse(event.data)
-                // Find the user-role chat message that holds the placeholder
-                // tool_result block and replace it with the real result. The
-                // envelope text is gone, so processMessages will stop
-                // producing the OAuth card on the next derivation tick.
-                for (const cm of chatMessages) {
-                    if (cm.message.role !== 'user') continue
-                    const content = cm.message.content
-                    if (!Array.isArray(content)) continue
-                    let replaced = false
-                    const next: ContentBlockParam[] = content.map((b) => {
-                        if (b.type === 'tool_result' && b.tool_use_id === data.tool_use_id) {
-                            replaced = true
-                            const replacement: ToolResultBlockParam = {
-                                type: 'tool_result',
-                                tool_use_id: data.tool_use_id,
-                                content: data.content as ToolResultBlockParam['content'],
-                                is_error: data.is_error,
-                            }
-                            return replacement
-                        }
-                        return b
-                    })
-                    if (replaced) {
-                        cm.message = { ...cm.message, content: next }
-                        delete oauthEventByToolCallId[data.tool_use_id]
-                        chatMessages = [...chatMessages]
+                        chatMessages = [...chatMessages, startedMessage]
+                        activeStreamingMessageId = startedMessage.id
+                        selectBranch(startedMessage.parentId, startedMessage.id)
+                        trackTempMessage(startedMessage.id)
                         markChatMessagesChanged()
-                        break
+                    } else if (data.type === 'content_block_start') {
+                        if (data.content_block.type === 'tool_use') {
+                            collectStreamingResponse(data.content_block, data.index)
+                            toolUseStateByIndex.set(data.index, {
+                                id: data.content_block.id,
+                                name: data.content_block.name,
+                                inputJson: '',
+                            })
+                            updateThinkingForTool(data.content_block.name)
+                        } else if (data.content_block.type === 'text') {
+                            collectStreamingResponse(data.content_block, data.index)
+                        }
+                    } else if (data.type === 'content_block_delta') {
+                        if (data.delta.type === 'text_delta' && data.delta.text) {
+                            updateThinkingForText()
+                            collectStreamingResponse(data.delta, data.index)
+                        } else if (data.delta.type === 'citations_delta') {
+                            collectStreamingResponse(data.delta, data.index)
+                        } else if (data.delta.type === 'input_json_delta') {
+                            const toolUseState = toolUseStateByIndex.get(data.index)
+                            if (!toolUseState) {
+                                console.warn(
+                                    `Received input JSON delta for unknown tool block index ${data.index}`,
+                                )
+                                return
+                            }
+
+                            // Parse partial JSON to show search query if possible
+                            toolUseState.inputJson += data.delta.partial_json
+                            try {
+                                const parsedInput = JSON.parse(toolUseState.inputJson)
+                                collectStreamingResponse(
+                                    {
+                                        type: 'tool_use',
+                                        id: toolUseState.id,
+                                        name: toolUseState.name,
+                                        input: parsedInput,
+                                    },
+                                    data.index,
+                                )
+                            } catch (err) {
+                                // Ignore JSON parse errors for partial input
+                            }
+                        }
+                    } else if (data.type == 'tool_result') {
+                        collectStreamingResponse(data)
                     }
+
+                    if (!userHasScrolled) scrollToBottom()
+                } catch (err) {
+                    console.error('Failed to parse SSE data:', event.data, err)
+                } finally {
+                    messageEventsReceived += 1
                 }
-            } catch (err) {
-                console.error('Failed to parse tool_result_replaced event:', err)
+            })
+
+            eventSource.addEventListener('approval_required', (event) => {
+                try {
+                    const approvalData: ApprovalRequiredEvent = JSON.parse(event.data)
+                    pendingApproval = approvalData
+                    isStreaming = false
+                    stopInProgress = false
+                    activeStreamingMessageId = null
+                    refreshProcessedMessages()
+                    stopThinkingText()
+                    requestAnimationFrame(() => recalcBottomPadding())
+                } catch (err) {
+                    console.error('Failed to parse approval_required event:', err)
+                }
+            })
+
+            eventSource.addEventListener('oauth_required', (event) => {
+                try {
+                    const oauthData: OAuthRequiredEvent = JSON.parse(event.data)
+                    oauthEventByToolCallId[oauthData.tool_call_id] = oauthData
+                    isStreaming = false
+                    stopInProgress = false
+                    activeStreamingMessageId = null
+                    refreshProcessedMessages()
+                    stopThinkingText()
+                    requestAnimationFrame(() => recalcBottomPadding())
+                } catch (err) {
+                    console.error('Failed to parse oauth_required event:', err)
+                }
+            })
+
+            eventSource.addEventListener('tool_result_replaced', (event) => {
+                try {
+                    const data: ToolResultReplacedEvent = JSON.parse(event.data)
+                    // Find the user-role chat message that holds the placeholder
+                    // tool_result block and replace it with the real result. The
+                    // envelope text is gone, so processMessages will stop
+                    // producing the OAuth card on the next derivation tick.
+                    for (const cm of chatMessages) {
+                        if (cm.message.role !== 'user') continue
+                        const content = cm.message.content
+                        if (!Array.isArray(content)) continue
+                        let replaced = false
+                        const next: ContentBlockParam[] = content.map((b) => {
+                            if (b.type === 'tool_result' && b.tool_use_id === data.tool_use_id) {
+                                replaced = true
+                                const replacement: ToolResultBlockParam = {
+                                    type: 'tool_result',
+                                    tool_use_id: data.tool_use_id,
+                                    content: data.content as ToolResultBlockParam['content'],
+                                    is_error: data.is_error,
+                                }
+                                return replacement
+                            }
+                            return b
+                        })
+                        if (replaced) {
+                            cm.message = { ...cm.message, content: next }
+                            delete oauthEventByToolCallId[data.tool_use_id]
+                            chatMessages = [...chatMessages]
+                            markChatMessagesChanged()
+                            break
+                        }
+                    }
+                } catch (err) {
+                    console.error('Failed to parse tool_result_replaced event:', err)
+                }
+            })
+
+            eventSource.addEventListener('end_of_stream', () => {
+                streamCompleted = true
+                isStreaming = false
+                stopInProgress = false
+                activeStreamingMessageId = null
+                refreshProcessedMessages()
+                stopThinkingText()
+                requestAnimationFrame(() => recalcBottomPadding())
+                userInputRef?.focus()
+                eventSource?.close()
+                eventSource = null
+                activeStreamChatId = null
+                clearReconnectState()
+
+                if (messageEventsReceived === 0 && !error) {
+                    error = 'Failed to generate response. Please try again.'
+                }
+            })
+
+            const handleStreamError = (event: Event) => {
+                streamCompleted = true
+                if (event instanceof MessageEvent) {
+                    const streamError = streamErrorMessage(event as MessageEvent<string>)
+                    error = streamError.message
+                    errorDetail = streamError.detail
+                } else {
+                    error = 'Failed to generate response. Please try again.'
+                    errorDetail = null
+                }
+                isStreaming = false
+                stopInProgress = false
+                activeStreamingMessageId = null
+                refreshProcessedMessages()
+                stopThinkingText()
+                requestAnimationFrame(() => recalcBottomPadding())
+                userInputRef?.focus()
+                eventSource?.close()
+                eventSource = null
+                activeStreamChatId = null
+                clearReconnectState()
             }
-        })
 
-        eventSource.addEventListener('end_of_stream', () => {
-            streamCompleted = true
-            isStreaming = false
-            activeStreamingMessageId = null
-            refreshProcessedMessages()
-            stopThinkingText()
-            requestAnimationFrame(() => recalcBottomPadding())
-            userInputRef?.focus()
-            eventSource?.close()
-            eventSource = null
-            activeStreamChatId = null
-            clearReconnectState()
+            const handleConnectionError = () => {
+                if (streamCompleted || !isStreaming) return
 
-            if (messageEventsReceived === 0 && !error) {
-                error = 'Failed to generate response. Please try again.'
-            }
-        })
+                // Transient drop (e.g. backgrounded tab): the server keeps the run
+                // alive and buffered, so reconnect from our last offset with backoff
+                // instead of failing. Only surface an error once the budget is spent.
+                eventSource?.close()
+                eventSource = null
+                if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
+                    reconnectAttempts += 1
+                    const delay = Math.min(1000 * 2 ** (reconnectAttempts - 1), 15000)
+                    if (reconnectTimer) clearTimeout(reconnectTimer)
+                    reconnectTimer = setTimeout(() => {
+                        reconnectTimer = null
+                        if (!isStreaming || streamCompleted || activeStreamChatId !== chatId) return
+                        reconnectStream?.()
+                    }, delay)
+                    return
+                }
 
-        const handleStreamError = (event: Event) => {
-            streamCompleted = true
-            if (event instanceof MessageEvent) {
-                const streamError = streamErrorMessage(event as MessageEvent<string>)
-                error = streamError.message
-                errorDetail = streamError.detail
-            } else {
-                error = 'Failed to generate response. Please try again.'
+                error =
+                    messageEventsReceived > 0
+                        ? 'Response stream disconnected before it finished. Please try again.'
+                        : 'Failed to connect to the response stream. Please try again.'
                 errorDetail = null
+                isStreaming = false
+                stopInProgress = false
+                activeStreamingMessageId = null
+                refreshProcessedMessages()
+                stopThinkingText()
+                requestAnimationFrame(() => recalcBottomPadding())
+                userInputRef?.focus()
+                activeStreamChatId = null
+                clearReconnectState()
             }
-            isStreaming = false
-            activeStreamingMessageId = null
-            refreshProcessedMessages()
-            stopThinkingText()
-            requestAnimationFrame(() => recalcBottomPadding())
-            userInputRef?.focus()
-            eventSource?.close()
-            eventSource = null
-            activeStreamChatId = null
-            clearReconnectState()
-        }
-
-        const handleConnectionError = () => {
-            // Guard against treating an intentional stop() as a connection error.
-            // handleStop() sets isStreaming = false before the EventSource fires its
-            // error event, so we can use that as a signal to skip cleanup here.
-            if (streamCompleted || !isStreaming) return
-
-            // Transient drop (e.g. backgrounded tab): the server keeps the run
-            // alive and buffered, so reconnect from our last offset with backoff
-            // instead of failing. Only surface an error once the budget is spent.
-            eventSource?.close()
-            eventSource = null
-            if (reconnectAttempts < MAX_RECONNECT_ATTEMPTS) {
-                reconnectAttempts += 1
-                const delay = Math.min(1000 * 2 ** (reconnectAttempts - 1), 15000)
-                if (reconnectTimer) clearTimeout(reconnectTimer)
-                reconnectTimer = setTimeout(() => {
-                    reconnectTimer = null
-                    if (!isStreaming || streamCompleted || activeStreamChatId !== chatId) return
-                    reconnectStream?.()
-                }, delay)
-                return
-            }
-
-            error =
-                messageEventsReceived > 0
-                    ? 'Response stream disconnected before it finished. Please try again.'
-                    : 'Failed to connect to the response stream. Please try again.'
-            errorDetail = null
-            isStreaming = false
-            activeStreamingMessageId = null
-            refreshProcessedMessages()
-            stopThinkingText()
-            requestAnimationFrame(() => recalcBottomPadding())
-            userInputRef?.focus()
-            activeStreamChatId = null
-            clearReconnectState()
-        }
 
             eventSource.addEventListener('stream_error', handleStreamError)
             eventSource.addEventListener('error', handleConnectionError)
@@ -2387,7 +2393,7 @@
                             chat: 'Ask a follow-up...',
                             search: 'Search for something else...',
                         }}
-                        {isStreaming}
+                        isStreaming={isStreaming || stopInProgress}
                         onStop={handleStop}
                         maxWidth="max-w-4xl" />
                 </div>

--- a/web/src/routes/api/chat/[chatId]/stop/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stop/+server.ts
@@ -25,7 +25,8 @@ export const POST: RequestHandler = async ({ params, locals }) => {
         return json({ error: 'Forbidden' }, { status: 403 })
     }
 
-    const replayPath = env.OMNI_CHAT_STREAM_REPLAY_PATH?.trim()
+    // Test-only replay mode bypasses omni-ai, so there is no AI run to cancel.
+    const replayPath = env.OMNI_TEST_CHAT_STREAM_REPLAY_PATH?.trim()
     if (replayPath) {
         return json({ status: 'ok' })
     }

--- a/web/src/routes/api/chat/[chatId]/stop/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stop/+server.ts
@@ -11,6 +11,10 @@ export const POST: RequestHandler = async ({ params, locals }) => {
         return json({ error: 'chatId parameter is required' }, { status: 400 })
     }
 
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
     const chat = await chatRepository.get(chatId)
     if (!chat) {
         return json({ error: 'Chat not found' }, { status: 404 })
@@ -21,12 +25,17 @@ export const POST: RequestHandler = async ({ params, locals }) => {
         return json({ error: 'Forbidden' }, { status: 403 })
     }
 
+    const replayPath = env.OMNI_CHAT_STREAM_REPLAY_PATH?.trim()
+    if (replayPath) {
+        return json({ status: 'ok' })
+    }
+
     try {
         const response = await fetch(`${env.AI_SERVICE_URL}/chat/${chatId}/cancel`, {
             method: 'POST',
         })
         if (!response.ok) {
-            logger.warn('AI service cancel returned non-OK', undefined, {
+            logger.warn('AI service cancel returned non-OK', {
                 chatId,
                 status: response.status,
             })
@@ -35,7 +44,6 @@ export const POST: RequestHandler = async ({ params, locals }) => {
         logger.error('Failed to cancel chat stream', err, { chatId })
     }
 
-    // Best-effort: report success even if the AI service is unreachable, since
-    // the client also tears down its own stream state on Stop.
+    // Best-effort: report success even if the AI service is unreachable.
     return json({ status: 'ok' })
 }

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -236,13 +236,9 @@ export const GET: RequestHandler = async ({ params, locals, cookies, request, ur
         // the AI service so it can resume the buffered run from that point.
         const lastEventId =
             request.headers.get('last-event-id') ?? url.searchParams.get('last_event_id')
-        const parentMessageId = url.searchParams.get('parent_message_id')
         let streamUrl = chat.agentId
             ? `${env.AI_SERVICE_URL}/chat/${chatId}/stream?auto_start=true`
             : `${env.AI_SERVICE_URL}/chat/${chatId}/stream`
-        if (parentMessageId) {
-            streamUrl += `${streamUrl.includes('?') ? '&' : '?'}parent_message_id=${encodeURIComponent(parentMessageId)}`
-        }
         if (lastEventId) {
             streamUrl += `${streamUrl.includes('?') ? '&' : '?'}last_event_id=${encodeURIComponent(lastEventId)}`
         }

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -60,7 +60,7 @@ function replayStreamFixturePath(cookies: {
     get(name: string): string | undefined
 }): string | null {
     const fixtureName = cookies.get(replayFixtureCookieName)?.trim()
-    const fixtureDir = env.OMNI_CHAT_STREAM_REPLAY_FIXTURE_DIR?.trim()
+    const fixtureDir = env.OMNI_TEST_CHAT_STREAM_REPLAY_FIXTURE_DIR?.trim()
     if (fixtureName && fixtureDir) {
         const baseDir = resolve(process.cwd(), fixtureDir)
         const fixturePath = resolve(baseDir, fixtureName)
@@ -71,7 +71,7 @@ function replayStreamFixturePath(cookies: {
         return fixturePath
     }
 
-    const fixturePath = env.OMNI_CHAT_STREAM_REPLAY_PATH?.trim()
+    const fixturePath = env.OMNI_TEST_CHAT_STREAM_REPLAY_PATH?.trim()
     return fixturePath ? resolve(process.cwd(), fixturePath) : null
 }
 
@@ -86,6 +86,9 @@ function eventData(event: string): string | null {
     return null
 }
 
+// Test-only SSE replay shim. Production streams come from omni-ai below; this
+// path is active only when OMNI_TEST_CHAT_STREAM_REPLAY_* is configured by the
+// Playwright web server or explicitly in a test environment.
 function replayStreamResponse(sampleStream: string, chatId: string): Response {
     const encoder = new TextEncoder()
     const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
@@ -110,6 +113,9 @@ function replayStreamResponse(sampleStream: string, chatId: string): Response {
                     if (event.startsWith('event: message_id')) {
                         eventToSend = `event: message_id\ndata: sample-${runId}-${messageIdCounter++}`
                     } else if (event.startsWith('event: save_message')) {
+                        // Test replay bypasses omni-ai, so emulate omni-ai's
+                        // production save_message transform: persist the row in
+                        // Postgres and send the browser the persisted message_id.
                         const data = eventData(event)
                         if (!data) continue
                         const savedMessage = await chatMessageRepository.create(

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -236,9 +236,13 @@ export const GET: RequestHandler = async ({ params, locals, cookies, request, ur
         // the AI service so it can resume the buffered run from that point.
         const lastEventId =
             request.headers.get('last-event-id') ?? url.searchParams.get('last_event_id')
+        const parentMessageId = url.searchParams.get('parent_message_id')
         let streamUrl = chat.agentId
             ? `${env.AI_SERVICE_URL}/chat/${chatId}/stream?auto_start=true`
             : `${env.AI_SERVICE_URL}/chat/${chatId}/stream`
+        if (parentMessageId) {
+            streamUrl += `${streamUrl.includes('?') ? '&' : '?'}parent_message_id=${encodeURIComponent(parentMessageId)}`
+        }
         if (lastEventId) {
             streamUrl += `${streamUrl.includes('?') ? '&' : '?'}last_event_id=${encodeURIComponent(lastEventId)}`
         }

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -3,7 +3,7 @@ import { relative, resolve } from 'node:path'
 import { json, error } from '@sveltejs/kit'
 import { env } from '$env/dynamic/private'
 import type { RequestHandler } from './$types.js'
-import { chatRepository } from '$lib/server/db/chats.js'
+import { chatMessageRepository, chatRepository } from '$lib/server/db/chats.js'
 import { getAgent } from '$lib/server/db/agents.js'
 import { isProviderConfigured } from '$lib/server/oauth/connectorOAuth.js'
 import { getSourceDisplayName } from '$lib/utils/icons.js'
@@ -79,7 +79,14 @@ function sleep(ms: number): Promise<void> {
     return new Promise((resolve) => setTimeout(resolve, ms))
 }
 
-function replayStreamResponse(sampleStream: string): Response {
+function eventData(event: string): string | null {
+    for (const line of event.split('\n')) {
+        if (line.startsWith('data:')) return line.substring(5).trim()
+    }
+    return null
+}
+
+function replayStreamResponse(sampleStream: string, chatId: string): Response {
     const encoder = new TextEncoder()
     const runId = `${Date.now()}-${Math.random().toString(36).slice(2)}`
     let messageIdCounter = 0
@@ -93,11 +100,26 @@ function replayStreamResponse(sampleStream: string): Response {
                 .filter((event) => event.length > 0)
 
             try {
+                let parentMessageId = (
+                    await chatMessageRepository.getLastMessageInActivePath(chatId)
+                )?.id
+
                 for (const event of events) {
                     if (cancelled) return
-                    const eventToSend = event.startsWith('event: message_id')
-                        ? `event: message_id\ndata: sample-${runId}-${messageIdCounter++}`
-                        : event
+                    let eventToSend = event
+                    if (event.startsWith('event: message_id')) {
+                        eventToSend = `event: message_id\ndata: sample-${runId}-${messageIdCounter++}`
+                    } else if (event.startsWith('event: save_message')) {
+                        const data = eventData(event)
+                        if (!data) continue
+                        const savedMessage = await chatMessageRepository.create(
+                            chatId,
+                            JSON.parse(data),
+                            parentMessageId,
+                        )
+                        parentMessageId = savedMessage.id
+                        eventToSend = `event: message_id\ndata: ${savedMessage.id}`
+                    }
                     controller.enqueue(encoder.encode(`${eventToSend}\n\n`))
                     await sleep(10)
                 }
@@ -179,7 +201,7 @@ export const GET: RequestHandler = async ({ params, locals, cookies, request, ur
     const replayPath = replayStreamFixturePath(cookies)
     if (replayPath) {
         const sampleStream = await readFile(replayPath, 'utf-8')
-        return replayStreamResponse(sampleStream)
+        return replayStreamResponse(sampleStream, params.chatId)
     }
 
     const logger = locals.logger.child('chat')


### PR DESCRIPTION
- Persist partial assistant responses from omni-ai when a user stops a stream, so stopped output survives reload.
- Keep the client EventSource open after Stop until the backend emits the persisted message id and terminal stream event.
- Throttle backend cancel polling to at most once per second to avoid excessive Redis checks during high-frequency streams.
- Add Playwright coverage for stopped-stream follow-ups, partial-content persistence, stream cleanup, and retry branch rendering.