### PR TITLE
fix(web): resolve misc chat UI issues

### DIFF
--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -7,6 +7,7 @@
         Sidebar,
         SidebarContent,
         SidebarHeader,
+        SidebarFooter,
         SidebarGroup,
         SidebarGroupContent,
         SidebarMenu,
@@ -369,33 +370,34 @@
                 </TooltipProvider>
             </div>
         </SidebarHeader>
-        <SidebarContent class="flex flex-col">
-            <SidebarGroup class="flex-1">
-                {#if data.agentsEnabled}
-                    <Button
-                        href="/agents"
-                        class="mb-2 flex w-full cursor-pointer items-center justify-start has-[>svg]:px-2"
-                        variant="ghost">
-                        <Bot />
-                        <span class="group-data-[collapsible=icon]:hidden">Agents</span>
-                    </Button>
-                    <hr />
-                {/if}
-
+        <SidebarGroup class="shrink-0">
+            {#if data.agentsEnabled}
                 <Button
-                    href="/"
-                    class="mt-2 flex w-full cursor-pointer items-center justify-start has-[>svg]:px-2"
+                    href="/agents"
+                    class="mb-2 flex w-full cursor-pointer items-center justify-start has-[>svg]:px-2"
                     variant="ghost">
-                    <MessageCircle />
-                    <span class="group-data-[collapsible=icon]:hidden">New Chat</span>
+                    <Bot />
+                    <span class="group-data-[collapsible=icon]:hidden">Agents</span>
                 </Button>
+                <hr />
+            {/if}
 
-                <!-- Chat history search -->
-                <ChatHistorySearch
-                    currentChatId={page.params.chatId}
-                    recentChats={data.recentChats}
-                    timeZone={data.user.configuration.timezone} />
+            <Button
+                href="/"
+                class="mt-2 flex w-full cursor-pointer items-center justify-start has-[>svg]:px-2"
+                variant="ghost">
+                <MessageCircle />
+                <span class="group-data-[collapsible=icon]:hidden">New Chat</span>
+            </Button>
 
+            <!-- Chat history search -->
+            <ChatHistorySearch
+                currentChatId={page.params.chatId}
+                recentChats={data.recentChats}
+                timeZone={data.user.configuration.timezone} />
+        </SidebarGroup>
+        <SidebarContent>
+            <SidebarGroup>
                 <SidebarGroupContent>
                     <!-- Starred chats -->
                     {#if data.starredChats.length > 0}
@@ -451,13 +453,13 @@
                     {/if}
                 </SidebarGroupContent>
             </SidebarGroup>
-            <SidebarGroup>
-                <SidebarUserMenu
-                    email={data.user.email}
-                    isAdmin={data.user.role === 'admin'}
-                    memoryEnabled={data.memoryEnabled} />
-            </SidebarGroup>
         </SidebarContent>
+        <SidebarFooter>
+            <SidebarUserMenu
+                email={data.user.email}
+                isAdmin={data.user.role === 'admin'}
+                memoryEnabled={data.memoryEnabled} />
+        </SidebarFooter>
         <SidebarRail />
     </Sidebar>
 

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -87,6 +87,8 @@
     let headerTitleValue = $state('')
     let headerTitleInputRef: HTMLInputElement | undefined = $state()
     let optimisticTitle = $state<string | null>(null)
+    let sidebarContentRef: HTMLDivElement | null = $state(null)
+    let sidebarContentScrolled = $state(false)
 
     let currentChatTitle = $derived(
         optimisticTitle ??
@@ -145,6 +147,10 @@
         }
     }
 
+    function updateSidebarScrollState() {
+        sidebarContentScrolled = (sidebarContentRef?.scrollTop ?? 0) > 0
+    }
+
     afterNavigate(() => {
         isEditingHeaderTitle = false
         optimisticTitle = null
@@ -159,6 +165,13 @@
         additionalRecentChats = []
         additionalRecentHasMore = null
         recentLoadError = ''
+    })
+
+    $effect(() => {
+        const sidebarListKey = `${recentChats.length}:${data.starredChats.length}`
+        requestAnimationFrame(() => {
+            if (sidebarListKey) updateSidebarScrollState()
+        })
     })
 
     async function loadMoreRecentChats() {
@@ -281,6 +294,7 @@
     }
 
     onMount(() => {
+        updateSidebarScrollState()
         saveDetectedTimezoneIfMissing().catch(() => {
             // Timezone auto-detection is best-effort; users can still set it manually.
         })
@@ -370,7 +384,11 @@
                 </TooltipProvider>
             </div>
         </SidebarHeader>
-        <SidebarGroup class="shrink-0">
+        <SidebarGroup
+            class={cn(
+                'shrink-0 border-b border-transparent transition-[border-color,box-shadow]',
+                sidebarContentScrolled && 'border-sidebar-border shadow-xs',
+            )}>
             {#if data.agentsEnabled}
                 <Button
                     href="/agents"
@@ -396,7 +414,7 @@
                 recentChats={data.recentChats}
                 timeZone={data.user.configuration.timezone} />
         </SidebarGroup>
-        <SidebarContent>
+        <SidebarContent bind:ref={sidebarContentRef} onscroll={updateSidebarScrollState}>
             <SidebarGroup>
                 <SidebarGroupContent>
                     <!-- Starred chats -->

--- a/web/src/routes/(app)/chat/[chatId]/+page.server.ts
+++ b/web/src/routes/(app)/chat/[chatId]/+page.server.ts
@@ -19,18 +19,30 @@ function collectActivePathToolCallIds(messages: ChatMessage[]): Set<string> {
     return ids
 }
 
+type OmniUploadSource = {
+    type: 'omni_upload'
+    upload_id: string
+}
+
+function isOmniUploadSource(source: unknown): source is OmniUploadSource {
+    if (typeof source !== 'object' || source === null) return false
+
+    const candidate = source as Record<string, unknown>
+    return candidate.type === 'omni_upload' && typeof candidate.upload_id === 'string'
+}
+
 function collectUploadIds(messages: ChatMessage[]): Set<string> {
     const ids = new Set<string>()
     for (const msg of messages) {
         const content = msg.message.content
         if (typeof content === 'string') continue
         for (const block of content) {
+            const source: unknown = 'source' in block ? block.source : null
             if (
                 (block.type === 'document' || block.type === 'image') &&
-                'source' in block &&
-                (block.source as { type: string }).type === 'omni_upload'
+                isOmniUploadSource(source)
             ) {
-                ids.add((block.source as { upload_id: string }).upload_id)
+                ids.add(source.upload_id)
             }
         }
     }
@@ -56,12 +68,14 @@ async function resolveUploadFilenames(
     return result
 }
 
-export const load = async ({ params, locals, fetch }) => {
+export const load = async ({ params, locals, fetch, depends }) => {
     const chat = await chatRepository.get(params.chatId)
     if (!chat) {
         // throw 404
         error(404, 'Chat not found')
     }
+
+    depends(`app:chat:${params.chatId}`)
 
     // Agent chats: fetch agent info and enforce admin access
     let agent: { id: string; name: string; agentType: string } | null = null

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -27,6 +27,7 @@
         ChevronLeft,
         ChevronRight,
         RotateCcw,
+        ArrowDown,
     } from '@lucide/svelte'
     import { marked } from 'marked'
     import { onDestroy, onMount } from 'svelte'
@@ -112,7 +113,6 @@
             editingMessageId = null
             uploadFilenames = { ...data.uploadFilenames }
             pendingApproval = pendingApprovalFromData()
-            markChatMessagesChanged()
         }
     })
 
@@ -455,26 +455,12 @@
     // Tracks user's branch choices: parentId -> chosen childId
     let branchSelections = $state<Record<string, string>>({})
     let activeStreamingMessageId = $state<string | null>(null)
-    let userHasScrolled = $state(false)
+    let isAwayFromBottom = $state(false)
     let showTopShadow = $state(false)
     let bottomPadding = $state(80)
 
-    let processedMessages = $state<ProcessedMessage[]>(processMessages(chatMessages))
-    let processedMessagesRefreshScheduled = false
+    let processedMessages = $derived(processMessages(chatMessages))
     let lastUserMessageIndex = $derived(processedMessages.findLastIndex((m) => m.role === 'user'))
-
-    function refreshProcessedMessages() {
-        processedMessages = processMessages(chatMessages)
-    }
-
-    function scheduleProcessedMessagesRefresh() {
-        if (processedMessagesRefreshScheduled) return
-        processedMessagesRefreshScheduled = true
-        requestAnimationFrame(() => {
-            processedMessagesRefreshScheduled = false
-            refreshProcessedMessages()
-        })
-    }
 
     function hashString(value: string): string {
         let hash = 2166136261
@@ -509,10 +495,6 @@
                 return `${block.type}:${index}`
             })
             .join('|')
-    }
-
-    function markChatMessagesChanged() {
-        scheduleProcessedMessagesRefresh()
     }
 
     async function copyMessageToClipboard(message: ProcessedMessage) {
@@ -751,7 +733,6 @@
         activeStreamingMessageId = null
         // Clear downstream selections so we follow the default (active) path from here
         clearDownstreamSelections(siblings[newIdx].id)
-        refreshProcessedMessages()
     }
 
     function clearDownstreamSelections(fromId: string) {
@@ -810,7 +791,6 @@
         clearDownstreamSelections(messageId)
         pendingApproval = null
         oauthEventByToolCallId = {}
-        markChatMessagesChanged()
 
         streamResponse(data.chat.id)
     }
@@ -1235,6 +1215,13 @@
         bottomPadding = Math.max(48, userMsgTop + containerHeight - contentHeight)
     }
 
+    function updateScrollState() {
+        if (!chatContainerRef) return
+        const { scrollTop, scrollHeight, clientHeight } = chatContainerRef
+        isAwayFromBottom = scrollTop + clientHeight < scrollHeight - 100
+        showTopShadow = scrollTop > 0
+    }
+
     function scrollUserMessageToTop() {
         requestAnimationFrame(() => {
             recalcBottomPadding()
@@ -1253,16 +1240,14 @@
             void resumeActiveStreamIfNeeded()
         }
 
-        const handleScroll = () => {
-            if (!chatContainerRef) return
-            const { scrollTop, scrollHeight, clientHeight } = chatContainerRef
-            const isNearBottom = scrollTop + clientHeight >= scrollHeight - 100
-            userHasScrolled = !isNearBottom
-            showTopShadow = scrollTop > 0
-        }
+        const handleScroll = () => updateScrollState()
         chatContainerRef?.addEventListener('scroll', handleScroll)
+        updateScrollState()
 
-        const resizeObserver = new ResizeObserver(() => recalcBottomPadding())
+        const resizeObserver = new ResizeObserver(() => {
+            recalcBottomPadding()
+            updateScrollState()
+        })
         if (chatContentRef) resizeObserver.observe(chatContentRef)
 
         // When returning to a backgrounded/frozen tab, the SSE connection is
@@ -1363,7 +1348,6 @@
                     message,
                     ...chatMessages.slice(replaceIndex + 1),
                 ]
-                markChatMessagesChanged()
             }
 
             const existingBlocks = Array.isArray(lastMessage.message.content)
@@ -1505,7 +1489,6 @@
                     chatMessages = [...chatMessages, toolResultMessage]
                     activeStreamingMessageId = toolResultMessage.id
                     selectBranch(toolResultMessage.parentId, toolResultMessage.id)
-                    markChatMessagesChanged()
                 }
 
                 return
