### PR TITLE
refactor(ai): split chat streaming pipeline

### DIFF
--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -140,7 +140,6 @@ _STREAM_MAXLEN = 5000  # cap buffered events per run
 _CANCEL_TTL = 300
 _CANCEL_CHECK_INTERVAL_SECONDS = 1.0
 
-_background_run_tasks: set[asyncio.Task] = set()
 # Producer tasks keyed by chat so an explicit Stop can cancel the right run
 # immediately in-process. The Redis cancel flag handles cross-worker stops.
 _run_tasks_by_chat: dict[str, asyncio.Task] = {}
@@ -1605,6 +1604,7 @@ async def stream_chat(
             # Initialized here so the error/cancel handlers below can always
             # reference whatever content was accumulated before the failure.
             content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
+            content_blocks_finalized = False
 
             if pending or pending_oauth:
                 if pending_oauth:
@@ -1791,6 +1791,7 @@ async def stream_chat(
 
                 logger.info(f"Iteration {iteration + 1}/{AGENT_MAX_ITERATIONS}")
                 content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
+                content_blocks_finalized = False
                 provider_extras = llm_provider.PERSISTED_BLOCK_EXTRAS
 
                 # Rebuild the per-turn tool list. The set of loaded connector
@@ -2002,6 +2003,7 @@ async def stream_chat(
 
                 # Send complete message to omni-web for database persistence
                 yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
+                content_blocks_finalized = True
 
                 if parse_errors:
                     tool_result_message = MessageParam(
@@ -2158,10 +2160,13 @@ async def stream_chat(
             # early-persisted assistant row is updated (not deleted) by
             # _persist_and_transform.  This mirrors the except Exception
             # block below.
-            partial = _partial_assistant_message(content_blocks)
-            if partial is not None:
-                conversation_messages.append(partial)
-                yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
+            # Only emit if the current content blocks haven't already been
+            # finalized via the normal per-iteration save.
+            if not content_blocks_finalized:
+                partial = _partial_assistant_message(content_blocks)
+                if partial is not None:
+                    conversation_messages.append(partial)
+                    yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
             raise
         except Exception as e:
             logger.error(
@@ -2169,10 +2174,13 @@ async def stream_chat(
             )
             # Finalize whatever partial assistant content was accumulated before
             # the failure, so the early-persisted row is not left empty.
-            partial = _partial_assistant_message(content_blocks)
-            if partial is not None:
-                conversation_messages.append(partial)
-                yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
+            # Only emit if the current content blocks haven't already been
+            # finalized via the normal per-iteration save.
+            if not content_blocks_finalized:
+                partial = _partial_assistant_message(content_blocks)
+                if partial is not None:
+                    conversation_messages.append(partial)
+                    yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
             yield _sse_event("stream_error", _chat_error_payload(e))
 
     parent_id = chat_messages[-1].id if chat_messages else None
@@ -2206,11 +2214,9 @@ async def stream_chat(
             redis_client, chat_id, stream_generator(), messages_repo, parent_id
         )
     )
-    _background_run_tasks.add(task)
     _run_tasks_by_chat[chat_id] = task
 
     def _cleanup_run_task(t: asyncio.Task, cid: str = chat_id) -> None:
-        _background_run_tasks.discard(t)
         # Only clear the registry slot if it still points at this task; a new run
         # for the same chat may have already claimed it.
         if _run_tasks_by_chat.get(cid) is t:

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -1,25 +1,24 @@
+"""Chat streaming API routes.
+
+Thin router extracted from the historical monolith.  Orchestrates request
+setup (chat lookup, registry build, compaction, provider resolution) and
+delegates the heavy streaming work to ``services/ai/streaming/`` modules.
+"""
+
+from __future__ import annotations
+
 import asyncio
 import json
 import logging
 import pathlib
-from collections.abc import Iterable
 from dataclasses import dataclass
-from enum import Enum
-from typing import Any, NotRequired, TypedDict, cast
+from typing import Any, cast
 
 import httpx
-from anthropic import AsyncStream, MessageStreamEvent
 from anthropic.types import (
-    CitationCharLocationParam,
-    CitationContentBlockLocationParam,
-    CitationPageLocationParam,
-    CitationsDelta,
-    CitationSearchResultLocationParam,
-    CitationWebSearchResultLocationParam,
     ContentBlockParam,
     MessageParam,
     TextBlockParam,
-    TextCitationParam,
     ToolResultBlockParam,
     ToolUseBlockParam,
 )
@@ -58,12 +57,37 @@ from memory import (
     user_key,
 )
 from prompts import build_agent_chat_system_prompt, build_chat_system_prompt
-from providers import LLMProvider, LLMProviderStreamError
-from providers import ProviderError
+from providers import LLMProvider
 from services.compaction import ConversationCompactor
 from services.title_generation import generate_title_for_conversation
 from services.usage import UsageContext, UsagePurpose, UsageTracker, track_usage
 from state import AppState
+from streaming.generate import (
+    active_path_tool_call_ids,
+    drop_empty_assistant_messages,
+    message_content_blocks,
+    repair_interrupted_tool_calls,
+    stream_generator,
+    tool_use_blocks,
+)
+from streaming.persist import (
+    EndOfStreamReason,
+    end_of_stream,
+    persist_and_transform,
+)
+from streaming.run import (
+    SSE_HEADERS,
+    _CANCEL_TTL,
+    _RUN_LOCK_TTL,
+    _run_tasks_by_chat,
+    cancel_key,
+    clear_producer_task,
+    consume_run,
+    run_lock_key,
+    run_producer,
+    set_producer_task,
+    stream_key,
+)
 from tools import (
     ConnectorToolHandler,
     DocumentToolHandler,
@@ -91,442 +115,12 @@ router = APIRouter(tags=["chat"])
 logger = logging.getLogger(__name__)
 
 
-def _chat_error_message(exc: Exception) -> str:
-    if isinstance(exc, ProviderError) and exc.message:
-        return f"Failed to generate response: {exc.message}"
-
-    if isinstance(exc, LLMProviderStreamError) and exc.message:
-        return f"Failed to generate response: {exc.message}"
-
-    message = str(exc).strip()
-    if message:
-        return f"Failed to generate response: {message}"
-
-    return "Failed to generate response. Please try again."
-
-
-def _chat_error_payload(exc: Exception) -> "StreamErrorEvent":
-    payload: StreamErrorEvent = {"message": _chat_error_message(exc)}
-    if isinstance(exc, ProviderError):
-        payload["provider"] = exc.provider_type
-        payload["model"] = exc.model
-        payload["statusCode"] = exc.status_code
-    return payload
-
-
-def _sse_event(event_type: str, data: object) -> str:
-    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
-
-
-# --- Decoupled streaming run (survives client disconnect; supports resume) ---
-# The agent loop runs as a background "producer" that writes each SSE event into
-# a per-chat Redis Stream. HTTP requests are thin "consumers" that tail that
-# stream from an offset (SSE Last-Event-ID), so a client that backgrounds/
-# reconnects resumes without interrupting generation. The producer is the single
-# DB writer of the streaming path (persists messages before client-visible
-# message events), which keeps replays free of duplicate writes.
-
-SSE_HEADERS = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
-
-_STREAM_HEARTBEAT_MS = 15000  # idle ping interval (keeps proxies from timing out)
-_RUN_LOCK_TTL = (
-    300  # seconds; refreshed on every produced event and by the heartbeat below
-)
-_LOCK_REFRESH_INTERVAL = 60  # seconds; independent of event production, so a long
-# silent gap in the agent loop (e.g. a slow tool call with no intermediate SSE
-# events) can't let the lock expire while the producer is still running.
-_STREAM_TTL = 300  # seconds a finished stream stays replayable
-_STREAM_MAXLEN = 5000  # cap buffered events per run
-_CANCEL_TTL = 300
-_CANCEL_CHECK_INTERVAL_SECONDS = 1.0
-
-# Producer tasks keyed by chat so an explicit Stop can cancel the right run
-# immediately in-process. The Redis cancel flag handles cross-worker stops.
-_run_tasks_by_chat: dict[str, asyncio.Task] = {}
-
-
-def _stream_key(chat_id: str) -> str:
-    return f"chat:stream:{chat_id}"
-
-
-def _run_lock_key(chat_id: str) -> str:
-    return f"chat:runlock:{chat_id}"
-
-
-def _cancel_key(chat_id: str) -> str:
-    return f"chat:cancel:{chat_id}"
-
-
-async def _is_run_cancelled(redis_client, chat_id: str) -> bool:
-    if redis_client is None:
-        return False
-    try:
-        return bool(await redis_client.exists(_cancel_key(chat_id)))
-    except Exception:
-        return False
-
-
-def _sse_event_type(event_str: str) -> str:
-    for line in event_str.split("\n"):
-        if line.startswith("event:"):
-            return line[len("event:") :].strip()
-    return "message"
-
-
-def _sse_event_data(event_str: str) -> str:
-    for line in event_str.split("\n"):
-        if line.startswith("data:"):
-            return line[len("data:") :].strip()
-    return ""
-
-
-class EndOfStreamReason(str, Enum):
-    """Typed reason for an ``end_of_stream`` terminal event."""
-
-    COMPLETED = "completed"
-    STOPPED = "stopped"
-    APPROVAL_REQUIRED = "approval_required"
-    OAUTH_REQUIRED = "oauth_required"
-    NO_NEW_MESSAGE = "no_new_message"
-
-
-class EndOfStreamEvent(TypedDict):
-    reason: EndOfStreamReason
-    message: NotRequired[str]
-
-
-class StreamErrorEvent(TypedDict):
-    message: str
-    provider: NotRequired[str]
-    model: NotRequired[str]
-    statusCode: NotRequired[int | None]
-
-
-class OAuthRequiredEvent(TypedDict):
-    tool_call_id: str
-    tool_name: str
-    source_id: str
-    source_type: str
-    provider: str
-    oauth_start_url: str
-
-
-def _oauth_event(
-    tool_call_id: str,
-    tool_name: str,
-    source_id: str,
-    source_type: str,
-    provider: str,
-    oauth_start_url: str,
-) -> OAuthRequiredEvent:
-    return {
-        "tool_call_id": tool_call_id,
-        "tool_name": tool_name,
-        "source_id": source_id,
-        "source_type": source_type,
-        "provider": provider,
-        "oauth_start_url": oauth_start_url,
-    }
-
-
-def _stream_error_event(exc: Exception) -> StreamErrorEvent:
-    return _chat_error_payload(exc)
-
-
-def _end_of_stream(reason: EndOfStreamReason, *, message: str | None = None) -> str:
-    """Build a typed ``end_of_stream`` SSE event string."""
-    payload: EndOfStreamEvent = {"reason": reason}
-    if message is not None:
-        payload["message"] = message
-    return _sse_event("end_of_stream", payload)
-
-
-def _partial_assistant_message(
-    content_blocks: list[TextBlockParam | ToolUseBlockParam],
-) -> MessageParam | None:
-    persisted_blocks: list[TextBlockParam | ToolUseBlockParam] = []
-    for block in content_blocks:
-        if block["type"] == "text":
-            text_block = cast(TextBlockParam, block)
-            if text_block["text"].strip():
-                persisted_blocks.append(cast(TextBlockParam, dict(text_block)))
-            continue
-
-        tool_block = cast(ToolUseBlockParam, dict(block))
-        raw_input = tool_block.get("input")
-        if isinstance(raw_input, str):
-            try:
-                tool_block["input"] = json.loads(raw_input) if raw_input else {}
-            except json.JSONDecodeError:
-                tool_block["input"] = {}
-        persisted_blocks.append(tool_block)
-
-    if not persisted_blocks:
-        return None
-
-    return MessageParam(role="assistant", content=persisted_blocks)
-
-
-def _parse_tool_call_inputs(
-    tool_calls: list[ToolUseBlockParam],
-) -> list[ToolResultBlockParam]:
-    parse_errors: list[ToolResultBlockParam] = []
-    for tool_call in tool_calls:
-        raw_input = cast(str, tool_call["input"])
-        try:
-            tool_call["input"] = json.loads(raw_input)
-        except json.JSONDecodeError as e:
-            logger.warning(
-                "Failed to parse tool call input for %s: %s. Raw input: %s",
-                tool_call["name"],
-                e,
-                raw_input,
-            )
-            raw_input_preview = raw_input[:4000]
-            if len(raw_input) > len(raw_input_preview):
-                raw_input_preview += "... [truncated]"
-            tool_call["input"] = {}
-            parse_errors.append(
-                ToolResultBlockParam(
-                    type="tool_result",
-                    tool_use_id=tool_call["id"],
-                    content=[
-                        {
-                            "type": "text",
-                            "text": (
-                                f"Invalid JSON in tool input: {e}. "
-                                "The tool was not executed. Retry with valid JSON.\n\n"
-                                f"Raw tool input:\n{raw_input_preview}"
-                            ),
-                        }
-                    ],
-                    is_error=True,
-                )
-            )
-    return parse_errors
-
-
-async def _persist_and_transform(gen, chat_id, messages_repo, parent_id):
-    """Persist streamed messages before exposing them to the client.
-
-    Assistant rows are created as soon as the provider emits message_start, so
-    the browser can use a durable chat_messages.id for the streaming bubble from
-    the beginning. Tool-result rows are persisted before their tool_result events
-    are forwarded. This keeps frontend render identities and future parent_id
-    values database-backed even if the run is cancelled mid-stream.
-    """
-    current_assistant_message_id: str | None = None
-    buffered_tool_result_events: list[str] = []
-
-    async for event_str in gen:
-        event_type = _sse_event_type(event_str)
-        event_data = _sse_event_data(event_str)
-
-        if event_type == "message":
-            try:
-                message_event = json.loads(event_data)
-            except json.JSONDecodeError:
-                yield event_str
-                continue
-
-            if message_event.get("type") == "message_start":
-                try:
-                    provider_message = message_event.get("message", {})
-                    assistant_message = {
-                        "role": provider_message.get("role", "assistant"),
-                        "content": provider_message.get("content") or [],
-                    }
-                    created = await messages_repo.create(
-                        chat_id, assistant_message, parent_id=parent_id
-                    )
-                    current_assistant_message_id = created.id
-                    parent_id = created.id
-                    message_event.setdefault("message", {})["id"] = created.id
-                    event_str = _sse_event("message", message_event)
-                except Exception as e:
-                    logger.error(
-                        f"Failed to pre-persist assistant message for chat {chat_id}: {e}",
-                        exc_info=True,
-                    )
-                yield event_str
-                continue
-
-            if message_event.get("type") == "tool_result":
-                buffered_tool_result_events.append(event_str)
-                continue
-
-            yield event_str
-            continue
-
-        if event_type == "save_message":
-            try:
-                message = json.loads(event_data)
-                if message.get("role") == "assistant" and current_assistant_message_id:
-                    await messages_repo.update_message_content(
-                        current_assistant_message_id, message
-                    )
-                    await messages_repo.update_content_text(
-                        current_assistant_message_id, message
-                    )
-                    current_assistant_message_id = None
-                    continue
-
-                created = await messages_repo.create(
-                    chat_id, message, parent_id=parent_id
-                )
-                parent_id = created.id
-
-                if message.get("role") == "user" and buffered_tool_result_events:
-                    for buffered_event in buffered_tool_result_events:
-                        try:
-                            tool_result_event = json.loads(_sse_event_data(buffered_event))
-                            tool_result_event["message_id"] = created.id
-                            yield _sse_event("message", tool_result_event)
-                        except json.JSONDecodeError:
-                            yield buffered_event
-                    buffered_tool_result_events = []
-                else:
-                    yield f"event: message_id\ndata: {created.id}\n\n"
-            except Exception as e:
-                logger.error(
-                    f"Failed to persist streamed message for chat {chat_id}: {e}",
-                    exc_info=True,
-                )
-            continue
-
-        yield event_str
-
-    # If the generator ended (cancel/error/client disconnect) without a
-    # matching save_message, the early-persisted assistant row was never
-    # finalized. With partial content the generator emits save_message itself;
-    # reaching here with the id still set means no content was ever committed,
-    # so delete the empty row rather than leave an invalid assistant message
-    # that would poison the next request's history.
-    if current_assistant_message_id is not None:
-        try:
-            await messages_repo.delete(current_assistant_message_id)
-            logger.info(
-                f"Deleted unfinalized assistant message "
-                f"{current_assistant_message_id} for chat {chat_id}"
-            )
-        except Exception as e:
-            logger.error(
-                f"Failed to delete unfinalized assistant message "
-                f"{current_assistant_message_id} for chat {chat_id}: {e}"
-            )
-        current_assistant_message_id = None
-
-
-async def _refresh_lock_periodically(redis_client, lock_key):
-    """Keep the run lock alive independently of event production, so a long
-    silent gap in the agent loop doesn't let it expire mid-run."""
-    while True:
-        await asyncio.sleep(_LOCK_REFRESH_INTERVAL)
-        await redis_client.expire(lock_key, _RUN_LOCK_TTL)
-
-
-async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
-    """Background task: drive the agent loop to completion independently of any
-    client connection, buffering every SSE event in a Redis Stream."""
-    stream_key = _stream_key(chat_id)
-    lock_key = _run_lock_key(chat_id)
-    refresh_task = asyncio.create_task(
-        _refresh_lock_periodically(redis_client, lock_key)
-    )
-    try:
-        async for event_str in _persist_and_transform(
-            gen, chat_id, messages_repo, parent_id
-        ):
-            await redis_client.xadd(
-                stream_key,
-                {"e": event_str},
-                maxlen=_STREAM_MAXLEN,
-                approximate=True,
-            )
-            await redis_client.expire(lock_key, _RUN_LOCK_TTL)
-    except asyncio.CancelledError:
-        # Explicit Stop cancelled this producer task. Emit a terminal event so
-        # any still-attached consumer ends cleanly instead of seeing the lock
-        # disappear and reporting "Generation ended unexpectedly".
-        try:
-            await redis_client.xadd(
-                stream_key, {"e": _end_of_stream(EndOfStreamReason.STOPPED)}
-            )
-        except Exception:
-            pass
-        raise
-    except Exception as e:
-        logger.error(f"Producer failed for chat {chat_id}: {e}", exc_info=True)
-        try:
-            await redis_client.xadd(
-                stream_key,
-                {"e": _sse_event("stream_error", _stream_error_event(e))},
-            )
-        except Exception:
-            pass
-    finally:
-        refresh_task.cancel()
-        try:
-            await refresh_task
-        except asyncio.CancelledError:
-            pass
-        for coro in (
-            redis_client.expire(stream_key, _STREAM_TTL),
-            redis_client.delete(lock_key),
-            redis_client.delete(_cancel_key(chat_id)),
-        ):
-            try:
-                await coro
-            except Exception:
-                pass
-
-
-async def _consume_run(redis_client, chat_id, start_id):
-    """Thin consumer: tail the Redis Stream from `start_id`, prefixing each event
-    with its Redis id (SSE `id:`) for Last-Event-ID resume. Emits heartbeats
-    while idle and a terminal event if the producer vanished.
-
-    Important id: invariant: no producer may template an ``id:`` line into its
-    own event body because this function prepends ``id: {entry_id}`` (the Redis
-    stream entry id) unconditionally. Heartbeats and synthetic terminal events
-    intentionally lack an id so they don't advance the resume position."""
-    stream_key = _stream_key(chat_id)
-    lock_key = _run_lock_key(chat_id)
-    last = start_id or "0"
-    while True:
-        resp = await redis_client.xread(
-            {stream_key: last}, block=_STREAM_HEARTBEAT_MS, count=200
-        )
-        if resp:
-            for _key, entries in resp:
-                for entry_id, fields in entries:
-                    last = entry_id
-                    event_str = fields.get("e", "")
-                    yield f"id: {entry_id}\n{event_str}"
-                    if _sse_event_type(event_str) in ("end_of_stream", "stream_error"):
-                        return
-            continue
-        # Idle: no new events within the heartbeat window.
-        if not await redis_client.exists(stream_key):
-            if await redis_client.exists(lock_key):
-                # Producer just started and hasn't written its first event yet.
-                yield _sse_event("heartbeat", {})
-                continue
-            yield "event: not_resumable\ndata: \n\n"
-            return
-        if not await redis_client.exists(lock_key):
-            # Producer is gone but never wrote a terminal event we forwarded.
-            yield _sse_event(
-                "stream_error", StreamErrorEvent(message="Generation ended unexpectedly.")
-            )
-            return
-        yield _sse_event("heartbeat", {})
+# ---------------------------------------------------------------------------
+# Provider resolution helpers
+# ---------------------------------------------------------------------------
 
 
 def _resolve_provider(state: AppState, model_id: str | None) -> LLMProvider:
-    """Resolve a model by ID, returning the provider.
-    Priority: requested model -> default model -> first available.
-    """
     models = state.models
     if not models:
         raise HTTPException(status_code=503, detail="No models configured")
@@ -539,73 +133,21 @@ def _resolve_provider(state: AppState, model_id: str | None) -> LLMProvider:
 
 
 def _resolve_llm_provider(state: AppState, chat: Chat) -> LLMProvider:
-    """Resolve which LLM provider to use for a chat."""
     return _resolve_provider(state, chat.model_id)
 
 
 def _resolve_secondary_provider(state: AppState) -> LLMProvider:
-    """Resolve the secondary (lightweight) model provider.
-    Used for title generation, suggested questions, compaction, etc.
-    """
     return _resolve_provider(state, state.secondary_model_id or state.default_model_id)
 
 
-def convert_citation_to_param(citation_delta: CitationsDelta) -> TextCitationParam:
-    citation = citation_delta.citation
-    if citation.type == "char_location":
-        return CitationCharLocationParam(
-            type="char_location",
-            start_char_index=citation.start_char_index,
-            end_char_index=citation.end_char_index,
-            document_title=citation.document_title,
-            document_index=citation.document_index,
-            cited_text=citation.cited_text,
-        )
-    elif citation.type == "page_location":
-        return CitationPageLocationParam(
-            type="page_location",
-            start_page_number=citation.start_page_number,
-            end_page_number=citation.end_page_number,
-            document_title=citation.document_title,
-            document_index=citation.document_index,
-            cited_text=citation.cited_text,
-        )
-    elif citation.type == "content_block_location":
-        return CitationContentBlockLocationParam(
-            type="content_block_location",
-            start_block_index=citation.start_block_index,
-            end_block_index=citation.end_block_index,
-            document_title=citation.document_title,
-            document_index=citation.document_index,
-            cited_text=citation.cited_text,
-        )
-    elif citation.type == "search_result_location":
-        return CitationSearchResultLocationParam(
-            type="search_result_location",
-            start_block_index=citation.start_block_index,
-            end_block_index=citation.end_block_index,
-            search_result_index=citation.search_result_index,
-            title=citation.title,
-            source=citation.source,
-            cited_text=citation.cited_text,
-        )
-    elif citation.type == "web_search_result_location":
-        return CitationWebSearchResultLocationParam(
-            type="web_search_result_location",
-            url=citation.url,
-            title=citation.title,
-            encrypted_index=citation.encrypted_index,
-            cited_text=citation.cited_text,
-        )
-    else:
-        raise ValueError(f"Unknown citation type: {citation.type}")
+# ---------------------------------------------------------------------------
+# Registry building helpers
+# ---------------------------------------------------------------------------
 
 
 @dataclass
 class RegistryResult:
     registry: ToolRegistry
-    # Handlers whose tools are always exposed in the LLM's per-turn tool list
-    # (built-ins + meta-tools). Connector tools are handled separately.
     always_on_handlers: list[ToolHandler]
     connector_handler: ConnectorToolHandler | None
     toolsets: list[ToolsetSummary]
@@ -616,12 +158,11 @@ class RegistryResult:
 def _loaded_tools_from_history(
     messages: list[MessageParam], connector_handler: ConnectorToolHandler
 ) -> set[str]:
-    """Rebuild loaded connector tool names from successful meta-tool calls."""
     tool_calls: dict[str, ToolUseBlockParam] = {}
     loaded: set[str] = set()
 
     for message in messages:
-        for block in _message_content_blocks(message):
+        for block in message_content_blocks(message):
             match block["type"]:
                 case "tool_use":
                     tool_use = cast(ToolUseBlockParam, block)
@@ -642,150 +183,6 @@ def _loaded_tools_from_history(
                     continue
 
     return loaded
-
-
-def _message_content_blocks(message: MessageParam) -> list[ContentBlockParam]:
-    content = message["content"]
-    if isinstance(content, str):
-        return []
-    return list(cast(Iterable[ContentBlockParam], content))
-
-
-def _interrupted_tool_result(tool_use: ToolUseBlockParam) -> ToolResultBlockParam:
-    return ToolResultBlockParam(
-        type="tool_result",
-        tool_use_id=tool_use["id"],
-        content=[
-            {
-                "type": "text",
-                "text": (
-                    f"Tool call {tool_use['name']} did not complete because the previous response was interrupted. "
-                    "Treat this tool call as failed and retry it if the result is still needed."
-                ),
-            }
-        ],
-        is_error=True,
-    )
-
-
-def _tool_use_blocks(message: MessageParam) -> list[ToolUseBlockParam]:
-    if message.get("role") != "assistant":
-        return []
-    return [
-        cast(ToolUseBlockParam, block)
-        for block in _message_content_blocks(message)
-        if block["type"] == "tool_use"
-    ]
-
-
-def _tool_result_ids(message: MessageParam) -> set[str]:
-    if message.get("role") != "user":
-        return set()
-    return {
-        cast(ToolResultBlockParam, block)["tool_use_id"]
-        for block in _message_content_blocks(message)
-        if block["type"] == "tool_result"
-    }
-
-
-def _repair_interrupted_tool_calls(
-    messages: list[MessageParam],
-) -> tuple[list[MessageParam], int]:
-    repaired: list[MessageParam] = []
-    repair_count = 0
-
-    for idx, message in enumerate(messages):
-        tool_uses = _tool_use_blocks(message)
-        if not tool_uses:
-            repaired.append(message)
-            continue
-
-        next_message = messages[idx + 1] if idx + 1 < len(messages) else None
-        answered_ids = _tool_result_ids(next_message) if next_message else set()
-        missing = [
-            tool_use for tool_use in tool_uses if tool_use["id"] not in answered_ids
-        ]
-
-        repaired.append(message)
-        if not missing:
-            continue
-
-        missing_results = [_interrupted_tool_result(tool_use) for tool_use in missing]
-        if answered_ids and next_message is not None:
-            content = next_message["content"]
-            if isinstance(content, list):
-                next_message = cast(MessageParam, dict(next_message))
-                next_message["content"] = [*content, *missing_results]
-                messages[idx + 1] = next_message
-                repair_count += len(missing_results)
-                continue
-
-        repaired.append(MessageParam(role="user", content=missing_results))
-        repair_count += len(missing_results)
-
-    return repaired, repair_count
-
-
-def _drop_empty_assistant_messages(
-    messages: list[MessageParam],
-) -> list[MessageParam]:
-    """Remove assistant messages that have no content and no tool_use blocks.
-
-    A streamed assistant row that was early-persisted at message_start but never
-    finalized (stream cancelled/errored before any content block) can be left as
-    {"role": "assistant", "content": []}. Providers reject such messages
-    ("content or tool_calls must be set"), so drop them from the history before
-    sending. They contribute nothing to the conversation.
-    """
-    kept: list[MessageParam] = []
-    for message in messages:
-        if message.get("role") == "assistant":
-            blocks = _message_content_blocks(message)
-            has_tool_use = any(b.get("type") == "tool_use" for b in blocks)
-            has_content = bool(blocks) and any(
-                b.get("type") == "text" and b.get("text") for b in blocks
-            )
-            if not has_tool_use and not has_content:
-                continue
-        kept.append(message)
-    return kept
-
-
-def _extract_text_for_title(
-    content: str | list[ContentBlockParam] | None,
-) -> str | None:
-    if isinstance(content, str):
-        text = content.strip()
-        return text if text else None
-
-    if not isinstance(content, list):
-        return None
-
-    parts: list[str] = []
-    for block in content:
-        if not isinstance(block, dict):
-            continue
-        if block.get("type") != "text":
-            continue
-        text = block.get("text")
-        if isinstance(text, str) and text.strip():
-            parts.append(text.strip())
-
-    if not parts:
-        return None
-    return "\n".join(parts)
-
-
-def _loaded_source_ids(
-    loaded_tool_names: set[str], connector_handler: ConnectorToolHandler | None
-) -> set[str]:
-    if connector_handler is None:
-        return set()
-    return {
-        action.source_id
-        for tool_name, action in connector_handler.actions.items()
-        if tool_name in loaded_tool_names
-    }
 
 
 def _loaded_tools_from_meta_call(
@@ -815,21 +212,19 @@ def _loaded_tools_from_meta_call(
     return set()
 
 
-def _copy_provider_extras(src: object, dst: dict, keys: tuple[str, ...]) -> None:
-    """Copy provider-declared sidecar fields off a Pydantic content_block
-    instance onto its persisted TypedDict block.
-
-    The set of keys is owned by each ``LLMProvider`` subclass via
-    ``PERSISTED_BLOCK_EXTRAS`` — chat.py stays provider-agnostic.
-    """
-    for key in keys:
-        value = getattr(src, key, None)
-        if value is not None:
-            dst[key] = value  # type: ignore[typeddict-unknown-key]
+def _loaded_source_ids(
+    loaded_tool_names: set[str], connector_handler: ConnectorToolHandler | None
+) -> set[str]:
+    if connector_handler is None:
+        return set()
+    return {
+        action.source_id
+        for tool_name, action in connector_handler.actions.items()
+        if tool_name in loaded_tool_names
+    }
 
 
 async def _fetch_sources_from_connector_manager() -> list[Source] | None:
-    """Fetch all sources from the connector manager. Returns None on failure."""
     try:
         async with httpx.AsyncClient(timeout=10.0) as client:
             resp = await client.get(f"{CONNECTOR_MANAGER_URL.rstrip('/')}/sources")
@@ -840,6 +235,10 @@ async def _fetch_sources_from_connector_manager() -> list[Source] | None:
         return None
 
 
+async def _noop_on_load(_: set[str]) -> None:
+    return None
+
+
 async def _build_registry(
     request: Request,
     chat: Chat,
@@ -847,18 +246,9 @@ async def _build_registry(
     loaded_toolsets: set[str],
     on_load: OnLoad | None = None,
 ) -> RegistryResult:
-    """Build a ToolRegistry with all available handlers.
-
-    Connector tools are registered for *dispatch* but not for *exposure*: the
-    chat router rebuilds the per-turn LLM tool list from `always_on_handlers`
-    plus `connector_handler.filtered_tools(loaded_toolsets)` so the model only
-    sees connector actions it has explicitly loaded via `load_tool` or
-    `load_tool_set` (issue #203).
-    """
     registry = ToolRegistry()
     always_on_handlers: list[ToolHandler] = []
 
-    # Fetch sources from connector manager once, share with all handlers
     sources = await _fetch_sources_from_connector_manager() or []
 
     connector_handler: ConnectorToolHandler | None = None
@@ -875,7 +265,6 @@ async def _build_registry(
         is_admin=is_admin,
     )
     await connector_handler._ensure_initialized()
-    # Register for dispatch / requires_approval; tool exposure is filtered per-turn.
     registry.register(connector_handler)
 
     if connector_handler.actions:
@@ -884,9 +273,6 @@ async def _build_registry(
     if connector_handler.search_operators:
         search_operators = connector_handler.search_operators
 
-    # Meta-tools: discoverable as always-on so the LLM can opt in to specific
-    # connector tools. Only register when there's actually a connector handler
-    # with toolsets to advertise.
     if connector_handler is not None and toolsets:
         meta_handler = MetaToolHandler(
             connector_handler=connector_handler,
@@ -909,7 +295,6 @@ async def _build_registry(
         registry.register(mcp_handler)
         always_on_handlers.append(mcp_handler)
 
-    # Fetch dynamic operator values for enriched search tool description
     active_sources = [s for s in sources if s.is_active and not s.is_deleted]
     connected_source_types = list({s.source_type for s in active_sources})
     operator_values: dict[str, list[str]] = {}
@@ -920,7 +305,6 @@ async def _build_registry(
             redis_client=request.app.state.redis_client,
         )
 
-    # Register search tools (with dynamic operators from connector manifests)
     search_handler = SearchToolHandler(
         searcher_tool=request.app.state.searcher_tool,
         search_operators=search_operators,
@@ -939,12 +323,10 @@ async def _build_registry(
         registry.register(web_handler)
         always_on_handlers.append(web_handler)
 
-    # Register people search tool
     people_handler = PeopleSearchHandler(searcher_tool=request.app.state.searcher_tool)
     registry.register(people_handler)
     always_on_handlers.append(people_handler)
 
-    # Register document handler (unified read_document tool)
     content_storage = getattr(request.app.state, "content_storage", None)
     document_handler = DocumentToolHandler(
         content_storage=content_storage,
@@ -955,13 +337,11 @@ async def _build_registry(
     registry.register(document_handler)
     always_on_handlers.append(document_handler)
 
-    # Register sandbox tools if sandbox service is configured
     if SANDBOX_URL:
         sandbox_handler = SandboxToolHandler(sandbox_url=SANDBOX_URL)
         registry.register(sandbox_handler)
         always_on_handlers.append(sandbox_handler)
 
-    # Register skill loader (load_skill tool)
     skills_dir = pathlib.Path(__file__).resolve().parent.parent / "skills"
     skill_handler = SkillHandler(
         skills_dir=skills_dir,
@@ -984,20 +364,9 @@ async def _build_registry(
     )
 
 
-async def _noop_on_load(_: set[str]) -> None:
-    """Default on_load when no persistence is wired up (e.g. agent chat)."""
-    return None
-
-
 async def _build_agent_chat_registry(
     request: Request, agent: Agent, is_admin: bool
 ) -> RegistryResult:
-    """Build a read-only ToolRegistry for agent chat sessions.
-
-    Uses the agent's own permissions (matching the background executor):
-    org agents read across everything; user agents are scoped by allowed_sources.
-    Write/connector-action tools are intentionally not registered — agent chats are read-only.
-    """
     registry = ToolRegistry()
     always_on_handlers: list[ToolHandler] = []
 
@@ -1005,7 +374,6 @@ async def _build_agent_chat_registry(
 
     source_filter = _build_source_filter(agent) if agent.agent_type == "user" else None
 
-    # We still need connector handler for search operators, but won't register it
     search_operators: list[SearchOperator] = []
     connector_handler = ConnectorToolHandler(
         connector_manager_url=CONNECTOR_MANAGER_URL,
@@ -1101,52 +469,39 @@ async def _build_agent_chat_registry(
     )
 
 
-class ApprovalRequiredEventItem(TypedDict):
-    approval_id: str
-    tool_name: str
-    tool_input: dict[str, Any]
-    tool_call_id: str | None
-    source_id: str | None
-    source_type: str | None
+# ---------------------------------------------------------------------------
+# Title-generation helper
+# ---------------------------------------------------------------------------
 
 
-class ApprovalRequiredEvent(ApprovalRequiredEventItem):
-    approvals: list[ApprovalRequiredEventItem]
+def _extract_text_for_title(
+    content: str | list[ContentBlockParam] | None,
+) -> str | None:
+    if isinstance(content, str):
+        text = content.strip()
+        return text if text else None
+
+    if not isinstance(content, list):
+        return None
+
+    parts: list[str] = []
+    for block in content:
+        if not isinstance(block, dict):
+            continue
+        if block.get("type") != "text":
+            continue
+        text = block.get("text")
+        if isinstance(text, str) and text.strip():
+            parts.append(text.strip())
+
+    if not parts:
+        return None
+    return "\n".join(parts)
 
 
-async def _active_path_tool_call_ids(
-    messages_repo: MessagesRepository, chat_id: str
-) -> set[str]:
-    active_path = await messages_repo.get_active_path(chat_id)
-    return {
-        tool_use["id"]
-        for message in active_path
-        for tool_use in _tool_use_blocks(MessageParam(**message.message))
-    }
-
-
-def _approval_required_event(approvals: list[ToolApproval]) -> ApprovalRequiredEvent:
-    first = approvals[0]
-    event: ApprovalRequiredEvent = {
-        "approval_id": first.id,
-        "tool_name": first.tool_name,
-        "tool_input": first.tool_input,
-        "tool_call_id": first.tool_call_id,
-        "source_id": first.source_id,
-        "source_type": first.source_type,
-        "approvals": [
-            {
-                "approval_id": approval.id,
-                "tool_name": approval.tool_name,
-                "tool_input": approval.tool_input,
-                "tool_call_id": approval.tool_call_id,
-                "source_id": approval.source_id,
-                "source_type": approval.source_type,
-            }
-            for approval in approvals
-        ],
-    }
-    return event
+# ---------------------------------------------------------------------------
+# Route: stream status
+# ---------------------------------------------------------------------------
 
 
 @router.get("/chat/{chat_id}/stream/status")
@@ -1156,13 +511,13 @@ async def stream_status(
     redis_client = getattr(request.app.state, "redis_client", None)
     messages_repo = MessagesRepository()
     approvals_repo = ToolApprovalsRepository()
-    active_tool_call_ids = await _active_path_tool_call_ids(messages_repo, chat_id)
+    active_tool_call_ids_set = await active_path_tool_call_ids(messages_repo, chat_id)
     pending_approval = bool(
         await approvals_repo.list_for_chat(
             chat_id=chat_id,
             approval_type=ToolApprovalType.APPROVAL,
             statuses={ToolApprovalStatus.PENDING},
-            active_tool_call_ids=active_tool_call_ids,
+            active_tool_call_ids=active_tool_call_ids_set,
         )
     )
     pending_oauth = bool(
@@ -1170,19 +525,510 @@ async def stream_status(
             chat_id=chat_id,
             approval_type=ToolApprovalType.OAUTH,
             statuses={ToolApprovalStatus.PENDING},
-            active_tool_call_ids=active_tool_call_ids,
+            active_tool_call_ids=active_tool_call_ids_set,
         )
     )
     if redis_client is None:
         raise HTTPException(status_code=500, detail="Redis client is not initialized")
 
     return {
-        "running": bool(await redis_client.exists(_run_lock_key(chat_id))),
-        "resumable": bool(await redis_client.exists(_stream_key(chat_id))),
+        "running": bool(await redis_client.exists(run_lock_key(chat_id))),
+        "resumable": bool(await redis_client.exists(stream_key(chat_id))),
         "pending_approval": pending_approval,
         "pending_oauth": pending_oauth,
     }
 
+
+# ---------------------------------------------------------------------------
+# Route: stream chat (main handler)
+# ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# Stream chat handler
+# ---------------------------------------------------------------------------
+
+class StreamChatHandler:
+    def __init__(self, request: Request, chat_id: str, auto_start: bool) -> None:
+        self.request = request
+        self.chat_id = chat_id
+        self.auto_start = auto_start
+
+    async def handle(self) -> StreamingResponse:
+        """Stream AI response for a chat thread using Server-Sent Events"""
+        request = self.request
+        chat_id = self.chat_id
+        auto_start = self.auto_start
+
+        if not request.app.state.searcher_tool:
+            raise HTTPException(status_code=500, detail="Searcher tool not initialized")
+
+        chats_repo = ChatsRepository()
+        chat = await chats_repo.get(chat_id)
+        if not chat:
+            raise HTTPException(status_code=404, detail="Chat thread not found")
+
+        llm_provider = _resolve_llm_provider(request.app.state, chat)
+        redis_client = request.app.state.redis_client
+
+        # Reconnect/resume fast path
+        last_event_id = request.headers.get("last-event-id") or request.query_params.get(
+            "last_event_id"
+        )
+        if redis_client is not None:
+            run_active = await redis_client.exists(run_lock_key(chat_id))
+            if run_active:
+                return StreamingResponse(
+                    consume_run(redis_client, chat_id, last_event_id or "0"),
+                    media_type="text/event-stream",
+                    headers=SSE_HEADERS,
+                )
+
+            if last_event_id is not None:
+                if await redis_client.exists(stream_key(chat_id)):
+                    return StreamingResponse(
+                        consume_run(redis_client, chat_id, last_event_id),
+                        media_type="text/event-stream",
+                        headers=SSE_HEADERS,
+                    )
+
+                async def _not_resumable_response():
+                    yield "event: not_resumable\ndata: \n\n"
+
+                return StreamingResponse(
+                    _not_resumable_response(),
+                    media_type="text/event-stream",
+                    headers=SSE_HEADERS,
+                )
+
+        messages_repo = MessagesRepository()
+        approvals_repo = ToolApprovalsRepository()
+        chat_messages = await messages_repo.get_active_path(chat_id)
+
+        # Shared state scoped to this request
+        memory_provider = None
+        effective_mode = MemoryMode.OFF
+        memories: list[str] = []
+        memory_write_key: str | None = None
+        pending: list[ToolApproval] = []
+        pending_oauth: list[ToolApproval] = []
+
+        if chat.agent_id:
+            # ---- Agent chat setup ----
+            agent_repo = AgentRepository()
+            agent = await agent_repo.get_agent(chat.agent_id)
+            if not agent:
+                raise HTTPException(status_code=404, detail="Agent not found")
+
+            users_repo = UsersRepository()
+            chat_user = await users_repo.find_by_id(chat.user_id)
+            if not chat_user:
+                raise HTTPException(status_code=404, detail="Chat user not found")
+
+            if agent.agent_type == "org":
+                if chat_user.role != "admin":
+                    raise HTTPException(
+                        status_code=403,
+                        detail="Admin access required for org agent chats",
+                    )
+            elif agent.user_id != chat.user_id:
+                raise HTTPException(
+                    status_code=403,
+                    detail="Only the agent owner can chat with this agent",
+                )
+
+            is_org_agent = agent.agent_type == "org"
+            tool_user_id = None if is_org_agent else agent.user_id
+            tool_skip_perm = is_org_agent
+
+            user_email = chat_user.email
+            user_name = chat_user.full_name
+            user_configuration = chat_user.configuration
+
+            if not chat_messages:
+                if auto_start:
+                    chat_messages = []
+                else:
+                    raise HTTPException(
+                        status_code=404, detail="No messages found for chat"
+                    )
+
+            build_result = await _build_agent_chat_registry(
+                request, agent, is_admin=chat_user.role == "admin"
+            )
+            registry = build_result.registry
+            loaded_toolsets: set[str] = set()
+            pending = []
+            pending_oauth = []
+
+            run_repo = AgentRunRepository()
+            runs = await run_repo.list_runs(agent.id, limit=20)
+            active_sources = [
+                s for s in build_result.sources if s.is_active and not s.is_deleted
+            ]
+
+            memory_provider = request.app.state.memory_provider
+            effective_mode = MemoryMode.OFF
+            memories = []
+            if memory_provider is not None:
+                config_repo = ConfigurationRepository()
+                org_default = (
+                    await config_repo.get_global_configuration()
+                ).memory_mode_default
+                if is_org_agent:
+                    effective_mode = org_default
+                elif user_configuration is not None:
+                    effective_mode = resolve_memory_mode(
+                        user_configuration.memory_mode, org_default
+                    )
+                memory_namespace = agent_key(agent.id)
+                if effective_mode >= MemoryMode.CHAT and chat_messages:
+                    last_user_text = ""
+                    for msg in reversed(chat_messages):
+                        m = msg.message
+                        if m.get("role") == "user":
+                            content = m.get("content", "")
+                            if isinstance(content, str):
+                                last_user_text = content
+                            elif isinstance(content, list):
+                                last_user_text = " ".join(
+                                    b.get("text", "")
+                                    for b in content
+                                    if isinstance(b, dict) and b.get("type") == "text"
+                                )
+                            break
+                    if last_user_text:
+                        hits = await memory_provider.search(
+                            query=last_user_text, key=memory_namespace, limit=5
+                        )
+                        memories = [h.record.text for h in hits if h.record.text]
+
+            system_prompt = build_agent_chat_system_prompt(
+                agent,
+                runs,
+                active_sources,
+                user_name=user_name,
+                user_email=user_email,
+                memories=memories if memories else None,
+                user_configuration=user_configuration,
+                include_web_search=getattr(request.app.state, "web_search_provider", None)
+                is not None,
+                include_fetch_web_page=getattr(
+                    request.app.state, "web_fetch_provider", None
+                )
+                is not None,
+            )
+
+            messages: list[MessageParam] = [
+                MessageParam(**msg.message) for msg in chat_messages
+            ]
+            needs_start = not messages or messages[-1].get("role") != "user"
+            if auto_start and needs_start:
+                messages.append(MessageParam(role="user", content="Go."))
+
+        else:
+            # ---- Regular chat setup ----
+            tool_user_id = chat.user_id
+            tool_skip_perm = False
+            user_email: str | None = None
+            user_name: str | None = None
+            user_configuration: UserConfiguration | None = None
+            is_admin = False
+            if chat.user_id:
+                users_repo = UsersRepository()
+                user = await users_repo.find_by_id(chat.user_id)
+                if user:
+                    user_email = user.email
+                    user_name = user.full_name
+                    user_configuration = user.configuration
+                    is_admin = user.role == "admin"
+
+            if not chat_messages:
+                raise HTTPException(status_code=404, detail="No messages found for chat")
+
+            messages = [MessageParam(**msg.message) for msg in chat_messages]
+
+            loaded_toolsets = set()
+
+            build_result = await _build_registry(
+                request,
+                chat,
+                is_admin=is_admin,
+                loaded_toolsets=loaded_toolsets,
+            )
+            if build_result.connector_handler is not None:
+                loaded_toolsets.update(
+                    _loaded_tools_from_history(messages, build_result.connector_handler)
+                )
+            registry = build_result.registry
+
+            active_tool_call_ids_set = {
+                tool_use["id"]
+                for message in messages
+                for tool_use in tool_use_blocks(message)
+            }
+            pending = await approvals_repo.list_for_chat(
+                chat_id=chat_id,
+                approval_type=ToolApprovalType.APPROVAL,
+                statuses={
+                    ToolApprovalStatus.PENDING,
+                    ToolApprovalStatus.APPROVED,
+                    ToolApprovalStatus.DENIED,
+                },
+                active_tool_call_ids=active_tool_call_ids_set,
+            )
+            pending_oauth = await approvals_repo.list_for_chat(
+                chat_id=chat_id,
+                approval_type=ToolApprovalType.OAUTH,
+                statuses={ToolApprovalStatus.PENDING},
+                active_tool_call_ids=active_tool_call_ids_set,
+            )
+
+            active_sources = [
+                s for s in build_result.sources if s.is_active and not s.is_deleted
+            ]
+
+            memory_provider = request.app.state.memory_provider
+            memories = []
+            effective_mode = MemoryMode.OFF
+            if memory_provider is not None and chat.user_id:
+                memory_write_key = user_key(chat.user_id)
+                config_repo = ConfigurationRepository()
+                org_default = (
+                    await config_repo.get_global_configuration()
+                ).memory_mode_default
+                user_memory_mode = (
+                    user_configuration.memory_mode if user_configuration else None
+                )
+                effective_mode = resolve_memory_mode(user_memory_mode, org_default)
+                if effective_mode >= MemoryMode.CHAT:
+                    last_user_text = ""
+                    for msg in reversed(chat_messages):
+                        m = msg.message
+                        if m.get("role") == "user":
+                            content = m.get("content", "")
+                            if isinstance(content, str):
+                                last_user_text = content
+                            elif isinstance(content, list):
+                                last_user_text = " ".join(
+                                    b.get("text", "")
+                                    for b in content
+                                    if isinstance(b, dict) and b.get("type") == "text"
+                                )
+                            break
+                    if last_user_text:
+                        hits = await memory_provider.search(
+                            query=last_user_text,
+                            key=user_key(chat.user_id),
+                            limit=5,
+                        )
+                        memories = [h.record.text for h in hits if h.record.text]
+
+            loaded_source_ids = _loaded_source_ids(
+                loaded_toolsets, build_result.connector_handler
+            )
+            system_prompt = build_chat_system_prompt(
+                active_sources,
+                toolsets=build_result.toolsets,
+                loaded_source_ids=loaded_source_ids,
+                user_name=user_name,
+                user_email=user_email,
+                memories=memories if memories else None,
+                user_configuration=user_configuration,
+                include_web_search=getattr(request.app.state, "web_search_provider", None)
+                is not None,
+                include_fetch_web_page=getattr(
+                    request.app.state, "web_fetch_provider", None
+                )
+                is not None,
+            )
+
+        # ---- Common setup (repair, compaction, etc.) ----
+        if not pending and not pending_oauth:
+            messages, repaired_tool_calls = repair_interrupted_tool_calls(messages)
+            if repaired_tool_calls:
+                logger.warning(
+                    f"Inserted {repaired_tool_calls} failed tool_result placeholder(s) for interrupted tool calls in chat {chat_id}"
+                )
+            before = len(messages)
+            messages = drop_empty_assistant_messages(messages)
+            dropped = before - len(messages)
+            if dropped:
+                logger.warning(
+                    f"Dropped {dropped} empty assistant message(s) from history for chat {chat_id}"
+                )
+
+        storage = request.app.state.content_storage
+        if storage is not None:
+            messages = await expand_uploads(
+                messages,
+                chat_id=chat_id,
+                storage=storage,
+                uploads_repo=UploadsRepository(),
+                sandbox_url=SANDBOX_URL,
+            )
+
+        last_message_role = messages[-1].get("role") if messages else None
+        if not pending and not pending_oauth and last_message_role != "user":
+            logger.info(
+                f"Last message is not from user, no processing needed. Chat ID: {chat_id}"
+            )
+
+            async def empty_generator():
+                yield end_of_stream(
+                    EndOfStreamReason.NO_NEW_MESSAGE,
+                    message="No new user message to process.",
+                ).encode()
+
+            return StreamingResponse(
+                empty_generator(),
+                media_type="text/event-stream",
+                headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
+            )
+
+        # Compaction
+        secondary_provider = _resolve_secondary_provider(request.app.state)
+
+        def _on_compaction_usage(usage):
+            track_usage(
+                UsageRepository(),
+                UsageContext(
+                    user_id=chat.user_id,
+                    model_id=secondary_provider.model_record_id,
+                    model_name=secondary_provider.model_name,
+                    provider_type=secondary_provider.provider_type,
+                    purpose=UsagePurpose.COMPACTION,
+                    chat_id=chat_id,
+                ),
+                input_tokens=usage.input_tokens,
+                output_tokens=usage.output_tokens,
+                cache_read_tokens=usage.cache_read_tokens,
+                cache_creation_tokens=usage.cache_creation_tokens,
+            )
+
+        compactor = ConversationCompactor(
+            llm_provider=secondary_provider,
+            on_usage=_on_compaction_usage,
+        )
+        initial_tools = build_turn_tools(
+            build_result.always_on_handlers,
+            build_result.connector_handler,
+            loaded_toolsets,
+        )
+
+        prepared = await compactor.prepare_chat_conversation(
+            chat_id=chat_id,
+            chat_messages=chat_messages,
+            messages=messages,
+            compactions_repo=CompactionsRepository(),
+            target_provider=llm_provider,
+            tools=initial_tools,
+            system_prompt=system_prompt,
+            max_output_tokens=DEFAULT_MAX_TOKENS,
+        )
+        messages = prepared.messages
+        latest_compaction = prepared.latest_compaction
+        summarizer_context = prepared.summarizer_context
+        logger.info(
+            "Resolved context windows for chat %s: model=%s (%s), summarizer=%s (%s)",
+            chat_id,
+            prepared.model_context.tokens,
+            prepared.model_context.source,
+            summarizer_context.tokens,
+            summarizer_context.source,
+        )
+
+        # Extract first user message for caching
+        original_user_query = None
+        for msg in messages:
+            if msg.get("role") == "user":
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    original_user_query = content
+                    break
+                elif isinstance(content, list):
+                    text_parts = [
+                        block.get("text", "")
+                        for block in content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    if text_parts:
+                        original_user_query = " ".join(text_parts)
+                        break
+
+        parent_id = chat_messages[-1].id if chat_messages else None
+
+        # ---- Build and run the generator ----
+        gen = stream_generator(
+            chat_id,
+            redis_client,
+            messages,
+            llm_provider,
+            chat.user_id,
+            tool_user_id=tool_user_id,
+            user_email=user_email,
+            user_configuration=user_configuration,
+            tool_skip_perm=tool_skip_perm,
+            system_prompt=system_prompt,
+            registry=registry,
+            always_on_handlers=build_result.always_on_handlers,
+            connector_handler=build_result.connector_handler,
+            loaded_toolsets=loaded_toolsets,
+            compactor=compactor,
+            latest_compaction_summary=latest_compaction.summary if latest_compaction else None,
+            summarizer_context_window_tokens=summarizer_context.tokens,
+            memory_provider=memory_provider,
+            memory_write_key=memory_write_key,
+            effective_mode=effective_mode,
+            approvals_repo=approvals_repo,
+            pending=pending,
+            pending_oauth=pending_oauth,
+            original_user_query=original_user_query,
+        )
+
+        if redis_client is None:
+            return StreamingResponse(
+                persist_and_transform(gen, chat_id, messages_repo, parent_id),
+                media_type="text/event-stream",
+                headers=SSE_HEADERS,
+            )
+
+        # Single producer per chat
+        got_lock = await redis_client.set(
+            run_lock_key(chat_id), "1", nx=True, ex=_RUN_LOCK_TTL
+        )
+        if not got_lock:
+            return StreamingResponse(
+                consume_run(redis_client, chat_id, last_event_id or "0"),
+                media_type="text/event-stream",
+                headers=SSE_HEADERS,
+            )
+
+        await redis_client.delete(stream_key(chat_id))
+        await redis_client.delete(cancel_key(chat_id))
+        task = asyncio.create_task(
+            run_producer(redis_client, chat_id, gen, messages_repo, parent_id)
+        )
+        set_producer_task(chat_id, task)
+
+        def _cleanup_run_task(
+            t: asyncio.Task, cid: str = chat_id  # type: ignore[assignment]
+        ) -> None:
+            if _run_tasks_by_chat.get(cid) is t:
+                clear_producer_task(cid, t)
+
+        task.add_done_callback(_cleanup_run_task)
+
+        return StreamingResponse(
+            consume_run(redis_client, chat_id, "0"),
+            media_type="text/event-stream",
+            headers=SSE_HEADERS,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Route: stream chat
+# ---------------------------------------------------------------------------
 
 @router.get("/chat/{chat_id}/stream")
 async def stream_chat(
@@ -1192,1082 +1038,44 @@ async def stream_chat(
         False, description="Auto-inject initial message for agent chats"
     ),
 ):
-    """Stream AI response for a chat thread using Server-Sent Events"""
-    if not request.app.state.searcher_tool:
-        raise HTTPException(status_code=500, detail="Searcher tool not initialized")
+    return await StreamChatHandler(request, chat_id, auto_start).handle()
 
-    # Retrieve chat and messages from database
-    chats_repo = ChatsRepository()
-    chat = await chats_repo.get(chat_id)
-    if not chat:
-        raise HTTPException(status_code=404, detail="Chat thread not found")
 
-    llm_provider = _resolve_llm_provider(request.app.state, chat)
-    redis_client = request.app.state.redis_client
-
-    # Reconnect/resume fast path: if a buffered run already exists for this chat,
-    # attach to it (tail from the client's offset) and skip all (re)setup so we
-    # never re-run registry build / compaction / tools on a reconnect.
-    last_event_id = request.headers.get("last-event-id") or request.query_params.get(
-        "last_event_id"
-    )
-    if redis_client is not None:
-        run_active = await redis_client.exists(_run_lock_key(chat_id))
-        if run_active:
-            # A run is in progress for this chat: attach to it instead of starting
-            # a fresh generation. Replay the buffered run from the client's offset,
-            # or from the beginning when (as on a full page reload) no offset is
-            # available. This keeps a reconnect that arrives without a Last-Event-ID
-            # from falling through to fresh-generation setup and bailing out with
-            # "No new user message to process".
-            return StreamingResponse(
-                _consume_run(redis_client, chat_id, last_event_id or "0"),
-                media_type="text/event-stream",
-                headers=SSE_HEADERS,
-            )
-
-        if last_event_id is not None:
-            if await redis_client.exists(_stream_key(chat_id)):
-                # The run has ended but its buffer is still live: replay the tail
-                # so the client receives any final events it missed, then the
-                # terminal end_of_stream/stream_error already in the buffer.
-                return StreamingResponse(
-                    _consume_run(redis_client, chat_id, last_event_id),
-                    media_type="text/event-stream",
-                    headers=SSE_HEADERS,
-                )
-            # No active run and the buffer is gone/expired. Starting a new
-            # generation would produce a duplicate response — tell the client to
-            # reload from the database instead.
-            async def _not_resumable_response():
-                yield "event: not_resumable\ndata: \n\n"
-
-            return StreamingResponse(
-                _not_resumable_response(),
-                media_type="text/event-stream",
-                headers=SSE_HEADERS,
-            )
-
-    messages_repo = MessagesRepository()
-    approvals_repo = ToolApprovalsRepository()
-    chat_messages = await messages_repo.get_active_path(chat_id)
-
-    # Memory state — populated in both agent and regular chat branches
-    memory_provider = None
-    effective_mode = MemoryMode.OFF
-    memories: list[str] = []
-    memory_write_key: str | None = (
-        None  # None = no write (e.g. agent chats are read-only)
-    )
-    pending: list[ToolApproval] = []
-    pending_oauth: list[ToolApproval] = []
-
-    if chat.agent_id:
-        # --- Agent chat setup ---
-        agent_repo = AgentRepository()
-        agent = await agent_repo.get_agent(chat.agent_id)
-        if not agent:
-            raise HTTPException(status_code=404, detail="Agent not found")
-
-        users_repo = UsersRepository()
-        chat_user = await users_repo.find_by_id(chat.user_id)
-        if not chat_user:
-            raise HTTPException(status_code=404, detail="Chat user not found")
-
-        if agent.agent_type == "org":
-            if chat_user.role != "admin":
-                raise HTTPException(
-                    status_code=403, detail="Admin access required for org agent chats"
-                )
-        elif agent.user_id != chat.user_id:
-            raise HTTPException(
-                status_code=403, detail="Only the agent owner can chat with this agent"
-            )
-
-        is_org_agent = agent.agent_type == "org"
-        tool_user_id = None if is_org_agent else agent.user_id
-        tool_skip_perm = is_org_agent
-
-        user_email = chat_user.email
-        user_name = chat_user.full_name
-        user_configuration = chat_user.configuration
-
-        # Handle auto_start: inject ephemeral message when no messages exist
-        if not chat_messages:
-            if auto_start:
-                chat_messages = []
-            else:
-                raise HTTPException(
-                    status_code=404, detail="No messages found for chat"
-                )
-
-        build_result = await _build_agent_chat_registry(
-            request, agent, is_admin=chat_user.role == "admin"
-        )
-        registry = build_result.registry
-        # Agent chats are read-only; no connector handler, so the per-turn
-        # builder collapses to just the always-on handlers.
-        loaded_toolsets: set[str] = set()
-        pending = []  # no approval flow for agent chats
-
-        # Build agent chat system prompt with run history
-        run_repo = AgentRunRepository()
-        runs = await run_repo.list_runs(agent.id, limit=20)
-        active_sources = [
-            s for s in build_result.sources if s.is_active and not s.is_deleted
-        ]
-
-        # Memory: fetch agent-scoped memories (same scoping as background executor)
-        memory_provider = request.app.state.memory_provider
-        effective_mode = MemoryMode.OFF
-        memories = []
-        if memory_provider is not None:
-            config_repo = ConfigurationRepository()
-            org_default = (
-                await config_repo.get_global_configuration()
-            ).memory_mode_default
-            if is_org_agent:
-                effective_mode = org_default
-            elif user_configuration is not None:
-                effective_mode = resolve_memory_mode(
-                    user_configuration.memory_mode, org_default
-                )
-            memory_namespace = agent_key(agent.id)
-            if effective_mode >= MemoryMode.CHAT and chat_messages:
-                last_user_text = ""
-                for msg in reversed(chat_messages):
-                    m = msg.message
-                    if m.get("role") == "user":
-                        content = m.get("content", "")
-                        if isinstance(content, str):
-                            last_user_text = content
-                        elif isinstance(content, list):
-                            last_user_text = " ".join(
-                                b.get("text", "")
-                                for b in content
-                                if isinstance(b, dict) and b.get("type") == "text"
-                            )
-                        break
-                if last_user_text:
-                    hits = await memory_provider.search(
-                        query=last_user_text, key=memory_namespace, limit=5
-                    )
-                    memories = [h.record.text for h in hits if h.record.text]
-
-        system_prompt = build_agent_chat_system_prompt(
-            agent,
-            runs,
-            active_sources,
-            user_name=user_name,
-            user_email=user_email,
-            memories=memories if memories else None,
-            user_configuration=user_configuration,
-            include_web_search=getattr(request.app.state, "web_search_provider", None)
-            is not None,
-            include_fetch_web_page=getattr(
-                request.app.state, "web_fetch_provider", None
-            )
-            is not None,
-        )
-
-        # Build messages, injecting ephemeral start message if needed
-        messages: list[MessageParam] = [
-            MessageParam(**msg.message) for msg in chat_messages
-        ]
-        needs_start = not messages or messages[-1].get("role") != "user"
-        if auto_start and needs_start:
-            messages.append(MessageParam(role="user", content="Go."))
-
-    else:
-        # --- Regular chat setup ---
-        tool_user_id = chat.user_id
-        tool_skip_perm = False
-        user_email: str | None = None
-        user_name: str | None = None
-        user_configuration: UserConfiguration | None = None
-        is_admin = False
-        if chat.user_id:
-            users_repo = UsersRepository()
-            user = await users_repo.find_by_id(chat.user_id)
-            if user:
-                user_email = user.email
-                user_name = user.full_name
-                user_configuration = user.configuration
-                is_admin = user.role == "admin"
-
-        if not chat_messages:
-            raise HTTPException(status_code=404, detail="No messages found for chat")
-
-        messages: list[MessageParam] = [
-            MessageParam(**msg.message) for msg in chat_messages
-        ]
-
-        # Rebuild loaded connector sources from prior meta-tool calls/results.
-        # Tool discovery is part of the conversation, not chat-session state.
-        loaded_toolsets: set[str] = set()
-
-        build_result = await _build_registry(
-            request,
-            chat,
-            is_admin=is_admin,
-            loaded_toolsets=loaded_toolsets,
-        )
-        if build_result.connector_handler is not None:
-            loaded_toolsets.update(
-                _loaded_tools_from_history(messages, build_result.connector_handler)
-            )
-        registry = build_result.registry
-
-        # Check for pending approval / OAuth resume flow from durable state.
-        active_tool_call_ids = {
-            tool_use["id"]
-            for message in messages
-            for tool_use in _tool_use_blocks(message)
-        }
-        pending = await approvals_repo.list_for_chat(
-            chat_id=chat_id,
-            approval_type=ToolApprovalType.APPROVAL,
-            statuses={
-                ToolApprovalStatus.PENDING,
-                ToolApprovalStatus.APPROVED,
-                ToolApprovalStatus.DENIED,
-            },
-            active_tool_call_ids=active_tool_call_ids,
-        )
-        pending_oauth = await approvals_repo.list_for_chat(
-            chat_id=chat_id,
-            approval_type=ToolApprovalType.OAUTH,
-            statuses={ToolApprovalStatus.PENDING},
-            active_tool_call_ids=active_tool_call_ids,
-        )
-
-        active_sources = [
-            s for s in build_result.sources if s.is_active and not s.is_deleted
-        ]
-
-        # Memory: resolve mode and fetch relevant memories
-        memory_provider = request.app.state.memory_provider
-        memories = []
-        effective_mode = MemoryMode.OFF
-        if memory_provider is not None and chat.user_id:
-            memory_write_key = user_key(chat.user_id)
-            config_repo = ConfigurationRepository()
-            org_default = (
-                await config_repo.get_global_configuration()
-            ).memory_mode_default
-            user_memory_mode = (
-                user_configuration.memory_mode if user_configuration else None
-            )
-            effective_mode = resolve_memory_mode(user_memory_mode, org_default)
-            if effective_mode >= MemoryMode.CHAT:
-                last_user_text = ""
-                for msg in reversed(chat_messages):
-                    m = msg.message
-                    if m.get("role") == "user":
-                        content = m.get("content", "")
-                        if isinstance(content, str):
-                            last_user_text = content
-                        elif isinstance(content, list):
-                            last_user_text = " ".join(
-                                b.get("text", "")
-                                for b in content
-                                if isinstance(b, dict) and b.get("type") == "text"
-                            )
-                        break
-                if last_user_text:
-                    hits = await memory_provider.search(
-                        query=last_user_text,
-                        key=user_key(chat.user_id),
-                        limit=5,
-                    )
-                    memories = [h.record.text for h in hits if h.record.text]
-
-        loaded_source_ids = _loaded_source_ids(
-            loaded_toolsets, build_result.connector_handler
-        )
-        system_prompt = build_chat_system_prompt(
-            active_sources,
-            toolsets=build_result.toolsets,
-            loaded_source_ids=loaded_source_ids,
-            user_name=user_name,
-            user_email=user_email,
-            memories=memories if memories else None,
-            user_configuration=user_configuration,
-            include_web_search=getattr(request.app.state, "web_search_provider", None)
-            is not None,
-            include_fetch_web_page=getattr(
-                request.app.state, "web_fetch_provider", None
-            )
-            is not None,
-        )
-
-    if not pending and not pending_oauth:
-        messages, repaired_tool_calls = _repair_interrupted_tool_calls(messages)
-        if repaired_tool_calls:
-            logger.warning(
-                f"Inserted {repaired_tool_calls} failed tool_result placeholder(s) for interrupted tool calls in chat {chat_id}"
-            )
-        before = len(messages)
-        messages = _drop_empty_assistant_messages(messages)
-        dropped = before - len(messages)
-        if dropped:
-            logger.warning(
-                f"Dropped {dropped} empty assistant message(s) from history for chat {chat_id}"
-            )
-
-    # Expand any omni_upload content blocks (inline small text, stage larger/binary in sandbox).
-    storage = request.app.state.content_storage
-    if storage is not None:
-        messages = await expand_uploads(
-            messages,
-            chat_id=chat_id,
-            storage=storage,
-            uploads_repo=UploadsRepository(),
-            sandbox_url=SANDBOX_URL,
-        )
-
-    # Check if we need to process - only if last message is from user (or resuming from approval / OAuth)
-    last_message_role = messages[-1].get("role") if messages else None
-    if not pending and not pending_oauth and last_message_role != "user":
-        logger.info(
-            f"Last message is not from user, no processing needed. Chat ID: {chat_id}"
-        )
-
-        async def empty_generator():
-            yield _end_of_stream(EndOfStreamReason.NO_NEW_MESSAGE, message="No new user message to process.").encode()
-
-        return StreamingResponse(
-            empty_generator(),
-            media_type="text/event-stream",
-            headers={"Cache-Control": "no-cache", "Connection": "keep-alive"},
-        )
-
-    # Check if conversation needs compaction
-    secondary_provider = _resolve_secondary_provider(request.app.state)
-
-    def _on_compaction_usage(usage):
-        track_usage(
-            UsageRepository(),
-            UsageContext(
-                user_id=chat.user_id,
-                model_id=secondary_provider.model_record_id,
-                model_name=secondary_provider.model_name,
-                provider_type=secondary_provider.provider_type,
-                purpose=UsagePurpose.COMPACTION,
-                chat_id=chat_id,
-            ),
-            input_tokens=usage.input_tokens,
-            output_tokens=usage.output_tokens,
-            cache_read_tokens=usage.cache_read_tokens,
-            cache_creation_tokens=usage.cache_creation_tokens,
-        )
-
-    compactor = ConversationCompactor(
-        llm_provider=secondary_provider,
-        on_usage=_on_compaction_usage,
-    )
-    # Compaction sees the *current* per-turn tool list — connector tools the
-    # chat hasn't loaded don't count against the budget, which is the whole
-    # point of lazy loading.
-    initial_tools = build_turn_tools(
-        build_result.always_on_handlers,
-        build_result.connector_handler,
-        loaded_toolsets,
-    )
-
-    prepared = await compactor.prepare_chat_conversation(
-        chat_id=chat_id,
-        chat_messages=chat_messages,
-        messages=messages,
-        compactions_repo=CompactionsRepository(),
-        target_provider=llm_provider,
-        tools=initial_tools,
-        system_prompt=system_prompt,
-        max_output_tokens=DEFAULT_MAX_TOKENS,
-    )
-    messages = prepared.messages
-    latest_compaction = prepared.latest_compaction
-    summarizer_context = prepared.summarizer_context
-    logger.info(
-        "Resolved context windows for chat %s: model=%s (%s), summarizer=%s (%s)",
-        chat_id,
-        prepared.model_context.tokens,
-        prepared.model_context.source,
-        summarizer_context.tokens,
-        summarizer_context.source,
-    )
-
-    # Stream AI response with tool calling
-    async def stream_generator():
-        try:
-            conversation_messages = messages.copy()
-            # Initialized here so the error/cancel handlers below can always
-            # reference whatever content was accumulated before the failure.
-            content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
-            content_blocks_finalized = False
-
-            if pending or pending_oauth:
-                if pending_oauth:
-                    intervention = pending_oauth[0]
-                    logger.info(f"Resuming from pending oauth for chat {chat_id}")
-                    oauth_event = _oauth_event(
-                        intervention.tool_call_id,
-                        intervention.tool_name,
-                        intervention.source_id,
-                        intervention.source_type,
-                        intervention.provider,
-                        intervention.oauth_start_url,
-                    )
-                    yield f"event: oauth_required\ndata: {json.dumps(oauth_event)}\n\n"
-                    yield _end_of_stream(EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required")
-                    return
-
-                logger.info(f"Resuming from pending approval batch for chat {chat_id}")
-                if any(
-                    approval.status == ToolApprovalStatus.PENDING
-                    for approval in pending
-                ):
-                    yield f"event: approval_required\ndata: {json.dumps(_approval_required_event(pending))}\n\n"
-                    yield _end_of_stream(EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required")
-                    return
-
-                approvals_by_tool_call_id = {
-                    approval.tool_call_id: approval
-                    for approval in pending
-                    if approval.tool_call_id is not None
-                }
-                answered_ids = (
-                    _tool_result_ids(conversation_messages[-1])
-                    if conversation_messages
-                    else set()
-                )
-                tool_calls_to_resume: list[ToolUseBlockParam] = []
-                for message in reversed(conversation_messages):
-                    tool_uses = _tool_use_blocks(message)
-                    if not tool_uses:
-                        answered_ids.update(_tool_result_ids(message))
-                        continue
-                    tool_calls_to_resume = [
-                        tool_use
-                        for tool_use in tool_uses
-                        if tool_use["id"] not in answered_ids
-                    ]
-                    break
-
-                context = ToolContext(
-                    chat_id=chat_id,
-                    user_id=tool_user_id,
-                    user_email=user_email,
-                    user_configuration=user_configuration,
-                    skip_permission_check=tool_skip_perm,
-                )
-                tool_results: list[ToolResultBlockParam] = []
-                completed_approval_ids: list[str] = []
-                for tool_call in tool_calls_to_resume:
-                    approval = approvals_by_tool_call_id.get(tool_call["id"])
-                    if approval and approval.status == ToolApprovalStatus.DENIED:
-                        tool_result = ToolResultBlockParam(
-                            type="tool_result",
-                            tool_use_id=tool_call["id"],
-                            content=[
-                                {
-                                    "type": "text",
-                                    "text": "The user denied approval for this tool call.",
-                                }
-                            ],
-                            is_error=True,
-                        )
-                        completed_approval_ids.append(approval.id)
-                    else:
-                        result = await registry.execute(
-                            tool_call["name"], tool_call["input"], context
-                        )
-                        if result.oauth_required is not None:
-                            payload = result.oauth_required
-                            if approval:
-                                completed_approval_ids.append(approval.id)
-                            saved_oauth_approval = await approvals_repo.create_pending(
-                                chat_id=chat_id,
-                                user_id=chat.user_id,
-                                tool_name=tool_call["name"],
-                                tool_input=tool_call["input"],
-                                tool_call_id=tool_call["id"],
-                                approval_type=ToolApprovalType.OAUTH,
-                                source_id=payload.source_id,
-                                source_type=payload.source_type,
-                                provider=payload.provider,
-                                oauth_start_url=payload.oauth_start_url,
-                            )
-                            logger.info(
-                                f"Saved pending oauth approval {saved_oauth_approval.id} for chat {chat_id}"
-                            )
-                            oauth_event = _oauth_event(
-                                tool_call["id"],
-                                tool_call["name"],
-                                payload.source_id,
-                                payload.source_type,
-                                payload.provider,
-                                payload.oauth_start_url,
-                            )
-                            if tool_results:
-                                tool_result_message = MessageParam(
-                                    role="user", content=tool_results
-                                )
-                                conversation_messages.append(tool_result_message)
-                                yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
-                            for approval_id in completed_approval_ids:
-                                await approvals_repo.update_status(
-                                    approval_id,
-                                    ToolApprovalStatus.COMPLETED,
-                                    chat.user_id,
-                                )
-                            yield f"event: oauth_required\ndata: {json.dumps(oauth_event)}\n\n"
-                            yield _end_of_stream(EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required")
-                            return
-                        tool_result = ToolResultBlockParam(
-                            type="tool_result",
-                            tool_use_id=tool_call["id"],
-                            content=result.content,
-                            is_error=result.is_error,
-                        )
-                        if approval:
-                            completed_approval_ids.append(approval.id)
-
-                    tool_results.append(tool_result)
-                    yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
-
-                if tool_results:
-                    tool_result_message = MessageParam(
-                        role="user", content=tool_results
-                    )
-                    conversation_messages.append(tool_result_message)
-                    yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
-                for approval_id in completed_approval_ids:
-                    await approvals_repo.update_status(
-                        approval_id, ToolApprovalStatus.COMPLETED, chat.user_id
-                    )
-
-            logger.info(
-                f"Starting conversation with {len(conversation_messages)} initial messages"
-            )
-
-            # Extract the first user message query for caching purposes
-            original_user_query = None
-            for msg in conversation_messages:
-                if msg.get("role") == "user":
-                    content = msg.get("content", "")
-                    if isinstance(content, str):
-                        original_user_query = content
-                        break
-                    elif isinstance(content, list):
-                        text_parts = [
-                            block.get("text", "")
-                            for block in content
-                            if isinstance(block, dict) and block.get("type") == "text"
-                        ]
-                        if text_parts:
-                            original_user_query = " ".join(text_parts)
-                            break
-
-            context = ToolContext(
-                chat_id=chat_id,
-                user_id=tool_user_id,
-                user_email=user_email,
-                user_configuration=user_configuration,
-                original_user_query=original_user_query,
-                skip_permission_check=tool_skip_perm,
-            )
-
-            usage_repo = UsageRepository()
-            assistant_message: MessageParam | None = None
-
-            for iteration in range(AGENT_MAX_ITERATIONS):
-                # Stop only on an explicit user cancel (Stop button). The run is
-                # decoupled from the client connection, so a backgrounded tab no
-                # longer aborts generation.
-                if await _is_run_cancelled(redis_client, chat_id):
-                    logger.info(f"Run cancelled, stopping stream for chat {chat_id}")
-                    break
-
-                logger.info(f"Iteration {iteration + 1}/{AGENT_MAX_ITERATIONS}")
-                content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
-                content_blocks_finalized = False
-                provider_extras = llm_provider.PERSISTED_BLOCK_EXTRAS
-
-                # Rebuild the per-turn tool list. The set of loaded connector
-                # loaded connector tools may have grown during the previous iteration via the
-                # load_tool / load_tool_set meta-tools.
-                turn_tools = build_turn_tools(
-                    build_result.always_on_handlers,
-                    build_result.connector_handler,
-                    loaded_toolsets,
-                )
-
-                logger.info("Sending request to LLM provider")
-                logger.debug(
-                    f"Messages being sent: {json.dumps(conversation_messages, indent=2)}"
-                )
-                logger.debug(
-                    f"Tools available: {[tool['name'] for tool in turn_tools]}"
-                )
-
-                async def _event_stream_with_context_retry(
-                    turn_tools_for_attempt=turn_tools,
-                ):
-                    nonlocal conversation_messages
-                    for llm_attempt in range(2):
-                        tracker = UsageTracker(
-                            usage_repo,
-                            UsageContext(
-                                user_id=chat.user_id,
-                                model_id=llm_provider.model_record_id,
-                                model_name=llm_provider.model_name,
-                                provider_type=llm_provider.provider_type,
-                                purpose=UsagePurpose.CHAT,
-                                chat_id=chat_id,
-                            ),
-                        )
-                        raw_stream: AsyncStream[MessageStreamEvent] = (
-                            llm_provider.stream_response(
-                                prompt="",  # Not used when messages provided
-                                messages=conversation_messages,
-                                tools=turn_tools_for_attempt,
-                                max_tokens=DEFAULT_MAX_TOKENS,
-                                temperature=DEFAULT_TEMPERATURE,
-                                top_p=DEFAULT_TOP_P,
-                                system_prompt=system_prompt,
-                            )
-                        )
-                        emitted_event = False
-                        try:
-                            async for wrapped_event in tracker.wrap_stream(raw_stream):
-                                emitted_event = True
-                                yield wrapped_event
-                            tracker.save()
-                            return
-                        except ProviderError as e:
-                            if (
-                                e.is_context_overflow
-                                and llm_attempt == 0
-                                and not emitted_event
-                            ):
-                                logger.warning(
-                                    "Chat %s hit provider context limit; retrying once after forced compaction",
-                                    chat_id,
-                                )
-                                conversation_messages = (
-                                    await compactor.compact_conversation(
-                                        chat_id,
-                                        conversation_messages,
-                                        previous_summary=(
-                                            latest_compaction.summary
-                                            if latest_compaction
-                                            else None
-                                        ),
-                                        summarizer_context_window_tokens=summarizer_context.tokens,
-                                    )
-                                )
-                                continue
-                            raise
-
-                stream = _event_stream_with_context_retry()
-
-                event_index = 0
-                message_stop_received = False
-                cancelled = False
-                last_cancel_check_at = 0.0
-                async for event in stream:
-                    logger.debug(f"Received event: {event} (index: {event_index})")
-                    event_index += 1
-
-                    now = asyncio.get_running_loop().time()
-                    if now - last_cancel_check_at >= _CANCEL_CHECK_INTERVAL_SECONDS:
-                        last_cancel_check_at = now
-                        if await _is_run_cancelled(redis_client, chat_id):
-                            cancelled = True
-                            break
-
-                    if event.type == "message_start":
-                        logger.info("Message start received.")
-
-                    if event.type == "content_block_delta":
-                        logger.debug(
-                            f"Content block delta received at index {event.index}: {event.delta}"
-                        )
-                        if event.delta.type == "text_delta":
-                            if event.index >= len(content_blocks):
-                                logger.warning(
-                                    f"Received text delta for unknown content block index {event.index}, creating new text block"
-                                )
-                                content_blocks.append(
-                                    TextBlockParam(type="text", text="")
-                                )
-                            text_block = cast(
-                                TextBlockParam, content_blocks[event.index]
-                            )
-                            text_block["text"] += event.delta.text
-                        elif event.delta.type == "input_json_delta":
-                            if event.index >= len(content_blocks):
-                                logger.warning(
-                                    f"Received input JSON delta for unknown content block index {event.index}, creating new tool use block"
-                                )
-                                content_blocks.append(
-                                    ToolUseBlockParam(
-                                        type="tool_use", id="", name="", input=""
-                                    )
-                                )
-                            tool_use_block = cast(
-                                ToolUseBlockParam, content_blocks[event.index]
-                            )
-                            tool_use_block["input"] = (
-                                cast(str, tool_use_block["input"])
-                                + event.delta.partial_json
-                            )
-                        elif event.delta.type == "citations_delta":
-                            if event.index >= len(content_blocks):
-                                logger.warning(
-                                    f"Received citations delta for unknown content block index {event.index}, creating new citations block"
-                                )
-                                content_blocks.append(
-                                    TextBlockParam(type="text", text="", citations=[])
-                                )
-                            text_block = cast(
-                                TextBlockParam, content_blocks[event.index]
-                            )
-                            if (
-                                "citations" not in text_block
-                                or not text_block["citations"]
-                            ):
-                                text_block["citations"] = []
-                            citations = cast(
-                                list[TextCitationParam], text_block["citations"]
-                            )
-                            citations.append(convert_citation_to_param(event.delta))
-                    elif event.type == "content_block_start":
-                        if event.content_block.type == "text":
-                            logger.info(f"Text block start: {event.content_block.text}")
-                            text_block: TextBlockParam = TextBlockParam(
-                                type="text", text=event.content_block.text
-                            )
-                            _copy_provider_extras(
-                                event.content_block, text_block, provider_extras
-                            )
-                            content_blocks.append(text_block)
-                        elif event.content_block.type == "tool_use":
-                            logger.info(
-                                f"Tool use block start: {event.content_block.name} (id: {event.content_block.id})"
-                            )
-                            tool_block: ToolUseBlockParam = ToolUseBlockParam(
-                                type="tool_use",
-                                id=event.content_block.id,
-                                name=event.content_block.name,
-                                input="",
-                            )
-                            _copy_provider_extras(
-                                event.content_block, tool_block, provider_extras
-                            )
-                            content_blocks.append(tool_block)
-                    elif event.type == "citation":
-                        logger.info(f"Citation received: {event.citation}")
-                    elif event.type == "message_stop":
-                        logger.info("Message stop received.")
-                        message_stop_received = True
-
-                    logger.debug(
-                        f"Yielding event to client: {event.to_json(indent=None)}"
-                    )
-                    yield f"event: message\ndata: {event.to_json(indent=None)}\n\n"
-
-                    if message_stop_received:
-                        break
-
-                if cancelled:
-                    assistant_message = _partial_assistant_message(content_blocks)
-                    if assistant_message is not None:
-                        conversation_messages.append(assistant_message)
-                        yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
-                    break
-
-                # Parse tool call inputs. Convert to JSON. If the provider emits
-                # malformed JSON, do not execute the tool with `{}`; feed the
-                # parse error back to the model so it can retry.
-                tool_calls = [b for b in content_blocks if b["type"] == "tool_use"]
-                parse_errors = _parse_tool_call_inputs(
-                    cast(list[ToolUseBlockParam], tool_calls)
-                )
-
-                assistant_message = MessageParam(
-                    role="assistant", content=content_blocks
-                )
-                conversation_messages.append(assistant_message)
-
-                # Send complete message to omni-web for database persistence
-                yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
-                content_blocks_finalized = True
-
-                if parse_errors:
-                    tool_result_message = MessageParam(
-                        role="user", content=parse_errors
-                    )
-                    conversation_messages.append(tool_result_message)
-                    for parse_error in parse_errors:
-                        yield f"event: message\ndata: {json.dumps(parse_error)}\n\n"
-                    yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
-                    continue
-
-                # If no tool calls, we're done
-                if not tool_calls:
-                    logger.info(
-                        f"No tool calls in iteration {iteration + 1}, completing response"
-                    )
-                    break
-
-                logger.info(f"Processing {len(tool_calls)} tool calls")
-
-                # Stop before expensive tool execution if the user cancelled.
-                if await _is_run_cancelled(redis_client, chat_id):
-                    logger.info(
-                        f"Run cancelled before tool execution for chat {chat_id}"
-                    )
-                    break
-
-                approval_required: list[ToolApproval] = []
-                for tool_call in tool_calls:
-                    tool_name = tool_call["name"]
-                    tool_input = tool_call["input"]
-                    if registry.requires_approval(tool_name):
-                        logger.info(f"Tool {tool_name} requires approval")
-                        approval = await approvals_repo.create_pending(
-                            chat_id=chat_id,
-                            user_id=chat.user_id,
-                            tool_name=tool_name,
-                            tool_input=tool_input,
-                            tool_call_id=tool_call["id"],
-                            approval_type=ToolApprovalType.APPROVAL,
-                            source_id=tool_input.get("source_id"),
-                            source_type=tool_input.get("source_type"),
-                        )
-                        logger.info(
-                            f"Saved pending approval {approval.id} for chat {chat_id}"
-                        )
-                        approval_required.append(approval)
-
-                if approval_required:
-                    logger.info(
-                        f"Pausing stream for {len(approval_required)} approval-required tool call(s)"
-                    )
-                    yield f"event: approval_required\ndata: {json.dumps(_approval_required_event(approval_required))}\n\n"
-                    yield _end_of_stream(EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required")
-                    return
-
-                tool_results: list[ToolResultBlockParam] = []
-                for tool_call in tool_calls:
-                    tool_name = tool_call["name"]
-                    tool_input = tool_call["input"]
-
-                    result = await registry.execute(tool_name, tool_input, context)
-                    if result.oauth_required is not None:
-                        payload = result.oauth_required
-                        oauth_approval = await approvals_repo.create_pending(
-                            chat_id=chat_id,
-                            user_id=chat.user_id,
-                            tool_name=tool_name,
-                            tool_input=tool_input,
-                            tool_call_id=tool_call["id"],
-                            approval_type=ToolApprovalType.OAUTH,
-                            source_id=payload.source_id,
-                            source_type=payload.source_type,
-                            provider=payload.provider,
-                            oauth_start_url=payload.oauth_start_url,
-                        )
-                        logger.info(
-                            f"Saved pending oauth approval {oauth_approval.id} for chat {chat_id}"
-                        )
-                        oauth_event = _oauth_event(
-                            tool_call["id"],
-                            tool_name,
-                            payload.source_id,
-                            payload.source_type,
-                            payload.provider,
-                            payload.oauth_start_url,
-                        )
-                        yield f"event: oauth_required\ndata: {json.dumps(oauth_event)}\n\n"
-                        yield _end_of_stream(EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required")
-                        return
-
-                    tool_result = ToolResultBlockParam(
-                        type="tool_result",
-                        tool_use_id=tool_call["id"],
-                        content=result.content,
-                        is_error=result.is_error,
-                    )
-                    tool_results.append(tool_result)
-                    yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
-
-                tool_result_message = MessageParam(role="user", content=tool_results)
-                conversation_messages.append(tool_result_message)
-                yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
-
-            # Memory write (fire-and-forget)
-            if (
-                memory_provider is not None
-                and memory_write_key
-                and effective_mode >= MemoryMode.CHAT
-            ):
-                try:
-                    last_user_content = None
-                    for msg in reversed(conversation_messages):
-                        m = msg if isinstance(msg, dict) else dict(msg)
-                        if m.get("role") == "user":
-                            raw = m.get("content", "")
-                            if isinstance(raw, list):
-                                # Extract text blocks only — skip image/tool_result blocks
-                                # so the provider never sees non-text content blocks.
-                                raw = " ".join(
-                                    b.get("text", "")
-                                    for b in raw
-                                    if isinstance(b, dict) and b.get("type") == "text"
-                                )
-                            if not raw:
-                                # Tool-result messages have no text — keep scanning back.
-                                continue
-                            last_user_content = raw
-                            break
-                    if last_user_content and assistant_message:
-                        assistant_content = "".join(
-                            b.get("text", "")
-                            for b in assistant_message.get("content", [])
-                            if isinstance(b, dict) and b.get("type") == "text"
-                        )
-                        if assistant_content:
-                            turn = [
-                                MessageParam(role="user", content=last_user_content),
-                                MessageParam(
-                                    role="assistant", content=assistant_content
-                                ),
-                            ]
-                            asyncio.create_task(
-                                memory_provider.add(messages=turn, key=memory_write_key)
-                            )
-                except Exception as e:
-                    logger.warning(f"Memory write setup failed for chat {chat_id}: {e}")
-
-            yield _end_of_stream(EndOfStreamReason.COMPLETED, message="Stream ended")
-
-        except asyncio.CancelledError:
-            logger.info(f"Stream cancelled for chat {chat_id}")
-            # Finalize partial content before re-raising so the
-            # early-persisted assistant row is updated (not deleted) by
-            # _persist_and_transform.  This mirrors the except Exception
-            # block below.
-            # Only emit if the current content blocks haven't already been
-            # finalized via the normal per-iteration save.
-            if not content_blocks_finalized:
-                partial = _partial_assistant_message(content_blocks)
-                if partial is not None:
-                    conversation_messages.append(partial)
-                    yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
-            raise
-        except Exception as e:
-            logger.error(
-                f"Failed to generate AI response with tools: {e}", exc_info=True
-            )
-            # Finalize whatever partial assistant content was accumulated before
-            # the failure, so the early-persisted row is not left empty.
-            # Only emit if the current content blocks haven't already been
-            # finalized via the normal per-iteration save.
-            if not content_blocks_finalized:
-                partial = _partial_assistant_message(content_blocks)
-                if partial is not None:
-                    conversation_messages.append(partial)
-                    yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
-            yield _sse_event("stream_error", _chat_error_payload(e))
-
-    parent_id = chat_messages[-1].id if chat_messages else None
-
-    if redis_client is None:
-        # No Redis: run inline (no resume), still persisting via the producer wrapper.
-        return StreamingResponse(
-            _persist_and_transform(
-                stream_generator(), chat_id, messages_repo, parent_id
-            ),
-            media_type="text/event-stream",
-            headers=SSE_HEADERS,
-        )
-
-    # Single producer per chat: the lock winner starts the background run; a
-    # racing connect attaches to it instead of starting a duplicate.
-    got_lock = await redis_client.set(
-        _run_lock_key(chat_id), "1", nx=True, ex=_RUN_LOCK_TTL
-    )
-    if not got_lock:
-        return StreamingResponse(
-            _consume_run(redis_client, chat_id, last_event_id or "0"),
-            media_type="text/event-stream",
-            headers=SSE_HEADERS,
-        )
-
-    await redis_client.delete(_stream_key(chat_id))
-    await redis_client.delete(_cancel_key(chat_id))
-    task = asyncio.create_task(
-        _run_producer(
-            redis_client, chat_id, stream_generator(), messages_repo, parent_id
-        )
-    )
-    _run_tasks_by_chat[chat_id] = task
-
-    def _cleanup_run_task(t: asyncio.Task, cid: str = chat_id) -> None:
-        # Only clear the registry slot if it still points at this task; a new run
-        # for the same chat may have already claimed it.
-        if _run_tasks_by_chat.get(cid) is t:
-            del _run_tasks_by_chat[cid]
-
-    task.add_done_callback(_cleanup_run_task)
-
-    return StreamingResponse(
-        _consume_run(redis_client, chat_id, "0"),
-        media_type="text/event-stream",
-        headers=SSE_HEADERS,
-    )
+# Route: cancel
+# ---------------------------------------------------------------------------
 
 
 @router.post("/chat/{chat_id}/cancel")
 async def cancel_chat_stream(
     request: Request, chat_id: str = Path(..., description="Chat thread ID")
 ):
-    """Explicit Stop: end the background run now.
-
-    Sets a Redis cancel flag (the cross-worker signal the producer checks at its
-    next checkpoint) and, if the producer task lives in this process, cancels it
-    directly so generation stops immediately — even mid-message or during a slow
-    tool call, where the next checkpoint could be far off.
-    """
     redis_client = request.app.state.redis_client
     try:
-        await redis_client.set(_cancel_key(chat_id), "1", ex=_CANCEL_TTL)
+        await redis_client.set(cancel_key(chat_id), "1", ex=_CANCEL_TTL)
     except Exception as e:
         logger.error(f"Failed to set cancel flag for chat {chat_id}: {e}")
 
     task = _run_tasks_by_chat.get(chat_id)
     if task is not None and not task.done():
-        # In-process cancel (task.cancel()) is best-effort in multi-worker
-        # deployments without sticky sessions: the Stop request may land on
-        # a worker that does not own the producer task.  The Redis cancel
-        # flag above provides the fallback cross-worker checkpoint.
+        # Best-effort immediate stop for this worker. The Redis cancel flag above
+        # is the cross-worker mechanism when Stop lands on a different process.
         task.cancel()
 
     return {"status": "cancelling"}
+
+
+# ---------------------------------------------------------------------------
+# Route: generate title
+# ---------------------------------------------------------------------------
 
 
 @router.post("/chat/{chat_id}/generate_title")
 async def generate_chat_title(
     request: Request, chat_id: str = Path(..., description="Chat thread ID")
 ):
-    """Generate a title for a chat thread based on its first messages"""
     logger.info(f"Generating title for chat: {chat_id}")
 
     try:
-        # Get chat from database
         chats_repo = ChatsRepository()
         chat = await chats_repo.get(chat_id)
         if not chat:
@@ -2275,12 +1083,10 @@ async def generate_chat_title(
 
         llm_provider = _resolve_secondary_provider(request.app.state)
 
-        # Check if title already exists
         if chat.title:
             logger.info(f"Chat already has a title: {chat.title}")
             return {"title": chat.title, "status": "existing"}
 
-        # Get messages from database
         messages_repo = MessagesRepository()
         chat_messages = await messages_repo.get_by_chat(chat_id)
         if not chat_messages:
@@ -2288,7 +1094,6 @@ async def generate_chat_title(
                 status_code=400, detail="Not enough messages to generate title"
             )
 
-        # Use only the user's first text-bearing message to generate the title.
         conversation_text = ""
         for msg in chat_messages:
             role = msg.message.get("role", "unknown")
@@ -2308,7 +1113,6 @@ async def generate_chat_title(
             return {"status": "skipped", "reason": "no_user_text"}
 
         logger.info(f"Extracted conversation text ({len(conversation_text)} chars)")
-        logger.debug(f"Conversation text: {conversation_text[:200]}...")
 
         title_result = await generate_title_for_conversation(
             llm_provider,
@@ -2336,7 +1140,6 @@ async def generate_chat_title(
 
         logger.info(f"Generated title: {title}")
 
-        # Update chat with the new title
         updated_chat = await chats_repo.update_title(chat_id, title)
         if not updated_chat:
             raise HTTPException(status_code=500, detail="Failed to update chat title")
@@ -2355,13 +1158,17 @@ async def generate_chat_title(
         )
 
 
+# ---------------------------------------------------------------------------
+# Route: download artifact
+# ---------------------------------------------------------------------------
+
+
 @router.get("/chat/{chat_id}/artifacts/{path:path}")
 async def download_artifact(
     request: Request,
     chat_id: str = Path(..., description="Chat thread ID"),
     path: str = Path(..., description="Relative file path in the sandbox"),
 ):
-    """Proxy artifact downloads from the sandbox service."""
     try:
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(
@@ -2388,3 +1195,9 @@ async def download_artifact(
     except Exception as e:
         logger.error(f"Artifact download error: {e}")
         raise HTTPException(status_code=500, detail="Internal error fetching artifact")
+
+
+# Re-exports for backward compatibility with tests.
+# The canonical homes are in ``services/ai/streaming/``.
+from streaming.persist import partial_assistant_message as _partial_assistant_message  # noqa: E402, F401
+from streaming.run import _run_tasks_by_chat  # noqa: E402, F401

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -4,7 +4,8 @@ import logging
 import pathlib
 from collections.abc import Iterable
 from dataclasses import dataclass
-from typing import Any, TypedDict, cast
+from enum import Enum
+from typing import Any, NotRequired, TypedDict, cast
 
 import httpx
 from anthropic import AsyncStream, MessageStreamEvent
@@ -104,8 +105,8 @@ def _chat_error_message(exc: Exception) -> str:
     return "Failed to generate response. Please try again."
 
 
-def _chat_error_payload(exc: Exception) -> dict[str, object]:
-    payload: dict[str, object] = {"message": _chat_error_message(exc)}
+def _chat_error_payload(exc: Exception) -> "StreamErrorEvent":
+    payload: StreamErrorEvent = {"message": _chat_error_message(exc)}
     if isinstance(exc, ProviderError):
         payload["provider"] = exc.provider_type
         payload["model"] = exc.model
@@ -178,6 +179,67 @@ def _sse_event_data(event_str: str) -> str:
         if line.startswith("data:"):
             return line[len("data:") :].strip()
     return ""
+
+
+class EndOfStreamReason(str, Enum):
+    """Typed reason for an ``end_of_stream`` terminal event."""
+
+    COMPLETED = "completed"
+    STOPPED = "stopped"
+    APPROVAL_REQUIRED = "approval_required"
+    OAUTH_REQUIRED = "oauth_required"
+    NO_NEW_MESSAGE = "no_new_message"
+
+
+class EndOfStreamEvent(TypedDict):
+    reason: EndOfStreamReason
+    message: NotRequired[str]
+
+
+class StreamErrorEvent(TypedDict):
+    message: str
+    provider: NotRequired[str]
+    model: NotRequired[str]
+    statusCode: NotRequired[int | None]
+
+
+class OAuthRequiredEvent(TypedDict):
+    tool_call_id: str
+    tool_name: str
+    source_id: str
+    source_type: str
+    provider: str
+    oauth_start_url: str
+
+
+def _oauth_event(
+    tool_call_id: str,
+    tool_name: str,
+    source_id: str,
+    source_type: str,
+    provider: str,
+    oauth_start_url: str,
+) -> OAuthRequiredEvent:
+    return {
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "source_id": source_id,
+        "source_type": source_type,
+        "provider": provider,
+        "oauth_start_url": oauth_start_url,
+    }
+
+
+def _stream_error_event(exc: Exception) -> StreamErrorEvent:
+    return _chat_error_payload(exc)
+
+
+def _end_of_stream(reason: EndOfStreamReason, *, message: str | None = None) -> str:
+    """Build a typed ``end_of_stream`` SSE event string."""
+    payload: EndOfStreamEvent = {"reason": reason}
+    if message is not None:
+        payload["message"] = message
+    return _sse_event("end_of_stream", payload)
 
 
 def _partial_assistant_message(
@@ -389,7 +451,7 @@ async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
         # disappear and reporting "Generation ended unexpectedly".
         try:
             await redis_client.xadd(
-                stream_key, {"e": "event: end_of_stream\ndata: Stopped\n\n"}
+                stream_key, {"e": _end_of_stream(EndOfStreamReason.STOPPED)}
             )
         except Exception:
             pass
@@ -399,7 +461,7 @@ async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
         try:
             await redis_client.xadd(
                 stream_key,
-                {"e": _sse_event("stream_error", {"message": _chat_error_message(e)})},
+                {"e": _sse_event("stream_error", _stream_error_event(e))},
             )
         except Exception:
             pass
@@ -423,7 +485,12 @@ async def _run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
 async def _consume_run(redis_client, chat_id, start_id):
     """Thin consumer: tail the Redis Stream from `start_id`, prefixing each event
     with its Redis id (SSE `id:`) for Last-Event-ID resume. Emits heartbeats
-    while idle and a terminal event if the producer vanished."""
+    while idle and a terminal event if the producer vanished.
+
+    Important id: invariant: no producer may template an ``id:`` line into its
+    own event body because this function prepends ``id: {entry_id}`` (the Redis
+    stream entry id) unconditionally. Heartbeats and synthetic terminal events
+    intentionally lack an id so they don't advance the resume position."""
     stream_key = _stream_key(chat_id)
     lock_key = _run_lock_key(chat_id)
     last = start_id or "0"
@@ -451,7 +518,7 @@ async def _consume_run(redis_client, chat_id, start_id):
         if not await redis_client.exists(lock_key):
             # Producer is gone but never wrote a terminal event we forwarded.
             yield _sse_event(
-                "stream_error", {"message": "Generation ended unexpectedly."}
+                "stream_error", StreamErrorEvent(message="Generation ended unexpectedly.")
             )
             return
         yield _sse_event("heartbeat", {})
@@ -1468,7 +1535,7 @@ async def stream_chat(
         )
 
         async def empty_generator():
-            yield b"event: end_of_stream\ndata: No new user message to process.\n\n"
+            yield _end_of_stream(EndOfStreamReason.NO_NEW_MESSAGE, message="No new user message to process.").encode()
 
         return StreamingResponse(
             empty_generator(),
@@ -1543,16 +1610,16 @@ async def stream_chat(
                 if pending_oauth:
                     intervention = pending_oauth[0]
                     logger.info(f"Resuming from pending oauth for chat {chat_id}")
-                    oauth_event = {
-                        "tool_call_id": intervention.tool_call_id,
-                        "tool_name": intervention.tool_name,
-                        "source_id": intervention.source_id,
-                        "source_type": intervention.source_type,
-                        "provider": intervention.provider,
-                        "oauth_start_url": intervention.oauth_start_url,
-                    }
+                    oauth_event = _oauth_event(
+                        intervention.tool_call_id,
+                        intervention.tool_name,
+                        intervention.source_id,
+                        intervention.source_type,
+                        intervention.provider,
+                        intervention.oauth_start_url,
+                    )
                     yield f"event: oauth_required\ndata: {json.dumps(oauth_event)}\n\n"
-                    yield "event: end_of_stream\ndata: OAuth required\n\n"
+                    yield _end_of_stream(EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required")
                     return
 
                 logger.info(f"Resuming from pending approval batch for chat {chat_id}")
@@ -1561,7 +1628,7 @@ async def stream_chat(
                     for approval in pending
                 ):
                     yield f"event: approval_required\ndata: {json.dumps(_approval_required_event(pending))}\n\n"
-                    yield "event: end_of_stream\ndata: Approval required\n\n"
+                    yield _end_of_stream(EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required")
                     return
 
                 approvals_by_tool_call_id = {
@@ -1634,14 +1701,14 @@ async def stream_chat(
                             logger.info(
                                 f"Saved pending oauth approval {saved_oauth_approval.id} for chat {chat_id}"
                             )
-                            oauth_event = {
-                                "tool_call_id": tool_call["id"],
-                                "tool_name": tool_call["name"],
-                                "source_id": payload.source_id,
-                                "source_type": payload.source_type,
-                                "provider": payload.provider,
-                                "oauth_start_url": payload.oauth_start_url,
-                            }
+                            oauth_event = _oauth_event(
+                                tool_call["id"],
+                                tool_call["name"],
+                                payload.source_id,
+                                payload.source_type,
+                                payload.provider,
+                                payload.oauth_start_url,
+                            )
                             if tool_results:
                                 tool_result_message = MessageParam(
                                     role="user", content=tool_results
@@ -1655,7 +1722,7 @@ async def stream_chat(
                                     chat.user_id,
                                 )
                             yield f"event: oauth_required\ndata: {json.dumps(oauth_event)}\n\n"
-                            yield "event: end_of_stream\ndata: OAuth required\n\n"
+                            yield _end_of_stream(EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required")
                             return
                         tool_result = ToolResultBlockParam(
                             type="tool_result",
@@ -1988,7 +2055,7 @@ async def stream_chat(
                         f"Pausing stream for {len(approval_required)} approval-required tool call(s)"
                     )
                     yield f"event: approval_required\ndata: {json.dumps(_approval_required_event(approval_required))}\n\n"
-                    yield "event: end_of_stream\ndata: Approval required\n\n"
+                    yield _end_of_stream(EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required")
                     return
 
                 tool_results: list[ToolResultBlockParam] = []
@@ -2014,16 +2081,16 @@ async def stream_chat(
                         logger.info(
                             f"Saved pending oauth approval {oauth_approval.id} for chat {chat_id}"
                         )
-                        oauth_event = {
-                            "tool_call_id": tool_call["id"],
-                            "tool_name": tool_name,
-                            "source_id": payload.source_id,
-                            "source_type": payload.source_type,
-                            "provider": payload.provider,
-                            "oauth_start_url": payload.oauth_start_url,
-                        }
+                        oauth_event = _oauth_event(
+                            tool_call["id"],
+                            tool_name,
+                            payload.source_id,
+                            payload.source_type,
+                            payload.provider,
+                            payload.oauth_start_url,
+                        )
                         yield f"event: oauth_required\ndata: {json.dumps(oauth_event)}\n\n"
-                        yield "event: end_of_stream\ndata: OAuth required\n\n"
+                        yield _end_of_stream(EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required")
                         return
 
                     tool_result = ToolResultBlockParam(
@@ -2083,18 +2150,25 @@ async def stream_chat(
                 except Exception as e:
                     logger.warning(f"Memory write setup failed for chat {chat_id}: {e}")
 
-            yield "event: end_of_stream\ndata: Stream ended\n\n"
+            yield _end_of_stream(EndOfStreamReason.COMPLETED, message="Stream ended")
 
         except asyncio.CancelledError:
             logger.info(f"Stream cancelled for chat {chat_id}")
-            raise  # Re-raise to let FastAPI handle cleanup
+            # Finalize partial content before re-raising so the
+            # early-persisted assistant row is updated (not deleted) by
+            # _persist_and_transform.  This mirrors the except Exception
+            # block below.
+            partial = _partial_assistant_message(content_blocks)
+            if partial is not None:
+                conversation_messages.append(partial)
+                yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
+            raise
         except Exception as e:
             logger.error(
                 f"Failed to generate AI response with tools: {e}", exc_info=True
             )
             # Finalize whatever partial assistant content was accumulated before
-            # the failure, so the early-persisted row is not left empty. The
-            # cancel path above does the same; this mirrors it for errors.
+            # the failure, so the early-persisted row is not left empty.
             partial = _partial_assistant_message(content_blocks)
             if partial is not None:
                 conversation_messages.append(partial)
@@ -2162,15 +2236,18 @@ async def cancel_chat_stream(
     directly so generation stops immediately — even mid-message or during a slow
     tool call, where the next checkpoint could be far off.
     """
-    redis_client = getattr(request.app.state, "redis_client", None)
-    if redis_client is not None:
-        try:
-            await redis_client.set(_cancel_key(chat_id), "1", ex=_CANCEL_TTL)
-        except Exception as e:
-            logger.error(f"Failed to set cancel flag for chat {chat_id}: {e}")
+    redis_client = request.app.state.redis_client
+    try:
+        await redis_client.set(_cancel_key(chat_id), "1", ex=_CANCEL_TTL)
+    except Exception as e:
+        logger.error(f"Failed to set cancel flag for chat {chat_id}: {e}")
 
     task = _run_tasks_by_chat.get(chat_id)
     if task is not None and not task.done():
+        # In-process cancel (task.cancel()) is best-effort in multi-worker
+        # deployments without sticky sessions: the Stop request may land on
+        # a worker that does not own the producer task.  The Redis cancel
+        # flag above provides the fallback cross-worker checkpoint.
         task.cancel()
 
     return {"status": "cancelling"}

--- a/services/ai/streaming/__init__.py
+++ b/services/ai/streaming/__init__.py
@@ -1,0 +1,8 @@
+"""Streaming subpackage — decoupled producer/consumer chat streaming.
+
+Extracted from the ``services/ai/routers/chat.py`` monolith into three layers:
+
+* ``persist`` — SSE event helpers, typed event types, persistence wrapper
+* ``run`` — Redis transport layer, producer/consumer/lifecycle
+* ``generate`` — Agent loop generator (the core stream generator)
+"""

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -1,0 +1,836 @@
+"""Agent loop generator for the chat streaming pipeline.
+
+Owns ``stream_generator``, the per-iteration event handler, and the message-
+content helpers that the agent loop uses to inspect/repair conversation history.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator, Iterable
+from typing import Any, cast
+
+from anthropic import AsyncStream, MessageStreamEvent
+from anthropic.types import (
+    CitationCharLocationParam,
+    CitationContentBlockLocationParam,
+    CitationPageLocationParam,
+    CitationsDelta,
+    CitationSearchResultLocationParam,
+    CitationWebSearchResultLocationParam,
+    ContentBlockParam,
+    MessageParam,
+    TextBlockParam,
+    TextCitationParam,
+    ToolResultBlockParam,
+    ToolUseBlockParam,
+)
+
+from config import (
+    AGENT_MAX_ITERATIONS,
+    DEFAULT_MAX_TOKENS,
+    DEFAULT_TEMPERATURE,
+    DEFAULT_TOP_P,
+)
+from db.tool_approvals import ToolApproval, ToolApprovalStatus, ToolApprovalType
+from db.usage import UsageRepository
+from memory import MemoryMode
+from providers import LLMProvider, ProviderError
+from services.compaction import ConversationCompactor
+from services.usage import UsageContext, UsagePurpose, UsageTracker
+from streaming.persist import (
+    EndOfStreamReason,
+    approval_required_event,
+    end_of_stream,
+    oauth_event,
+    parse_tool_call_inputs,
+    partial_assistant_message,
+    sse_event,
+    stream_error_sse,
+)
+from streaming.run import _CANCEL_CHECK_INTERVAL_SECONDS, is_run_cancelled
+from tools import (
+    ConnectorToolHandler,
+    ToolContext,
+    ToolHandler,
+    ToolRegistry,
+)
+from tools.omni_tool_result import OAuthRequiredPayload
+from tools.turn_builder import build_turn_tools
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Per-iteration event stream provider (with compaction retry)
+# ---------------------------------------------------------------------------
+
+
+async def event_stream_with_context_retry(
+    turn_tools: list[dict],
+    conversation_messages: list[MessageParam],
+    llm_provider: LLMProvider,
+    chat_user_id: str,
+    chat_id: str,
+    system_prompt: str,
+    compactor: ConversationCompactor,
+    latest_compaction_summary: str | None,
+    summarizer_context_window_tokens: int,
+) -> AsyncIterator[MessageStreamEvent]:
+    """Stream events from the LLM provider with one automatic compaction retry
+    on context-overflow errors.
+
+    ``conversation_messages`` is mutated in-place when a compaction retry
+    replaces the full history with a compacted version.
+    """
+    for llm_attempt in range(2):
+        tracker = UsageTracker(
+            UsageRepository(),
+            UsageContext(
+                user_id=chat_user_id,
+                model_id=llm_provider.model_record_id,
+                model_name=llm_provider.model_name,
+                provider_type=llm_provider.provider_type,
+                purpose=UsagePurpose.CHAT,
+                chat_id=chat_id,
+            ),
+        )
+        raw_stream: AsyncStream[MessageStreamEvent] = llm_provider.stream_response(
+            prompt="",
+            messages=conversation_messages,
+            tools=turn_tools,
+            max_tokens=DEFAULT_MAX_TOKENS,
+            temperature=DEFAULT_TEMPERATURE,
+            top_p=DEFAULT_TOP_P,
+            system_prompt=system_prompt,
+        )
+        emitted_event = False
+        try:
+            async for wrapped_event in tracker.wrap_stream(raw_stream):
+                emitted_event = True
+                yield wrapped_event
+            tracker.save()
+            return
+        except ProviderError as e:
+            if e.is_context_overflow and llm_attempt == 0 and not emitted_event:
+                logger.warning(
+                    "Chat %s hit provider context limit; retrying once after forced compaction",
+                    chat_id,
+                )
+                conversation_messages[:] = await compactor.compact_conversation(
+                    chat_id,
+                    conversation_messages,
+                    previous_summary=latest_compaction_summary,
+                    summarizer_context_window_tokens=summarizer_context_window_tokens,
+                )
+                continue
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Message-content helpers
+# ---------------------------------------------------------------------------
+
+
+def message_content_blocks(message: MessageParam) -> list[ContentBlockParam]:
+    content = message["content"]
+    if isinstance(content, str):
+        return []
+    return list(cast(Iterable[ContentBlockParam], content))
+
+
+def tool_use_blocks(message: MessageParam) -> list[ToolUseBlockParam]:
+    if message.get("role") != "assistant":
+        return []
+    return [
+        cast(ToolUseBlockParam, block)
+        for block in message_content_blocks(message)
+        if block["type"] == "tool_use"
+    ]
+
+
+def tool_result_ids(message: MessageParam) -> set[str]:
+    if message.get("role") != "user":
+        return set()
+    return {
+        cast(ToolResultBlockParam, block)["tool_use_id"]
+        for block in message_content_blocks(message)
+        if block["type"] == "tool_result"
+    }
+
+
+def _interrupted_tool_result(tool_use: ToolUseBlockParam) -> ToolResultBlockParam:
+    return ToolResultBlockParam(
+        type="tool_result",
+        tool_use_id=tool_use["id"],
+        content=[
+            {
+                "type": "text",
+                "text": (
+                    f"Tool call {tool_use['name']} did not complete because the previous response was interrupted. "
+                    "Treat this tool call as failed and retry it if the result is still needed."
+                ),
+            }
+        ],
+        is_error=True,
+    )
+
+
+def repair_interrupted_tool_calls(
+    messages: list[MessageParam],
+) -> tuple[list[MessageParam], int]:
+    """Insert ToolResultBlockParam placeholders for tool calls whose
+    responses were lost (interrupted stream)."""
+    repaired: list[MessageParam] = []
+    repair_count = 0
+
+    for idx, message in enumerate(messages):
+        tool_uses = tool_use_blocks(message)
+        if not tool_uses:
+            repaired.append(message)
+            continue
+
+        next_message = messages[idx + 1] if idx + 1 < len(messages) else None
+        answered_ids = tool_result_ids(next_message) if next_message else set()
+        missing = [
+            tool_use for tool_use in tool_uses if tool_use["id"] not in answered_ids
+        ]
+
+        repaired.append(message)
+        if not missing:
+            continue
+
+        missing_results = [_interrupted_tool_result(tool_use) for tool_use in missing]
+        if answered_ids and next_message is not None:
+            content = next_message["content"]
+            if isinstance(content, list):
+                next_message = cast(MessageParam, dict(next_message))
+                next_message["content"] = [*content, *missing_results]
+                messages[idx + 1] = next_message
+                repair_count += len(missing_results)
+                continue
+
+        repaired.append(MessageParam(role="user", content=missing_results))
+        repair_count += len(missing_results)
+
+    return repaired, repair_count
+
+
+def drop_empty_assistant_messages(
+    messages: list[MessageParam],
+) -> list[MessageParam]:
+    """Remove assistant messages with no content and no tool_use blocks."""
+    kept: list[MessageParam] = []
+    for message in messages:
+        if message.get("role") == "assistant":
+            blocks = message_content_blocks(message)
+            has_tool_use = any(b.get("type") == "tool_use" for b in blocks)
+            has_content = bool(blocks) and any(
+                b.get("type") == "text" and b.get("text") for b in blocks
+            )
+            if not has_tool_use and not has_content:
+                continue
+        kept.append(message)
+    return kept
+
+
+def convert_citation_to_param(citation_delta: CitationsDelta) -> TextCitationParam:
+    citation = citation_delta.citation
+    if citation.type == "char_location":
+        return CitationCharLocationParam(
+            type="char_location",
+            start_char_index=citation.start_char_index,
+            end_char_index=citation.end_char_index,
+            document_title=citation.document_title,
+            document_index=citation.document_index,
+            cited_text=citation.cited_text,
+        )
+    elif citation.type == "page_location":
+        return CitationPageLocationParam(
+            type="page_location",
+            start_page_number=citation.start_page_number,
+            end_page_number=citation.end_page_number,
+            document_title=citation.document_title,
+            document_index=citation.document_index,
+            cited_text=citation.cited_text,
+        )
+    elif citation.type == "content_block_location":
+        return CitationContentBlockLocationParam(
+            type="content_block_location",
+            start_block_index=citation.start_block_index,
+            end_block_index=citation.end_block_index,
+            document_title=citation.document_title,
+            document_index=citation.document_index,
+            cited_text=citation.cited_text,
+        )
+    elif citation.type == "search_result_location":
+        return CitationSearchResultLocationParam(
+            type="search_result_location",
+            start_block_index=citation.start_block_index,
+            end_block_index=citation.end_block_index,
+            search_result_index=citation.search_result_index,
+            title=citation.title,
+            source=citation.source,
+            cited_text=citation.cited_text,
+        )
+    elif citation.type == "web_search_result_location":
+        return CitationWebSearchResultLocationParam(
+            type="web_search_result_location",
+            url=citation.url,
+            title=citation.title,
+            encrypted_index=citation.encrypted_index,
+            cited_text=citation.cited_text,
+        )
+    else:
+        raise ValueError(f"Unknown citation type: {citation.type}")
+
+
+def _copy_provider_extras(src: object, dst: dict, keys: tuple[str, ...]) -> None:
+    """Copy provider-declared sidecar fields off a Pydantic content_block
+    instance onto its persisted TypedDict block."""
+    for key in keys:
+        value = getattr(src, key, None)
+        if value is not None:
+            dst[key] = value  # type: ignore[typeddict-unknown-key]
+
+
+async def active_path_tool_call_ids(messages_repo, chat_id: str) -> set[str]:
+    active_path = await messages_repo.get_active_path(chat_id)
+    return {
+        tool_use["id"]
+        for message in active_path
+        for tool_use in tool_use_blocks(MessageParam(**message.message))
+    }
+
+
+# ---------------------------------------------------------------------------
+# The main generator
+# ---------------------------------------------------------------------------
+
+
+async def stream_generator(
+    chat_id: str,
+    redis_client,
+    messages: list[MessageParam],
+    llm_provider: LLMProvider,
+    chat_user_id: str,
+    *,
+    tool_user_id: str | None = None,
+    user_email: str | None = None,
+    user_configuration=None,
+    tool_skip_perm: bool = False,
+    system_prompt: str,
+    registry: ToolRegistry,
+    always_on_handlers: list[ToolHandler],
+    connector_handler: ConnectorToolHandler | None,
+    loaded_toolsets: set[str],
+    compactor: ConversationCompactor,
+    latest_compaction_summary: str | None = None,
+    summarizer_context_window_tokens: int = 0,
+    memory_provider=None,
+    memory_write_key: str | None = None,
+    effective_mode=MemoryMode.OFF,
+    approvals_repo=None,
+    pending: list | None = None,
+    pending_oauth: list | None = None,
+    original_user_query: str | None = None,
+) -> AsyncIterator[str]:
+    """Core agent loop: yields SSE event strings.
+
+    This is the extracted, module-level version of the generator that was
+    formerly defined inside ``stream_chat``.  All closure-captured locals are
+    now explicit parameters.
+    """
+    try:
+        conversation_messages = messages.copy()
+        content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
+        content_blocks_finalized = False
+
+        # ----- Pending approval / OAuth resume ---------------------------------
+        if pending or pending_oauth:
+            if pending_oauth:
+                intervention = pending_oauth[0]
+                logger.info(f"Resuming from pending oauth for chat {chat_id}")
+                ev = oauth_event(
+                    intervention.tool_call_id,
+                    intervention.tool_name,
+                    intervention.source_id,
+                    intervention.source_type,
+                    intervention.provider,
+                    intervention.oauth_start_url,
+                )
+                yield f"event: oauth_required\ndata: {json.dumps(ev)}\n\n"
+                yield end_of_stream(
+                    EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                )
+                return
+
+            logger.info(f"Resuming from pending approval batch for chat {chat_id}")
+            if any(
+                approval.status == ToolApprovalStatus.PENDING
+                for approval in pending or []
+            ):
+                yield (
+                    f"event: approval_required\ndata: "
+                    f"{json.dumps(approval_required_event(pending or [], tool_use_blocks))}\n\n"
+                )
+                yield end_of_stream(
+                    EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
+                )
+                return
+
+            approvals_by_tool_call_id = {
+                approval.tool_call_id: approval
+                for approval in (pending or [])
+                if approval.tool_call_id is not None
+            }
+            answered_ids = (
+                tool_result_ids(conversation_messages[-1])
+                if conversation_messages
+                else set()
+            )
+            tool_calls_to_resume: list[ToolUseBlockParam] = []
+            for message in reversed(conversation_messages):
+                tool_uses = tool_use_blocks(message)
+                if not tool_uses:
+                    answered_ids.update(tool_result_ids(message))
+                    continue
+                tool_calls_to_resume = [
+                    tool_use
+                    for tool_use in tool_uses
+                    if tool_use["id"] not in answered_ids
+                ]
+                break
+
+            context = ToolContext(
+                chat_id=chat_id,
+                user_id=tool_user_id,
+                user_email=user_email,
+                user_configuration=user_configuration,
+                skip_permission_check=tool_skip_perm,
+            )
+            tool_results: list[ToolResultBlockParam] = []
+            completed_approval_ids: list[str] = []
+            for tool_call in tool_calls_to_resume:
+                approval = approvals_by_tool_call_id.get(tool_call["id"])
+                if approval and approval.status == ToolApprovalStatus.DENIED:
+                    tool_result = ToolResultBlockParam(
+                        type="tool_result",
+                        tool_use_id=tool_call["id"],
+                        content=[
+                            {
+                                "type": "text",
+                                "text": "The user denied approval for this tool call.",
+                            }
+                        ],
+                        is_error=True,
+                    )
+                    completed_approval_ids.append(approval.id)
+                else:
+                    result = await registry.execute(
+                        tool_call["name"], tool_call["input"], context
+                    )
+                    if result.oauth_required is not None:
+                        payload = result.oauth_required
+                        if approval:
+                            completed_approval_ids.append(approval.id)
+                        await approvals_repo.create_pending(
+                            chat_id=chat_id,
+                            user_id=chat_user_id,
+                            tool_name=tool_call["name"],
+                            tool_input=tool_call["input"],
+                            tool_call_id=tool_call["id"],
+                            approval_type=ToolApprovalType.OAUTH,
+                            source_id=payload.source_id,
+                            source_type=payload.source_type,
+                            provider=payload.provider,
+                            oauth_start_url=payload.oauth_start_url,
+                        )
+                        if tool_results:
+                            tool_result_message = MessageParam(
+                                role="user", content=tool_results
+                            )
+                            conversation_messages.append(tool_result_message)
+                            yield (
+                                f"event: save_message\ndata: "
+                                f"{json.dumps(tool_result_message)}\n\n"
+                            )
+                        for aid in completed_approval_ids:
+                            await approvals_repo.update_status(
+                                aid, ToolApprovalStatus.COMPLETED, chat_user_id
+                            )
+                        yield (
+                            f"event: oauth_required\ndata: "
+                            f"{json.dumps(oauth_event(tool_call['id'], tool_call['name'], payload.source_id, payload.source_type, payload.provider, payload.oauth_start_url))}\n\n"
+                        )
+                        yield end_of_stream(
+                            EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                        )
+                        return
+
+                    tool_result = ToolResultBlockParam(
+                        type="tool_result",
+                        tool_use_id=tool_call["id"],
+                        content=result.content,
+                        is_error=result.is_error,
+                    )
+                    if approval:
+                        completed_approval_ids.append(approval.id)
+
+                tool_results.append(tool_result)
+                yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
+
+            if tool_results:
+                tool_result_message = MessageParam(role="user", content=tool_results)
+                conversation_messages.append(tool_result_message)
+                yield (
+                    f"event: save_message\ndata: "
+                    f"{json.dumps(tool_result_message)}\n\n"
+                )
+            for aid in completed_approval_ids:
+                await approvals_repo.update_status(
+                    aid, ToolApprovalStatus.COMPLETED, chat_user_id
+                )
+
+        logger.info(
+            f"Starting conversation with {len(conversation_messages)} initial messages"
+        )
+
+        # Extract the first user message for caching purposes
+        original_user_query_final = original_user_query
+        if original_user_query_final is None:
+            for msg in conversation_messages:
+                if msg.get("role") == "user":
+                    raw = msg.get("content", "")
+                    if isinstance(raw, str):
+                        original_user_query_final = raw
+                        break
+                    elif isinstance(raw, list):
+                        parts = [
+                            b.get("text", "")
+                            for b in raw
+                            if isinstance(b, dict) and b.get("type") == "text"
+                        ]
+                        if parts:
+                            original_user_query_final = " ".join(parts)
+                            break
+
+        context = ToolContext(
+            chat_id=chat_id,
+            user_id=tool_user_id,
+            user_email=user_email,
+            user_configuration=user_configuration,
+            original_user_query=original_user_query_final,
+            skip_permission_check=tool_skip_perm,
+        )
+
+        usage_repo = UsageRepository()
+        assistant_message: MessageParam | None = None
+
+        # ----- Main agent loop -------------------------------------------------
+        for iteration in range(AGENT_MAX_ITERATIONS):
+            if await is_run_cancelled(redis_client, chat_id):
+                logger.info(f"Run cancelled, stopping stream for chat {chat_id}")
+                break
+
+            logger.info(f"Iteration {iteration + 1}/{AGENT_MAX_ITERATIONS}")
+            content_blocks = []
+            content_blocks_finalized = False
+            provider_extras = llm_provider.PERSISTED_BLOCK_EXTRAS
+
+            turn_tools = build_turn_tools(
+                always_on_handlers,
+                connector_handler,
+                loaded_toolsets,
+            )
+
+            logger.info("Sending request to LLM provider")
+
+            stream = event_stream_with_context_retry(
+                turn_tools,
+                conversation_messages,
+                llm_provider,
+                chat_user_id,
+                chat_id,
+                system_prompt,
+                compactor,
+                latest_compaction_summary,
+                summarizer_context_window_tokens,
+            )
+
+            event_index = 0
+            message_stop_received = False
+            cancelled = False
+            last_cancel_check_at = 0.0
+            async for event in stream:
+                logger.debug(f"Received event: {event} (index: {event_index})")
+                event_index += 1
+
+                now = asyncio.get_running_loop().time()
+                if now - last_cancel_check_at >= _CANCEL_CHECK_INTERVAL_SECONDS:
+                    last_cancel_check_at = now
+                    if await is_run_cancelled(redis_client, chat_id):
+                        cancelled = True
+                        break
+
+                if event.type == "message_start":
+                    logger.info("Message start received.")
+
+                if event.type == "content_block_delta":
+                    logger.debug(
+                        f"Content block delta received at index {event.index}: {event.delta}"
+                    )
+                    if event.delta.type == "text_delta":
+                        if event.index >= len(content_blocks):
+                            logger.warning(
+                                f"Received text delta for unknown content block index {event.index}, creating new text block"
+                            )
+                            content_blocks.append(TextBlockParam(type="text", text=""))
+                        text_block = cast(TextBlockParam, content_blocks[event.index])
+                        text_block["text"] += event.delta.text
+                    elif event.delta.type == "input_json_delta":
+                        if event.index >= len(content_blocks):
+                            logger.warning(
+                                f"Received input JSON delta for unknown content block index {event.index}, creating new tool use block"
+                            )
+                            content_blocks.append(
+                                ToolUseBlockParam(
+                                    type="tool_use", id="", name="", input=""
+                                )
+                            )
+                        tool_use_block = cast(
+                            ToolUseBlockParam, content_blocks[event.index]
+                        )
+                        tool_use_block["input"] = (
+                            cast(str, tool_use_block["input"])
+                            + event.delta.partial_json
+                        )
+                    elif event.delta.type == "citations_delta":
+                        if event.index >= len(content_blocks):
+                            logger.warning(
+                                f"Received citations delta for unknown content block index {event.index}, creating new citations block"
+                            )
+                            content_blocks.append(
+                                TextBlockParam(type="text", text="", citations=[])
+                            )
+                        text_block = cast(TextBlockParam, content_blocks[event.index])
+                        if "citations" not in text_block or not text_block["citations"]:
+                            text_block["citations"] = []
+                        citations = cast(
+                            list[TextCitationParam], text_block["citations"]
+                        )
+                        citations.append(convert_citation_to_param(event.delta))
+
+                elif event.type == "content_block_start":
+                    if event.content_block.type == "text":
+                        logger.info(f"Text block start: {event.content_block.text}")
+                        text_block: TextBlockParam = TextBlockParam(
+                            type="text", text=event.content_block.text
+                        )
+                        _copy_provider_extras(
+                            event.content_block, text_block, provider_extras
+                        )
+                        content_blocks.append(text_block)
+                    elif event.content_block.type == "tool_use":
+                        logger.info(
+                            f"Tool use block start: {event.content_block.name} (id: {event.content_block.id})"
+                        )
+                        tool_block: ToolUseBlockParam = ToolUseBlockParam(
+                            type="tool_use",
+                            id=event.content_block.id,
+                            name=event.content_block.name,
+                            input="",
+                        )
+                        _copy_provider_extras(
+                            event.content_block, tool_block, provider_extras
+                        )
+                        content_blocks.append(tool_block)
+
+                elif event.type == "citation":
+                    logger.info(f"Citation received: {event.citation}")
+                elif event.type == "message_stop":
+                    logger.info("Message stop received.")
+                    message_stop_received = True
+
+                logger.debug(f"Yielding event to client: {event.to_json(indent=None)}")
+                yield f"event: message\ndata: {event.to_json(indent=None)}\n\n"
+
+                if message_stop_received:
+                    break
+
+            # ----- Per-iteration post-processing --------------------------------
+            if cancelled:
+                assistant_message = partial_assistant_message(content_blocks)
+                if assistant_message is not None:
+                    conversation_messages.append(assistant_message)
+                    yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
+                break
+
+            tool_calls = [b for b in content_blocks if b["type"] == "tool_use"]
+            parse_errors = parse_tool_call_inputs(
+                cast(list[ToolUseBlockParam], tool_calls)
+            )
+
+            assistant_message = MessageParam(role="assistant", content=content_blocks)
+            conversation_messages.append(assistant_message)
+            yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
+            content_blocks_finalized = True
+
+            if parse_errors:
+                tool_result_message = MessageParam(role="user", content=parse_errors)
+                conversation_messages.append(tool_result_message)
+                for pe in parse_errors:
+                    yield f"event: message\ndata: {json.dumps(pe)}\n\n"
+                yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
+                continue
+
+            if not tool_calls:
+                logger.info(
+                    f"No tool calls in iteration {iteration + 1}, completing response"
+                )
+                break
+
+            logger.info(f"Processing {len(tool_calls)} tool calls")
+
+            if await is_run_cancelled(redis_client, chat_id):
+                logger.info(f"Run cancelled before tool execution for chat {chat_id}")
+                break
+
+            # ----- Approval checks before tool execution ------------------------
+            approval_required: list[ToolApproval] = []
+            for tool_call in tool_calls:
+                tool_name = tool_call["name"]
+                tool_input = tool_call["input"]
+                if registry.requires_approval(tool_name):
+                    logger.info(f"Tool {tool_name} requires approval")
+                    approval = await approvals_repo.create_pending(
+                        chat_id=chat_id,
+                        user_id=chat_user_id,
+                        tool_name=tool_name,
+                        tool_input=tool_input,
+                        tool_call_id=tool_call["id"],
+                        approval_type=ToolApprovalType.APPROVAL,
+                        source_id=tool_input.get("source_id"),
+                        source_type=tool_input.get("source_type"),
+                    )
+                    logger.info(
+                        f"Saved pending approval {approval.id} for chat {chat_id}"
+                    )
+                    approval_required.append(approval)
+
+            if approval_required:
+                logger.info(
+                    f"Pausing stream for {len(approval_required)} approval-required tool call(s)"
+                )
+                yield (
+                    f"event: approval_required\ndata: "
+                    f"{json.dumps(approval_required_event(approval_required, tool_use_blocks))}\n\n"
+                )
+                yield end_of_stream(
+                    EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
+                )
+                return
+
+            # ----- Execute tools -----------------------------------------------
+            tool_results = []
+            for tool_call in tool_calls:
+                tool_name = tool_call["name"]
+                tool_input = tool_call["input"]
+
+                result = await registry.execute(tool_name, tool_input, context)
+                if result.oauth_required is not None:
+                    payload = result.oauth_required
+                    await approvals_repo.create_pending(
+                        chat_id=chat_id,
+                        user_id=chat_user_id,
+                        tool_name=tool_name,
+                        tool_input=tool_input,
+                        tool_call_id=tool_call["id"],
+                        approval_type=ToolApprovalType.OAUTH,
+                        source_id=payload.source_id,
+                        source_type=payload.source_type,
+                        provider=payload.provider,
+                        oauth_start_url=payload.oauth_start_url,
+                    )
+                    logger.info(f"Saved pending oauth approval for chat {chat_id}")
+                    yield (
+                        f"event: oauth_required\ndata: "
+                        f"{json.dumps(oauth_event(tool_call['id'], tool_name, payload.source_id, payload.source_type, payload.provider, payload.oauth_start_url))}\n\n"
+                    )
+                    yield end_of_stream(
+                        EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                    )
+                    return
+
+                tool_result = ToolResultBlockParam(
+                    type="tool_result",
+                    tool_use_id=tool_call["id"],
+                    content=result.content,
+                    is_error=result.is_error,
+                )
+                tool_results.append(tool_result)
+                yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
+
+            tool_result_message = MessageParam(role="user", content=tool_results)
+            conversation_messages.append(tool_result_message)
+            yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
+
+        # ----- Memory write (fire-and-forget) ----------------------------------
+        if (
+            memory_provider is not None
+            and memory_write_key
+            and effective_mode >= MemoryMode.CHAT
+        ):
+            try:
+                last_user_content = None
+                for msg in reversed(conversation_messages):
+                    m = msg if isinstance(msg, dict) else dict(msg)
+                    if m.get("role") == "user":
+                        raw = m.get("content", "")
+                        if isinstance(raw, list):
+                            raw = " ".join(
+                                b.get("text", "")
+                                for b in raw
+                                if isinstance(b, dict) and b.get("type") == "text"
+                            )
+                        if not raw:
+                            continue
+                        last_user_content = raw
+                        break
+                if last_user_content and assistant_message:
+                    assistant_content = "".join(
+                        b.get("text", "")
+                        for b in assistant_message.get("content", [])
+                        if isinstance(b, dict) and b.get("type") == "text"
+                    )
+                    if assistant_content:
+                        turn = [
+                            MessageParam(role="user", content=last_user_content),
+                            MessageParam(role="assistant", content=assistant_content),
+                        ]
+                        asyncio.create_task(
+                            memory_provider.add(messages=turn, key=memory_write_key)
+                        )
+            except Exception as e:
+                logger.warning(f"Memory write setup failed for chat {chat_id}: {e}")
+
+        yield end_of_stream(EndOfStreamReason.COMPLETED, message="Stream ended")
+
+    except asyncio.CancelledError:
+        logger.info(f"Stream cancelled for chat {chat_id}")
+        if not content_blocks_finalized:
+            partial = partial_assistant_message(content_blocks)
+            if partial is not None:
+                conversation_messages.append(partial)
+                yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
+        raise
+    except Exception as e:
+        logger.error(f"Failed to generate AI response with tools: {e}", exc_info=True)
+        if not content_blocks_finalized:
+            partial = partial_assistant_message(content_blocks)
+            if partial is not None:
+                conversation_messages.append(partial)
+                yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
+        yield stream_error_sse(e)

--- a/services/ai/streaming/persist.py
+++ b/services/ai/streaming/persist.py
@@ -1,0 +1,389 @@
+"""Persistence and SSE event helpers for the chat streaming pipeline.
+
+Owns pure helpers, typed event definitions, and the ``persist_and_transform``
+wrapper that owns the ``current_assistant_message_id`` lifecycle for
+early-persisted assistant rows.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Iterable
+from enum import Enum
+from typing import Any, NotRequired, TypedDict, cast
+
+from anthropic.types import (
+    MessageParam,
+    TextBlockParam,
+    ToolResultBlockParam,
+    ToolUseBlockParam,
+)
+
+from db.tool_approvals import ToolApproval
+from providers import LLMProviderStreamError, ProviderError
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# SSE event string helpers
+# ---------------------------------------------------------------------------
+
+
+def sse_event(event_type: str, data: object) -> str:
+    """Build an SSE ``event:`` / ``data:`` string pair."""
+    return f"event: {event_type}\ndata: {json.dumps(data)}\n\n"
+
+
+def sse_event_type(event_str: str) -> str:
+    """Extract the event type from an SSE event string."""
+    for line in event_str.split("\n"):
+        if line.startswith("event:"):
+            return line[len("event:") :].strip()
+    return "message"
+
+
+def sse_event_data(event_str: str) -> str:
+    """Extract the JSON data string from an SSE event string."""
+    for line in event_str.split("\n"):
+        if line.startswith("data:"):
+            return line[len("data:") :].strip()
+    return ""
+
+
+# ---------------------------------------------------------------------------
+# Typed event envelopes
+# ---------------------------------------------------------------------------
+
+
+class EndOfStreamReason(str, Enum):
+    """Typed reason for an ``end_of_stream`` terminal event."""
+
+    COMPLETED = "completed"
+    STOPPED = "stopped"
+    APPROVAL_REQUIRED = "approval_required"
+    OAUTH_REQUIRED = "oauth_required"
+    NO_NEW_MESSAGE = "no_new_message"
+
+
+class EndOfStreamEvent(TypedDict):
+    reason: EndOfStreamReason
+    message: NotRequired[str]
+
+
+class StreamErrorEvent(TypedDict):
+    message: str
+    provider: NotRequired[str]
+    model: NotRequired[str]
+    statusCode: NotRequired[int | None]
+
+
+class OAuthRequiredEvent(TypedDict):
+    tool_call_id: str
+    tool_name: str
+    source_id: str
+    source_type: str
+    provider: str
+    oauth_start_url: str
+
+
+class ApprovalRequiredEventItem(TypedDict):
+    approval_id: str
+    tool_name: str
+    tool_input: dict[str, Any]
+    tool_call_id: str | None
+    source_id: str | None
+    source_type: str | None
+
+
+class ApprovalRequiredEvent(ApprovalRequiredEventItem):
+    approvals: list[ApprovalRequiredEventItem]
+
+
+# ---------------------------------------------------------------------------
+# Event-builders
+# ---------------------------------------------------------------------------
+
+
+def _chat_error_message(exc: Exception) -> str:
+    if isinstance(exc, ProviderError) and exc.message:
+        return f"Failed to generate response: {exc.message}"
+    if isinstance(exc, LLMProviderStreamError) and exc.message:
+        return f"Failed to generate response: {exc.message}"
+    message = str(exc).strip()
+    if message:
+        return f"Failed to generate response: {message}"
+    return "Failed to generate response. Please try again."
+
+
+def _chat_error_payload(exc: Exception) -> StreamErrorEvent:
+    payload: StreamErrorEvent = {"message": _chat_error_message(exc)}
+    if isinstance(exc, ProviderError):
+        payload["provider"] = exc.provider_type
+        payload["model"] = exc.model
+        payload["statusCode"] = exc.status_code
+    return payload
+
+
+def stream_error_event(exc: Exception) -> StreamErrorEvent:
+    """Build a ``StreamErrorEvent`` from an exception."""
+    return _chat_error_payload(exc)
+
+
+def stream_error_sse(exc: Exception) -> str:
+    """Build an SSE ``stream_error`` event string from an exception."""
+    return sse_event("stream_error", _chat_error_payload(exc))
+
+
+def end_of_stream(reason: EndOfStreamReason, *, message: str | None = None) -> str:
+    """Build a typed ``end_of_stream`` SSE event string."""
+    payload: EndOfStreamEvent = {"reason": reason}
+    if message is not None:
+        payload["message"] = message
+    return sse_event("end_of_stream", payload)
+
+
+def oauth_event(
+    tool_call_id: str,
+    tool_name: str,
+    source_id: str,
+    source_type: str,
+    provider: str,
+    oauth_start_url: str,
+) -> OAuthRequiredEvent:
+    return {
+        "tool_call_id": tool_call_id,
+        "tool_name": tool_name,
+        "source_id": source_id,
+        "source_type": source_type,
+        "provider": provider,
+        "oauth_start_url": oauth_start_url,
+    }
+
+
+def approval_required_event(
+    approvals: list[ToolApproval],
+    tool_use_blocks_fn,  # callable: list[MessageParam] -> list[ToolUseBlockParam]
+) -> ApprovalRequiredEvent:
+    """Build an ``ApprovalRequiredEvent`` from a list of pending approvals."""
+    first = approvals[0]
+    event: ApprovalRequiredEvent = {
+        "approval_id": first.id,
+        "tool_name": first.tool_name,
+        "tool_input": first.tool_input,
+        "tool_call_id": first.tool_call_id,
+        "source_id": first.source_id,
+        "source_type": first.source_type,
+        "approvals": [
+            {
+                "approval_id": approval.id,
+                "tool_name": approval.tool_name,
+                "tool_input": approval.tool_input,
+                "tool_call_id": approval.tool_call_id,
+                "source_id": approval.source_id,
+                "source_type": approval.source_type,
+            }
+            for approval in approvals
+        ],
+    }
+    return event
+
+
+# ---------------------------------------------------------------------------
+# Assistant message building
+# ---------------------------------------------------------------------------
+
+
+def partial_assistant_message(
+    content_blocks: list[TextBlockParam | ToolUseBlockParam],
+) -> MessageParam | None:
+    """Build a ``MessageParam`` from partial content blocks.
+
+    Returns ``None`` when there is nothing to persist (no non-empty text or
+    tool-use blocks), which lets the caller avoid emitting a ``save_message``
+    event for a genuinely empty response.
+    """
+    persisted_blocks: list[TextBlockParam | ToolUseBlockParam] = []
+    for block in content_blocks:
+        if block["type"] == "text":
+            text_block = cast(TextBlockParam, block)
+            if text_block["text"].strip():
+                persisted_blocks.append(cast(TextBlockParam, dict(text_block)))
+            continue
+
+        tool_block = cast(ToolUseBlockParam, dict(block))
+        raw_input = tool_block.get("input")
+        if isinstance(raw_input, str):
+            try:
+                tool_block["input"] = json.loads(raw_input) if raw_input else {}
+            except json.JSONDecodeError:
+                tool_block["input"] = {}
+        persisted_blocks.append(tool_block)
+
+    if not persisted_blocks:
+        return None
+    return MessageParam(role="assistant", content=persisted_blocks)
+
+
+def parse_tool_call_inputs(
+    tool_calls: list[ToolUseBlockParam],
+) -> list[ToolResultBlockParam]:
+    """Parse raw JSON input strings on tool-call blocks into Python dicts.
+
+    Returns a list of error ``ToolResultBlockParam`` for any tool calls whose
+    input could not be parsed, so the model can retry.
+    """
+    parse_errors: list[ToolResultBlockParam] = []
+    for tool_call in tool_calls:
+        raw_input = cast(str, tool_call["input"])
+        try:
+            tool_call["input"] = json.loads(raw_input)
+        except json.JSONDecodeError as e:
+            logger.warning(
+                "Failed to parse tool call input for %s: %s. Raw input: %s",
+                tool_call["name"],
+                e,
+                raw_input,
+            )
+            raw_input_preview = raw_input[:4000]
+            if len(raw_input) > len(raw_input_preview):
+                raw_input_preview += "... [truncated]"
+            tool_call["input"] = {}
+            parse_errors.append(
+                ToolResultBlockParam(
+                    type="tool_result",
+                    tool_use_id=tool_call["id"],
+                    content=[
+                        {
+                            "type": "text",
+                            "text": (
+                                f"Invalid JSON in tool input: {e}. "
+                                "The tool was not executed. Retry with valid JSON.\n\n"
+                                f"Raw tool input:\n{raw_input_preview}"
+                            ),
+                        }
+                    ],
+                    is_error=True,
+                )
+            )
+    return parse_errors
+
+
+# ---------------------------------------------------------------------------
+# Stream persistence wrapper
+# ---------------------------------------------------------------------------
+
+
+async def persist_and_transform(gen, chat_id, messages_repo, parent_id):
+    """Persist streamed messages before exposing them to the client.
+
+    Assistant rows are created as soon as the provider emits ``message_start``,
+    so the browser can use a durable ``chat_messages.id`` for the streaming
+    bubble from the beginning.  Tool-result rows are persisted before their
+    ``tool_result`` events are forwarded.  This keeps frontend render identities
+    and future ``parent_id`` values database-backed even if the run is cancelled
+    mid-stream.
+    """
+    current_assistant_message_id: str | None = None
+    buffered_tool_result_events: list[str] = []
+
+    async for event_str in gen:
+        event_type = sse_event_type(event_str)
+        event_data = sse_event_data(event_str)
+
+        if event_type == "message":
+            try:
+                message_event = json.loads(event_data)
+            except json.JSONDecodeError:
+                yield event_str
+                continue
+
+            if message_event.get("type") == "message_start":
+                try:
+                    provider_message = message_event.get("message", {})
+                    assistant_message = {
+                        "role": provider_message.get("role", "assistant"),
+                        "content": provider_message.get("content") or [],
+                    }
+                    created = await messages_repo.create(
+                        chat_id, assistant_message, parent_id=parent_id
+                    )
+                    current_assistant_message_id = created.id
+                    parent_id = created.id
+                    message_event.setdefault("message", {})["id"] = created.id
+                    event_str = sse_event("message", message_event)
+                except Exception as e:
+                    logger.error(
+                        f"Failed to pre-persist assistant message for chat {chat_id}: {e}",
+                        exc_info=True,
+                    )
+                yield event_str
+                continue
+
+            if message_event.get("type") == "tool_result":
+                buffered_tool_result_events.append(event_str)
+                continue
+
+            yield event_str
+            continue
+
+        if event_type == "save_message":
+            try:
+                message = json.loads(event_data)
+                if message.get("role") == "assistant" and current_assistant_message_id:
+                    await messages_repo.update_message_content(
+                        current_assistant_message_id, message
+                    )
+                    await messages_repo.update_content_text(
+                        current_assistant_message_id, message
+                    )
+                    current_assistant_message_id = None
+                    continue
+
+                created = await messages_repo.create(
+                    chat_id, message, parent_id=parent_id
+                )
+                parent_id = created.id
+
+                if message.get("role") == "user" and buffered_tool_result_events:
+                    for buffered_event in buffered_tool_result_events:
+                        try:
+                            tool_result_event = json.loads(
+                                sse_event_data(buffered_event)
+                            )
+                            tool_result_event["message_id"] = created.id
+                            yield sse_event("message", tool_result_event)
+                        except json.JSONDecodeError:
+                            yield buffered_event
+                    buffered_tool_result_events = []
+                else:
+                    yield f"event: message_id\ndata: {created.id}\n\n"
+            except Exception as e:
+                logger.error(
+                    f"Failed to persist streamed message for chat {chat_id}: {e}",
+                    exc_info=True,
+                )
+            continue
+
+        yield event_str
+
+    # If the generator ended (cancel/error/client disconnect) without a
+    # matching save_message, the early-persisted assistant row was never
+    # finalized.  With partial content the generator emits ``save_message``
+    # itself; reaching here with the id still set means no content was ever
+    # committed, so delete the empty row rather than leave an invalid
+    # assistant message that would poison the next request's history.
+    if current_assistant_message_id is not None:
+        try:
+            await messages_repo.delete(current_assistant_message_id)
+            logger.info(
+                f"Deleted unfinalized assistant message "
+                f"{current_assistant_message_id} for chat {chat_id}"
+            )
+        except Exception as e:
+            logger.error(
+                f"Failed to delete unfinalized assistant message "
+                f"{current_assistant_message_id} for chat {chat_id}: {e}"
+            )
+        current_assistant_message_id = None

--- a/services/ai/streaming/run.py
+++ b/services/ai/streaming/run.py
@@ -1,0 +1,214 @@
+"""Redis transport layer for the chat streaming pipeline.
+
+Owns the run-lifecycle primitives: the producer task registry, Redis
+stream/lock/cancel keys, the background producer that writes every SSE event to
+a Redis Stream, and the consumer that tails the stream for SSE delivery to
+clients.
+
+All module-level state (``_run_tasks_by_chat``) is consolidated here — the
+process-local task registry used for cross-worker best-effort in-process
+cancellation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from streaming.persist import (
+    EndOfStreamReason,
+    StreamErrorEvent,
+    end_of_stream,
+    persist_and_transform,
+    sse_event,
+    sse_event_type,
+    stream_error_event,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Constants
+# ---------------------------------------------------------------------------
+
+SSE_HEADERS = {"Cache-Control": "no-cache", "Connection": "keep-alive"}
+
+_STREAM_HEARTBEAT_MS = 15000  # idle ping interval (keeps proxies from timing out)
+_RUN_LOCK_TTL = (
+    300  # seconds; refreshed on every produced event and by the heartbeat below
+)
+_LOCK_REFRESH_INTERVAL = 60  # seconds; independent of event production, so a long
+# silent gap in the agent loop (e.g. a slow tool call with no intermediate SSE
+# events) can't let the lock expire while the producer is still running.
+_STREAM_TTL = 300  # seconds a finished stream stays replayable
+_STREAM_MAXLEN = 5000  # cap buffered events per run
+_CANCEL_TTL = 300
+_CANCEL_CHECK_INTERVAL_SECONDS = 1.0
+
+
+# ---------------------------------------------------------------------------
+# Producer task registry  (process-local; cross-worker best-effort only)
+# ---------------------------------------------------------------------------
+
+_run_tasks_by_chat: dict[str, asyncio.Task] = {}
+
+
+def get_producer_task(chat_id: str) -> asyncio.Task | None:
+    return _run_tasks_by_chat.get(chat_id)
+
+
+def set_producer_task(chat_id: str, task: asyncio.Task) -> None:
+    _run_tasks_by_chat[chat_id] = task
+
+
+def clear_producer_task(chat_id: str, task: asyncio.Task) -> None:
+    if _run_tasks_by_chat.get(chat_id) is task:
+        del _run_tasks_by_chat[chat_id]
+
+
+# ---------------------------------------------------------------------------
+# Redis key helpers
+# ---------------------------------------------------------------------------
+
+
+def stream_key(chat_id: str) -> str:
+    return f"chat:stream:{chat_id}"
+
+
+def run_lock_key(chat_id: str) -> str:
+    return f"chat:runlock:{chat_id}"
+
+
+def cancel_key(chat_id: str) -> str:
+    return f"chat:cancel:{chat_id}"
+
+
+# ---------------------------------------------------------------------------
+# Run-lock management
+# ---------------------------------------------------------------------------
+
+
+async def is_run_cancelled(redis_client, chat_id: str) -> bool:
+    """Check whether the Redis cancel flag is set."""
+    if redis_client is None:
+        return False
+    try:
+        return bool(await redis_client.exists(cancel_key(chat_id)))
+    except Exception:
+        return False
+
+
+async def _refresh_lock_periodically(redis_client, lock_key):
+    """Keep the run lock alive independently of event production, so a long
+    silent gap in the agent loop doesn't let it expire mid-run."""
+    while True:
+        await asyncio.sleep(_LOCK_REFRESH_INTERVAL)
+        await redis_client.expire(lock_key, _RUN_LOCK_TTL)
+
+
+# ---------------------------------------------------------------------------
+# Producer
+# ---------------------------------------------------------------------------
+
+
+async def run_producer(redis_client, chat_id, gen, messages_repo, parent_id):
+    """Background task: drive the agent loop to completion independently of any
+    client connection, buffering every SSE event in a Redis Stream."""
+    sk = stream_key(chat_id)
+    lk = run_lock_key(chat_id)
+    refresh_task = asyncio.create_task(_refresh_lock_periodically(redis_client, lk))
+    try:
+        async for event_str in persist_and_transform(
+            gen, chat_id, messages_repo, parent_id
+        ):
+            await redis_client.xadd(
+                sk,
+                {"e": event_str},
+                maxlen=_STREAM_MAXLEN,
+                approximate=True,
+            )
+            await redis_client.expire(lk, _RUN_LOCK_TTL)
+    except asyncio.CancelledError:
+        # Explicit Stop cancelled this producer task.  Emit a terminal event so
+        # any still-attached consumer ends cleanly instead of seeing the lock
+        # disappear and reporting "Generation ended unexpectedly".
+        try:
+            await redis_client.xadd(sk, {"e": end_of_stream(EndOfStreamReason.STOPPED)})
+        except Exception:
+            pass
+        raise
+    except Exception as e:
+        logger.error(f"Producer failed for chat {chat_id}: {e}", exc_info=True)
+        try:
+            await redis_client.xadd(
+                sk,
+                {"e": sse_event("stream_error", stream_error_event(e))},
+            )
+        except Exception:
+            pass
+    finally:
+        refresh_task.cancel()
+        try:
+            await refresh_task
+        except asyncio.CancelledError:
+            pass
+        for coro in (
+            redis_client.expire(sk, _STREAM_TTL),
+            redis_client.delete(lk),
+            redis_client.delete(cancel_key(chat_id)),
+        ):
+            try:
+                await coro
+            except Exception:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Consumer
+# ---------------------------------------------------------------------------
+
+
+async def consume_run(redis_client, chat_id, start_id):
+    """Thin consumer: tail the Redis Stream from ``start_id``, prefixing each
+    event with its Redis id (SSE ``id:``) for Last-Event-ID resume.  Emits
+    heartbeats while idle and a terminal event if the producer vanished.
+
+    Important id: invariant: no producer may template an ``id:`` line into its
+    own event body because this function prepends ``id: {entry_id}`` (the Redis
+    stream entry id) unconditionally.  Heartbeats and synthetic terminal events
+    intentionally lack an id so they don't advance the resume position.
+    """
+    sk = stream_key(chat_id)
+    lk = run_lock_key(chat_id)
+    last = start_id or "0"
+    while True:
+        resp = await redis_client.xread(
+            {sk: last}, block=_STREAM_HEARTBEAT_MS, count=200
+        )
+        if resp:
+            for _key, entries in resp:
+                for entry_id, fields in entries:
+                    last = entry_id
+                    event_str = fields.get("e", "")
+                    yield f"id: {entry_id}\n{event_str}"
+                    if sse_event_type(event_str) in ("end_of_stream", "stream_error"):
+                        return
+            continue
+        # Idle: no new events within the heartbeat window.
+        if not await redis_client.exists(sk):
+            if await redis_client.exists(lk):
+                # Producer just started and hasn't written its first event yet.
+                yield sse_event("heartbeat", {})
+                continue
+            yield "event: not_resumable\ndata: \n\n"
+            return
+        if not await redis_client.exists(lk):
+            # Producer is gone but never wrote a terminal event we forwarded.
+            yield sse_event(
+                "stream_error",
+                StreamErrorEvent(message="Generation ended unexpectedly."),
+            )
+            return
+        yield sse_event("heartbeat", {})

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -4,6 +4,7 @@ Provides reusable DB data factories and mock LLM event generators
 so that individual test files don't duplicate boilerplate.
 """
 
+import asyncio
 import json
 from typing import Any
 from unittest.mock import AsyncMock
@@ -277,3 +278,229 @@ def create_mock_llm_multi(
     provider.stream_response = stream_response
     provider.health_check.return_value = True
     return provider
+
+
+# =============================================================================
+# SSE streaming helpers
+# =============================================================================
+
+
+async def stream_sse(
+    client,
+    chat_id: str,
+    headers: dict[str, str] | None = None,
+):
+    """Async generator yielding (event_type, data, sse_id) triples from the
+    chat SSE endpoint using httpx streaming, so the caller can react to events
+    as they arrive (e.g. fire a POST /cancel mid-stream).
+
+    Usage::
+
+        async for event_type, data, sse_id in stream_sse(client, chat_id):
+            if event_type == "message":
+                payload = json.loads(data)
+                if payload.get("type") == "message_stop":
+                    break
+
+    Args:
+        client: An ``httpx.AsyncClient`` (with ``ASGITransport`` wired to the
+            test app).
+        chat_id: The chat ID.
+        headers: Optional request headers (e.g. ``{"Last-Event-ID": "1234-0"}``).
+
+    Yields:
+        ``(event_type: str | None, data: str, sse_id: str | None)``. The
+        ``sse_id`` is the ``id:`` prefix from the consumer's Redis-stream
+        entry (``None`` for heartbeats and synthetic events).
+    """
+    url = f"/chat/{chat_id}/stream"
+    async with client.stream("GET", url, headers=headers) as response:
+        assert response.status_code == 200, f"Expected 200, got {response.status_code}"
+        lines: list[str] = []
+        sse_id: str | None = None
+        async for raw_line in response.aiter_lines():
+            line = raw_line.rstrip("\r")
+            if line == "":
+                if not lines:
+                    continue
+                event_type: str | None = None
+                data_parts: list[str] = []
+                for ln in lines:
+                    if ln.startswith("id: "):
+                        sse_id = ln[4:].strip()
+                    elif ln.startswith("event: "):
+                        event_type = ln[7:].strip()
+                    elif ln.startswith("data: "):
+                        data_parts.append(ln[6:])
+                data = "\n".join(data_parts)
+                yield (event_type, data, sse_id)
+                lines = []
+                continue
+            lines.append(line)
+
+
+async def collect_sse_events(
+    client,
+    chat_id: str,
+    headers: dict[str, str] | None = None,
+    timeout: float = 30,
+) -> list[tuple[str | None, str, str | None]]:
+    """Convenience helper: read all SSE events from the stream until a
+    terminal event (``end_of_stream``, ``stream_error``, ``not_resumable``) is
+    encountered, then return the complete list.
+
+    Use this for simple assertion-based tests that don't need to interleave
+    other actions (like ``POST /cancel``) while the stream is active.
+    """
+    events: list[tuple[str | None, str, str | None]] = []
+    async for event_type, data, sse_id in stream_sse(client, chat_id, headers=headers):
+        events.append((event_type, data, sse_id))
+        if event_type in ("end_of_stream", "stream_error", "not_resumable"):
+            break
+    return events
+
+
+def assert_sse_wire(events: list[tuple[str | None, str, str | None]]) -> None:
+    """Validate the SSE wire format of a list of consumer events.
+
+    Checks:
+    * Every event from the Redis stream carries a non-None ``sse_id``.
+      Heartbeats (spontaneous without an ``id:`` line) are exempt because
+      ``_consume_run`` yields them directly, not from a Redis stream entry.
+    * ``sse_id`` values are strictly increasing (when present).
+    * Every event has at least an ``event_type`` and a ``data`` value.
+    """
+    seen_ids: list[str] = []
+    for idx, (event_type, data, sse_id) in enumerate(events):
+        assert event_type is not None, (
+            f"Event {idx} is missing event: field. data={data!r}"
+        )
+        assert data is not None, (
+            f"Event {idx} (type={event_type}) has no data: line"
+        )
+        if event_type == "heartbeat":
+            # Heartbeats are synthetic and don't carry an id: line.
+            continue
+        assert (
+            sse_id is not None
+        ), f"Event {idx} (type={event_type}) missing id: line. data={data!r}"
+        seen_ids.append(sse_id)
+    # Verify monotonic ordering
+    for i in range(1, len(seen_ids)):
+        assert seen_ids[i] > seen_ids[i - 1], (
+            f"sse_id not strictly increasing at position {i}: "
+            f"{seen_ids[i - 1]} -> {seen_ids[i]}"
+        )
+
+
+# =============================================================================
+# Gated mock LLM
+# =============================================================================
+
+
+class GatedRecordingLLM:
+    """Mock LLMProvider that records every call's kwargs and can be gated with
+    ``asyncio.Event`` per call.
+
+    Each response entry follows the same convention as ``create_mock_llm_multi``:
+
+    * ``("text", "response string")``
+    * ``("tool_call", {"name": ..., "input": ..., "id": ...})``
+
+    Gates are **open by default** (the call proceeds immediately).  Call
+    ``hold(call_idx, at="pre")`` *before starting the stream* to close the
+    gate for a specific call index; ``release(call_idx)`` opens it again.
+
+    ``at="pre"`` blocks before yielding any SDK events; ``at="post"`` blocks
+    after yielding all events.  ``at="pre"`` is what you want to make the LLM
+    "hang" at the start of generation; ``at="post"`` is useful for idle-window
+    scenarios where you need the agent loop to pause after a turn.
+    """
+
+    PERSISTED_BLOCK_EXTRAS: tuple[str, ...] = ()
+    model_name = "gated-test"
+    provider_type = "test"
+
+    def __init__(
+        self,
+        responses: list[tuple[str, Any]],
+        model_record_id: str,
+        *,
+        inter_event_delay: float = 0.0,
+        fail_on_call: int | None = None,
+        fail_exc: BaseException | None = None,
+    ) -> None:
+        self.responses = responses
+        self.model_record_id = model_record_id
+        self._inter_event_delay = inter_event_delay
+        self._fail_on_call = fail_on_call
+        self._fail_exc = fail_exc or Exception("GatedRecordingLLM simulated failure")
+        # Recorded kwargs for every call to stream_response.
+        self.calls: list[dict[str, Any]] = []
+        # call_idx -> "pre" | "post"
+        self._held: dict[int, str] = {}
+        self._gates: dict[int, asyncio.Event] = {}
+
+    def hold(self, call_idx: int, at: str = "pre") -> None:
+        """Gate the call at ``call_idx`` so it blocks at ``at``.
+
+        Must be called **before** the stream starts (or at least before the
+        gate is awaited by the producer).
+        """
+        self._held[call_idx] = at
+
+    def release(self, call_idx: int) -> None:
+        """Open the gate for the call, letting it proceed."""
+        gate = self._gates.get(call_idx)
+        if gate is not None:
+            gate.set()
+
+    async def stream_response(self, **kwargs):
+        call_idx = len(self.calls)
+        # Record BEFORE the fail check so the retry counter is accurate
+        captured = {}
+        for k, v in kwargs.items():
+            if isinstance(v, (list, dict)):
+                captured[k] = json.loads(json.dumps(v))
+            else:
+                captured[k] = v
+        self.calls.append(captured)
+        if call_idx == self._fail_on_call:
+            raise self._fail_exc
+
+        if call_idx in self._held and self._held[call_idx] == "pre":
+            gate = asyncio.Event()
+            self._gates[call_idx] = gate
+            await gate.wait()
+
+        idx = min(call_idx, len(self.responses) - 1)
+        kind, payload = self.responses[idx]
+        if kind == "tool_call":
+            for event in tool_call_events(
+                payload["input"],
+                tool_name=payload.get("name", "search_documents"),
+                tool_id=payload.get("id", f"toolu_{call_idx}"),
+            ):
+                yield event
+                if self._inter_event_delay:
+                    await asyncio.sleep(self._inter_event_delay)
+        else:
+            for event in text_response_events(payload):
+                yield event
+                if self._inter_event_delay:
+                    await asyncio.sleep(self._inter_event_delay)
+
+        if call_idx in self._held and self._held[call_idx] == "post":
+            gate = asyncio.Event()
+            self._gates[call_idx] = gate
+            await gate.wait()
+
+    async def health_check(self) -> bool:
+        return True
+
+    async def get_context_window_tokens(self):
+        from providers import ContextWindowInfo, SAFE_DEFAULT_CONTEXT_WINDOW_TOKENS
+
+        return ContextWindowInfo(
+            tokens=SAFE_DEFAULT_CONTEXT_WINDOW_TOKENS, source="safe_default"
+        )

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -45,6 +45,8 @@ from tests.helpers import (
     stream_sse,
 )
 
+import routers.chat as chat_module
+
 pytestmark = pytest.mark.integration
 
 
@@ -420,6 +422,67 @@ class TestCancel:
         cancel_key = f"chat:cancel:{chat_id}"
         exists = await redis_client.exists(cancel_key)
         assert exists == 0, "Cancel key was not cleaned up by producer"
+
+    @pytest.mark.asyncio
+    async def test_task_cancel_mid_stream_persists_partial(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """``task.cancel()`` (immediate Stop) mid-token-stream persists the
+        partial assistant text in the database, so the row survives a page
+        reload.
+
+        Strategy: LLM with inter-event delay yields events slowly.  After the
+        text_delta is processed (content_blocks has the partial text), cancel
+        the producer task directly.  The fixed ``except CancelledError`` handler
+        yields ``save_message``, which ``_persist_and_transform`` uses to update
+        the early-persisted row instead of deleting it.
+        """
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [("text", "Partial content after task cancel.")],
+            model_id,
+            inter_event_delay=0.3,
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Wait for the LLM to yield text_delta (content accumulated)
+            # With inter_event_delay=0.3:
+            #   t=0.0 message_start, t=0.3 content_block_start, t=0.6 text_delta
+            await asyncio.sleep(0.8)
+
+            # Cancel the producer task directly (immediate Stop)
+            task = chat_module._run_tasks_by_chat.get(chat_id)
+            assert task is not None, "Producer task not found"
+            task.cancel()
+
+            events = await stream_task
+
+        # The stream must terminate with end_of_stream (clean stop, not error)
+        assert any(
+            et == "end_of_stream" for et, _, _ in events
+        ), f"Expected end_of_stream after task.cancel(). Events: {[et for et, _, _ in events]}"
+
+        # The partial assistant message must be persisted with its content
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert assistant_msgs, (
+            "No assistant message persisted after task.cancel(). "
+            "The partial content was lost!"
+        )
+        latest_asst = assistant_msgs[-1].message
+        content = latest_asst["content"]
+        text_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "text"]
+        assert text_blocks, "No text block in persisted assistant message"
+        text = " ".join(b["text"] for b in text_blocks)
+        assert "Partial content" in text, (
+            f"Partial assistant text missing after task.cancel(). "
+            f"Got: {text!r}"
+        )
 
 
 # =============================================================================

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -484,6 +484,68 @@ class TestCancel:
             f"Got: {text!r}"
         )
 
+    @pytest.mark.asyncio
+    async def test_redis_flag_cancel_finalizes_partial_assistant(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Cross-worker Stop via the Redis cancel flag finalizes the
+        partial assistant content through the ``if cancelled: yield
+        save_message`` checkpoint path (not the ``task.cancel()`` path).
+
+        Strategy: LLM with inter-event delay yields text_delta events
+        slowly so content_blocks accumulates content.  After text has
+        started flowing, set the Redis cancel flag.  The event-loop
+        cancel check (every ``_CANCEL_CHECK_INTERVAL_SECONDS``) detects
+        it and finalizes via the checkpoint path.
+        """
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [("text", "Partial content to persist via Redis flag.")],
+            model_id,
+            inter_event_delay=0.3,
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Wait for text_delta to be processed (content_blocks accumulates)
+            await asyncio.sleep(0.8)
+
+            # Set the Redis cancel flag (simulates cross-worker Stop)
+            await redis_client.set(
+                f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL
+            )
+
+            events = await stream_task
+
+        # The stream must terminate cleanly (not with stream_error)
+        assert any(
+            et == "end_of_stream" for et, _, _ in events
+        ), f"Expected end_of_stream after Redis-flag cancel. Events: {[et for et, _, _ in events]}"
+
+        # The partial assistant message must be persisted
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert assistant_msgs, (
+            "No assistant message persisted after Redis-flag cancel. "
+            "The partial content was lost!"
+        )
+        latest_asst = assistant_msgs[-1].message
+        content = latest_asst["content"]
+        text_blocks = [
+            b for b in content
+            if isinstance(b, dict) and b.get("type") == "text"
+        ]
+        assert text_blocks, "No text block in persisted assistant message"
+        text = " ".join(b["text"] for b in text_blocks)
+        assert "Partial content" in text, (
+            f"Partial assistant text missing after Redis-flag cancel. "
+            f"Got: {text!r}"
+        )
+
 
 # =============================================================================
 # /chat/{id}/stream/status
@@ -1049,6 +1111,142 @@ class TestCancelEarly:
                 for b in blocks:
                     assert b.get("type") != "tool_result", (
                         "tool_result found in user message despite cancel before execution"
+                    )
+
+
+# =============================================================================
+# Cancel mid-tool-call (immediate Stop during tool execution)
+# =============================================================================
+
+
+class TestCancelMidToolCall:
+    """Immediate Stop (``task.cancel()``) while a tool is executing.
+
+    Pins #362's stated goal: stopping mid-tool-call must end generation
+    promptly without running further tools or LLM calls, and the prior
+    turn's assistant message (with the tool_use block) must be finalized.
+    """
+
+    MOCK_SEARCH_RESPONSE = SearchResponse(
+        results=[
+            SearchResult(
+                document=Document(
+                    id="doc_1", title="Result", content_type="text",
+                    url="", source_type="test",
+                ),
+                highlights=["test highlight"],
+                source_type="test",
+            ),
+        ],
+        total_count=1,
+        query_time_ms=5,
+    )
+
+    @pytest.mark.asyncio
+    async def test_task_cancel_mid_tool_call_ends_promptly(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """``task.cancel()`` during tool execution → no further LLM calls
+        (no second turn), the prior turn's assistant message (with tool_use)
+        is persisted.
+
+        Strategy: multi-turn LLM (tool_call then text), gated searcher that
+        blocks until released.  Start the stream, wait for the tool to start
+        executing (blocked on the gate), then cancel the producer task.
+        """
+
+        chat_id, _user_id, model_id = seeded_chat
+
+        # Gated searcher: blocks until cancelled/never released
+        searcher_gate = asyncio.Event()
+
+        async def gated_handle(_request):
+            await searcher_gate.wait()
+            return self.MOCK_SEARCH_RESPONSE
+
+        gated_searcher = AsyncMock(spec=SearcherTool)
+        gated_searcher.handle = gated_handle
+        gated_searcher.client = AsyncMock()
+
+        # Multi-turn LLM: tool_call then text (second call should NOT happen)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": "search_documents",
+                        "input": {"query": "test"},
+                        "id": "toolu_mt_cancel",
+                    },
+                ),
+                ("text", "This should NOT be reached."),
+            ],
+            model_id,
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        app.state.searcher_tool = gated_searcher
+
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Wait for the LLM to emit tool_use and the router to start
+            # executing the tool (which blocks on searcher_gate)
+            await asyncio.sleep(0.5)
+
+            # Cancel the producer task (immediate Stop)
+            task = chat_module._run_tasks_by_chat.get(chat_id)
+            assert task is not None, "Producer task not found"
+            task.cancel()
+
+            events = await stream_task
+
+        # No further LLM calls beyond the first (tool_call) turn
+        assert len(llm.calls) == 1, (
+            f"Expected exactly 1 LLM call (tool_call), "
+            f"got {len(llm.calls)}. A second turn was not prevented!"
+        )
+
+        # The stream terminated (end_of_stream from the cancel path)
+        assert any(
+            et == "end_of_stream" for et, _, _ in events
+        ), f"No end_of_stream after mid-tool-call cancel. Events: {[et for et, _, _ in events]}"
+
+        # The prior turn's assistant message with tool_use is persisted
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert assistant_msgs, (
+            "No assistant message persisted after mid-tool-call cancel."
+        )
+        latest_asst = assistant_msgs[-1].message
+        blocks = latest_asst.get("content", [])
+        tool_use_blocks = [
+            b for b in blocks
+            if isinstance(b, dict) and b.get("type") == "tool_use"
+        ]
+        assert tool_use_blocks, (
+            "Prior turn's tool_use was not persisted after mid-tool-call cancel."
+        )
+
+        # Exactly one assistant message — no duplicate rows from a
+        # late CancelledError handler re-saving the same content_blocks.
+        assert len(assistant_msgs) == 1, (
+            f"Expected exactly 1 assistant message after mid-tool-call cancel, "
+            f"got {len(assistant_msgs)}. A duplicate save was not prevented!"
+        )
+
+        # No tool_result should be present because the tool was never
+        # executed to completion
+        user_msgs = [m for m in db_msgs if m.message["role"] == "user"]
+        for um in user_msgs:
+            blocks = um.message.get("content", [])
+            if isinstance(blocks, list):
+                for b in blocks:
+                    assert b.get("type") != "tool_result", (
+                        "tool_result found in user message despite "
+                        "tool being cancelled mid-execution"
                     )
 
 

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -1,0 +1,1415 @@
+"""Integration tests for the chat stream lifecycle (producer/consumer, resume,
+cancel, locks, heartbeat, persistence transform, interruption repair, approval).
+
+Exercises the **Redis-backed decoupled streaming path** with real Postgres and
+real Redis.
+
+Design principle: **never let the consumer block on an empty stream.**  The
+consumer (``_consume_run``) calls ``xread`` with ``block=_STREAM_HEARTBEAT_MS``
+which defaults to 15 s.  If the LLM never writes events (e.g. it's gated at
+``"pre"``), the consumer loops until ``_RUN_LOCK_TTL`` (300 s).  Instead:
+* Gate at ``"post"`` (after events are written) or gate the **second** LLM call
+  so the stream has data from the first call.
+* Monkeypatch ``_RUN_LOCK_TTL`` and ``_STREAM_HEARTBEAT_MS`` to short values
+  for timing-sensitive tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from ulid import ULID
+
+from unittest.mock import AsyncMock
+
+from db import ChatsRepository, MessagesRepository, UsersRepository
+from db.tool_approvals import (
+    ToolApprovalStatus,
+    ToolApprovalType,
+    ToolApprovalsRepository,
+)
+import db.connection
+from routers import chat_router
+from state import AppState
+from tools import SearchResponse, SearchResult
+from tools.searcher_client import Document
+from tools.searcher_tool import SearcherTool
+from tests.helpers import (
+    GatedRecordingLLM,
+    assert_sse_wire,
+    collect_sse_events,
+    stream_sse,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# =============================================================================
+# Timing constants — patched short for fast tests
+# =============================================================================
+
+_FAST_LOCK_TTL = 30         # seconds (was 300)
+_FAST_HEARTBEAT_MS = 1000   # ms (was 15000)
+_FAST_TTL = 10              # stream TTL seconds (was 300)
+
+
+@pytest.fixture
+def _patch_timing(monkeypatch):
+    """Shrink all timing constants so consumers/producers fail fast."""
+    monkeypatch.setattr("routers.chat._RUN_LOCK_TTL", _FAST_LOCK_TTL)
+    monkeypatch.setattr("routers.chat._STREAM_HEARTBEAT_MS", _FAST_HEARTBEAT_MS)
+    monkeypatch.setattr("routers.chat._STREAM_TTL", _FAST_TTL)
+    monkeypatch.setattr("routers.chat._CANCEL_CHECK_INTERVAL_SECONDS", 0.5)
+
+
+# =============================================================================
+# App builder
+# =============================================================================
+
+
+def _build_chat_app(
+    llm_provider,
+    redis_client,
+    model_id: str,
+) -> FastAPI:
+    """Build a minimal test FastAPI app wired to the real Redis client."""
+    app = FastAPI()
+    app.state = AppState()
+    app.state.models = {model_id: llm_provider}
+    app.state.default_model_id = model_id
+    app.state.secondary_model_id = model_id
+    app.state.searcher_tool = SearcherTool()
+    app.state.content_storage = None
+    app.state.redis_client = redis_client
+    app.state.memory_provider = None
+    app.include_router(chat_router)
+    return app
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest.fixture
+def _patch_db_pool(db_pool, monkeypatch):
+    monkeypatch.setattr(db.connection, "_db_pool", db_pool)
+
+
+@pytest.fixture
+def _patch_chat_config(monkeypatch):
+    monkeypatch.setattr("routers.chat.CONNECTOR_MANAGER_URL", "http://127.0.0.1:1")
+    monkeypatch.setattr("routers.chat.SANDBOX_URL", "")
+    monkeypatch.setenv("SEARCHER_URL", "http://127.0.0.1:1")
+
+
+@pytest.fixture
+async def seeded_chat(db_pool, _patch_db_pool, _patch_chat_config, _patch_timing) -> tuple[str, str, str]:
+    """Create a user, model, chat, and first user message.
+
+    Returns ``(chat_id, user_id, model_id)``.  Cleans up DB rows on teardown.
+    """
+    users_repo = UsersRepository()
+    user = await users_repo.create(
+        email=f"{ULID()}@test.local",
+        password_hash="not-a-real-hash",
+        full_name="Stream Test User",
+    )
+
+    async with db_pool.acquire() as conn:
+        provider_id = str(ULID())
+        await conn.execute(
+            "INSERT INTO model_providers (id, name, provider_type, config) VALUES ($1, $2, $3, $4)",
+            provider_id,
+            "Stream Test Provider",
+            "anthropic",
+            "{}",
+        )
+        model_id = str(ULID())
+        await conn.execute(
+            "INSERT INTO models (id, model_provider_id, model_id, display_name, is_default) VALUES ($1, $2, $3, $4, $5)",
+            model_id,
+            provider_id,
+            "stream-test-model",
+            "Stream Test Model",
+            False,
+        )
+
+    chat = await ChatsRepository().create(user_id=user.id, model_id=model_id)
+    chat_id = chat.id
+
+    await MessagesRepository().create(
+        chat_id,
+        {"role": "user", "content": "Hello"},
+    )
+
+    try:
+        yield (chat_id, user.id, model_id)
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute("DELETE FROM chat_messages WHERE chat_id = $1", chat_id)
+            await conn.execute("DELETE FROM chats WHERE id = $1", chat_id)
+        async with db_pool.acquire() as conn:
+            await conn.execute("DELETE FROM models WHERE id = $1", model_id)
+            await conn.execute("DELETE FROM model_providers WHERE id = $1", provider_id)
+        async with db_pool.acquire() as conn:
+            await conn.execute("DELETE FROM users WHERE id = $1", user.id)
+
+
+@pytest.fixture
+async def redis_keys(redis_client) -> None:
+    """Teardown-only: clean up Redis stream/lock/cancel keys after each test."""
+    yield
+    for pattern in ("chat:stream:*", "chat:runlock:*", "chat:cancel:*"):
+        cursor = 0
+        while True:
+            cursor, keys = await redis_client.scan(cursor, match=pattern, count=100)
+            if keys:
+                await redis_client.delete(*keys)
+            if cursor == 0:
+                break
+
+
+def _client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+# =============================================================================
+# Buffered-run baseline (producer/consumer)
+# =============================================================================
+
+
+class TestBaseline:
+    """Happy-path assertions on the decoupled producer/consumer."""
+
+    @pytest.mark.asyncio
+    async def test_happy_path_streams_text_and_persists_assistant(self, seeded_chat, redis_client, redis_keys):
+        """E2E: stream a text response → DB has persisted assistant row;
+        consumer events have strictly increasing ``id:`` lines; no duplicate
+        writes."""
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "This is a test response.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        terminal = [(e[0], e[1]) for e in events if e[0] in ("end_of_stream", "stream_error")]
+        assert terminal, "Expected a terminal event"
+        assert terminal[-1][0] == "end_of_stream", f"Unexpected terminal: {terminal[-1]}"
+
+        msg_events = [e for e in events if e[0] == "message"]
+        assert msg_events, "No message (SDK) events in stream"
+
+        assert_sse_wire(events)
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assert len(db_msgs) >= 2, f"Expected ≥2 messages, got {len(db_msgs)}"
+        assert db_msgs[-1].message["role"] == "assistant"
+        assistant_text = db_msgs[-1].message["content"]
+        if isinstance(assistant_text, list):
+            text = " ".join(b.get("text", "") for b in assistant_text if b.get("type") == "text")
+        else:
+            text = str(assistant_text)
+        assert "This is a test response." in text
+
+        stream_key = f"chat:stream:{chat_id}"
+        exists = await redis_client.exists(stream_key)
+        assert exists == 1, "Stream key should exist after run completes (within TTL)"
+
+    @pytest.mark.asyncio
+    async def test_message_start_id_matches_db_row(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """``message_start``'s ``message.id`` equals the DB-assigned
+        ``chat_messages.id`` of the assistant row."""
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "Match the message id.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        msg_start_id: str | None = None
+        for event_type, data, _sse_id in events:
+            if event_type == "message":
+                payload = json.loads(data)
+                if payload.get("type") == "message_start":
+                    msg_start_id = payload["message"]["id"]
+                    break
+        assert msg_start_id is not None, "No message_start event found"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_rows = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert assistant_rows, "No assistant message in DB"
+        assert assistant_rows[-1].id == msg_start_id, (
+            f"message_start id {msg_start_id} != DB id {assistant_rows[-1].id}"
+        )
+
+
+# =============================================================================
+# Resume / reconnect (Last-Event-ID)
+# =============================================================================
+
+
+class TestResume:
+    """Tests for the ``Last-Event-ID`` resume/reconnect logic."""
+
+    @pytest.mark.asyncio
+    async def test_resume_from_last_event_id_yields_suffix_only(self, seeded_chat, redis_client, redis_keys):
+        """Drop connection at ``id: k``, reconnect with ``Last-Event-ID: k`` →
+        suffix events only, no duplicates."""
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "First part. Second part. Final part.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            first_batch: list[tuple[str | None, str, str | None]] = []
+            last_sse_id: str | None = None
+            async for event_type, data, sse_id in stream_sse(client, chat_id):
+                first_batch.append((event_type, data, sse_id))
+                if sse_id is not None:
+                    last_sse_id = sse_id
+                if len(first_batch) >= 4:
+                    break
+
+            assert last_sse_id is not None, "No sse_id captured before disconnect"
+
+            suffix_events = await collect_sse_events(
+                client, chat_id, headers={"Last-Event-ID": last_sse_id}
+            )
+
+        suffix_ids = [sid for _et, _d, sid in suffix_events if sid is not None]
+        assert all(sid > last_sse_id for sid in suffix_ids), (
+            f"Suffix events include ids ≤ {last_sse_id}: {suffix_ids}"
+        )
+
+        suffix_terminals = [
+            et for et, _d, _sid in suffix_events
+            if et in ("end_of_stream", "stream_error", "not_resumable")
+        ]
+        assert suffix_terminals, "No terminal event in suffix"
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_run_replays_suffix(self, seeded_chat, redis_client, redis_keys):
+        """Reconnect after run finished, within ``_STREAM_TTL``, with a
+        ``Last-Event-ID`` → replays from that offset, then buffered
+        ``end_of_stream``."""
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "Complete stream.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            # Consume the full stream first
+            first_events = await collect_sse_events(client, chat_id)
+            first_sse_ids = [sid for _et, _d, sid in first_events if sid is not None]
+            assert first_sse_ids, "No sse_ids in first stream"
+            checkpoint_id = first_sse_ids[len(first_sse_ids) // 2]  # mid-point
+
+            # Reconnect with Last-Event-ID at mid-point
+            suffix = await collect_sse_events(
+                client, chat_id, headers={"Last-Event-ID": checkpoint_id}
+            )
+
+        suffix_ids = [sid for _et, _d, sid in suffix if sid is not None]
+        assert all(sid > checkpoint_id for sid in suffix_ids), (
+            f"Suffix ids not all > {checkpoint_id}: {suffix_ids}"
+        )
+        assert any(
+            et in ("end_of_stream", "stream_error") for et, _d, _ in suffix
+        ), "No terminal event in suffix"
+
+    @pytest.mark.asyncio
+    async def test_reconnect_after_ttl_returns_not_resumable(self, seeded_chat, redis_client, redis_keys):
+        """Reconnect after ``_STREAM_TTL`` expired with a ``Last-Event-ID`` →
+        ``event: not_resumable`` and no fresh generation."""
+        # _STREAM_TTL is already 10s from _patch_timing; the run completes
+        # in <1s, so waiting 12s guarantees expiry.
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "Transient response.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            first_events = await collect_sse_events(client, chat_id)
+            assert first_events, "First stream produced no events"
+
+        # Wait for TTL + margin
+        await asyncio.sleep(_FAST_TTL + 3)
+
+        async with _client(app) as client:
+            events = await collect_sse_events(
+                client, chat_id, headers={"Last-Event-ID": "0"}
+            )
+
+        event_types = [et for et, _d, _sid in events]
+        assert "not_resumable" in event_types, (
+            f"Expected not_resumable, got {event_types}"
+        )
+        msg_events = [et for et, _d, _sid in events if et == "message"]
+        assert not msg_events, (
+            f"Got message events after TTL expired: {msg_events}"
+        )
+
+
+# =============================================================================
+# Cancellation
+# =============================================================================
+
+
+class TestCancel:
+    """Graceful stop via the Redis cancel flag."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_during_text_stream(self, seeded_chat, redis_client, redis_keys):
+        """Cancel (cross‑worker style via the Redis flag) during a text
+        response → consumer sees terminal event; ``stream/status`` later
+        shows ``running=false``."""
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "Response.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Let the run start and write at least the first event
+            await asyncio.sleep(0.3)
+
+            # Set the cancel flag directly (cross‑worker).  The producer's
+            # event-loop cancel check (every 0.5s with our patch) will
+            # detect it and finalize.
+            await redis_client.set(f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL)
+
+            # Wait for cancel check + margin
+            await asyncio.sleep(1.0)
+
+            events = await stream_task
+
+        terminal = [(et, d) for et, d, _ in events if et in ("end_of_stream", "stream_error")]
+        assert terminal, "No terminal event after cancel"
+
+        async with _client(app) as status_client:
+            resp = await status_client.get(f"/chat/{chat_id}/stream/status")
+            assert resp.status_code == 200
+            assert resp.json()["running"] is False
+
+    @pytest.mark.asyncio
+    async def test_pre_set_cancel_flag_cleaned_on_fresh_start(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Cancel flag set with no producer running (cross‑worker) →
+        subsequent stream starts cleanly (key cleaned up)."""
+        chat_id, _user_id, model_id = seeded_chat
+
+        await redis_client.set(f"chat:cancel:{chat_id}", "1", ex=300)
+
+        llm = GatedRecordingLLM([("text", "I should be generated.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        terminal = [et for et, _d, _ in events if et in ("end_of_stream", "stream_error")]
+        assert terminal, "No terminal event"
+
+        cancel_key = f"chat:cancel:{chat_id}"
+        exists = await redis_client.exists(cancel_key)
+        assert exists == 0, "Cancel key was not cleaned up by producer"
+
+
+# =============================================================================
+# /chat/{id}/stream/status
+# =============================================================================
+
+
+class TestStreamStatus:
+    """Correctness of the ``stream/status`` endpoint at each lifecycle phase."""
+
+    @pytest.mark.asyncio
+    async def test_status_idle_all_flags_false(self, seeded_chat, redis_client, redis_keys):
+        """Idle (no run active, no buffer) → all flags false."""
+        chat_id, _user_id, _model_id = seeded_chat
+        app = FastAPI()
+        app.state = AppState()
+        app.state.redis_client = redis_client
+        app.include_router(chat_router)
+
+        async with _client(app) as client:
+            resp = await client.get(f"/chat/{chat_id}/stream/status")
+            assert resp.status_code == 200
+            status = resp.json()
+            assert status["running"] is False
+            assert status["resumable"] is False
+            assert status["pending_approval"] is False
+            assert status["pending_oauth"] is False
+
+    @pytest.mark.asyncio
+    async def test_status_running_true_during_run_then_false_after(self, seeded_chat, redis_client, redis_keys):
+        """During a run → ``running=True``, then after the run completes →
+        ``running=False, resumable=True``.
+
+        The LLM is gated at ``"pre"`` so the producer stays alive (lock held,
+        no events written) while we poll status.  This avoids a race where
+        the stream finishes before the status poll catches ``running=True``.
+        """
+        import time
+
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "Status check.")], model_id)
+        llm.hold(0, at="pre")
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        # Separate clients: one for the long-lived stream, one for status
+        async with _client(app) as stream_cl, _client(app) as status_cl:
+            stream_task = asyncio.create_task(
+                collect_sse_events(stream_cl, chat_id)
+            )
+
+            # Poll for running=True (the route handler sets the lock before
+            # returning; polling handles any startup delay).
+            deadline = time.monotonic() + 5.0
+            running = False
+            while time.monotonic() < deadline:
+                resp = await status_cl.get(f"/chat/{chat_id}/stream/status")
+                assert resp.status_code == 200
+                status = resp.json()
+                if status["running"]:
+                    running = True
+                    break
+                await asyncio.sleep(0.05)
+
+            assert running is True, "Timed out waiting for running=True"
+
+            # Release the LLM so the run completes and the lock is released.
+            llm.release(0)
+            await stream_task
+
+        async with _client(app) as status_cl:
+            resp = await status_cl.get(f"/chat/{chat_id}/stream/status")
+            assert resp.status_code == 200
+            status = resp.json()
+            assert status["running"] is False
+            assert status["resumable"] is True
+
+
+# =============================================================================
+# Lock & heartbeat resilience (slow / timing-sensitive)
+# =============================================================================
+
+
+@pytest.mark.slow
+class TestLockAndHeartbeat:
+    """Lock refresh, heartbeat emission, and vanished-producer detection."""
+
+    @pytest.mark.asyncio
+    async def test_consumer_emits_heartbeat_when_idle(self, seeded_chat, redis_client, redis_keys):
+        """Consumer emits a ``heartbeat`` after ``_STREAM_HEARTBEAT_MS`` of
+        idleness.  We make the LLM take a while to produce its first event
+        (via a ``pre`` gate released after the heartbeat interval), so the
+        consumer idles long enough."""
+        chat_id, _user_id, model_id = seeded_chat
+        # Gate at "pre" so the producer doesn't write anything for a while
+        llm = GatedRecordingLLM([("text", "X.")], model_id)
+        llm.hold(0, at="pre")
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Wait > heartbeat interval while LLM is gated and stream is
+            # empty.  During this time the consumer should fire a heartbeat.
+            await asyncio.sleep(_FAST_HEARTBEAT_MS / 1000 + 0.5)
+
+            # Now release the LLM so it writes events and the stream
+            # completes.
+            llm.release(0)
+
+            events = await stream_task
+
+        event_types = [et for et, _d, _sid in events]
+        assert "heartbeat" in event_types, f"No heartbeat found in events: {event_types}"
+
+    @pytest.mark.asyncio
+    async def test_lock_refresh_keeps_lock_alive_past_ttl(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        """Lock refresh task keeps the producer lock alive while the LLM is
+        silent longer than ``_RUN_LOCK_TTL``.
+
+        Strategy: gate the LLM at ``"pre"``, wait past the TTL (which would
+        expire without the background refresh), then verify the lock key still
+        exists.  Finally release the LLM and consume the stream normally.
+        """
+        chat_id, _user_id, model_id = seeded_chat
+        # Override the _patch_timing values for this test: fast refresh so
+        # the lock is renewed well within its short TTL.
+        monkeypatch.setattr("routers.chat._LOCK_REFRESH_INTERVAL", 2)
+        monkeypatch.setattr("routers.chat._RUN_LOCK_TTL", 5)
+
+        llm = GatedRecordingLLM([("text", "OK.")], model_id)
+        llm.hold(0, at="pre")
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        lock_key = f"chat:runlock:{chat_id}"
+
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Wait for the lock to be acquired
+            await asyncio.sleep(0.3)
+            assert await redis_client.exists(lock_key), "Lock was not acquired"
+
+            # Sleep longer than _RUN_LOCK_TTL (5 s).  Without the refresh
+            # background task the lock would expire.  With it the lock stays
+            # alive.
+            await asyncio.sleep(6)
+            assert await redis_client.exists(
+                lock_key
+            ), "Lock expired even with refresh task running"
+
+            llm.release(0)
+            await stream_task
+
+    @pytest.mark.asyncio
+    async def test_producer_crash_delivers_stream_error(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """The producer encounters an unexpected error while
+        streaming → ``stream_error`` event is delivered to the consumer and
+        the run lock is cleaned up."""
+        import routers.chat as chat_module
+
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [("text", "Crash.")],
+            model_id,
+            fail_on_call=0,
+            fail_exc=RuntimeError("Unexpected producer crash"),
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        lock_key = f"chat:runlock:{chat_id}"
+
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        # Wait for the producer task to finish its cleanup
+        producer_task = chat_module._run_tasks_by_chat.get(chat_id)
+        if producer_task is not None:
+            try:
+                await asyncio.wait_for(producer_task, timeout=5)
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        event_types = [et for et, _d, _sid in events]
+        assert "stream_error" in event_types, (
+            f"Expected stream_error, got events: {event_types}"
+        )
+
+        # Lock should be cleaned up after the crash
+        exists = await redis_client.exists(lock_key)
+        assert exists == 0, "Lock was not cleaned up after crash"
+
+
+# =============================================================================
+# /chat/{id}/stream/status with pending approval
+# =============================================================================
+
+
+class TestStreamStatusPending:
+    """stream/status pending_approval/pending_oauth flags."""
+
+    @pytest.mark.asyncio
+    async def test_status_pending_approval_true(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """A pending ``ToolApproval`` row with a ``tool_call_id`` that
+        matches an active-path ``tool_use`` → ``pending_approval=true``."""
+        chat_id, _user_id, model_id = seeded_chat
+
+        # Seed: user msg → assistant with tool_use → user tool_result
+        msgs_repo = MessagesRepository()
+        active = await msgs_repo.get_active_path(chat_id)
+        parent_id = active[-1].id
+
+        tool_use_id = "toolu_for_approval"
+        assistant_msg = await msgs_repo.create(
+            chat_id,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": tool_use_id,
+                        "name": "search_documents",
+                        "input": {"query": "test"},
+                    }
+                ],
+            },
+            parent_id=parent_id,
+        )
+
+        # Pending approval row
+        approvals_repo = ToolApprovalsRepository()
+        await approvals_repo.create_pending(
+            chat_id=chat_id,
+            user_id=_user_id,
+            tool_name="search_documents",
+            tool_input={"query": "test"},
+            tool_call_id=tool_use_id,
+            approval_type=ToolApprovalType.APPROVAL,
+        )
+
+        # Check status without starting a stream
+        app = FastAPI()
+        app.state = AppState()
+        app.state.redis_client = redis_client
+        app.include_router(chat_router)
+
+        async with _client(app) as client:
+            resp = await client.get(f"/chat/{chat_id}/stream/status")
+            assert resp.status_code == 200
+            status = resp.json()
+            assert status["pending_approval"] is True, (
+                f"Expected pending_approval=True, got {status}"
+            )
+            assert status["pending_oauth"] is False
+            assert status["resumable"] is False
+
+
+# =============================================================================
+# Partial assistant message utility
+# =============================================================================
+
+
+class TestPartialAssistant:
+    """Unit-level tests for ``_partial_assistant_message``."""
+
+    def test_partial_assistant_strips_empty_text_blocks(self):
+        """Empty text blocks are removed; non-empty text blocks are kept.
+        Tool inputs with string JSON are parsed to dict."""
+        from routers.chat import _partial_assistant_message
+        from anthropic.types import TextBlockParam, ToolUseBlockParam
+
+        blocks: list[TextBlockParam | ToolUseBlockParam] = [
+            TextBlockParam(type="text", text="   "),  # stripped
+            TextBlockParam(type="text", text="Hello"),  # kept
+            ToolUseBlockParam(
+                type="tool_use",
+                id="toolu_test",
+                name="test_tool",
+                input='{"key": "value"}',  # JSON string → parsed
+            ),
+        ]
+
+        result = _partial_assistant_message(blocks)
+        assert result is not None
+        content = result["content"]
+        assert len(content) == 2, f"Expected 2 blocks, got {len(content)}"
+        assert content[0]["text"] == "Hello"
+        assert content[1]["type"] == "tool_use"
+        assert content[1]["input"] == {"key": "value"}
+
+    def test_partial_assistant_returns_none_when_all_blocks_empty(self):
+        """All-empty blocks → returns None."""
+        from routers.chat import _partial_assistant_message
+        from anthropic.types import TextBlockParam
+
+        result = _partial_assistant_message([
+            TextBlockParam(type="text", text=""),
+            TextBlockParam(type="text", text="   "),
+        ])
+        assert result is None
+
+    def test_partial_assistant_parses_empty_tool_input(self):
+        """Empty string tool input becomes empty dict."""
+        from routers.chat import _partial_assistant_message
+        from anthropic.types import ToolUseBlockParam
+
+        result = _partial_assistant_message([
+            ToolUseBlockParam(
+                type="tool_use",
+                id="toolu_empty",
+                name="empty_tool",
+                input="",
+            ),
+        ])
+        assert result is not None
+        assert result["content"][0]["input"] == {}
+
+
+# =============================================================================
+# Drop empty assistant messages from history
+# =============================================================================
+
+
+class TestDropEmpty:
+    """``_drop_empty_assistant_messages`` filters out empty assistant rows."""
+
+    @pytest.mark.asyncio
+    async def test_drop_empty_assistant_from_history_before_llm_call(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """DB history contains an empty assistant row → it is removed before
+        the provider call so the LLM never sees it."""
+        chat_id, _user_id, model_id = seeded_chat
+        msgs_repo = MessagesRepository()
+
+        # Get current user message and append empty assistant + another user msg
+        active = await msgs_repo.get_active_path(chat_id)
+        parent_id = active[-1].id
+
+        empty_asst = await msgs_repo.create(
+            chat_id,
+            {"role": "assistant", "content": []},
+            parent_id=parent_id,
+        )
+        await msgs_repo.create(
+            chat_id,
+            {"role": "user", "content": "Continue"},
+            parent_id=empty_asst.id,
+        )
+
+        llm = GatedRecordingLLM([("text", "Continuing.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            await collect_sse_events(client, chat_id)
+
+        # The empty assistant should have been dropped from the LLM's history
+        assert len(llm.calls) == 1, f"Expected 1 LLM call, got {len(llm.calls)}"
+        msgs_for_llm = llm.calls[0]["messages"]
+        roles = [m["role"] for m in msgs_for_llm]
+        assert roles == ["user", "user"], (
+            f"Expected [user, user], got {roles}. "
+            "Empty assistant was not dropped."
+        )
+
+
+# =============================================================================
+# Reconnect while run is active
+# =============================================================================
+
+
+class TestReconnectActive:
+    """Reconnect while the producer is still running (lock alive)."""
+
+    MOCK_SEARCH_RESPONSE = SearchResponse(
+        results=[
+            SearchResult(
+                document=Document(
+                    id="doc_1", title="Result", content_type="text",
+                    url="", source_type="test",
+                ),
+                highlights=["test highlight"],
+                source_type="test",
+            ),
+        ],
+        total_count=1,
+        query_time_ms=5,
+    )
+
+    @pytest.mark.asyncio
+    async def test_reconnect_while_active_replays_from_zero(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Reconnect while run active, no ``Last-Event-ID`` (page-reload) →
+        attaches and replays whole buffer from ``\"0\"``.
+
+        Strategy: LLM emits a tool call → router executes it → tool handler
+        blocks on a gate → producer stays alive with events in stream →
+        Phase 2 reconnects and reads from "0" → release gate → tool
+        completes → LLM finishes → terminal event.
+        """
+        chat_id, _user_id, model_id = seeded_chat
+
+        # Gated searcher: blocks until we release it.
+        # Must provide a ``.client`` attribute (used by ``McpCapabilityHandler``
+        # and ``SkillHandler`` in the registry build).
+        searcher_gate = asyncio.Event()
+
+        async def gated_handle(_request):
+            await searcher_gate.wait()
+            return self.MOCK_SEARCH_RESPONSE
+
+        gated_searcher = AsyncMock(spec=SearcherTool)
+        gated_searcher.handle = gated_handle
+        gated_searcher.client = AsyncMock()
+
+        # Two-turn LLM: tool call then text
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": "search_documents",
+                        "input": {"query": "test"},
+                        "id": "toolu_b2_active",
+                    },
+                ),
+                ("text", "Search complete."),
+            ],
+            model_id,
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        app.state.searcher_tool = gated_searcher
+
+        async with _client(app) as stream_cl, _client(app) as ctrl_cl:
+            # Phase 1: start the stream in a background task
+            stream_task = asyncio.create_task(
+                collect_sse_events(stream_cl, chat_id)
+            )
+
+            # Wait for the producer to write the tool-call events and
+            # block on the searcher gate
+            await asyncio.sleep(0.5)
+
+            # Phase 2: reconnect without Last-Event-ID (page reload)
+            reload_events = await collect_sse_events(ctrl_cl, chat_id)
+
+            # Release the searcher gate so the producer finishes
+            searcher_gate.set()
+            await stream_task
+
+        # Phase 2 should have received the first-turn events (tool call)
+        # plus the remaining events and terminal
+        reload_msg = [et for et, _d, _sid in reload_events if et == "message"]
+        assert reload_msg, "No message events in reload stream"
+        assert any(
+            et in ("end_of_stream", "stream_error")
+            for et, _d, _ in reload_events
+        ), "No terminal event in reload"
+
+
+# =============================================================================
+# Cancel before tool execution
+# =============================================================================
+
+
+class TestCancelEarly:
+    """Cancel happens between the LLM's tool_use and tool execution."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_before_tool_execution_persists_partial_assistant(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Cancel flag set after the LLM emits a tool_use but before the
+        router executes the tool → partial assistant (with the tool_use) is
+        persisted; no tool_result row is created.
+
+        Strategy: gate the LLM at ``"pre"`` (no events yet), set cancel,
+        then release.  The router processes events and hits the cancel
+        check before tool execution.
+        """
+        chat_id, _user_id, model_id = seeded_chat
+
+        # Use an inter-event delay so the router's cancel check (inside
+        # the event loop, every ``_CANCEL_CHECK_INTERVAL_SECONDS``) has
+        # time to detect the flag before the tool execution check.
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": "search_documents",
+                        "input": {"query": "cancel me"},
+                        "id": "toolu_c2",
+                    },
+                ),
+            ],
+            model_id,
+            inter_event_delay=0.15,  # 150ms between events → total ~900ms
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Wait for the LLM to start producing events (message_start
+            # through part of the tool_use content blocks)
+            await asyncio.sleep(0.5)
+
+            # Set cancel flag — the next cancel check inside the event
+            # loop will detect it and break before tool execution.
+            await redis_client.set(
+                f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL
+            )
+
+            events = await stream_task
+
+        # Should have received the tool_use events and a terminal
+        msg_events = [
+            json.loads(d) for et, d, _ in events
+            if et == "message" and d
+        ]
+        tool_use_events = [
+            e for e in msg_events
+            if e.get("type") == "content_block_start"
+            and e.get("content_block", {}).get("type") == "tool_use"
+        ]
+        assert tool_use_events, "No tool_use content_block_start in events"
+
+        terminal = [
+            et for et, _d, _ in events
+            if et in ("end_of_stream", "stream_error")
+        ]
+        assert terminal, "No terminal event after cancel"
+
+        # Check that the assistant message with tool_use was persisted
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert assistant_msgs, "No assistant message persisted"
+        latest_asst = assistant_msgs[-1].message
+        blocks = latest_asst.get("content", [])
+        assert any(
+            b.get("type") == "tool_use" for b in blocks
+        ), "Assistant message lacks tool_use block"
+
+        # No tool_result should be present because the tool was never
+        # executed (cancel happened before execution)
+        user_msgs = [m for m in db_msgs if m.message["role"] == "user"]
+        for um in user_msgs:
+            blocks = um.message.get("content", [])
+            if isinstance(blocks, list):
+                for b in blocks:
+                    assert b.get("type") != "tool_result", (
+                        "tool_result found in user message despite cancel before execution"
+                    )
+
+
+# =============================================================================
+# Racing connect (concurrent streams)
+# =============================================================================
+
+
+class TestRacingConnect:
+    """Two concurrent ``GET /chat/{id}/stream`` requests — one wins the
+    ``SET NX`` lock, the other attaches as a consumer.  No duplicate DB writes."""
+
+    @pytest.mark.asyncio
+    async def test_racing_connect_no_duplicate_db_writes(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM([("text", "Racing.")], model_id)
+        llm.hold(0, at="pre")
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        lock_key = f"chat:runlock:{chat_id}"
+
+        async with _client(app) as client1, _client(app) as client2:
+            # Stream 1: will acquire the lock and become producer
+            stream1_task = asyncio.create_task(
+                collect_sse_events(client1, chat_id)
+            )
+
+            # Wait for lock acquisition
+            import time
+
+            deadline = time.monotonic() + 10
+            while time.monotonic() < deadline:
+                if await redis_client.exists(lock_key):
+                    break
+                await asyncio.sleep(0.05)
+            assert await redis_client.exists(lock_key), "Lock not acquired"
+
+            # Stream 2: should detect ``run_active`` and attach as consumer
+            stream2_task = asyncio.create_task(
+                collect_sse_events(client2, chat_id)
+            )
+
+            # Let stream 2 attach before releasing
+            await asyncio.sleep(0.3)
+            llm.release(0)
+
+            events1 = await stream1_task
+            events2 = await stream2_task
+
+        assert any(
+            et in ("end_of_stream", "stream_error") for et, _, _ in events1
+        ), "Stream 1 has no terminal"
+        assert any(
+            et in ("end_of_stream", "stream_error") for et, _, _ in events2
+        ), "Stream 2 has no terminal"
+
+        # Exactly one assistant message in the DB — no duplicate writes
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert len(assistant_msgs) == 1, (
+            f"Expected 1 assistant message, got {len(assistant_msgs)}. "
+            "A duplicate run was created!"
+        )
+
+
+# =============================================================================
+# Empty-row deletion on early cancel
+# =============================================================================
+
+
+class TestEmptyRowDelete:
+    """When the run is cancelled before any content block, the early-persisted
+    empty assistant row is deleted from the DB."""
+
+    @pytest.mark.asyncio
+    async def test_early_cancel_deletes_empty_assistant_row(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """LLM yields ``message_start`` (which triggers an early-persisted
+        assistant row), then cancel fires before any content block.  The
+        empty row should be deleted, leaving zero assistant rows in the DB
+        for this chat."""
+        import routers.chat as chat_module
+
+        chat_id, _user_id, model_id = seeded_chat
+
+        # inter_event_delay > _CANCEL_CHECK_INTERVAL_SECONDS (0.5s) so the
+        # cancel check fires between message_start and content_block_start.
+        # Since the check runs BEFORE processing the event, content_blocks
+        # stays empty and _partial_assistant_message returns None.
+        llm = GatedRecordingLLM(
+            [("text", "X.")], model_id, inter_event_delay=0.55
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            stream_task = asyncio.create_task(
+                collect_sse_events(client, chat_id)
+            )
+
+            # Wait for ``message_start`` to be processed
+            await asyncio.sleep(0.2)
+
+            # Set cancel flag — the cancel check will fire when
+            # content_block_start arrives (0.55s after message_start),
+            # detect the flag, and break before processing the event.
+            await redis_client.set(
+                f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL
+            )
+
+            events = await stream_task
+
+        # Wait for the producer task to finish its cleanup
+        producer_task = chat_module._run_tasks_by_chat.get(chat_id)
+        if producer_task is not None:
+            try:
+                await asyncio.wait_for(producer_task, timeout=5)
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        event_types = [et for et, _d, _sid in events]
+        # Should only have message_start + end_of_stream, no content
+        msg_count = sum(1 for et, _, _ in events if et == "message")
+        assert msg_count == 1, (
+            f"Expected 1 message event (message_start), got {msg_count}. "
+            f"Event types: {event_types}"
+        )
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert len(assistant_msgs) == 0, (
+            f"Expected 0 assistant messages (empty row should be deleted), "
+            f"got {len(assistant_msgs)}. "
+            f"Event types: {event_types}"
+        )
+
+
+# =============================================================================
+# Interrupted tool call repair
+# =============================================================================
+
+
+class TestInterruptedToolCall:
+    """``_repair_interrupted_tool_calls`` injects ``is_error`` tool_results
+    into the LLM history when the DB ends on an unanswered ``tool_use``."""
+
+    @pytest.mark.asyncio
+    async def test_repair_interrupted_tool_calls_injects_error_result(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Seed the DB with: user → assistant (tool_use, no tool_result).
+        The repair path should inject an ``is_error`` tool_result message
+        before the LLM call, and the LLM should receive the repaired history."""
+        chat_id, _user_id, model_id = seeded_chat
+        msgs_repo = MessagesRepository()
+
+        # Get current user message and append an assistant with an unanswered
+        # tool_use (no corresponding tool_result from the user).
+        active = await msgs_repo.get_active_path(chat_id)
+        parent_id = active[-1].id
+
+        tool_use_id = "toolu_g1_unanswered"
+        await msgs_repo.create(
+            chat_id,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": tool_use_id,
+                        "name": "search_documents",
+                        "input": {"query": "interrupted"},
+                    }
+                ],
+            },
+            parent_id=parent_id,
+        )
+
+        llm = GatedRecordingLLM([("text", "Repaired.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            await collect_sse_events(client, chat_id)
+
+        # The LLM should have been called with the repaired history
+        assert len(llm.calls) == 1, f"Expected 1 LLM call, got {len(llm.calls)}"
+        msgs_for_llm = llm.calls[0]["messages"]
+
+        # The last user message should contain the injected tool_result
+        last_user = [m for m in msgs_for_llm if m["role"] == "user"][-1]
+        content = last_user.get("content", [])
+        if isinstance(content, str):
+            content = [{"type": "text", "text": content}]
+        tool_results = [b for b in content if b.get("type") == "tool_result"]
+        assert tool_results, (
+            "No tool_result injected by repair path. "
+            f"Content: {content}"
+        )
+        assert tool_results[0]["tool_use_id"] == tool_use_id
+        assert tool_results[0]["is_error"] is True, (
+            "Repair tool_result should have is_error=True"
+        )
+
+
+# =============================================================================
+# Multi-turn (multiple agent iterations)
+# =============================================================================
+
+
+class TestMultiTurn:
+    """The agent loop runs through multiple LLM + tool-execution iterations."""
+
+    @pytest.mark.asyncio
+    async def test_multi_turn_executes_tool_then_responds(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """LLM produces tool_call → router executes tool → LLM second call
+        produces text → stream completes with terminal.  Each iteration
+        creates a separate assistant message.
+        """
+        chat_id, _user_id, model_id = seeded_chat
+
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": "search_documents",
+                        "input": {"query": "multi-turn"},
+                        "id": "toolu_mt",
+                    },
+                ),
+                ("text", "Here are the search results."),
+            ],
+            model_id,
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            et in ("end_of_stream", "stream_error") for et, _, _ in events
+        ), "No terminal event"
+
+        # Each iteration creates its own assistant message:
+        # iteration 1 → tool_use block, iteration 2 → text block
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert len(assistant_msgs) == 2, (
+            f"Expected exactly 2 assistant msgs (one per iteration), "
+            f"got {len(assistant_msgs)}"
+        )
+
+        # At least one has a tool_use block
+        assert any(
+            any(b.get("type") == "tool_use" for b in m.message.get("content", []))
+            for m in assistant_msgs
+        ), "No assistant with tool_use block"
+
+        # At least one has a text block
+        assert any(
+            any(b.get("type") == "text" for b in m.message.get("content", []))
+            for m in assistant_msgs
+        ), "No assistant with text block"
+
+        # The searcher mock returns empty results (ECONNREFUSED), but the
+        # tool executes and produces a tool_result.  The user's next message
+        # should contain the tool_result.
+        user_msgs = [m for m in db_msgs if m.message["role"] == "user"]
+        user_with_tool_result = None
+        for um in user_msgs:
+            content = um.message.get("content", [])
+            if isinstance(content, list):
+                if any(b.get("type") == "tool_result" for b in content):
+                    user_with_tool_result = um
+                    break
+        assert user_with_tool_result is not None, (
+            "No user message with tool_result found. "
+            "Tool was not executed."
+        )
+
+
+# =============================================================================
+# Agent chat path
+# =============================================================================
+
+
+class TestAgentChat:
+    """The ``chat.agent_id != None`` branch: agent registry, system prompt,
+    memory scoping, no approval flow."""
+
+    @pytest.mark.asyncio
+    async def test_agent_chat_uses_agent_system_prompt(
+        self, db_pool, seeded_chat, redis_client, redis_keys
+    ):
+        """Agent chat creates a different registry and system prompt.  Basic
+        streaming should still work end-to-end."""
+        chat_id, user_id, model_id = seeded_chat
+
+        # Create an agent
+        agent_id = str(ULID())
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                """INSERT INTO agents
+                     (id, user_id, name, instructions, agent_type,
+                      schedule_type, schedule_value, is_enabled, is_deleted)
+                   VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)""",
+                agent_id,
+                user_id,
+                "Test Agent",
+                "You are a test agent.",
+                "user",
+                "interval",
+                "3600",
+                True,
+                False,
+            )
+
+        # Update the seeded chat to be an agent chat
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE chats SET agent_id = $1 WHERE id = $2",
+                agent_id,
+                chat_id,
+            )
+
+        llm = GatedRecordingLLM([("text", "Agent response.")], model_id)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            et in ("end_of_stream", "stream_error") for et, _, _ in events
+        ), "No terminal event in agent chat"
+
+        msg_events = [et for et, _, _ in events if et == "message"]
+        assert msg_events, "No message events in agent chat"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert assistant_msgs, "No assistant message in agent chat DB"
+
+        # The LLM's system prompt should contain agent instructions
+        assert len(llm.calls) == 1, f"Expected 1 LLM call, got {len(llm.calls)}"
+        system_prompt = llm.calls[0].get("system_prompt", "")
+        assert "Test Agent" in system_prompt or "test agent" in system_prompt, (
+            f"Agent instructions not found in system prompt: {system_prompt[:200]}"
+        )
+
+
+# =============================================================================
+# Standalone endpoints (cancel API, context-overflow retry)
+# =============================================================================
+
+
+class TestStandaloneEndpoints:
+    """Endpoint-level tests for non-streaming routes."""
+
+    @pytest.mark.asyncio
+    async def test_cancel_api_sets_redis_flag(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """``POST /chat/{id}/cancel`` sets the cancel flag."""
+        chat_id, _user_id, model_id = seeded_chat
+
+        app = FastAPI()
+        app.state = AppState()
+        app.state.redis_client = redis_client
+        app.state.default_model_id = model_id
+        app.state.searcher_tool = AsyncMock()
+        app.include_router(chat_router)
+
+        async with _client(app) as client:
+            resp = await client.post(f"/chat/{chat_id}/cancel")
+            assert resp.status_code == 200
+            data = resp.json()
+            assert data["status"] == "cancelling"
+
+        # Verify the side effect: the Redis cancel flag was actually set,
+        # not just an HTTP 200 returned.
+        assert await redis_client.exists(f"chat:cancel:{chat_id}"), (
+            "Cancel flag was not set in Redis"
+        )
+
+    @pytest.mark.asyncio
+    async def test_context_overflow_triggers_compaction_retry(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """When the LLM raises ``ProviderError(is_context_overflow=True)``
+        on the first call with no events emitted, the router retries once
+        after forced compaction.  The second call succeeds."""
+        from providers.types import ProviderError, ProviderType
+
+        chat_id, _user_id, model_id = seeded_chat
+
+        # The first LLM call raises context overflow; the second succeeds
+        llm = GatedRecordingLLM(
+            [("text", "Retried.")],
+            model_id,
+            fail_on_call=0,
+            fail_exc=ProviderError(
+                "Context window exceeded",
+                provider_type=ProviderType.ANTHROPIC,
+                is_context_overflow=True,
+            ),
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            et in ("end_of_stream", "stream_error") for et, _, _ in events
+        ), "No terminal event after context-overflow retry"
+
+        # The LLM should have been called twice: first fails, second succeeds
+        assert len(llm.calls) >= 2, (
+            f"Expected ≥2 LLM calls for retry, got {len(llm.calls)}"
+        )
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert assistant_msgs, "No assistant message persisted after retry"

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -62,10 +62,15 @@ _FAST_TTL = 10              # stream TTL seconds (was 300)
 @pytest.fixture
 def _patch_timing(monkeypatch):
     """Shrink all timing constants so consumers/producers fail fast."""
+    monkeypatch.setattr("streaming.run._RUN_LOCK_TTL", _FAST_LOCK_TTL)
     monkeypatch.setattr("routers.chat._RUN_LOCK_TTL", _FAST_LOCK_TTL)
-    monkeypatch.setattr("routers.chat._STREAM_HEARTBEAT_MS", _FAST_HEARTBEAT_MS)
-    monkeypatch.setattr("routers.chat._STREAM_TTL", _FAST_TTL)
-    monkeypatch.setattr("routers.chat._CANCEL_CHECK_INTERVAL_SECONDS", 0.5)
+    monkeypatch.setattr("streaming.run._STREAM_HEARTBEAT_MS", _FAST_HEARTBEAT_MS)
+    monkeypatch.setattr("streaming.run._STREAM_TTL", _FAST_TTL)
+    # _CANCEL_CHECK_INTERVAL_SECONDS and _RUN_LOCK_TTL are imported by name
+    # in multiple modules; patch each local binding so monkeypatched values
+    # take effect everywhere.
+    monkeypatch.setattr("streaming.run._CANCEL_CHECK_INTERVAL_SECONDS", 0.5)
+    monkeypatch.setattr("streaming.generate._CANCEL_CHECK_INTERVAL_SECONDS", 0.5)
 
 
 # =============================================================================
@@ -675,7 +680,8 @@ class TestLockAndHeartbeat:
         chat_id, _user_id, model_id = seeded_chat
         # Override the _patch_timing values for this test: fast refresh so
         # the lock is renewed well within its short TTL.
-        monkeypatch.setattr("routers.chat._LOCK_REFRESH_INTERVAL", 2)
+        monkeypatch.setattr("streaming.run._LOCK_REFRESH_INTERVAL", 2)
+        monkeypatch.setattr("streaming.run._RUN_LOCK_TTL", 5)
         monkeypatch.setattr("routers.chat._RUN_LOCK_TTL", 5)
 
         llm = GatedRecordingLLM([("text", "OK.")], model_id)
@@ -743,6 +749,43 @@ class TestLockAndHeartbeat:
         # Lock should be cleaned up after the crash
         exists = await redis_client.exists(lock_key)
         assert exists == 0, "Lock was not cleaned up after crash"
+
+    @pytest.mark.asyncio
+    async def test_provider_error_stream_error_includes_metadata(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """ProviderError stream_error payloads keep provider/model/status details."""
+        from providers.types import ProviderError, ProviderType
+
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [("text", "unused")],
+            model_id,
+            fail_on_call=0,
+            fail_exc=ProviderError(
+                "Rate limited",
+                provider_type=ProviderType.ANTHROPIC,
+                model=model_id,
+                status_code=429,
+            ),
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        stream_errors = [
+            json.loads(data)
+            for event_type, data, _sid in events
+            if event_type == "stream_error"
+        ]
+        assert stream_errors, f"Expected stream_error, got events: {events}"
+        assert stream_errors[-1] == {
+            "message": "Failed to generate response: Rate limited",
+            "provider": "anthropic",
+            "model": model_id,
+            "statusCode": 429,
+        }
 
 
 # =============================================================================
@@ -822,7 +865,7 @@ class TestPartialAssistant:
     def test_partial_assistant_strips_empty_text_blocks(self):
         """Empty text blocks are removed; non-empty text blocks are kept.
         Tool inputs with string JSON are parsed to dict."""
-        from routers.chat import _partial_assistant_message
+        from streaming.persist import partial_assistant_message as _partial_assistant_message
         from anthropic.types import TextBlockParam, ToolUseBlockParam
 
         blocks: list[TextBlockParam | ToolUseBlockParam] = [
@@ -846,7 +889,7 @@ class TestPartialAssistant:
 
     def test_partial_assistant_returns_none_when_all_blocks_empty(self):
         """All-empty blocks → returns None."""
-        from routers.chat import _partial_assistant_message
+        from streaming.persist import partial_assistant_message as _partial_assistant_message
         from anthropic.types import TextBlockParam
 
         result = _partial_assistant_message([
@@ -857,7 +900,7 @@ class TestPartialAssistant:
 
     def test_partial_assistant_parses_empty_tool_input(self):
         """Empty string tool input becomes empty dict."""
-        from routers.chat import _partial_assistant_message
+        from streaming.persist import partial_assistant_message as _partial_assistant_message
         from anthropic.types import ToolUseBlockParam
 
         result = _partial_assistant_message([

--- a/web/src/lib/types/message.ts
+++ b/web/src/lib/types/message.ts
@@ -94,12 +94,6 @@ export type OAuthRequiredEvent = OAuthRequiredAIEvent & {
     provider_configured: boolean
 }
 
-export type ToolResultReplacedEvent = {
-    tool_use_id: string
-    content: unknown
-    is_error: boolean
-}
-
 export type ToolName = 'search_documents' | 'read_document' | string
 
 export type UploadMessageContent = {

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -40,7 +40,6 @@
         ApprovalRequiredEvent,
         OAuthRequired,
         OAuthRequiredEvent,
-        ToolResultReplacedEvent,
         OmniUploadBlock,
     } from '$lib/types/message'
     import { ToolApprovalStatus } from '$lib/types/message'
@@ -1568,10 +1567,6 @@
                 invalidate('app:recent_chats') // This will force a re-fetch of recent chats and update the title in the sidebar
             })
 
-            eventSource.addEventListener('title_error', () => {
-                // Title generation is best-effort; answer streaming should not surface its failures.
-            })
-
             eventSource.addEventListener('heartbeat', () => {
                 if (!isCurrentStream()) return
                 lastStreamEventAt = Date.now()
@@ -1598,9 +1593,7 @@
                         // self-cycle (id === parentId) that hangs getDisplayPath. Adopt
                         // the existing row as the streaming target and let the replayed
                         // content deltas rebuild it in place instead.
-                        const existingIndex = chatMessages.findIndex(
-                            (m) => m.id === messageId,
-                        )
+                        const existingIndex = chatMessages.findIndex((m) => m.id === messageId)
                         if (existingIndex !== -1) {
                             const existing = chatMessages[existingIndex]
                             chatMessages = [
@@ -1727,45 +1720,6 @@
                     requestAnimationFrame(() => recalcBottomPadding())
                 } catch (err) {
                     console.error('Failed to parse oauth_required event:', err)
-                }
-            })
-
-            eventSource.addEventListener('tool_result_replaced', (event) => {
-                if (!isCurrentStream()) return
-                try {
-                    const data: ToolResultReplacedEvent = JSON.parse(event.data)
-                    // Find the user-role chat message that holds the placeholder
-                    // tool_result block and replace it with the real result. The
-                    // envelope text is gone, so processMessages will stop
-                    // producing the OAuth card on the next derivation tick.
-                    for (const cm of chatMessages) {
-                        if (cm.message.role !== 'user') continue
-                        const content = cm.message.content
-                        if (!Array.isArray(content)) continue
-                        let replaced = false
-                        const next: ContentBlockParam[] = content.map((b) => {
-                            if (b.type === 'tool_result' && b.tool_use_id === data.tool_use_id) {
-                                replaced = true
-                                const replacement: ToolResultBlockParam = {
-                                    type: 'tool_result',
-                                    tool_use_id: data.tool_use_id,
-                                    content: data.content as ToolResultBlockParam['content'],
-                                    is_error: data.is_error,
-                                }
-                                return replacement
-                            }
-                            return b
-                        })
-                        if (replaced) {
-                            cm.message = { ...cm.message, content: next }
-                            delete oauthEventByToolCallId[data.tool_use_id]
-                            chatMessages = [...chatMessages]
-                            markChatMessagesChanged()
-                            break
-                        }
-                    }
-                } catch (err) {
-                    console.error('Failed to parse tool_result_replaced event:', err)
                 }
             })
 
@@ -2827,8 +2781,8 @@
                             chat: 'Ask a follow-up...',
                             search: 'Search for something else...',
                         }}
-                        isStreaming={isStreaming}
-                        stopInProgress={stopInProgress}
+                        {isStreaming}
+                        {stopInProgress}
                         onStop={handleStop}
                         maxWidth="max-w-4xl" />
                 </div>

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -264,10 +264,17 @@ export const GET: RequestHandler = async ({ params, locals, cookies, request, ur
 
         logger.info('Chat stream started successfully', { chatId })
 
-        // Create a transformed stream that:
-        // 1. Intercepts save_message events for database writes
-        // 2. Filters out save_message events from client
-        // 3. Triggers title generation after completion
+        // Create a transformed stream that enriches or redacts selected events
+        // before forwarding them to the browser. The AI service's
+        // _persist_and_transform has already converted internal save_message
+        // events (the producer's single writer) into message_id or
+        // update_message_content events, so they never reach this proxy.
+        //
+        // Transformations performed here:
+        // 1. oauth_required – enrich with provider_configured / source_display_name
+        // 2. message (tool_result) – redact search highlights and truncate text
+        // 3. Forward approval_required and all others as-is
+        // 4. Trigger title generation after the initial connection
         const reader = response.body?.getReader()
 
         if (!reader) {

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -9,6 +9,27 @@ import { isProviderConfigured } from '$lib/server/oauth/connectorOAuth.js'
 import { getSourceDisplayName } from '$lib/utils/icons.js'
 import { SourceType } from '$lib/types.js'
 import type { OAuthRequiredAIEvent } from '$lib/types/message.js'
+import type { Logger } from '$lib/server/logger.js'
+import type { SearchResultBlockParam, TextBlockParam } from '@anthropic-ai/sdk/resources/messages'
+
+/** Wire shape of the ``title`` SSE event emitted by the proxy after a title
+ *  generation completes on first connect. */
+type TitleEvent = {
+    title: string
+}
+
+/** An Omni extension of the SDK SearchResultBlockParam that includes the
+ *  internal source_type field, which the AI service attaches for rendering
+ *  but strips before forwarding to external LLM APIs. */
+type OmniSearchResultBlockParam = SearchResultBlockParam & {
+    source_type?: string | null
+}
+
+/** Any content block inside a tool_result's content array. */
+type ToolResultContentBlock =
+    | TextBlockParam
+    | OmniSearchResultBlockParam
+    | (Record<string, unknown> & { type: string })
 
 function sseEvent(eventType: string, data: object): string {
     return `event: ${eventType}\ndata: ${JSON.stringify(data)}\n\n`
@@ -154,7 +175,10 @@ function replayStreamResponse(sampleStream: string, chatId: string): Response {
     })
 }
 
-async function triggerTitleGeneration(chatId: string, logger: any): Promise<TitleGenerationResult> {
+async function triggerTitleGeneration(
+    chatId: string,
+    logger: Logger,
+): Promise<TitleGenerationResult> {
     try {
         // First check if title already exists
         const chat = await chatRepository.get(chatId)
@@ -197,7 +221,7 @@ async function triggerTitleGeneration(chatId: string, logger: any): Promise<Titl
             return { status: 'failed', message }
         }
     } catch (error) {
-        logger.warn('Error during title generation', error, { chatId })
+        logger.warn('Error during title generation', { error, chatId })
         const message = error instanceof Error ? error.message : 'Failed to generate chat title'
         return { status: 'failed', message }
     }
@@ -297,10 +321,9 @@ export const GET: RequestHandler = async ({ params, locals, cookies, request, ur
                                         `Generated title for chat ${chatId}: ${result.title}`,
                                     )
                                     try {
+                                        const titleEvent: TitleEvent = { title: result.title }
                                         controller.enqueue(
-                                            encoder.encode(
-                                                sseEvent('title', { title: result.title }),
-                                            ),
+                                            encoder.encode(sseEvent('title', titleEvent)),
                                         )
                                     } catch {
                                         // The browser may have disconnected while title generation ran.
@@ -403,51 +426,61 @@ export const GET: RequestHandler = async ({ params, locals, cookies, request, ur
                             // Special handling for certain events
                             if (eventType === 'message' && data) {
                                 try {
-                                    const parsedData = JSON.parse(data)
+                                    const parsedData: Record<string, unknown> = JSON.parse(data)
                                     // Redact tool result content before forwarding to client
                                     // Check if this is a tool_result block
                                     if (
                                         parsedData.type === 'tool_result' &&
                                         Array.isArray(parsedData.content)
                                     ) {
+                                        const content =
+                                            parsedData.content as ToolResultContentBlock[]
+
                                         // Separate search results from other content types
-                                        const hasSearchResults = parsedData.content.some(
-                                            (item: any) => item.type === 'search_result',
+                                        const hasSearchResults = content.some(
+                                            (item): item is OmniSearchResultBlockParam =>
+                                                item.type === 'search_result',
                                         )
 
-                                        let redactedContent
+                                        let redactedContent: ToolResultContentBlock[]
                                         if (hasSearchResults) {
                                             // Redact search result content (keep title/source, remove highlights)
-                                            redactedContent = parsedData.content
+                                            redactedContent = content
                                                 .filter(
-                                                    (item: any) => item.type === 'search_result',
+                                                    (item): item is OmniSearchResultBlockParam =>
+                                                        item.type === 'search_result',
                                                 )
-                                                .map((searchResult: any) => ({
-                                                    type: 'search_result',
-                                                    title: searchResult.title,
-                                                    source: searchResult.source,
-                                                    source_type: searchResult.source_type ?? null,
-                                                    content: [], // Redact the highlights
-                                                }))
+                                                .map(
+                                                    (searchResult): OmniSearchResultBlockParam => ({
+                                                        type: 'search_result',
+                                                        title: searchResult.title,
+                                                        source: searchResult.source,
+                                                        source_type:
+                                                            searchResult.source_type ?? null,
+                                                        content: [], // Redact the highlights
+                                                    }),
+                                                )
                                         } else {
                                             // For non-search results (connector actions, sandbox, etc.)
                                             // Forward text content as-is (truncated for safety)
-                                            redactedContent = parsedData.content.map(
-                                                (item: any) => {
-                                                    if (
-                                                        item.type === 'text' &&
-                                                        item.text?.length > 5000
-                                                    ) {
+                                            redactedContent = content.map((item) => {
+                                                if (
+                                                    item.type === 'text' &&
+                                                    typeof (item as TextBlockParam).text ===
+                                                        'string'
+                                                ) {
+                                                    const textBlock = item as TextBlockParam
+                                                    if (textBlock.text.length > 5000) {
                                                         return {
-                                                            ...item,
+                                                            ...textBlock,
                                                             text:
-                                                                item.text.substring(0, 5000) +
+                                                                textBlock.text.substring(0, 5000) +
                                                                 '\n... (truncated)',
                                                         }
                                                     }
-                                                    return item
-                                                },
-                                            )
+                                                }
+                                                return item
+                                            })
                                         }
 
                                         const redactedData = {


### PR DESCRIPTION
- Split chat streaming into dedicated generation, persistence, and Redis run-lifecycle modules to reduce router complexity.
- Preserve Stop/reconnect behavior while making cancellation, resume, and message persistence boundaries explicit.
- Add typed terminal/error event helpers so stream consumers get structured reasons and provider error metadata.
- Expand lifecycle integration coverage for Redis-backed streaming, cancellation, and stream error metadata.