### PR TITLE
fix(web): prevent self password reset lockout

### DIFF
--- a/web/src/routes/(admin)/admin/settings/user-management/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/user-management/+page.server.ts
@@ -107,6 +107,13 @@ export const actions: Actions = {
             return fail(400, { error: 'User ID is required', field: 'general' })
         }
 
+        if (userId === currentUser.id) {
+            return fail(400, {
+                error: 'Use Change Password from your profile to update your own password',
+                field: 'general',
+            })
+        }
+
         try {
             const targetUser = await userRepository.findById(userId)
             if (!targetUser) {

--- a/web/src/routes/(admin)/admin/settings/user-management/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/user-management/+page.svelte
@@ -201,31 +201,46 @@
                                         <Tooltip.Provider delayDuration={300}>
                                             <Tooltip.Root>
                                                 <Tooltip.Trigger>
-                                                    <form
-                                                        method="POST"
-                                                        action="?/resetPassword"
-                                                        use:enhance={() => {
-                                                            isSubmitting = true
-                                                            return async ({ update }) => {
-                                                                await update()
-                                                            }
-                                                        }}>
-                                                        <input
-                                                            type="hidden"
-                                                            name="userId"
-                                                            value={user.id} />
+                                                    {#if user.id === data.user.id}
                                                         <Button
-                                                            type="submit"
+                                                            type="button"
                                                             variant="ghost"
                                                             size="icon"
                                                             class="h-8 w-8 cursor-pointer"
-                                                            disabled={isSubmitting}>
+                                                            disabled>
                                                             <Key class="h-4 w-4" />
                                                         </Button>
-                                                    </form>
+                                                    {:else}
+                                                        <form
+                                                            method="POST"
+                                                            action="?/resetPassword"
+                                                            use:enhance={() => {
+                                                                isSubmitting = true
+                                                                return async ({ update }) => {
+                                                                    await update()
+                                                                }
+                                                            }}>
+                                                            <input
+                                                                type="hidden"
+                                                                name="userId"
+                                                                value={user.id} />
+                                                            <Button
+                                                                type="submit"
+                                                                variant="ghost"
+                                                                size="icon"
+                                                                class="h-8 w-8 cursor-pointer"
+                                                                disabled={isSubmitting}>
+                                                                <Key class="h-4 w-4" />
+                                                            </Button>
+                                                        </form>
+                                                    {/if}
                                                 </Tooltip.Trigger>
                                                 <Tooltip.Content>
-                                                    <p>Reset password</p>
+                                                    <p>
+                                                        {user.id === data.user.id
+                                                            ? 'Use Change Password from your profile for your own account'
+                                                            : 'Reset password'}
+                                                    </p>
                                                 </Tooltip.Content>
                                             </Tooltip.Root>
                                         </Tooltip.Provider>

--- a/web/src/routes/(app)/change-password/+page.server.ts
+++ b/web/src/routes/(app)/change-password/+page.server.ts
@@ -61,7 +61,9 @@ export const actions: Actions = {
             const validPassword = await verifyPassword(dbUser.passwordHash, currentPassword)
             if (!validPassword) {
                 return fail(400, {
-                    error: 'Current password is incorrect',
+                    error: user.mustChangePassword
+                        ? 'Temporary password is incorrect'
+                        : 'Current password is incorrect',
                     field: 'currentPassword',
                 })
             }

--- a/web/src/routes/(app)/change-password/+page.svelte
+++ b/web/src/routes/(app)/change-password/+page.svelte
@@ -83,7 +83,9 @@
                 }}>
                 <div class="space-y-4">
                     <div class="space-y-2">
-                        <Label for="currentPassword">Current Password</Label>
+                        <Label for="currentPassword">
+                            {data.mustChangePassword ? 'Temporary Password' : 'Current Password'}
+                        </Label>
                         <Input
                             id="currentPassword"
                             name="currentPassword"


### PR DESCRIPTION
- Block admins from resetting their own password in user management to avoid invalidating their active credentials.
- Disable the self-reset action in the users table and direct admins to the normal Change Password flow.
- Rename the forced-change password prompt/error to “Temporary Password” so users know which credential is required.