@@ -1554,7 +1537,6 @@
                 isStreaming = false
                 stopInProgress = false
                 activeStreamingMessageId = null
-                refreshProcessedMessages()
                 stopThinkingText()
                 eventSource?.close()
                 eventSource = null
@@ -1564,7 +1546,9 @@
             })
 
             eventSource.addEventListener('title', () => {
-                invalidate('app:recent_chats') // This will force a re-fetch of recent chats and update the title in the sidebar
+                if (!isCurrentStream()) return
+                void invalidate('app:recent_chats')
+                void invalidate(`app:chat:${chatId}`)
             })
 
             eventSource.addEventListener('heartbeat', () => {
@@ -1608,7 +1592,6 @@
                                 ...chatMessages.slice(existingIndex + 1),
                             ]
                             activeStreamingMessageId = messageId
-                            markChatMessagesChanged()
                             return
                         }
                         // Find the last message in current display path to use as parent
@@ -1632,7 +1615,6 @@
                         chatMessages = [...chatMessages, startedMessage]
                         activeStreamingMessageId = startedMessage.id
                         selectBranch(startedMessage.parentId, startedMessage.id)
-                        markChatMessagesChanged()
                     } else if (data.type === 'content_block_start') {
                         if (data.content_block.type === 'tool_use') {
                             collectStreamingResponse(data.content_block, data.index)
@@ -1681,7 +1663,7 @@
                         collectStreamingResponse(data)
                     }
 
-                    if (!userHasScrolled) scrollToBottom()
+                    updateScrollState()
                 } catch (err) {
                     console.error('Failed to parse SSE data:', event.data, err)
                 } finally {
@@ -1698,7 +1680,6 @@
                     isStreaming = false
                     stopInProgress = false
                     activeStreamingMessageId = null
-                    refreshProcessedMessages()
                     stopThinkingText()
                     requestAnimationFrame(() => recalcBottomPadding())
                 } catch (err) {
@@ -1715,7 +1696,6 @@
                     isStreaming = false
                     stopInProgress = false
                     activeStreamingMessageId = null
-                    refreshProcessedMessages()
                     stopThinkingText()
                     requestAnimationFrame(() => recalcBottomPadding())
                 } catch (err) {
@@ -1730,7 +1710,6 @@
                 isStreaming = false
                 stopInProgress = false
                 activeStreamingMessageId = null
-                refreshProcessedMessages()
                 stopThinkingText()
                 requestAnimationFrame(() => recalcBottomPadding())
                 userInputRef?.focus()
@@ -1758,7 +1737,6 @@
                 isStreaming = false
                 stopInProgress = false
                 activeStreamingMessageId = null
-                refreshProcessedMessages()
                 stopThinkingText()
                 requestAnimationFrame(() => recalcBottomPadding())
                 userInputRef?.focus()
@@ -1800,7 +1778,6 @@
                 isStreaming = false
                 stopInProgress = false
                 activeStreamingMessageId = null
-                refreshProcessedMessages()
                 stopThinkingText()
                 requestAnimationFrame(() => recalcBottomPadding())
                 userInputRef?.focus()
@@ -1923,7 +1900,6 @@
                     }
                     chatMessages = [...chatMessages, denialMessage]
                     selectBranch(parentMessage.id, denialMessage.id)
