### PR TITLE
fix(chat): make Stop immediate and recover stream after a backgrounded tab

### DIFF
--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -140,6 +140,9 @@ _CANCEL_TTL = 300
 _CANCEL_CHECK_INTERVAL_SECONDS = 1.0
 
 _background_run_tasks: set[asyncio.Task] = set()
+# Producer tasks keyed by chat so an explicit Stop can cancel the right run
+# immediately in-process. The Redis cancel flag handles cross-worker stops.
+_run_tasks_by_chat: dict[str, asyncio.Task] = {}
 
 
 def _stream_key(chat_id: str) -> str:
@@ -380,6 +383,17 @@ async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
                 approximate=True,
             )
             await redis_client.expire(lock_key, _RUN_LOCK_TTL)
+    except asyncio.CancelledError:
+        # Explicit Stop cancelled this producer task. Emit a terminal event so
+        # any still-attached consumer ends cleanly instead of seeing the lock
+        # disappear and reporting "Generation ended unexpectedly".
+        try:
+            await redis_client.xadd(
+                stream_key, {"e": "event: end_of_stream\ndata: Stopped\n\n"}
+            )
+        except Exception:
+            pass
+        raise
     except Exception as e:
         logger.error(f"Producer failed for chat {chat_id}: {e}", exc_info=True)
         try:
@@ -2119,7 +2133,16 @@ async def stream_chat(
         )
     )
     _background_run_tasks.add(task)
