### PR TITLE
fix(chat): handle Google schema OAuth prompts

### DIFF
--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -1,5 +1,5 @@
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, Instant};
 
 use crate::admin::AdminClient;
 use crate::auth::{
@@ -23,11 +23,14 @@ use serde::Deserialize;
 use serde_json::{json, Value as JsonValue};
 use std::collections::HashMap;
 use tokio::process::Command;
+use tokio::sync::RwLock;
 use tokio::time::timeout;
 use tracing::debug;
 
 const GWS_COMMAND: &str = "gws";
 const GWS_TIMEOUT: Duration = Duration::from_secs(60);
+const GWS_SCHEMA_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
+const GWS_SCHEMA_CACHE_MAX_ENTRIES: usize = 256;
 const GOOGLE_WORKSPACE_CLI_TOKEN: &str = "GOOGLE_WORKSPACE_CLI_TOKEN";
 const GOOGLE_DRIVE_READ_SCOPE: &str = "https://www.googleapis.com/auth/drive.readonly";
 const GOOGLE_DRIVE_WRITE_SCOPE: &str = "https://www.googleapis.com/auth/drive.file";
@@ -52,9 +55,21 @@ const GOOGLE_WORKSPACE_SCOPES: &[&str] = &[
 
 #[derive(Debug, Deserialize)]
 struct GwsSchemaRequest {
+    #[serde(alias = "method")]
     schema: String,
     #[serde(default)]
     resolve_refs: bool,
+}
+
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
+struct GwsSchemaCacheKey {
+    schema: String,
+    resolve_refs: bool,
+}
+
+struct GwsSchemaCacheEntry {
+    result: JsonValue,
+    expires_at: Instant,
 }
 
 #[derive(Debug, Deserialize)]
@@ -181,6 +196,7 @@ fn find_attachment_part_by_name<'a>(
 pub struct GoogleConnector {
     pub sync_manager: Arc<SyncManager>,
     pub admin_client: Arc<AdminClient>,
+    schema_cache: Arc<RwLock<HashMap<GwsSchemaCacheKey, GwsSchemaCacheEntry>>>,
 }
 
 fn validate_gws_token(value: &str, label: &str) -> Result<()> {
@@ -365,6 +381,7 @@ impl GoogleConnector {
         Self {
             sync_manager,
             admin_client,
+            schema_cache: Arc::new(RwLock::new(HashMap::new())),
         }
     }
 
@@ -409,19 +426,17 @@ impl GoogleConnector {
         auth.get_fresh_token(principal_email).await
     }
 
-    async fn execute_gws_args(
-        &self,
+    async fn execute_gws_action(
         args: Vec<String>,
-        creds: &ServiceCredential,
-    ) -> Result<Response> {
-        let token = self.gws_token(creds).await?;
+        token: Option<String>,
+    ) -> Result<ActionResponse> {
         debug!("Executing gws with args: {:?}", args);
 
         let mut command = Command::new(GWS_COMMAND);
-        command
-            .args(&args)
-            .env(GOOGLE_WORKSPACE_CLI_TOKEN, token)
-            .kill_on_drop(true);
+        command.args(&args).kill_on_drop(true);
+        if let Some(token) = token {
+            command.env(GOOGLE_WORKSPACE_CLI_TOKEN, token);
+        }
 
         let output = timeout(GWS_TIMEOUT, command.output())
             .await
@@ -440,19 +455,80 @@ impl GoogleConnector {
             output.status.code(),
             &stdout,
             &stderr,
-        )
-        .into_response())
+        ))
     }
 
-    async fn execute_gws_schema(
+    async fn execute_gws_command(
         &self,
-        params: JsonValue,
+        args: Vec<String>,
+        token: Option<String>,
+    ) -> Result<Response> {
+        Ok(Self::execute_gws_action(args, token).await?.into_response())
+    }
+
+    async fn execute_gws_args(
+        &self,
+        args: Vec<String>,
         creds: &ServiceCredential,
     ) -> Result<Response> {
+        let token = self.gws_token(creds).await?;
+        self.execute_gws_command(args, Some(token)).await
+    }
+
+    async fn execute_gws_schema(&self, params: JsonValue) -> Result<Response> {
         let request: GwsSchemaRequest =
             serde_json::from_value(params).context("Invalid google_workspace_schema params")?;
+        let key = GwsSchemaCacheKey {
+            schema: request.schema.clone(),
+            resolve_refs: request.resolve_refs,
+        };
+        let now = Instant::now();
+
+        if let Some(result) = {
+            let cache = self.schema_cache.read().await;
+            cache
+                .get(&key)
+                .filter(|entry| entry.expires_at > now)
+                .map(|entry| entry.result.clone())
+        } {
+            debug!("Using cached gws schema for {}", key.schema);
+            return Ok(ActionResponse::success(result).into_response());
+        }
+
         let args = build_gws_schema_args(&request)?;
-        self.execute_gws_args(args, creds).await
+        let mut cache = self.schema_cache.write().await;
+        cache.retain(|_, entry| entry.expires_at > now);
+        if let Some(result) = cache
+            .get(&key)
+            .filter(|entry| entry.expires_at > now)
+            .map(|entry| entry.result.clone())
+        {
+            debug!("Using cached gws schema for {}", key.schema);
+            return Ok(ActionResponse::success(result).into_response());
+        }
+
+        let response = Self::execute_gws_action(args, None).await?;
+        if response.status == "success" {
+            if let Some(result) = response.result.clone() {
+                if cache.len() >= GWS_SCHEMA_CACHE_MAX_ENTRIES {
+                    if let Some(oldest_key) = cache
+                        .iter()
+                        .min_by_key(|(_, entry)| entry.expires_at)
+                        .map(|(key, _)| key.clone())
+                    {
+                        cache.remove(&oldest_key);
+                    }
+                }
+                cache.insert(
+                    key,
+                    GwsSchemaCacheEntry {
+                        result,
+                        expires_at: now + GWS_SCHEMA_CACHE_TTL,
+                    },
+                );
+            }
+        }
+        Ok(response.into_response())
     }
 
     async fn execute_gws_call(
@@ -1078,7 +1154,7 @@ impl Connector for GoogleConnector {
         match action {
             "fetch_file" => self.execute_fetch_file(params, &creds).await,
             "search_users" => self.execute_search_users(params, &creds).await,
-            "google_workspace_schema" => self.execute_gws_schema(params, &creds).await,
+            "google_workspace_schema" => self.execute_gws_schema(params).await,
             "google_workspace_call" => self.execute_gws_call(params, &creds).await,
             _ => {
                 use axum::http::StatusCode;
@@ -1223,6 +1299,15 @@ mod tests {
         .unwrap();
 
         assert_eq!(args, ["schema", "drive.files.list"]);
+    }
+
+    #[test]
+    fn gws_schema_request_accepts_method_alias() {
+        let request: GwsSchemaRequest =
+            serde_json::from_value(json!({"method": "sheets.spreadsheets.create"})).unwrap();
+
+        assert_eq!(request.schema, "sheets.spreadsheets.create");
+        assert!(!request.resolve_refs);
     }
 
     #[test]

--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -271,13 +271,19 @@ class OAuthCredentialReadyRequest(BaseModel):
     authenticated MCP catalog discovery.
     """
 
-    source_id: str = Field(description="Source whose OAuth credential became available.")
+    source_id: str = Field(
+        description="Source whose OAuth credential became available."
+    )
     user_id: str | None = Field(
         default=None,
         description="User that owns the OAuth credential, or None for org-source credentials.",
     )
-    provider: str = Field(description="Service provider identifier for the OAuth credential.")
-    flow: str = Field(description="OAuth flow that stored the credential, such as user_read.")
+    provider: str = Field(
+        description="Service provider identifier for the OAuth credential."
+    )
+    flow: str = Field(
+        description="OAuth flow that stored the credential, such as user_read."
+    )
     credentials: dict[str, Any] = Field(
         default_factory=dict,
         description="Resolved credential payload forwarded by connector-manager.",

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -351,21 +351,115 @@ async def stream_generator(
         # ----- Pending approval / OAuth resume ---------------------------------
         if pending or pending_oauth:
             if pending_oauth:
-                intervention = pending_oauth[0]
                 logger.info(f"Resuming from pending oauth for chat {chat_id}")
-                ev = oauth_event(
-                    intervention.tool_call_id,
-                    intervention.tool_name,
-                    intervention.source_id,
-                    intervention.source_type,
-                    intervention.provider,
-                    intervention.oauth_start_url,
+                oauth_by_tool_call_id = {
+                    approval.tool_call_id: approval
+                    for approval in pending_oauth
+                    if approval.tool_call_id is not None
+                }
+                answered_ids = (
+                    tool_result_ids(conversation_messages[-1])
+                    if conversation_messages
+                    else set()
                 )
-                yield f"event: oauth_required\ndata: {json.dumps(ev)}\n\n"
-                yield end_of_stream(
-                    EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                tool_calls_to_resume: list[ToolUseBlockParam] = []
+                for message in reversed(conversation_messages):
+                    tool_uses = tool_use_blocks(message)
+                    if not tool_uses:
+                        answered_ids.update(tool_result_ids(message))
+                        continue
+                    tool_calls_to_resume = [
+                        tool_use
+                        for tool_use in tool_uses
+                        if tool_use["id"] not in answered_ids
+                    ]
+                    break
+
+                context = ToolContext(
+                    chat_id=chat_id,
+                    user_id=tool_user_id,
+                    user_email=user_email,
+                    user_configuration=user_configuration,
+                    skip_permission_check=tool_skip_perm,
                 )
-                return
+                tool_results: list[ToolResultBlockParam] = []
+                completed_oauth_ids: list[str] = []
+                for tool_call in tool_calls_to_resume:
+                    result = await registry.execute(
+                        tool_call["name"], tool_call["input"], context
+                    )
+                    if result.oauth_required is not None:
+                        payload = result.oauth_required
+                        if tool_results:
+                            tool_result_message = MessageParam(
+                                role="user", content=tool_results
+                            )
+                            conversation_messages.append(tool_result_message)
+                            for tool_result in tool_results:
+                                yield (
+                                    f"event: message\ndata: "
+                                    f"{json.dumps(tool_result)}\n\n"
+                                )
+                            yield (
+                                f"event: save_message\ndata: "
+                                f"{json.dumps(tool_result_message)}\n\n"
+                            )
+                        for aid in completed_oauth_ids:
+                            await approvals_repo.update_status(
+                                aid, ToolApprovalStatus.COMPLETED, chat_user_id
+                            )
+                        yield (
+                            f"event: oauth_required\ndata: "
+                            f"{json.dumps(oauth_event(tool_call['id'], tool_call['name'], payload.source_id, payload.source_type, payload.provider, payload.oauth_start_url))}\n\n"
+                        )
+                        yield end_of_stream(
+                            EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                        )
+                        return
+
+                    tool_results.append(
+                        ToolResultBlockParam(
+                            type="tool_result",
+                            tool_use_id=tool_call["id"],
+                            content=result.content,
+                            is_error=result.is_error,
+                        )
+                    )
+                    approval = oauth_by_tool_call_id.get(tool_call["id"])
+                    if approval:
+                        completed_oauth_ids.append(approval.id)
+
+                if tool_results:
+                    tool_result_message = MessageParam(
+                        role="user", content=tool_results
+                    )
+                    conversation_messages.append(tool_result_message)
+                    for tool_result in tool_results:
+                        yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
+                    yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
+
+                for aid in completed_oauth_ids:
+                    await approvals_repo.update_status(
+                        aid, ToolApprovalStatus.COMPLETED, chat_user_id
+                    )
+
+                if tool_results:
+                    pending_oauth = []
+                else:
+                    intervention = pending_oauth[0]
+                    ev = oauth_event(
+                        intervention.tool_call_id,
+                        intervention.tool_name,
+                        intervention.source_id,
+                        intervention.source_type,
+                        intervention.provider,
+                        intervention.oauth_start_url,
+                    )
+                    yield f"event: oauth_required\ndata: {json.dumps(ev)}\n\n"
+                    yield end_of_stream(
+                        EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                    )
+                    return
 
             logger.info(f"Resuming from pending approval batch for chat {chat_id}")
             if any(
@@ -453,6 +547,11 @@ async def stream_generator(
                                 role="user", content=tool_results
                             )
                             conversation_messages.append(tool_result_message)
+                            for tool_result in tool_results:
+                                yield (
+                                    f"event: message\ndata: "
+                                    f"{json.dumps(tool_result)}\n\n"
+                                )
                             yield (
                                 f"event: save_message\ndata: "
                                 f"{json.dumps(tool_result_message)}\n\n"

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -113,6 +113,7 @@
             editingMessageId = null
             uploadFilenames = { ...data.uploadFilenames }
             pendingApproval = pendingApprovalFromData()
+            oauthEventByToolCallId = {}
         }
     })
 
@@ -450,6 +451,21 @@
     // source display name; the persisted envelope on its own can render the
     // card in degraded mode (provider treated as "configured" optimistically).
     let oauthEventByToolCallId = $state<Record<string, OAuthRequiredEvent>>({})
+
+    function oauthRequiredFromEvent(event: OAuthRequiredEvent): OAuthRequired {
+        return {
+            sourceId: event.source_id,
+            sourceType: event.source_type,
+            sourceDisplayName:
+                event.source_display_name ??
+                getSourceDisplayName(event.source_type as SourceType) ??
+                event.source_type,
+            provider: event.provider,
+            providerConfigured: event.provider_configured ?? true,
+            oauthStartUrl: event.oauth_start_url,
+            status: 'pending',
+        }
+    }
     let editingMessageId = $state<string | null>(null)
     let editingContent = $state('')
     // Tracks user's branch choices: parentId -> chosen childId
@@ -936,7 +952,11 @@
             text: string
             isError: boolean
         }) => {
-            updateToolBlock(actionResult.toolUseId, (block) => ({ ...block, actionResult }))
+            updateToolBlock(actionResult.toolUseId, (block) => ({
+                ...block,
+                actionResult,
+                oauthRequired: undefined,
+            }))
         }
 
         const updateOAuthRequired = (toolUseId: string, oauthRequired: OAuthRequired) => {
@@ -1066,7 +1086,10 @@
                                 },
                             }
 
-                            if (
+                            const liveOAuth = oauthEventByToolCallId[block.id]
+                            if (liveOAuth) {
+                                toolMsgContent.oauthRequired = oauthRequiredFromEvent(liveOAuth)
+                            } else if (
                                 data.pendingOAuth &&
                                 data.pendingOAuth.toolCallId === block.id &&
                                 data.pendingOAuth.sourceId &&
@@ -1123,23 +1146,27 @@
                                     envelope.omni_kind === OmniToolResultKind.OauthRequired
                                 ) {
                                     const live = oauthEventByToolCallId[toolUseId]
-                                    updateOAuthRequired(toolUseId, {
-                                        sourceId: envelope.payload.source_id,
-                                        sourceType: envelope.payload.source_type,
-                                        sourceDisplayName:
-                                            live?.source_display_name ??
-                                            getSourceDisplayName(
-                                                envelope.payload.source_type as SourceType,
-                                            ) ??
-                                            envelope.payload.source_type,
-                                        provider: envelope.payload.provider,
-                                        // Optimistic default on refresh; corrected by
-                                        // the live SSE event when present, and the
-                                        // card itself can re-check via /api/oauth/provider-status.
-                                        providerConfigured: live?.provider_configured ?? true,
-                                        oauthStartUrl: envelope.payload.oauth_start_url,
-                                        status: 'pending',
-                                    })
+                                    updateOAuthRequired(
+                                        toolUseId,
+                                        live
+                                            ? oauthRequiredFromEvent(live)
+                                            : {
+                                                  sourceId: envelope.payload.source_id,
+                                                  sourceType: envelope.payload.source_type,
+                                                  sourceDisplayName:
+                                                      getSourceDisplayName(
+                                                          envelope.payload
+                                                              .source_type as SourceType,
+                                                      ) ?? envelope.payload.source_type,
+                                                  provider: envelope.payload.provider,
+                                                  // Optimistic default on refresh; corrected by
+                                                  // the live SSE event when present, and the
+                                                  // card itself can re-check via /api/oauth/provider-status.
+                                                  providerConfigured: true,
+                                                  oauthStartUrl: envelope.payload.oauth_start_url,
+                                                  status: 'pending',
+                                              },
+                                    )
                                     promptHandled = true
                                 } else if (
                                     envelope &&
@@ -1692,7 +1719,10 @@
                 pauseEventReceived = true
                 try {
                     const oauthData: OAuthRequiredEvent = JSON.parse(event.data)
-                    oauthEventByToolCallId[oauthData.tool_call_id] = oauthData
+                    oauthEventByToolCallId = {
+                        ...oauthEventByToolCallId,
+                        [oauthData.tool_call_id]: oauthData,
+                    }
                     isStreaming = false
                     stopInProgress = false
                     activeStreamingMessageId = null


### PR DESCRIPTION
- Render live OAuth-required connector prompts immediately so users see the connect card without refreshing the chat.
- Let Google Workspace schema inspection run without user OAuth because it only reads local CLI schema metadata.
- Accept `method` as an alias for Google Workspace schema lookups so model-generated calls resolve correctly.