-                    markChatMessagesChanged()
                 }
             }
 
@@ -2023,10 +1999,9 @@
         }
         chatMessages = [...chatMessages, newUserMessage]
         selectBranch(newUserMessage.parentId, newUserMessage.id)
-        markChatMessagesChanged()
 
         pendingUploads = []
-        userHasScrolled = false
+        isAwayFromBottom = false
 
         scrollUserMessageToTop()
         streamResponse(data.chat.id)
@@ -2759,6 +2734,21 @@
 
             <!-- Input -->
             <div class="bg-background sticky bottom-0 flex flex-col items-center pb-4">
+                {#if isAwayFromBottom}
+                    <div
+                        class="pointer-events-none absolute inset-x-0 -top-12 z-20 mx-auto flex w-full max-w-4xl justify-end px-4">
+                        <Button
+                            type="button"
+                            variant="outline"
+                            size="icon"
+                            class="bg-background pointer-events-auto h-9 w-9 cursor-pointer rounded-full shadow-md"
+                            aria-label="Scroll to bottom"
+                            title="Scroll to bottom"
+                            onclick={scrollToBottom}>
+                            <ArrowDown class="h-4 w-4" />
+                        </Button>
+                    </div>
+                {/if}
                 <div class="w-full max-w-4xl">
                     <input
                         bind:this={uploadInputEl}

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -2736,12 +2736,12 @@
             <div class="bg-background sticky bottom-0 flex flex-col items-center pb-4">
                 {#if isAwayFromBottom}
                     <div
-                        class="pointer-events-none absolute inset-x-0 -top-12 z-20 mx-auto flex w-full max-w-4xl justify-end px-4">
+                        class="pointer-events-none absolute inset-x-0 -top-12 z-20 mx-auto flex w-full max-w-4xl justify-center px-4">
                         <Button
                             type="button"
                             variant="outline"
                             size="icon"
-                            class="bg-background pointer-events-auto h-9 w-9 cursor-pointer rounded-full shadow-md"
+                            class="bg-card pointer-events-auto h-9 w-9 cursor-pointer rounded-full shadow-md"
                             aria-label="Scroll to bottom"
                             title="Scroll to bottom"
                             onclick={scrollToBottom}>


### PR DESCRIPTION
- Refresh current chat route data when an autogenerated title arrives so the browser tab and header update without a reload.
- Derive processed chat messages directly from message state to avoid stale manual refreshes during streaming.
- Stop forcing the chat viewport to the bottom during streamed responses, while adding a manual centered scroll-to-bottom control.
- Keep sidebar actions/search and profile fixed so only the chat history list scrolls.