### PR TITLE
fix(chat): harden streaming tool calls, message ids, and reload resume

### DIFF
--- a/services/ai/db/messages.py
+++ b/services/ai/db/messages.py
@@ -125,6 +125,19 @@ class MessagesRepository:
 
         return ChatMessage.from_row(dict(row))
 
+    async def delete(self, message_id: str) -> None:
+        """Delete a chat_messages row.
+
+        Used to clean up an early-persisted assistant row when the stream ends
+        before any content is committed, so an empty assistant message never
+        poisons the conversation history.
+        """
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "DELETE FROM chat_messages WHERE id = $1", message_id
+            )
+
     async def get_by_chat(self, chat_id: str) -> List[ChatMessage]:
         """Get all messages for a chat"""
         pool = await self._get_pool()

--- a/services/ai/db/messages.py
+++ b/services/ai/db/messages.py
@@ -53,14 +53,35 @@ class MessagesRepository:
     async def update_message_content(
         self, message_id: str, message: Dict[str, Any]
     ) -> None:
-        """Replace the JSONB `message` payload for a chat_messages row."""
+        """Replace only the JSONB `message` payload for a chat_messages row.
+
+        Intentionally does not touch `content_text`: that column carries a BM25
+        index, so it should be written once when a streamed message is finalized,
+        not on every intermediate content update. Use `update_content_text` for
+        the finalization write.
+        """
         pool = await self._get_pool()
         message = _sanitize_jsonb_value(message)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE chat_messages SET message = $1 WHERE id = $2",
+                json.dumps(message),
+                message_id,
+            )
+
+    async def update_content_text(
+        self, message_id: str, message: Dict[str, Any]
+    ) -> None:
+        """Derive and persist the BM25-indexed `content_text` for a message.
+
+        Call once when a streamed message is finalized (all content received),
+        not on intermediate updates, to avoid repeated BM25 index writes.
+        """
+        pool = await self._get_pool()
         content_text = _extract_content_text(message)
         async with pool.acquire() as conn:
             await conn.execute(
-                "UPDATE chat_messages SET message = $1, content_text = $2 WHERE id = $3",
-                json.dumps(message),
+                "UPDATE chat_messages SET content_text = $1 WHERE id = $2",
                 content_text,
                 message_id,
             )

--- a/services/ai/db/messages.py
+++ b/services/ai/db/messages.py
@@ -55,10 +55,13 @@ class MessagesRepository:
     ) -> None:
         """Replace the JSONB `message` payload for a chat_messages row."""
         pool = await self._get_pool()
+        message = _sanitize_jsonb_value(message)
+        content_text = _extract_content_text(message)
         async with pool.acquire() as conn:
             await conn.execute(
-                "UPDATE chat_messages SET message = $1 WHERE id = $2",
-                json.dumps(_sanitize_jsonb_value(message)),
+                "UPDATE chat_messages SET message = $1, content_text = $2 WHERE id = $3",
+                json.dumps(message),
+                content_text,
                 message_id,
             )
 

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -301,6 +301,9 @@ async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
                     await messages_repo.update_message_content(
                         current_assistant_message_id, message
                     )