-    task.add_done_callback(_background_run_tasks.discard)
+    _run_tasks_by_chat[chat_id] = task
+
+    def _cleanup_run_task(t: asyncio.Task, cid: str = chat_id) -> None:
+        _background_run_tasks.discard(t)
+        # Only clear the registry slot if it still points at this task; a new run
+        # for the same chat may have already claimed it.
+        if _run_tasks_by_chat.get(cid) is t:
+            del _run_tasks_by_chat[cid]
+
+    task.add_done_callback(_cleanup_run_task)
 
     return StreamingResponse(
         _consume_run(redis_client, chat_id, "0"),
@@ -2132,13 +2155,24 @@ async def stream_chat(
 async def cancel_chat_stream(
     request: Request, chat_id: str = Path(..., description="Chat thread ID")
 ):
-    """Explicit Stop: signal the background run to stop at its next checkpoint."""
-    redis_client = request.app.state.redis_client
+    """Explicit Stop: end the background run now.
+
+    Sets a Redis cancel flag (the cross-worker signal the producer checks at its
+    next checkpoint) and, if the producer task lives in this process, cancels it
+    directly so generation stops immediately — even mid-message or during a slow
+    tool call, where the next checkpoint could be far off.
+    """
+    redis_client = getattr(request.app.state, "redis_client", None)
     if redis_client is not None:
         try:
             await redis_client.set(_cancel_key(chat_id), "1", ex=_CANCEL_TTL)
         except Exception as e:
             logger.error(f"Failed to set cancel flag for chat {chat_id}: {e}")
+
+    task = _run_tasks_by_chat.get(chat_id)
+    if task is not None and not task.done():
+        task.cancel()
+
     return {"status": "cancelling"}
 
 

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -1270,15 +1270,15 @@
         // often dead without an 'error' event firing. If we're still streaming,
         // reconnect from the last offset and resume.
         const handleVisibility = () => {
-            if (
-                document.visibilityState === 'visible' &&
-                isStreaming &&
-                activeStreamChatId === data.chat.id &&
-                (!eventSource || eventSource.readyState === EventSource.CLOSED) &&
-                !reconnectTimer
-            ) {
-                reconnectStream?.()
-            }
+            if (document.visibilityState !== 'visible') return
+            if (!isStreaming || activeStreamChatId !== data.chat.id) return
+            if (reconnectTimer) return
+            // The socket is usually dead on return without ever firing 'error'
+            // (it can even still report readyState OPEN). Reconnect if it isn't
+            // open or no event/heartbeat arrived within the stall window.
+            const stalled = Date.now() - lastStreamEventAt > STREAM_STALL_MS
+            const notOpen = !eventSource || eventSource.readyState !== EventSource.OPEN
+            if (stalled || notOpen) reconnectStream?.()
         }
         document.addEventListener('visibilitychange', handleVisibility)
 
@@ -1536,6 +1536,10 @@
                 { withCredentials: true },
             )
 
+            // Each (re)connect gets a fresh stall window so the watchdog below
+            // doesn't fire while a new connection is still being established.
+            lastStreamEventAt = Date.now()
+
             eventSource.addEventListener('message_id', (event) => {
                 if (!isCurrentStream()) return
                 streamLastEventId = event.lastEventId || streamLastEventId
@@ -1571,6 +1575,7 @@
             eventSource.addEventListener('heartbeat', () => {
                 if (!isCurrentStream()) return
                 lastStreamEventAt = Date.now()
+                reconnectAttempts = 0
             })
 
             eventSource.addEventListener('message', (event) => {
@@ -1866,12 +1871,12 @@
         if (streamWatchdog) clearInterval(streamWatchdog)
         streamWatchdog = setInterval(() => {
             if (!isStreaming || streamCompleted || activeStreamChatId !== chatId) return
-            const stalled = Date.now() - lastStreamEventAt > STREAM_STALL_MS
-            if (stalled && !reconnectTimer) {
-                eventSource?.close()
-                eventSource = null
-                reconnectStream?.()
-            }
+            if (reconnectTimer) return
+            // Heartbeats arrive ~every 15s while the run is alive, so no event within
+            // the stall window means the socket is dead — even if the browser
+            // still reports it OPEN (the half-open socket left by a backgrounded
+            // tab). Reconnect from the last offset regardless of readyState.
+            if (Date.now() - lastStreamEventAt > STREAM_STALL_MS) reconnectStream?.()
         }, 5000)
     }
 


### PR DESCRIPTION
## Summary

Two follow-up fixes on top of #327 (already merged) for remaining chat-UI issues.

- **Stop now actually stops generation.** With generation decoupled from the browser connection, closing the EventSource no longer ends the run, and the Redis cancel flag was only checked at iteration boundaries / every 32 stream events / before tool execution — so Stop could appear to do nothing during a long token stream or a slow tool call. The cancel endpoint now also cancels the producer's asyncio task in-process (keyed by chat), stopping generation immediately; the Redis flag is kept as the cross-worker signal. A cancelled producer emits a terminal `end_of_stream` so any still-attached consumer ends cleanly.

- **Resume after a backgrounded/minimized tab.** A backgrounded tab's SSE socket usually dies silently — no `error` event fires and the browser often still reports `readyState === OPEN` (half-open socket). The previous watchdog / `visibilitychange` only reconnected when the connection was `CLOSED` / not-`OPEN`, so this case was never recovered and progress froze. The `visibilitychange` handler and watchdog now reconnect from the last offset whenever no event/heartbeat arrives within the stall window, regardless of `readyState`.

## Changes

- `services/ai/routers/chat.py`: add `_run_tasks_by_chat` dict; register each producer task; cancel in-process on Stop; emit terminal `end_of_stream` on `CancelledError`.
- `web/src/routes/(app)/chat/[chatId]/+page.svelte`: rewrite `handleVisibility` with stall-based check; simplify watchdog to reconnect on stall alone regardless of `readyState`; reset `lastStreamEventAt` on each (re)connect; add `reconnectAttempts` reset to heartbeat listener.

## Test plan

- [ ] Start a long generation, click Stop mid-stream — generation ends immediately (no further tokens/tool calls) and the input is ready again.
- [ ] Click Stop during a slow tool call — generation ends promptly instead of waiting for the next checkpoint.
- [ ] Start a generation, switch tabs / minimize for >20s, return — the stream reconnects from the last offset and resumes rendering without a manual reload.
- [ ] A generation with a long silent gap (slow tool call) — heartbeats keep the connection alive and no spurious reconnect occurs.