### PR TITLE
fix(mcp): remove deprecated bootstrap endpoint

### DIFF
--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -335,14 +335,6 @@ class ActionRequest(BaseModel):
     credentials: dict[str, Any]
 
 
-class BootstrapMcpRequest(BaseModel):
-    """Carries resolved credentials from the connector-manager to the connector
-    so the connector can perform authenticated MCP catalog discovery after an
-    OAuth credential has been stored for a source."""
-
-    credentials: dict[str, Any] = Field(default_factory=dict)
-
-
 class ActionResponse(BaseModel):
     status: str
     result: dict[str, Any] | None = None

--- a/sdk/python/omni_connector/server.py
+++ b/sdk/python/omni_connector/server.py
@@ -13,7 +13,6 @@ from .context import SyncContext
 from .exceptions import SdkClientError
 from .models import (
     ActionRequest,
-    BootstrapMcpRequest,
     CancelRequest,
     CancelResponse,
     OAuthCredentialReadyRequest,
@@ -105,17 +104,6 @@ def create_app(connector: "Connector") -> FastAPI:
     async def manifest() -> dict[str, Any]:
         m = await connector.get_manifest(connector_url=connector_url)
         return m.model_dump()
-
-    @app.post("/mcp/bootstrap")
-    async def bootstrap_mcp(request: BootstrapMcpRequest) -> JSONResponse:
-        """Discover MCP catalog with supplied credentials and refresh manifest registration."""
-        await connector.bootstrap_mcp(request.credentials)
-        m = await connector.get_manifest(connector_url=connector_url)
-        try:
-            await server.sdk_client.register(m.model_dump())
-        except Exception as e:
-            logger.warning("MCP bootstrap manifest registration failed: %s", e)
-        return JSONResponse(status_code=status.HTTP_200_OK, content=m.model_dump())
 
     @app.post("/oauth/credential-ready")
     async def oauth_credential_ready(

--- a/services/connector-manager/src/connector_client.rs
+++ b/services/connector-manager/src/connector_client.rs
@@ -3,7 +3,6 @@ use crate::models::{
     PromptRequest, ResourceRequest, SkillRequest, SyncRequest, SyncResponse, SyncStatusResponse,
 };
 use reqwest::Client;
-use serde_json::json;
 use shared::models::SyncType;
 use shared::{RateLimiter, RetryableError};
 use std::sync::atomic::{AtomicU32, Ordering};
@@ -269,38 +268,6 @@ impl ConnectorClient {
         // Return the raw response regardless of status code so the handler
         // can proxy status, headers, and body verbatim.
         Ok(response)
-    }
-
-    pub async fn bootstrap_mcp(
-        &self,
-        connector_url: &str,
-        credentials: &serde_json::Value,
-    ) -> Result<ConnectorManifest, ClientError> {
-        let url = format!("{}/mcp/bootstrap", connector_url);
-        debug!("Bootstrapping MCP catalog at {}", url);
-
-        let response = self
-            .client
-            .post(&url)
-            .json(&json!({"credentials": credentials}))
-            .send()
-            .await
-            .map_err(|e| ClientError::RequestFailed(e.to_string()))?;
-
-        if !response.status().is_success() {
-            let status = response.status();
-            let body = response.text().await.unwrap_or_default();
-            error!("Failed to bootstrap MCP: {} - {}", status, body);
-            return Err(ClientError::ConnectorError {
-                status: status.as_u16(),
-                message: body,
-            });
-        }
-
-        response
-            .json()
-            .await
-            .map_err(|e| ClientError::InvalidResponse(e.to_string()))
     }
 
     /// Notify a connector that a new OAuth credential has been stored.

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -1,9 +1,9 @@
 use crate::connector_client::ConnectorClient;
 use crate::models::{
-    ActionContext, ActionRequest, BootstrapMcpRequest, ConnectorInfo, ExecuteActionRequest,
-    ExecutePromptRequest, ExecuteResourceRequest, ExecuteSkillRequest, McpCredentials,
-    OAuthCredentialReadyRequest, PromptRequest, ResourceRequest, ScheduleInfo, SourceHealth,
-    SourceSyncOverview, SyncProgress, TriggerSyncRequest, TriggerSyncResponse, TriggerType,
+    ActionContext, ActionRequest, ConnectorInfo, ExecuteActionRequest, ExecutePromptRequest,
+    ExecuteResourceRequest, ExecuteSkillRequest, McpCredentials, OAuthCredentialReadyRequest,
+    PromptRequest, ResourceRequest, ScheduleInfo, SourceHealth, SourceSyncOverview, SyncProgress,
+    TriggerSyncRequest, TriggerSyncResponse, TriggerType,
 };
 use crate::sync_circuit_breaker::has_failure_streak;
 use crate::sync_manager::SyncError;
@@ -932,81 +932,6 @@ pub async fn get_prompt(
         .map_err(|e| ApiError::Internal(e.to_string()))?;
 
     Ok(Json(result))
-}
-
-pub async fn bootstrap_mcp(
-    State(state): State<AppState>,
-    Json(request): Json<BootstrapMcpRequest>,
-) -> Result<Json<ConnectorManifest>, ApiError> {
-    info!(
-        "Bootstrapping MCP catalog for source {} (user={:?})",
-        request.source_id, request.user_id
-    );
-
-    let source_repo = SourceRepository::new(state.db_pool.pool());
-    let source = source_repo
-        .find_by_id(request.source_id.clone())
-        .await
-        .map_err(|e| ApiError::Internal(e.to_string()))?
-        .ok_or_else(|| ApiError::NotFound(format!("Source not found: {}", request.source_id)))?;
-
-    let connector_url = get_connector_url_for_source(&state.redis_client, source.source_type)
-        .await
-        .ok_or_else(|| {
-            ApiError::NotFound(format!(
-                "Connector not registered for type: {:?}",
-                source.source_type
-            ))
-        })?;
-
-    let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let creds = match resolve_credentials(
-        &creds_repo,
-        &request.source_id,
-        request.user_id.as_deref(),
-        false,
-    )
-    .await?
-    {
-        CredentialResolution::Resolved(creds) => creds,
-        CredentialResolution::NeedsUserAuth { provider } => {
-            return Err(ApiError::BadRequest(format!(
-                "User OAuth required before MCP bootstrap for provider {:?}",
-                provider
-            )));
-        }
-        CredentialResolution::NoCredentials => {
-            return Err(ApiError::NotFound(format!(
-                "Credentials not found for source: {}",
-                request.source_id
-            )));
-        }
-    };
-
-    let credentials = serde_json::to_value(McpCredentials::from_service_credential(&creds))
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let client = ConnectorClient::new();
-    let manifest = client
-        .bootstrap_mcp(&connector_url, &credentials)
-        .await
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-
-    validate_connector_manifest_action_schemas(&manifest).map_err(ApiError::BadRequest)?;
-    let manifest_json = serde_json::to_string(&manifest)
-        .map_err(|e| ApiError::Internal(format!("Failed to serialize manifest: {}", e)))?;
-    let key = format!("connector:manifest:{}", manifest.connector_id);
-    let mut conn = state
-        .redis_client
-        .get_multiplexed_async_connection()
-        .await
-        .map_err(|e| ApiError::Internal(format!("Redis connection error: {}", e)))?;
-    let _: () = conn
-        .set_ex(&key, &manifest_json, REGISTRATION_TTL_SECONDS)
-        .await
-        .map_err(|e| ApiError::Internal(format!("Failed to store registration: {}", e)))?;
-
-    Ok(Json(manifest))
 }
 
 /// Generic OAuth credential-ready notification from omni-web after a user

--- a/services/connector-manager/src/lib.rs
+++ b/services/connector-manager/src/lib.rs
@@ -56,7 +56,6 @@ pub fn create_app(state: AppState) -> Router {
         .route("/resources", get(handlers::list_resources))
         .route("/prompt", post(handlers::get_prompt))
         .route("/prompts", get(handlers::list_prompts))
-        .route("/mcp/bootstrap", post(handlers::bootstrap_mcp))
         .route(
             "/oauth/credential-ready",
             post(handlers::oauth_credential_ready),

--- a/services/connector-manager/src/models.rs
+++ b/services/connector-manager/src/models.rs
@@ -106,13 +106,6 @@ pub struct ExecuteActionRequest {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct BootstrapMcpRequest {
-    pub source_id: String,
-    #[serde(default)]
-    pub user_id: Option<String>,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct OAuthCredentialReadyRequest {
     pub source_id: String,
     #[serde(default)]


### PR DESCRIPTION
- Removes the legacy `/mcp/bootstrap` endpoint from connector-manager and the Python connector SDK.
- Keeps post-OAuth MCP setup on the generic credential-ready lifecycle path.