+                    await messages_repo.update_content_text(
+                        current_assistant_message_id, message
+                    )
                     current_assistant_message_id = None
                     continue
 

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -1083,24 +1083,42 @@ async def stream_chat(
     last_event_id = request.headers.get("last-event-id") or request.query_params.get(
         "last_event_id"
     )
-    if redis_client is not None and last_event_id is not None:
-        if await redis_client.exists(_stream_key(chat_id)):
+    if redis_client is not None:
+        run_active = await redis_client.exists(_run_lock_key(chat_id))
+        if run_active:
+            # A run is in progress for this chat: attach to it instead of starting
+            # a fresh generation. Replay the buffered run from the client's offset,
+            # or from the beginning when (as on a full page reload) no offset is
+            # available. This keeps a reconnect that arrives without a Last-Event-ID
+            # from falling through to fresh-generation setup and bailing out with
+            # "No new user message to process".
             return StreamingResponse(
-                _consume_run(redis_client, chat_id, last_event_id),
+                _consume_run(redis_client, chat_id, last_event_id or "0"),
                 media_type="text/event-stream",
                 headers=SSE_HEADERS,
             )
 
-        # Stream expired (TTL elapsed). Starting a new generation would produce a
-        # duplicate response — tell the client to reload from the database instead.
-        async def _not_resumable_response():
-            yield "event: not_resumable\ndata: \n\n"
+        if last_event_id is not None:
+            if await redis_client.exists(_stream_key(chat_id)):
+                # The run has ended but its buffer is still live: replay the tail
+                # so the client receives any final events it missed, then the
+                # terminal end_of_stream/stream_error already in the buffer.
+                return StreamingResponse(
+                    _consume_run(redis_client, chat_id, last_event_id),
+                    media_type="text/event-stream",
+                    headers=SSE_HEADERS,
+                )
+            # No active run and the buffer is gone/expired. Starting a new
+            # generation would produce a duplicate response — tell the client to
+            # reload from the database instead.
+            async def _not_resumable_response():
+                yield "event: not_resumable\ndata: \n\n"
 
-        return StreamingResponse(
-            _not_resumable_response(),
-            media_type="text/event-stream",
-            headers=SSE_HEADERS,
-        )
+            return StreamingResponse(
+                _not_resumable_response(),
+                media_type="text/event-stream",
+                headers=SSE_HEADERS,
+            )
 
     messages_repo = MessagesRepository()
     approvals_repo = ToolApprovalsRepository()

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -122,8 +122,8 @@ def _sse_event(event_type: str, data: object) -> str:
 # a per-chat Redis Stream. HTTP requests are thin "consumers" that tail that
 # stream from an offset (SSE Last-Event-ID), so a client that backgrounds/
 # reconnects resumes without interrupting generation. The producer is the single
-# DB writer of the streaming path (persists messages, then emits `message_id`),
-# which keeps replays free of duplicate writes.
+# DB writer of the streaming path (persists messages before client-visible
+# message events), which keeps replays free of duplicate writes.
 
 SSE_HEADERS = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
 
@@ -180,19 +180,27 @@ def _sse_event_data(event_str: str) -> str:
 def _partial_assistant_message(
     content_blocks: list[TextBlockParam | ToolUseBlockParam],
 ) -> MessageParam | None:
-    text_blocks: list[TextBlockParam] = []
+    persisted_blocks: list[TextBlockParam | ToolUseBlockParam] = []
     for block in content_blocks:
-        if block["type"] != "text":
+        if block["type"] == "text":
+            text_block = cast(TextBlockParam, block)
+            if text_block["text"].strip():
+                persisted_blocks.append(cast(TextBlockParam, dict(text_block)))
             continue
-        text_block = cast(TextBlockParam, block)
-        if not text_block["text"].strip():
-            continue
-        text_blocks.append(cast(TextBlockParam, dict(text_block)))
 
-    if not text_blocks:
+        tool_block = cast(ToolUseBlockParam, dict(block))
+        raw_input = tool_block.get("input")
+        if isinstance(raw_input, str):
+            try:
+                tool_block["input"] = json.loads(raw_input) if raw_input else {}
+            except json.JSONDecodeError:
+                tool_block["input"] = {}
+        persisted_blocks.append(tool_block)
+
+    if not persisted_blocks:
         return None
 
-    return MessageParam(role="assistant", content=text_blocks)
+    return MessageParam(role="assistant", content=persisted_blocks)
 
 
 def _parse_tool_call_inputs(
@@ -235,23 +243,90 @@ def _parse_tool_call_inputs(
 
 
 async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
-    """Persist assistant/tool_result messages (single writer of the streaming
-    path) and replace each internal `save_message` event with a client-facing
-    `message_id` event. Deterministic parent_id chaining makes replays safe."""
+    """Persist streamed messages before exposing them to the client.
+
+    Assistant rows are created as soon as the provider emits message_start, so
+    the browser can use a durable chat_messages.id for the streaming bubble from
+    the beginning. Tool-result rows are persisted before their tool_result events
+    are forwarded. This keeps frontend render identities and future parent_id
+    values database-backed even if the run is cancelled mid-stream.
+    """
+    current_assistant_message_id: str | None = None
+    buffered_tool_result_events: list[str] = []
+
     async for event_str in gen:
-        if _sse_event_type(event_str) == "save_message":
+        event_type = _sse_event_type(event_str)
+        event_data = _sse_event_data(event_str)
+
+        if event_type == "message":
             try:
-                message = json.loads(_sse_event_data(event_str))
+                message_event = json.loads(event_data)
+            except json.JSONDecodeError:
+                yield event_str
+                continue
+
+            if message_event.get("type") == "message_start":
+                try:
+                    provider_message = message_event.get("message", {})
+                    assistant_message = {
+                        "role": provider_message.get("role", "assistant"),
+                        "content": provider_message.get("content") or [],
+                    }
+                    created = await messages_repo.create(
+                        chat_id, assistant_message, parent_id=parent_id
+                    )
+                    current_assistant_message_id = created.id
+                    parent_id = created.id
+                    message_event.setdefault("message", {})["id"] = created.id
+                    event_str = _sse_event("message", message_event)
+                except Exception as e:
+                    logger.error(
+                        f"Failed to pre-persist assistant message for chat {chat_id}: {e}",
+                        exc_info=True,
+                    )
+                yield event_str
+                continue
+
+            if message_event.get("type") == "tool_result":
+                buffered_tool_result_events.append(event_str)
+                continue
+
+            yield event_str
+            continue
+
+        if event_type == "save_message":
+            try:
+                message = json.loads(event_data)
+                if message.get("role") == "assistant" and current_assistant_message_id:
+                    await messages_repo.update_message_content(
+                        current_assistant_message_id, message
+                    )
+                    current_assistant_message_id = None
+                    continue
+
                 created = await messages_repo.create(
                     chat_id, message, parent_id=parent_id
                 )
                 parent_id = created.id
-                yield f"event: message_id\ndata: {created.id}\n\n"
+
+                if message.get("role") == "user" and buffered_tool_result_events:
+                    for buffered_event in buffered_tool_result_events:
+                        try:
+                            tool_result_event = json.loads(_sse_event_data(buffered_event))
+                            tool_result_event["message_id"] = created.id
+                            yield _sse_event("message", tool_result_event)
+                        except json.JSONDecodeError:
+                            yield buffered_event
+                    buffered_tool_result_events = []
+                else:
+                    yield f"event: message_id\ndata: {created.id}\n\n"
             except Exception as e:
                 logger.error(
-                    f"Failed to persist streamed message for chat {chat_id}: {e}"
+                    f"Failed to persist streamed message for chat {chat_id}: {e}",
+                    exc_info=True,
                 )
             continue
+
         yield event_str
 
 

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -332,6 +332,26 @@ async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
 
         yield event_str
 
+    # If the generator ended (cancel/error/client disconnect) without a
+    # matching save_message, the early-persisted assistant row was never
+    # finalized. With partial content the generator emits save_message itself;
+    # reaching here with the id still set means no content was ever committed,
+    # so delete the empty row rather than leave an invalid assistant message
+    # that would poison the next request's history.
+    if current_assistant_message_id is not None:
+        try:
+            await messages_repo.delete(current_assistant_message_id)
+            logger.info(
+                f"Deleted unfinalized assistant message "
+                f"{current_assistant_message_id} for chat {chat_id}"
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to delete unfinalized assistant message "
+                f"{current_assistant_message_id} for chat {chat_id}: {e}"
+            )
+        current_assistant_message_id = None
+
 
 async def _refresh_lock_periodically(redis_client, lock_key):
     """Keep the run lock alive independently of event production, so a long
@@ -624,6 +644,31 @@ def _repair_interrupted_tool_calls(
         repair_count += len(missing_results)
 
     return repaired, repair_count
+
+
+def _drop_empty_assistant_messages(
+    messages: list[MessageParam],
+) -> list[MessageParam]:
+    """Remove assistant messages that have no content and no tool_use blocks.
+
+    A streamed assistant row that was early-persisted at message_start but never
+    finalized (stream cancelled/errored before any content block) can be left as
+    {"role": "assistant", "content": []}. Providers reject such messages
+    ("content or tool_calls must be set"), so drop them from the history before
+    sending. They contribute nothing to the conversation.
+    """
+    kept: list[MessageParam] = []
+    for message in messages:
+        if message.get("role") == "assistant":
+            blocks = _message_content_blocks(message)
+            has_tool_use = any(b.get("type") == "tool_use" for b in blocks)
+            has_content = bool(blocks) and any(
+                b.get("type") == "text" and b.get("text") for b in blocks
+            )
+            if not has_tool_use and not has_content:
+                continue
+        kept.append(message)
+    return kept
 
 
 def _extract_text_for_title(
@@ -1382,6 +1427,13 @@ async def stream_chat(
             logger.warning(
                 f"Inserted {repaired_tool_calls} failed tool_result placeholder(s) for interrupted tool calls in chat {chat_id}"
             )
+        before = len(messages)
+        messages = _drop_empty_assistant_messages(messages)
+        dropped = before - len(messages)
+        if dropped:
+            logger.warning(
+                f"Dropped {dropped} empty assistant message(s) from history for chat {chat_id}"
+            )
 
     # Expand any omni_upload content blocks (inline small text, stage larger/binary in sandbox).
     storage = request.app.state.content_storage
@@ -1469,6 +1521,9 @@ async def stream_chat(
     async def stream_generator():
         try:
             conversation_messages = messages.copy()
+            # Initialized here so the error/cancel handlers below can always
+            # reference whatever content was accumulated before the failure.
+            content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
 
             if pending or pending_oauth:
                 if pending_oauth:
@@ -2023,6 +2078,13 @@ async def stream_chat(
             logger.error(
                 f"Failed to generate AI response with tools: {e}", exc_info=True
             )
+            # Finalize whatever partial assistant content was accumulated before
+            # the failure, so the early-persisted row is not left empty. The
+            # cancel path above does the same; this mirrors it for errors.
+            partial = _partial_assistant_message(content_blocks)
+            if partial is not None:
+                conversation_messages.append(partial)
+                yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
             yield _sse_event("stream_error", _chat_error_payload(e))
 
     parent_id = chat_messages[-1].id if chat_messages else None

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -195,6 +195,45 @@ def _partial_assistant_message(
     return MessageParam(role="assistant", content=text_blocks)
 
 
+def _parse_tool_call_inputs(
+    tool_calls: list[ToolUseBlockParam],
+) -> list[ToolResultBlockParam]:
+    parse_errors: list[ToolResultBlockParam] = []
+    for tool_call in tool_calls:
+        raw_input = cast(str, tool_call["input"])
+        try:
+            tool_call["input"] = json.loads(raw_input)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                "Failed to parse tool call input for %s: %s. Raw input: %s",
+                tool_call["name"],
+                e,
+                raw_input,
+            )
+            raw_input_preview = raw_input[:4000]
+            if len(raw_input) > len(raw_input_preview):
+                raw_input_preview += "... [truncated]"
+            tool_call["input"] = {}
+            parse_errors.append(
+                ToolResultBlockParam(
+                    type="tool_result",
+                    tool_use_id=tool_call["id"],
+                    content=[
+                        {
+                            "type": "text",
+                            "text": (
+                                f"Invalid JSON in tool input: {e}. "
+                                "The tool was not executed. Retry with valid JSON.\n\n"
+                                f"Raw tool input:\n{raw_input_preview}"
+                            ),
+                        }
+                    ],
+                    is_error=True,
+                )
+            )
+    return parse_errors
+
+
 async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
     """Persist assistant/tool_result messages (single writer of the streaming
     path) and replace each internal `save_message` event with a client-facing
@@ -1716,16 +1755,13 @@ async def stream_chat(
                         yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
                     break
 
-                # Parse tool call inputs. Convert to JSON.
+                # Parse tool call inputs. Convert to JSON. If the provider emits
+                # malformed JSON, do not execute the tool with `{}`; feed the
+                # parse error back to the model so it can retry.
                 tool_calls = [b for b in content_blocks if b["type"] == "tool_use"]
-                for tool_call in tool_calls:
-                    try:
-                        tool_call["input"] = json.loads(cast(str, tool_call["input"]))
-                    except json.JSONDecodeError as e:
-                        logger.error(
-                            f"Failed to parse tool call input as JSON: {tool_call['input']}. Error: {e}"
-                        )
-                        tool_call["input"] = {}
+                parse_errors = _parse_tool_call_inputs(
+                    cast(list[ToolUseBlockParam], tool_calls)
+                )
 
                 assistant_message = MessageParam(
                     role="assistant", content=content_blocks
@@ -1734,6 +1770,16 @@ async def stream_chat(
 
                 # Send complete message to omni-web for database persistence
                 yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
+
+                if parse_errors:
+                    tool_result_message = MessageParam(
+                        role="user", content=parse_errors
+                    )
+                    conversation_messages.append(tool_result_message)
+                    for parse_error in parse_errors:
+                        yield f"event: message\ndata: {json.dumps(parse_error)}\n\n"
+                    yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
+                    continue
 
                 # If no tool calls, we're done
                 if not tool_calls:

--- a/services/ai/tests/integration/test_chat_attribute_search.py
+++ b/services/ai/tests/integration/test_chat_attribute_search.py
@@ -17,13 +17,25 @@ from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from ulid import ULID
 
+from anthropic.types import (
+    InputJSONDelta,
+    MessageDeltaUsage,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStopEvent,
+    ToolUseBlock,
+)
+from anthropic.types.raw_message_delta_event import Delta
+
 from db import UsersRepository, ChatsRepository, MessagesRepository
 import db.connection
 from routers import chat_router
 from state import AppState
 from tools import SearchResponse, SearchResult
 from tools.searcher_client import Document
-from tests.helpers import create_mock_llm
+from tests.helpers import create_mock_llm, message_start_event, text_response_events
 
 pytestmark = pytest.mark.integration
 
@@ -67,6 +79,50 @@ def create_mock_searcher():
     searcher = AsyncMock()
     searcher.handle.return_value = MOCK_SEARCH_RESPONSE
     return searcher
+
+
+def create_mock_llm_with_invalid_tool_json(raw_json: str, response_text: str):
+    """Return a mock LLM that emits malformed tool arguments, then a text retry."""
+    call_count = 0
+
+    async def stream_response(*_args, **_kwargs):
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            yield message_start_event()
+            yield RawContentBlockStartEvent(
+                type="content_block_start",
+                index=0,
+                content_block=ToolUseBlock(
+                    type="tool_use",
+                    id="toolu_invalid_json",
+                    name="search_documents",
+                    input={},
+                ),
+            )
+            yield RawContentBlockDeltaEvent(
+                type="content_block_delta",
+                index=0,
+                delta=InputJSONDelta(
+                    type="input_json_delta",
+                    partial_json=raw_json,
+                ),
+            )
+            yield RawContentBlockStopEvent(type="content_block_stop", index=0)
+            yield RawMessageDeltaEvent(
+                type="message_delta",
+                delta=Delta(stop_reason="tool_use", stop_sequence=None),
+                usage=MessageDeltaUsage(output_tokens=30),
+            )
+            yield RawMessageStopEvent(type="message_stop")
+        else:
+            for evt in text_response_events(response_text):
+                yield evt
+
+    provider = AsyncMock()
+    provider.stream_response = stream_response
+    provider.health_check.return_value = True
+    return provider
 
 
 # ---------------------------------------------------------------------------
@@ -252,3 +308,35 @@ async def test_stream_completes_with_tool_results(
 
     text_deltas = [d for t, d in events if t == "message" and response_text in d]
     assert len(text_deltas) >= 1
+
+
+@pytest.mark.asyncio
+async def test_malformed_tool_input_is_not_executed(
+    db_pool, chat_with_message, _patch_db_pool
+):
+    chat_id, _, model_id = chat_with_message
+    response_text = "Retried after receiving the JSON parse error."
+    searcher = create_mock_searcher()
+    app = _build_app(
+        create_mock_llm_with_invalid_tool_json(
+            '{"query": "missing brace"', response_text
+        ),
+        searcher,
+        model_id,
+    )
+
+    body = await _stream_chat(app, chat_id)
+    events = parse_sse_events(body)
+
+    searcher.handle.assert_not_called()
+    tool_result_events = [
+        json.loads(data)
+        for event_type, data in events
+        if event_type == "message" and "tool_result" in data
+    ]
+    assert tool_result_events
+    assert tool_result_events[0]["is_error"] is True
+    assert "Invalid JSON in tool input" in tool_result_events[0]["content"][0]["text"]
+    assert any(
+        response_text in data for event_type, data in events if event_type == "message"
+    )

--- a/web/src/lib/components/user-input.svelte
+++ b/web/src/lib/components/user-input.svelte
@@ -41,6 +41,7 @@
         placeholders?: Record<InputMode, string>
         isLoading?: boolean
         isStreaming?: boolean
+        stopInProgress?: boolean
         onStop?: () => void
         disabled?: boolean
         popoverItems?: PopoverItem[]
@@ -71,6 +72,7 @@
         placeholders = DEFAULT_PLACEHOLDERS,
         isLoading = false,
         isStreaming = false,
+        stopInProgress = false,
         onStop,
         disabled = false,
         popoverItems = [],
@@ -558,12 +560,21 @@
                     </Select.Root>
                 {/if}
                 {#if isStreaming}
-                    <Button
-                        size="icon"
-                        class="omni-composer-send cursor-pointer rounded-full"
-                        onclick={handleStopClick}>
-                        <CircleStop class="h-4 w-4" />
-                    </Button>
+                    {#if stopInProgress}
+                        <Button
+                            size="icon"
+                            class="omni-composer-send cursor-pointer rounded-full"
+                            disabled>
+                            <Loader2 class="h-4 w-4 animate-spin" />
+                        </Button>
+                    {:else}
+                        <Button
+                            size="icon"
+                            class="omni-composer-send cursor-pointer rounded-full"
+                            onclick={handleStopClick}>
+                            <CircleStop class="h-4 w-4" />
+                        </Button>
+                    {/if}
                 {:else if isLoading}
                     <Button size="icon" class="omni-composer-send cursor-pointer" disabled>
                         <Loader2 class="h-4 w-4 animate-spin" />

--- a/web/src/lib/server/db/chats.ts
+++ b/web/src/lib/server/db/chats.ts
@@ -231,6 +231,16 @@ export class ChatMessageRepository {
             .orderBy(chatMessages.messageSeqNum)
     }
 
+    async getByIdInChat(chatId: string, messageId: string): Promise<ChatMessage | null> {
+        const [message] = await this.db
+            .select()
+            .from(chatMessages)
+            .where(and(eq(chatMessages.chatId, chatId), eq(chatMessages.id, messageId)))
+            .limit(1)
+
+        return message || null
+    }
+
     private async getNextSequenceNumber(chatId: string): Promise<number> {
         const [lastMessage] = await this.db
             .select({ maxSeq: chatMessages.messageSeqNum })

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -735,7 +735,21 @@
             ? roots.find((r) => r.id === branchSelections['.root']) || roots[roots.length - 1]
             : roots[roots.length - 1]
 
+        const visited = new Set<string>()
         while (current) {
+            if (visited.has(current.id)) {
+                console.error('[chat-stream-debug]', 'getDisplayPath:cycle-detected', {
+                    cycleAt: current.id,
+                    pathSoFar: path.map((m) => ({ id: m.id, parentId: m.parentId })),
+                    childrenOfCycle: childrenMap.get(current.id)?.map((m) => ({
+                        id: m.id,
+                        parentId: m.parentId,
+                        seq: m.messageSeqNum,
+                    })),
+                })
+                break
+            }
+            visited.add(current.id)
             path.push(current)
             const children = childrenMap.get(current.id)
             if (!children || children.length === 0) break
@@ -1379,7 +1393,8 @@
         )
 
         const streamRunId = ++streamRunCounter
-        const isCurrentStream = () => streamRunId === streamRunCounter && activeStreamChatId === chatId
+        const isCurrentStream = () =>
+            streamRunId === streamRunCounter && activeStreamChatId === chatId
 
         isStreaming = true
         activeStreamChatId = chatId
@@ -1592,7 +1607,8 @@
                         })
                     }
                 } else {
-                    const messageId = (block as ToolResultBlockParam & { message_id?: string }).message_id
+                    const messageId = (block as ToolResultBlockParam & { message_id?: string })
+                        .message_id
                     if (!messageId) {
                         missingStreamMessageId('tool-result-message')
                         return
@@ -1709,18 +1725,32 @@
                             missingStreamMessageId('message_start')
                             return
                         }
+                        const existingMessage = chatMessages.find((m) => m.id === messageId)
                         // Find the last message in current display path to use as parent
                         const displayPath = getDisplayPath(chatMessages)
                         const streamParentId =
                             displayPath.length > 0
                                 ? displayPath[displayPath.length - 1].id
                                 : undefined
-                        debugStream('message_start:parent', {
-                            streamParentId,
-                            displayPathLength: displayPath.length,
-                            displayPathLastId: displayPath[displayPath.length - 1]?.id,
-                            chatMessageCount: chatMessages.length,
-                        })
+                        debugStream(
+                            'message_start:parent',
+                            {
+                                messageId,
+                                messageIdAlreadyExists: !!existingMessage,
+                                existingMessageParentId: existingMessage?.parentId ?? null,
+                                streamParentId,
+                                selfParent: streamParentId === messageId,
+                                displayPathLength: displayPath.length,
+                                displayPathLastId: displayPath[displayPath.length - 1]?.id,
+                                chatMessageCount: chatMessages.length,
+                                chatMessageIds: chatMessages.map((m) => ({
+                                    id: m.id,
+                                    parentId: m.parentId,
+                                    role: m.message.role,
+                                })),
+                            },
+                            true,
+                        )
                         const startedMessage: ChatMessage = {
                             id: messageId,
                             chatId,
@@ -1911,12 +1941,34 @@
                 clearReconnectState()
 
                 if (messageEventsReceived === 0 && !pauseEventReceived && !error && !wasStopping) {
+                    console.error('[chat-stream-debug]', 'end_of_stream:no-messages', {
+                        messageEventsReceived,
+                        pauseEventReceived,
+                        hadError: !!error,
+                        wasStopping,
+                        streamLastEventId,
+                    })
                     error = 'Failed to generate response. Please try again.'
+                } else {
+                    console.debug('[chat-stream-debug]', 'end_of_stream:normal', {
+                        messageEventsReceived,
+                        pauseEventReceived,
+                        hadError: !!error,
+                        wasStopping,
+                        streamLastEventId,
+                    })
                 }
             })
 
             const handleStreamError = (event: Event) => {
                 if (!isCurrentStream()) return
+                console.error('[chat-stream-debug]', 'handleStreamError', {
+                    isMessageEvent: event instanceof MessageEvent,
+                    data: event instanceof MessageEvent ? event.data : null,
+                    lastEventId: event instanceof MessageEvent ? event.lastEventId : null,
+                    messageEventsReceived,
+                    streamLastEventId,
+                })
                 streamCompleted = true
                 if (event instanceof MessageEvent) {
                     const streamError = streamErrorMessage(event as MessageEvent<string>)
@@ -1946,6 +1998,12 @@
                 // error event, so we can use that as a signal to skip cleanup here.
                 if (streamCompleted || !isStreaming) return
 
+                console.error('[chat-stream-debug]', 'handleConnectionError', {
+                    readyState: eventSource?.readyState,
+                    reconnectAttempts,
+                    messageEventsReceived,
+                    streamLastEventId,
+                })
                 // Transient drop (e.g. backgrounded tab): the server keeps the run
                 // alive and buffered, so reconnect from our last offset with backoff
                 // instead of failing. Only surface an error once the budget is spent.

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -628,8 +628,8 @@
 
         // The run is decoupled from this connection, so closing the EventSource
         // is no longer enough — tell the server to actually stop generating.
-        // Keep the stream open until omni-ai emits message_id/end_of_stream for
-        // the partial assistant message it persisted on cancellation.
+        // Keep the stream open until omni-ai emits end_of_stream for the partial
+        // assistant message it persisted on cancellation.
         const stopChatId = activeStreamChatId ?? data.chat.id
         stopInProgress = true
         error = null
@@ -779,20 +779,6 @@
 
     function selectBranch(parentId: string | null | undefined, messageId: string) {
         branchSelections[branchSelectionKey(parentId)] = messageId
-    }
-
-    function replaceMessageIdInBranchSelections(oldId: string, newId: string) {
-        const nextBranchSelections = { ...branchSelections }
-        if (nextBranchSelections[oldId] !== undefined) {
-            nextBranchSelections[newId] = nextBranchSelections[oldId]
-            delete nextBranchSelections[oldId]
-        }
-        for (const [parentId, selectedId] of Object.entries(nextBranchSelections)) {
-            if (selectedId === oldId) {
-                nextBranchSelections[parentId] = newId
-            }
-        }
-        branchSelections = nextBranchSelections
     }
 
     function switchBranch(parentId: string | null, direction: 'prev' | 'next') {
@@ -1406,89 +1392,18 @@
             number,
             { id: string; name: string; inputJson: string }
         >()
-        const pendingTempMessageIds: string[] = []
-        const pendingPersistedMessageIds: string[] = []
-        let tempMessageCounter = 0
-
         let streamCompleted = false
         let messageEventsReceived = 0
         let pauseEventReceived = false
         reconnectAttempts = 0
 
-        const nextTempMessageId = () => `temp-${Date.now()}-${tempMessageCounter++}`
-
-        const replaceTempMessageId = (tempId: string, messageId: string) => {
-            debugStream('replaceTempMessageId', { tempId, messageId })
-            chatMessages = chatMessages.map((message) => {
-                if (message.id === tempId) {
-                    return { ...message, id: messageId }
-                }
-                if (message.parentId === tempId) {
-                    return { ...message, parentId: messageId }
-                }
-                return message
-            })
-            if (activeStreamingMessageId === tempId) {
-                activeStreamingMessageId = messageId
-            }
-            debugStream('replaceTempMessageId:done', {
-                activeStreamingMessageId,
-                messageCount: chatMessages.length,
-            })
-            replaceMessageIdInBranchSelections(tempId, messageId)
-            markChatMessagesChanged()
-        }
-
-        const trackTempMessage = (tempId: string) => {
-            debugStream('trackTempMessage', {
-                tempId,
-                pendingPersistedMessageIds: [...pendingPersistedMessageIds],
-            })
-            const persistedMessageId = pendingPersistedMessageIds.shift()
-            if (persistedMessageId) {
-                replaceTempMessageId(tempId, persistedMessageId)
-                return
-            }
-            pendingTempMessageIds.push(tempId)
-        }
-
-        const applyPersistedMessageId = (messageId: string) => {
-            debugStream('applyPersistedMessageId', {
-                messageId,
-                pendingTempMessageIds: [...pendingTempMessageIds],
-            })
-            const tempId = pendingTempMessageIds.shift()
-            if (!tempId) {
-                pendingPersistedMessageIds.push(messageId)
-                return
-            }
-            replaceTempMessageId(tempId, messageId)
+        const missingStreamMessageId = (reason: string) => {
+            console.error('Missing persisted stream message id', { reason })
+            error = 'Response stream did not provide a message id. Please reload the chat.'
+            errorDetail = null
         }
 
         let collectStreamingResponseCount = 0
-        const appendStreamingAssistantMessage = (): ChatMessage => {
-            const displayPath = getDisplayPath(chatMessages)
-            const streamParentId =
-                displayPath.length > 0 ? displayPath[displayPath.length - 1].id : undefined
-            const startedMessage: ChatMessage = {
-                id: nextTempMessageId(),
-                chatId,
-                parentId: streamParentId ?? null,
-                message: {
-                    role: 'assistant',
-                    content: [],
-                },
-                contentText: null,
-                messageSeqNum: nextMessageSeqNum(chatMessages),
-                createdAt: new Date(),
-            }
-            chatMessages = [...chatMessages, startedMessage]
-            activeStreamingMessageId = startedMessage.id
-            selectBranch(startedMessage.parentId, startedMessage.id)
-            trackTempMessage(startedMessage.id)
-            markChatMessagesChanged()
-            return startedMessage
-        }
         const collectStreamingResponse = (
             block:
                 | ToolUseBlock
@@ -1515,9 +1430,14 @@
                     lastMessage.message.role !== 'assistant' ||
                     !Array.isArray(lastMessage.message.content))
             ) {
-                lastMessage = appendStreamingAssistantMessage()
-                targetMessageId = lastMessage.id
-                targetMessageIndex = chatMessages.length - 1
+                console.error('Received streamed assistant content before message_start', {
+                    blockType: block.type,
+                    blockIdx,
+                    activeStreamingMessageId,
+                })
+                error = 'Response stream sent content before a message id. Please reload the chat.'
+                errorDetail = null
+                return
             }
 
             debugStream('collectStreamingResponse', {
@@ -1672,11 +1592,16 @@
                         })
                     }
                 } else {
+                    const messageId = (block as ToolResultBlockParam & { message_id?: string }).message_id
+                    if (!messageId) {
+                        missingStreamMessageId('tool-result-message')
+                        return
+                    }
                     const displayPath = getDisplayPath(chatMessages)
                     const toolParentId =
                         displayPath.length > 0 ? displayPath[displayPath.length - 1].id : undefined
                     const toolResultMessage: ChatMessage = {
-                        id: nextTempMessageId(),
+                        id: messageId,
                         chatId,
                         parentId: toolParentId ?? null,
                         message: {
@@ -1695,7 +1620,6 @@
                     chatMessages = [...chatMessages, toolResultMessage]
                     activeStreamingMessageId = toolResultMessage.id
                     selectBranch(toolResultMessage.parentId, toolResultMessage.id)
-                    trackTempMessage(toolResultMessage.id)
                     markChatMessagesChanged()
                 }
 
@@ -1736,7 +1660,6 @@
                 streamLastEventId = event.lastEventId || streamLastEventId
                 lastStreamEventAt = Date.now()
                 reconnectAttempts = 0
-                applyPersistedMessageId(event.data)
             })
 
             eventSource.addEventListener('not_resumable', () => {
@@ -1781,6 +1704,11 @@
                         lastEventId: event.lastEventId,
                     })
                     if (data.type === 'message_start') {
+                        const messageId = data.message.id
+                        if (!messageId) {
+                            missingStreamMessageId('message_start')
+                            return
+                        }
                         // Find the last message in current display path to use as parent
                         const displayPath = getDisplayPath(chatMessages)
                         const streamParentId =
@@ -1794,7 +1722,7 @@
                             chatMessageCount: chatMessages.length,
                         })
                         const startedMessage: ChatMessage = {
-                            id: nextTempMessageId(),
+                            id: messageId,
                             chatId,
                             parentId: streamParentId ?? null,
                             message: {
@@ -1814,7 +1742,6 @@
                             messageCount: chatMessages.length,
                         })
                         selectBranch(startedMessage.parentId, startedMessage.id)
-                        trackTempMessage(startedMessage.id)
                         markChatMessagesChanged()
                     } else if (data.type === 'content_block_start') {
                         if (data.content_block.type === 'tool_use') {

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -2822,7 +2822,8 @@
                             chat: 'Ask a follow-up...',
                             search: 'Search for something else...',
                         }}
-                        isStreaming={isStreaming || stopInProgress}
+                        isStreaming={isStreaming}
+                        stopInProgress={stopInProgress}
                         onStop={handleStop}
                         maxWidth="max-w-4xl" />
                 </div>

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -460,7 +460,6 @@
     let showTopShadow = $state(false)
     let bottomPadding = $state(80)
 
-    let processMessagesCallCount = 0
     let processedMessages = $state<ProcessedMessage[]>(processMessages(chatMessages))
     let processedMessagesRefreshScheduled = false
     let lastUserMessageIndex = $derived(processedMessages.findLastIndex((m) => m.role === 'user'))
@@ -512,63 +511,6 @@
             })
             .join('|')
     }
-
-    function summarizeChatMessagesForDebug(messages: ChatMessage[]) {
-        return messages.slice(-6).map((message) => ({
-            id: message.id,
-            parentId: message.parentId,
-            seq: message.messageSeqNum,
-            role: message.message.role,
-            contentType: Array.isArray(message.message.content) ? 'array' : 'string',
-            blockTypes: Array.isArray(message.message.content)
-                ? message.message.content.map((block) => block.type)
-                : undefined,
-        }))
-    }
-
-    function summarizeProcessedMessagesForDebug(messages: ProcessedMessage[]) {
-        return messages.slice(-4).map((message) => ({
-            origMessageId: message.origMessageId,
-            role: message.role,
-            sourceMessageIds: message.sourceMessageIds,
-            contentTypes: message.content.map((block) => block.type),
-            toolIds: message.content
-                .filter((block): block is ToolMessageContent => block.type === 'tool')
-                .map((block) => block.toolUse.id),
-            textLengths: message.content
-                .filter((block): block is TextMessageContent => block.type === 'text')
-                .map((block) => block.text.length),
-        }))
-    }
-
-    $effect(() => {
-        const displayPath = getDisplayPath(chatMessages)
-        console.debug('[chat-state-debug]', {
-            isStreaming,
-            activeStreamingMessageId,
-            chatMessageCount: chatMessages.length,
-            processedMessageCount: processedMessages.length,
-            displayPathLength: displayPath.length,
-            displayPathTail: displayPath.slice(-5).map((message) => ({
-                id: message.id,
-                parentId: message.parentId,
-                seq: message.messageSeqNum,
-                role: message.message.role,
-            })),
-            chatTail: summarizeChatMessagesForDebug(chatMessages),
-            processedTail: summarizeProcessedMessagesForDebug(processedMessages),
-            pendingApproval: pendingApproval
-                ? {
-                      approvalId: pendingApproval.approval_id,
-                      toolCallId: pendingApproval.tool_call_id,
-                      approvals: pendingApproval.approvals?.map((approval) => ({
-                          approvalId: approval.approval_id,
-                          toolCallId: approval.tool_call_id,
-                      })),
-                  }
-                : null,
-        })
-    })
 
     function markChatMessagesChanged() {
         scheduleProcessedMessagesRefresh()
@@ -735,21 +677,7 @@
             ? roots.find((r) => r.id === branchSelections['.root']) || roots[roots.length - 1]
             : roots[roots.length - 1]
 
-        const visited = new Set<string>()
         while (current) {
-            if (visited.has(current.id)) {
-                console.error('[chat-stream-debug]', 'getDisplayPath:cycle-detected', {
-                    cycleAt: current.id,
-                    pathSoFar: path.map((m) => ({ id: m.id, parentId: m.parentId })),
-                    childrenOfCycle: childrenMap.get(current.id)?.map((m) => ({
-                        id: m.id,
-                        parentId: m.parentId,
-                        seq: m.messageSeqNum,
-                    })),
-                })
-                break
-            }
-            visited.add(current.id)
             path.push(current)
             const children = childrenMap.get(current.id)
             if (!children || children.length === 0) break
@@ -885,8 +813,6 @@
     // Converts messages into a format that makes it easy to render the messages
     // E.g., combines multiple content blocks into a single content block, handles citations, etc.
     function processMessages(chatMessages: ChatMessage[]): ProcessedMessage[] {
-        const processStartedAt = performance.now()
-        processMessagesCallCount += 1
         let result: ProcessedMessage[] = []
         const siblingInfo = computeSiblingInfo(chatMessages)
         const displayPath = getDisplayPath(chatMessages)
@@ -1272,18 +1198,6 @@
             }
         }
 
-        const durationMs = performance.now() - processStartedAt
-        if (durationMs > 50 || processMessagesCallCount % 25 === 0) {
-            console.debug('[chat-stream-debug]', 'processMessages:done', {
-                processMessagesCallCount,
-                durationMs,
-                chatMessageCount: chatMessages.length,
-                displayPathLength: displayPath.length,
-                processedMessageCount: result.length,
-                activeStreamingMessageId,
-            })
-        }
-
         return result
     }
 
@@ -1370,28 +1284,6 @@
     })
 
     function streamResponse(chatId: string) {
-        let debugEventCount = 0
-        const debugStream = (label: string, details?: Record<string, unknown>, force = false) => {
-            debugEventCount += 1
-            if (!force && debugEventCount > 200 && debugEventCount % 50 !== 0) return
-            console.debug('[chat-stream-debug]', label, {
-                debugEventCount,
-                ...details,
-            })
-        }
-
-        debugStream(
-            'streamResponse:start',
-            {
-                chatId,
-                existingMessageCount: chatMessages.length,
-                processedMessageCount: processedMessages.length,
-                activeStreamingMessageId,
-                branchSelections: { ...branchSelections },
-            },
-            true,
-        )
-
         const streamRunId = ++streamRunCounter
         const isCurrentStream = () =>
             streamRunId === streamRunCounter && activeStreamChatId === chatId
@@ -1418,7 +1310,6 @@
             errorDetail = null
         }
 
-        let collectStreamingResponseCount = 0
         const collectStreamingResponse = (
             block:
                 | ToolUseBlock
@@ -1429,7 +1320,6 @@
                 | CitationsDelta,
             blockIdx?: number, // This should be defined for all block types above except ToolResultBlockParam (since this one doesn't come from the LLM)
         ) => {
-            collectStreamingResponseCount += 1
             let targetMessageId = activeStreamingMessageId
             let targetMessageIndex = targetMessageId
                 ? chatMessages.findIndex((message) => message.id === targetMessageId)
@@ -1455,18 +1345,6 @@
                 return
             }
 
-            debugStream('collectStreamingResponse', {
-                collectStreamingResponseCount,
-                blockType: block.type,
-                blockIdx,
-                targetMessageId,
-                targetMessageIndex,
-                lastMessageId: lastMessage?.id,
-                lastMessageRole: lastMessage?.message.role,
-                lastMessageContentIsArray: Array.isArray(lastMessage?.message.content),
-                messageCount: chatMessages.length,
-                activeStreamingMessageId,
-            })
             if (!lastMessage) {
                 console.error('No last message found when streaming response')
                 return
@@ -1475,15 +1353,6 @@
             const replaceLastMessage = (message: ChatMessage) => {
                 const replaceIndex =
                     targetMessageIndex === -1 ? chatMessages.length - 1 : targetMessageIndex
-                debugStream('replaceStreamingMessage', {
-                    replaceIndex,
-                    oldMessageId: lastMessage.id,
-                    newMessageId: message.id,
-                    role: message.message.role,
-                    contentBlockCount: Array.isArray(message.message.content)
-                        ? message.message.content.length
-                        : null,
-                })
                 chatMessages = [
                     ...chatMessages.slice(0, replaceIndex),
                     message,
@@ -1628,11 +1497,6 @@
                         messageSeqNum: nextMessageSeqNum(chatMessages),
                         createdAt: new Date(),
                     }
-                    debugStream('appendToolResultMessage', {
-                        toolResultMessageId: toolResultMessage.id,
-                        parentId: toolResultMessage.parentId,
-                        toolUseId: block.tool_use_id,
-                    })
                     chatMessages = [...chatMessages, toolResultMessage]
                     activeStreamingMessageId = toolResultMessage.id
                     selectBranch(toolResultMessage.parentId, toolResultMessage.id)
@@ -1668,11 +1532,6 @@
 
             eventSource.addEventListener('message_id', (event) => {
                 if (!isCurrentStream()) return
-                debugStream('event:message_id', {
-                    data: event.data,
-                    lastEventId: event.lastEventId,
-                    streamLastEventId,
-                })
                 streamLastEventId = event.lastEventId || streamLastEventId
                 lastStreamEventAt = Date.now()
                 reconnectAttempts = 0
@@ -1715,42 +1574,18 @@
                 reconnectAttempts = 0
                 try {
                     const data: MessageStreamEvent | ToolResultBlockParam = JSON.parse(event.data)
-                    debugStream('event:message', {
-                        eventType: data.type,
-                        lastEventId: event.lastEventId,
-                    })
                     if (data.type === 'message_start') {
                         const messageId = data.message.id
                         if (!messageId) {
                             missingStreamMessageId('message_start')
                             return
                         }
-                        const existingMessage = chatMessages.find((m) => m.id === messageId)
                         // Find the last message in current display path to use as parent
                         const displayPath = getDisplayPath(chatMessages)
                         const streamParentId =
                             displayPath.length > 0
                                 ? displayPath[displayPath.length - 1].id
                                 : undefined
-                        debugStream(
-                            'message_start:parent',
-                            {
-                                messageId,
-                                messageIdAlreadyExists: !!existingMessage,
-                                existingMessageParentId: existingMessage?.parentId ?? null,
-                                streamParentId,
-                                selfParent: streamParentId === messageId,
-                                displayPathLength: displayPath.length,
-                                displayPathLastId: displayPath[displayPath.length - 1]?.id,
-                                chatMessageCount: chatMessages.length,
-                                chatMessageIds: chatMessages.map((m) => ({
-                                    id: m.id,
-                                    parentId: m.parentId,
-                                    role: m.message.role,
-                                })),
-                            },
-                            true,
-                        )
                         const startedMessage: ChatMessage = {
                             id: messageId,
                             chatId,
@@ -1765,12 +1600,6 @@
                         }
                         chatMessages = [...chatMessages, startedMessage]
                         activeStreamingMessageId = startedMessage.id
-                        debugStream('message_start:appended', {
-                            startedMessageId: startedMessage.id,
-                            parentId: startedMessage.parentId,
-                            activeStreamingMessageId,
-                            messageCount: chatMessages.length,
-                        })
                         selectBranch(startedMessage.parentId, startedMessage.id)
                         markChatMessagesChanged()
                     } else if (data.type === 'content_block_start') {
@@ -1786,12 +1615,6 @@
                             collectStreamingResponse(data.content_block, data.index)
                         }
                     } else if (data.type === 'content_block_delta') {
-                        debugStream('content_block_delta', {
-                            index: data.index,
-                            deltaType: data.delta.type,
-                            textLength:
-                                data.delta.type === 'text_delta' ? data.delta.text?.length : null,
-                        })
                         if (data.delta.type === 'text_delta' && data.delta.text) {
                             updateThinkingForText()
                             collectStreamingResponse(data.delta, data.index)
@@ -1837,7 +1660,6 @@
 
             eventSource.addEventListener('approval_required', (event) => {
                 if (!isCurrentStream()) return
-                debugStream('event:approval_required', { data: event.data })
                 pauseEventReceived = true
                 try {
                     const approvalData: ApprovalRequiredEvent = JSON.parse(event.data)
@@ -1855,7 +1677,6 @@
 
             eventSource.addEventListener('oauth_required', (event) => {
                 if (!isCurrentStream()) return
-                debugStream('event:oauth_required', { data: event.data })
                 pauseEventReceived = true
                 try {
                     const oauthData: OAuthRequiredEvent = JSON.parse(event.data)
@@ -1912,20 +1733,6 @@
 
             eventSource.addEventListener('end_of_stream', () => {
                 if (!isCurrentStream()) return
-                debugStream(
-                    'event:end_of_stream',
-                    {
-                        messageEventsReceived,
-                        pauseEventReceived,
-                        error,
-                        stopInProgress,
-                        chatMessageCount: chatMessages.length,
-                        processedMessageCount: processedMessages.length,
-                        activeStreamingMessageId,
-                        collectStreamingResponseCount,
-                    },
-                    true,
-                )
                 const wasStopping = stopInProgress
                 streamCompleted = true
                 isStreaming = false
@@ -1941,34 +1748,12 @@
                 clearReconnectState()
 
                 if (messageEventsReceived === 0 && !pauseEventReceived && !error && !wasStopping) {
-                    console.error('[chat-stream-debug]', 'end_of_stream:no-messages', {
-                        messageEventsReceived,
-                        pauseEventReceived,
-                        hadError: !!error,
-                        wasStopping,
-                        streamLastEventId,
-                    })
                     error = 'Failed to generate response. Please try again.'
-                } else {
-                    console.debug('[chat-stream-debug]', 'end_of_stream:normal', {
-                        messageEventsReceived,
-                        pauseEventReceived,
-                        hadError: !!error,
-                        wasStopping,
-                        streamLastEventId,
-                    })
                 }
             })
 
             const handleStreamError = (event: Event) => {
                 if (!isCurrentStream()) return
-                console.error('[chat-stream-debug]', 'handleStreamError', {
-                    isMessageEvent: event instanceof MessageEvent,
-                    data: event instanceof MessageEvent ? event.data : null,
-                    lastEventId: event instanceof MessageEvent ? event.lastEventId : null,
-                    messageEventsReceived,
-                    streamLastEventId,
-                })
                 streamCompleted = true
                 if (event instanceof MessageEvent) {
                     const streamError = streamErrorMessage(event as MessageEvent<string>)
@@ -1998,12 +1783,6 @@
                 // error event, so we can use that as a signal to skip cleanup here.
                 if (streamCompleted || !isStreaming) return
 
-                console.error('[chat-stream-debug]', 'handleConnectionError', {
-                    readyState: eventSource?.readyState,
-                    reconnectAttempts,
-                    messageEventsReceived,
-                    streamLastEventId,
-                })
                 // Transient drop (e.g. backgrounded tab): the server keeps the run
                 // alive and buffered, so reconnect from our last offset with backoff
                 // instead of failing. Only surface an error once the budget is spent.

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -677,7 +677,13 @@
             ? roots.find((r) => r.id === branchSelections['.root']) || roots[roots.length - 1]
             : roots[roots.length - 1]
 
+        const visited = new Set<string>()
         while (current) {
+            if (visited.has(current.id)) {
+                console.error('getDisplayPath: message tree cycle detected at', current.id)
+                break
+            }
+            visited.add(current.id)
             path.push(current)
             const children = childrenMap.get(current.id)
             if (!children || children.length === 0) break
@@ -1578,6 +1584,33 @@
                         const messageId = data.message.id
                         if (!messageId) {
                             missingStreamMessageId('message_start')
+                            return
+                        }
+                        // On a reload/reconnect replay, the assistant row was already
+                        // persisted at the original message_start and loaded from the DB,
+                        // so it is already in chatMessages. Re-appending it would derive
+                        // its parent from the display-path leaf (itself) and create a
+                        // self-cycle (id === parentId) that hangs getDisplayPath. Adopt
+                        // the existing row as the streaming target and let the replayed
+                        // content deltas rebuild it in place instead.
+                        const existingIndex = chatMessages.findIndex(
+                            (m) => m.id === messageId,
+                        )
+                        if (existingIndex !== -1) {
+                            const existing = chatMessages[existingIndex]
+                            chatMessages = [
+                                ...chatMessages.slice(0, existingIndex),
+                                {
+                                    ...existing,
+                                    message: {
+                                        role: data.message.role,
+                                        content: data.message.content,
+                                    },
+                                },
+                                ...chatMessages.slice(existingIndex + 1),
+                            ]
+                            activeStreamingMessageId = messageId
+                            markChatMessagesChanged()
                             return
                         }
                         // Find the last message in current display path to use as parent

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -182,6 +182,7 @@
     let errorDetail = $state<string | null>(null)
     let eventSource: EventSource | null = $state(null)
     let activeStreamChatId: string | null = null
+    let streamRunCounter = 0
 
     // --- Stream resilience (reconnect after a backgrounded tab / transient drop) ---
     // The server keeps the run alive and buffered, so we reconnect from the last
@@ -1391,6 +1392,9 @@
             true,
         )
 
+        const streamRunId = ++streamRunCounter
+        const isCurrentStream = () => streamRunId === streamRunCounter && activeStreamChatId === chatId
+
         isStreaming = true
         activeStreamChatId = chatId
         activeStreamingMessageId = null
@@ -1462,6 +1466,29 @@
         }
 
         let collectStreamingResponseCount = 0
+        const appendStreamingAssistantMessage = (): ChatMessage => {
+            const displayPath = getDisplayPath(chatMessages)
+            const streamParentId =
+                displayPath.length > 0 ? displayPath[displayPath.length - 1].id : undefined
+            const startedMessage: ChatMessage = {
+                id: nextTempMessageId(),
+                chatId,
+                parentId: streamParentId ?? null,
+                message: {
+                    role: 'assistant',
+                    content: [],
+                },
+                contentText: null,
+                messageSeqNum: nextMessageSeqNum(chatMessages),
+                createdAt: new Date(),
+            }
+            chatMessages = [...chatMessages, startedMessage]
+            activeStreamingMessageId = startedMessage.id
+            selectBranch(startedMessage.parentId, startedMessage.id)
+            trackTempMessage(startedMessage.id)
+            markChatMessagesChanged()
+            return startedMessage
+        }
         const collectStreamingResponse = (
             block:
                 | ToolUseBlock
@@ -1473,14 +1500,26 @@
             blockIdx?: number, // This should be defined for all block types above except ToolResultBlockParam (since this one doesn't come from the LLM)
         ) => {
             collectStreamingResponseCount += 1
-            const targetMessageId = activeStreamingMessageId
-            const targetMessageIndex = targetMessageId
+            let targetMessageId = activeStreamingMessageId
+            let targetMessageIndex = targetMessageId
                 ? chatMessages.findIndex((message) => message.id === targetMessageId)
                 : -1
-            const lastMessage =
+            let lastMessage =
                 targetMessageIndex === -1
                     ? chatMessages[chatMessages.length - 1]
                     : chatMessages[targetMessageIndex]
+
+            if (
+                block.type !== 'tool_result' &&
+                (!lastMessage ||
+                    lastMessage.message.role !== 'assistant' ||
+                    !Array.isArray(lastMessage.message.content))
+            ) {
+                lastMessage = appendStreamingAssistantMessage()
+                targetMessageId = lastMessage.id
+                targetMessageIndex = chatMessages.length - 1
+            }
+
             debugStream('collectStreamingResponse', {
                 collectStreamingResponseCount,
                 blockType: block.type,
@@ -1494,7 +1533,6 @@
                 activeStreamingMessageId,
             })
             if (!lastMessage) {
-                // This should never happen
                 console.error('No last message found when streaming response')
                 return
             }
@@ -1517,12 +1555,6 @@
                     ...chatMessages.slice(replaceIndex + 1),
                 ]
                 markChatMessagesChanged()
-            }
-
-            if (block.type !== 'tool_result' && !Array.isArray(lastMessage.message.content)) {
-                throw new Error(
-                    'Cannot append streamed assistant content to non-array message content',
-                )
             }
 
             const existingBlocks = Array.isArray(lastMessage.message.content)
@@ -1695,6 +1727,7 @@
             )
 
             eventSource.addEventListener('message_id', (event) => {
+                if (!isCurrentStream()) return
                 debugStream('event:message_id', {
                     data: event.data,
                     lastEventId: event.lastEventId,
@@ -1707,6 +1740,7 @@
             })
 
             eventSource.addEventListener('not_resumable', () => {
+                if (!isCurrentStream()) return
                 // The buffered run is gone (expired or never existed). Reload the
                 // persisted messages from the server and clear streaming state.
                 streamCompleted = true
@@ -1731,10 +1765,12 @@
             })
 
             eventSource.addEventListener('heartbeat', () => {
+                if (!isCurrentStream()) return
                 lastStreamEventAt = Date.now()
             })
 
             eventSource.addEventListener('message', (event) => {
+                if (!isCurrentStream()) return
                 streamLastEventId = event.lastEventId || streamLastEventId
                 lastStreamEventAt = Date.now()
                 reconnectAttempts = 0
@@ -1843,6 +1879,7 @@
             })
 
             eventSource.addEventListener('approval_required', (event) => {
+                if (!isCurrentStream()) return
                 debugStream('event:approval_required', { data: event.data })
                 pauseEventReceived = true
                 try {
@@ -1860,6 +1897,7 @@
             })
 
             eventSource.addEventListener('oauth_required', (event) => {
+                if (!isCurrentStream()) return
                 debugStream('event:oauth_required', { data: event.data })
                 pauseEventReceived = true
                 try {
@@ -1877,6 +1915,7 @@
             })
 
             eventSource.addEventListener('tool_result_replaced', (event) => {
+                if (!isCurrentStream()) return
                 try {
                     const data: ToolResultReplacedEvent = JSON.parse(event.data)
                     // Find the user-role chat message that holds the placeholder
@@ -1915,6 +1954,7 @@
             })
 
             eventSource.addEventListener('end_of_stream', () => {
+                if (!isCurrentStream()) return
                 debugStream(
                     'event:end_of_stream',
                     {
@@ -1949,6 +1989,7 @@
             })
 
             const handleStreamError = (event: Event) => {
+                if (!isCurrentStream()) return
                 streamCompleted = true
                 if (event instanceof MessageEvent) {
                     const streamError = streamErrorMessage(event as MessageEvent<string>)
@@ -1972,6 +2013,7 @@
             }
 
             const handleConnectionError = () => {
+                if (!isCurrentStream()) return
                 // Guard against treating an intentional stop() as a connection error.
                 // handleStop() sets isStreaming = false before the EventSource fires its
                 // error event, so we can use that as a signal to skip cleanup here.

--- a/web/src/routes/api/chat/[chatId]/messages/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/messages/+server.ts
@@ -183,28 +183,42 @@ export const POST: RequestHandler = async ({ params, request, locals }) => {
             userMessage = { role: 'user', content: trimmedText }
         }
 
-        // Determine parentId: use provided value, or find the last message in the active path.
-        // If the active leaf is an assistant tool_use without a tool_result, first insert an
-        // error tool_result so the next user turn does not create invalid provider history.
-        let parentId = messageRequest.parentId
-        if (!parentId) {
-            const lastMessage = await chatMessageRepository.getLastMessageInActivePath(chatId)
-            if (lastMessage) {
-                const repairMessage = interruptedToolResultMessage(lastMessage.message)
-                if (repairMessage) {
-                    const savedRepairMessage = await chatMessageRepository.create(
-                        chatId,
-                        repairMessage,
-                        lastMessage.id,
-                    )
-                    parentId = savedRepairMessage.id
-                    logger.warn('Inserted failed tool_result for interrupted tool call', {
-                        chatId,
-                        repairMessageId: savedRepairMessage.id,
-                    })
-                } else {
-                    parentId = lastMessage.id
-                }
+        // Determine parentId: prefer a valid persisted parent from the client, otherwise
+        // derive the active DB leaf. Client-only streaming ids must never become FK values.
+        let parentId = messageRequest.parentId?.trim() || undefined
+        let parentMessage = parentId
+            ? await chatMessageRepository.getByIdInChat(chatId, parentId)
+            : null
+        if (parentId && !parentMessage) {
+            logger.warn('Ignoring unknown client-provided parent message id', {
+                chatId,
+                parentId,
+            })
+            parentId = undefined
+            parentMessage = null
+        }
+
+        if (!parentMessage) {
+            parentMessage = await chatMessageRepository.getLastMessageInActivePath(chatId)
+            parentId = parentMessage?.id
+        }
+
+        // If the selected parent is an assistant tool_use without a tool_result,
+        // first insert an error tool_result so the next user turn does not create
+        // invalid provider history.
+        if (parentMessage) {
+            const repairMessage = interruptedToolResultMessage(parentMessage.message)
+            if (repairMessage) {
+                const savedRepairMessage = await chatMessageRepository.create(
+                    chatId,
+                    repairMessage,
+                    parentMessage.id,
+                )
+                parentId = savedRepairMessage.id
+                logger.warn('Inserted failed tool_result for interrupted tool call', {
+                    chatId,
+                    repairMessageId: savedRepairMessage.id,
+                })
             }
         }
 


### PR DESCRIPTION
- Malformed tool-call arguments were silently coerced to `{}` and executed; now they return an error `tool_result` to the model so it can recover instead of running a no-op tool.
- Streamed assistant/tool messages used client-only temp ids that could leak into persisted `parent_id` and cause FK failures; the backend now persists the row at `message_start` and emits a durable id immediately.
- Reloading mid-stream returned "Failed to generate response" because a reconnect without `Last-Event-ID` fell through to fresh-generation setup and hit the "no new user message" guard; the stream endpoint now attaches to an active run regardless of offset and replays from 0.
- On reload replay, `message_start` re-appended an already-persisted assistant row, deriving its parent from the display-path leaf (itself) and creating a self-cycle that hung the browser; the frontend now adopts the existing row as the streaming target.
- Stale EventSource callbacks from a cancelled/previous stream could mutate new stream state; added run-identity guards and DB-backed validation of `parentId` on message POST.