### PR TITLE
fix(ai): simplify chat tool intervention loop

### DIFF
--- a/services/ai/db/tool_approvals.py
+++ b/services/ai/db/tool_approvals.py
@@ -145,8 +145,11 @@ class ToolApprovalsRepository:
                 """
                 UPDATE tool_approvals
                 SET status = $2,
-                    resolved_at = NOW(),
-                    resolved_by = COALESCE($3, resolved_by)
+                    resolved_at = CASE WHEN $2 = 'pending' THEN NULL ELSE NOW() END,
+                    resolved_by = CASE
+                        WHEN $2 = 'pending' THEN NULL
+                        ELSE COALESCE($3, resolved_by)
+                    END
                 WHERE id = $1
                 """,
                 approval_id,

--- a/services/ai/db/tool_approvals.py
+++ b/services/ai/db/tool_approvals.py
@@ -161,7 +161,7 @@ class ToolApprovalsRepository:
         self,
         *,
         chat_id: str,
-        approval_type: ToolApprovalType,
+        approval_type: ToolApprovalType | None = None,
         statuses: set[ToolApprovalStatus],
         active_tool_call_ids: set[str] | None = None,
     ) -> list[ToolApproval]:
@@ -177,13 +177,13 @@ class ToolApprovalsRepository:
                        tool_call_id, source_id, source_type, provider, oauth_start_url
                 FROM tool_approvals
                 WHERE chat_id = $1
-                  AND approval_type = $2
+                  AND ($2::text IS NULL OR approval_type = $2)
                   AND status = ANY($3::text[])
                   AND ($4::text[] IS NULL OR tool_call_id = ANY($4::text[]))
                 ORDER BY created_at ASC
                 """,
                 chat_id,
-                approval_type.value,
+                approval_type.value if approval_type is not None else None,
                 [status.value for status in statuses],
                 (
                     list(active_tool_call_ids)

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -549,6 +549,7 @@ async def stream_status(
 # Stream chat handler
 # ---------------------------------------------------------------------------
 
+
 class StreamChatHandler:
     def __init__(self, request: Request, chat_id: str, auto_start: bool) -> None:
         self.request = request
@@ -573,9 +574,9 @@ class StreamChatHandler:
         redis_client = request.app.state.redis_client
 
         # Reconnect/resume fast path
-        last_event_id = request.headers.get("last-event-id") or request.query_params.get(
-            "last_event_id"
-        )
+        last_event_id = request.headers.get(
+            "last-event-id"
+        ) or request.query_params.get("last_event_id")
         if redis_client is not None:
             run_active = await redis_client.exists(run_lock_key(chat_id))
             if run_active:
@@ -611,8 +612,7 @@ class StreamChatHandler:
         effective_mode = MemoryMode.OFF
         memories: list[str] = []
         memory_write_key: str | None = None
-        pending: list[ToolApproval] = []
-        pending_oauth: list[ToolApproval] = []
+        pending_interventions: list[ToolApproval] = []
 
         if chat.agent_id:
             # ---- Agent chat setup ----
@@ -659,8 +659,7 @@ class StreamChatHandler:
             )
             registry = build_result.registry
             loaded_toolsets: set[str] = set()
-            pending = []
-            pending_oauth = []
+            pending_interventions = []
 
             run_repo = AgentRunRepository()
             runs = await run_repo.list_runs(agent.id, limit=20)
@@ -712,7 +711,9 @@ class StreamChatHandler:
                 user_email=user_email,
                 memories=memories if memories else None,
                 user_configuration=user_configuration,
-                include_web_search=getattr(request.app.state, "web_search_provider", None)
+                include_web_search=getattr(
+                    request.app.state, "web_search_provider", None
+                )
                 is not None,
                 include_fetch_web_page=getattr(
                     request.app.state, "web_fetch_provider", None
@@ -745,7 +746,9 @@ class StreamChatHandler:
                     is_admin = user.role == "admin"
 
             if not chat_messages:
-                raise HTTPException(status_code=404, detail="No messages found for chat")
+                raise HTTPException(
+                    status_code=404, detail="No messages found for chat"
+                )
 
             messages = [MessageParam(**msg.message) for msg in chat_messages]
 
@@ -766,9 +769,8 @@ class StreamChatHandler:
             active_tool_call_ids_set = {
                 tool_use["id"] for tool_use in unanswered_tool_calls(messages)
             }
-            pending = await approvals_repo.list_for_chat(
+            pending_interventions = await approvals_repo.list_for_chat(
                 chat_id=chat_id,
-                approval_type=ToolApprovalType.APPROVAL,
                 statuses={
                     ToolApprovalStatus.PENDING,
                     ToolApprovalStatus.APPROVED,
@@ -776,12 +778,19 @@ class StreamChatHandler:
                 },
                 active_tool_call_ids=active_tool_call_ids_set,
             )
-            pending_oauth = await approvals_repo.list_for_chat(
-                chat_id=chat_id,
-                approval_type=ToolApprovalType.OAUTH,
-                statuses={ToolApprovalStatus.PENDING, ToolApprovalStatus.APPROVED},
-                active_tool_call_ids=active_tool_call_ids_set,
-            )
+            oauth_intervention_statuses = {
+                ToolApprovalStatus.PENDING,
+                ToolApprovalStatus.APPROVED,
+            }
+            pending_interventions = [
+                intervention
+                for intervention in pending_interventions
+                if intervention.approval_type == ToolApprovalType.APPROVAL
+                or (
+                    intervention.approval_type == ToolApprovalType.OAUTH
+                    and intervention.status in oauth_intervention_statuses
+                )
+            ]
 
             active_sources = [
                 s for s in build_result.sources if s.is_active and not s.is_deleted
@@ -834,7 +843,9 @@ class StreamChatHandler:
                 user_email=user_email,
                 memories=memories if memories else None,
                 user_configuration=user_configuration,
-                include_web_search=getattr(request.app.state, "web_search_provider", None)
+                include_web_search=getattr(
+                    request.app.state, "web_search_provider", None
+                )
                 is not None,
                 include_fetch_web_page=getattr(
                     request.app.state, "web_fetch_provider", None
@@ -845,7 +856,7 @@ class StreamChatHandler:
         # ---- Common setup (repair, compaction, etc.) ----
         intervention_tool_call_ids = {
             approval.tool_call_id
-            for approval in [*pending, *pending_oauth]
+            for approval in pending_interventions
             if approval.tool_call_id is not None
         }
         preserved_batch_ids = latest_intervention_tool_batch_ids(
@@ -877,7 +888,7 @@ class StreamChatHandler:
             )
 
         last_message_role = messages[-1].get("role") if messages else None
-        if not pending and not pending_oauth and last_message_role != "user":
+        if not pending_interventions and last_message_role != "user":
             logger.info(
                 f"Last message is not from user, no processing needed. Chat ID: {chat_id}"
             )
@@ -983,14 +994,15 @@ class StreamChatHandler:
             connector_handler=build_result.connector_handler,
             loaded_toolsets=loaded_toolsets,
             compactor=compactor,
-            latest_compaction_summary=latest_compaction.summary if latest_compaction else None,
+            latest_compaction_summary=(
+                latest_compaction.summary if latest_compaction else None
+            ),
             summarizer_context_window_tokens=summarizer_context.tokens,
             memory_provider=memory_provider,
             memory_write_key=memory_write_key,
             effective_mode=effective_mode,
             approvals_repo=approvals_repo,
-            pending=pending,
-            pending_oauth=pending_oauth,
+            pending_interventions=pending_interventions,
             original_user_query=original_user_query,
         )
 
@@ -1037,6 +1049,7 @@ class StreamChatHandler:
 # ---------------------------------------------------------------------------
 # Route: stream chat
 # ---------------------------------------------------------------------------
+
 
 @router.get("/chat/{chat_id}/stream")
 async def stream_chat(
@@ -1207,5 +1220,7 @@ async def download_artifact(
 
 # Re-exports for backward compatibility with tests.
 # The canonical homes are in ``services/ai/streaming/``.
-from streaming.persist import partial_assistant_message as _partial_assistant_message  # noqa: E402, F401
+from streaming.persist import (
+    partial_assistant_message as _partial_assistant_message,
+)  # noqa: E402, F401
 from streaming.run import _run_tasks_by_chat  # noqa: E402, F401

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -65,10 +65,11 @@ from state import AppState
 from streaming.generate import (
     active_path_tool_call_ids,
     drop_empty_assistant_messages,
+    latest_intervention_tool_batch_ids,
     message_content_blocks,
     repair_interrupted_tool_calls,
     stream_generator,
-    tool_use_blocks,
+    unanswered_tool_calls,
 )
 from streaming.persist import (
     EndOfStreamReason,
@@ -763,9 +764,7 @@ class StreamChatHandler:
             registry = build_result.registry
 
             active_tool_call_ids_set = {
-                tool_use["id"]
-                for message in messages
-                for tool_use in tool_use_blocks(message)
+                tool_use["id"] for tool_use in unanswered_tool_calls(messages)
             }
             pending = await approvals_repo.list_for_chat(
                 chat_id=chat_id,
@@ -780,7 +779,7 @@ class StreamChatHandler:
             pending_oauth = await approvals_repo.list_for_chat(
                 chat_id=chat_id,
                 approval_type=ToolApprovalType.OAUTH,
-                statuses={ToolApprovalStatus.PENDING},
+                statuses={ToolApprovalStatus.PENDING, ToolApprovalStatus.APPROVED},
                 active_tool_call_ids=active_tool_call_ids_set,
             )
 
@@ -844,19 +843,28 @@ class StreamChatHandler:
             )
 
         # ---- Common setup (repair, compaction, etc.) ----
-        if not pending and not pending_oauth:
-            messages, repaired_tool_calls = repair_interrupted_tool_calls(messages)
-            if repaired_tool_calls:
-                logger.warning(
-                    f"Inserted {repaired_tool_calls} failed tool_result placeholder(s) for interrupted tool calls in chat {chat_id}"
-                )
-            before = len(messages)
-            messages = drop_empty_assistant_messages(messages)
-            dropped = before - len(messages)
-            if dropped:
-                logger.warning(
-                    f"Dropped {dropped} empty assistant message(s) from history for chat {chat_id}"
-                )
+        intervention_tool_call_ids = {
+            approval.tool_call_id
+            for approval in [*pending, *pending_oauth]
+            if approval.tool_call_id is not None
+        }
+        preserved_batch_ids = latest_intervention_tool_batch_ids(
+            messages, intervention_tool_call_ids
+        )
+        messages, repaired_tool_calls = repair_interrupted_tool_calls(
+            messages, preserve_tool_call_ids=preserved_batch_ids
+        )
+        if repaired_tool_calls:
+            logger.warning(
+                f"Inserted {repaired_tool_calls} failed tool_result placeholder(s) for interrupted tool calls in chat {chat_id}"
+            )
+        before = len(messages)
+        messages = drop_empty_assistant_messages(messages)
+        dropped = before - len(messages)
+        if dropped:
+            logger.warning(
+                f"Dropped {dropped} empty assistant message(s) from history for chat {chat_id}"
+            )
 
         storage = request.app.state.content_storage
         if storage is not None:

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -10,7 +10,7 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator, Iterable
-from typing import Any, cast
+from typing import cast
 
 from anthropic import AsyncStream, MessageStreamEvent
 from anthropic.types import (
@@ -42,6 +42,7 @@ from services.compaction import ConversationCompactor
 from services.usage import UsageContext, UsagePurpose, UsageTracker
 from streaming.persist import (
     EndOfStreamReason,
+    OAuthRequiredEvent,
     approval_required_event,
     end_of_stream,
     oauth_event,
@@ -57,7 +58,6 @@ from tools import (
     ToolHandler,
     ToolRegistry,
 )
-from tools.omni_tool_result import OAuthRequiredPayload
 from tools.turn_builder import build_turn_tools
 
 logger = logging.getLogger(__name__)
@@ -161,6 +161,58 @@ def tool_result_ids(message: MessageParam) -> set[str]:
     }
 
 
+def unanswered_tool_calls(messages: list[MessageParam]) -> list[ToolUseBlockParam]:
+    answered_ids = {
+        tool_result_id
+        for message in messages
+        for tool_result_id in tool_result_ids(message)
+    }
+    return [
+        tool_use
+        for message in messages
+        for tool_use in tool_use_blocks(message)
+        if tool_use["id"] not in answered_ids
+    ]
+
+
+def latest_intervention_tool_batch_ids(
+    messages: list[MessageParam], intervention_tool_call_ids: set[str]
+) -> set[str]:
+    for message in reversed(messages):
+        tool_calls = tool_use_blocks(message)
+        tool_call_ids = {tool_call["id"] for tool_call in tool_calls}
+        if tool_call_ids & intervention_tool_call_ids:
+            return tool_call_ids
+    return set()
+
+
+def coalesce_adjacent_tool_result_messages(
+    messages: list[MessageParam],
+) -> list[MessageParam]:
+    coalesced: list[MessageParam] = []
+    for message in messages:
+        blocks = message_content_blocks(message)
+        is_tool_result_message = (
+            message.get("role") == "user"
+            and bool(blocks)
+            and all(block["type"] == "tool_result" for block in blocks)
+        )
+        if is_tool_result_message and coalesced:
+            previous_blocks = message_content_blocks(coalesced[-1])
+            previous_is_tool_result_message = (
+                coalesced[-1].get("role") == "user"
+                and bool(previous_blocks)
+                and all(block["type"] == "tool_result" for block in previous_blocks)
+            )
+            if previous_is_tool_result_message:
+                coalesced[-1] = MessageParam(
+                    role="user", content=[*previous_blocks, *blocks]
+                )
+                continue
+        coalesced.append(message)
+    return coalesced
+
+
 def _interrupted_tool_result(tool_use: ToolUseBlockParam) -> ToolResultBlockParam:
     return ToolResultBlockParam(
         type="tool_result",
@@ -180,11 +232,13 @@ def _interrupted_tool_result(tool_use: ToolUseBlockParam) -> ToolResultBlockPara
 
 def repair_interrupted_tool_calls(
     messages: list[MessageParam],
+    preserve_tool_call_ids: set[str] | None = None,
 ) -> tuple[list[MessageParam], int]:
     """Insert ToolResultBlockParam placeholders for tool calls whose
     responses were lost (interrupted stream)."""
     repaired: list[MessageParam] = []
     repair_count = 0
+    preserved_ids = preserve_tool_call_ids or set()
 
     for idx, message in enumerate(messages):
         tool_uses = tool_use_blocks(message)
@@ -195,7 +249,10 @@ def repair_interrupted_tool_calls(
         next_message = messages[idx + 1] if idx + 1 < len(messages) else None
         answered_ids = tool_result_ids(next_message) if next_message else set()
         missing = [
-            tool_use for tool_use in tool_uses if tool_use["id"] not in answered_ids
+            tool_use
+            for tool_use in tool_uses
+            if tool_use["id"] not in answered_ids
+            and tool_use["id"] not in preserved_ids
         ]
 
         repaired.append(message)
@@ -298,11 +355,28 @@ def _copy_provider_extras(src: object, dst: dict, keys: tuple[str, ...]) -> None
 
 async def active_path_tool_call_ids(messages_repo, chat_id: str) -> set[str]:
     active_path = await messages_repo.get_active_path(chat_id)
-    return {
-        tool_use["id"]
-        for message in active_path
-        for tool_use in tool_use_blocks(MessageParam(**message.message))
-    }
+    messages = [MessageParam(**message.message) for message in active_path]
+    return {tool_use["id"] for tool_use in unanswered_tool_calls(messages)}
+
+
+def oauth_event_from_approval(approval: ToolApproval) -> OAuthRequiredEvent:
+    if (
+        approval.tool_call_id is None
+        or approval.source_id is None
+        or approval.source_type is None
+        or approval.provider is None
+        or approval.oauth_start_url is None
+    ):
+        raise ValueError(f"OAuth approval {approval.id} is missing required metadata")
+    return oauth_event(
+        approval.id,
+        approval.tool_call_id,
+        approval.tool_name,
+        approval.source_id,
+        approval.source_type,
+        approval.provider,
+        approval.oauth_start_url,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -348,250 +422,62 @@ async def stream_generator(
         content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
         content_blocks_finalized = False
 
-        # ----- Pending approval / OAuth resume ---------------------------------
-        if pending or pending_oauth:
-            if pending_oauth:
-                logger.info(f"Resuming from pending oauth for chat {chat_id}")
-                oauth_by_tool_call_id = {
-                    approval.tool_call_id: approval
-                    for approval in pending_oauth
-                    if approval.tool_call_id is not None
-                }
-                answered_ids = (
-                    tool_result_ids(conversation_messages[-1])
-                    if conversation_messages
-                    else set()
-                )
-                tool_calls_to_resume: list[ToolUseBlockParam] = []
-                for message in reversed(conversation_messages):
-                    tool_uses = tool_use_blocks(message)
-                    if not tool_uses:
-                        answered_ids.update(tool_result_ids(message))
-                        continue
-                    tool_calls_to_resume = [
-                        tool_use
-                        for tool_use in tool_uses
-                        if tool_use["id"] not in answered_ids
-                    ]
-                    break
+        normal_interventions_by_tool_call_id = {
+            approval.tool_call_id: approval
+            for approval in pending or []
+            if approval.tool_call_id is not None
+        }
+        oauth_interventions_by_tool_call_id = {
+            approval.tool_call_id: approval
+            for approval in pending_oauth or []
+            if approval.tool_call_id is not None
+        }
+        unanswered_calls = unanswered_tool_calls(conversation_messages)
+        unanswered_ids = {tool_call["id"] for tool_call in unanswered_calls}
 
-                context = ToolContext(
-                    chat_id=chat_id,
-                    user_id=tool_user_id,
-                    user_email=user_email,
-                    user_configuration=user_configuration,
-                    skip_permission_check=tool_skip_perm,
-                )
-                tool_results: list[ToolResultBlockParam] = []
-                completed_oauth_ids: list[str] = []
-                for tool_call in tool_calls_to_resume:
-                    result = await registry.execute(
-                        tool_call["name"], tool_call["input"], context
-                    )
-                    if result.oauth_required is not None:
-                        payload = result.oauth_required
-                        if tool_results:
-                            tool_result_message = MessageParam(
-                                role="user", content=tool_results
-                            )
-                            conversation_messages.append(tool_result_message)
-                            for tool_result in tool_results:
-                                yield (
-                                    f"event: message\ndata: "
-                                    f"{json.dumps(tool_result)}\n\n"
-                                )
-                            yield (
-                                f"event: save_message\ndata: "
-                                f"{json.dumps(tool_result_message)}\n\n"
-                            )
-                        for aid in completed_oauth_ids:
-                            await approvals_repo.update_status(
-                                aid, ToolApprovalStatus.COMPLETED, chat_user_id
-                            )
-                        yield (
-                            f"event: oauth_required\ndata: "
-                            f"{json.dumps(oauth_event(tool_call['id'], tool_call['name'], payload.source_id, payload.source_type, payload.provider, payload.oauth_start_url))}\n\n"
-                        )
-                        yield end_of_stream(
-                            EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
-                        )
-                        return
-
-                    tool_results.append(
-                        ToolResultBlockParam(
-                            type="tool_result",
-                            tool_use_id=tool_call["id"],
-                            content=result.content,
-                            is_error=result.is_error,
-                        )
-                    )
-                    approval = oauth_by_tool_call_id.get(tool_call["id"])
-                    if approval:
-                        completed_oauth_ids.append(approval.id)
-
-                if tool_results:
-                    tool_result_message = MessageParam(
-                        role="user", content=tool_results
-                    )
-                    conversation_messages.append(tool_result_message)
-                    for tool_result in tool_results:
-                        yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
-                    yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
-
-                for aid in completed_oauth_ids:
-                    await approvals_repo.update_status(
-                        aid, ToolApprovalStatus.COMPLETED, chat_user_id
-                    )
-
-                if tool_results:
-                    pending_oauth = []
-                else:
-                    intervention = pending_oauth[0]
-                    ev = oauth_event(
-                        intervention.tool_call_id,
-                        intervention.tool_name,
-                        intervention.source_id,
-                        intervention.source_type,
-                        intervention.provider,
-                        intervention.oauth_start_url,
-                    )
-                    yield f"event: oauth_required\ndata: {json.dumps(ev)}\n\n"
-                    yield end_of_stream(
-                        EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
-                    )
-                    return
-
-            logger.info(f"Resuming from pending approval batch for chat {chat_id}")
-            if any(
-                approval.status == ToolApprovalStatus.PENDING
-                for approval in pending or []
-            ):
-                yield (
-                    f"event: approval_required\ndata: "
-                    f"{json.dumps(approval_required_event(pending or [], tool_use_blocks))}\n\n"
-                )
-                yield end_of_stream(
-                    EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
-                )
-                return
-
-            approvals_by_tool_call_id = {
-                approval.tool_call_id: approval
-                for approval in (pending or [])
-                if approval.tool_call_id is not None
-            }
-            answered_ids = (
-                tool_result_ids(conversation_messages[-1])
-                if conversation_messages
-                else set()
+        blocked_approvals = [
+            approval
+            for tool_call_id, approval in normal_interventions_by_tool_call_id.items()
+            if tool_call_id in unanswered_ids
+            and approval.status == ToolApprovalStatus.PENDING
+        ]
+        if blocked_approvals:
+            yield sse_event(
+                "approval_required",
+                approval_required_event(blocked_approvals, tool_use_blocks),
             )
-            tool_calls_to_resume: list[ToolUseBlockParam] = []
-            for message in reversed(conversation_messages):
-                tool_uses = tool_use_blocks(message)
-                if not tool_uses:
-                    answered_ids.update(tool_result_ids(message))
-                    continue
-                tool_calls_to_resume = [
-                    tool_use
-                    for tool_use in tool_uses
-                    if tool_use["id"] not in answered_ids
-                ]
-                break
-
-            context = ToolContext(
-                chat_id=chat_id,
-                user_id=tool_user_id,
-                user_email=user_email,
-                user_configuration=user_configuration,
-                skip_permission_check=tool_skip_perm,
+            yield end_of_stream(
+                EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
             )
-            tool_results: list[ToolResultBlockParam] = []
-            completed_approval_ids: list[str] = []
-            for tool_call in tool_calls_to_resume:
-                approval = approvals_by_tool_call_id.get(tool_call["id"])
-                if approval and approval.status == ToolApprovalStatus.DENIED:
-                    tool_result = ToolResultBlockParam(
-                        type="tool_result",
-                        tool_use_id=tool_call["id"],
-                        content=[
-                            {
-                                "type": "text",
-                                "text": "The user denied approval for this tool call.",
-                            }
-                        ],
-                        is_error=True,
-                    )
-                    completed_approval_ids.append(approval.id)
-                else:
-                    result = await registry.execute(
-                        tool_call["name"], tool_call["input"], context
-                    )
-                    if result.oauth_required is not None:
-                        payload = result.oauth_required
-                        if approval:
-                            completed_approval_ids.append(approval.id)
-                        await approvals_repo.create_pending(
-                            chat_id=chat_id,
-                            user_id=chat_user_id,
-                            tool_name=tool_call["name"],
-                            tool_input=tool_call["input"],
-                            tool_call_id=tool_call["id"],
-                            approval_type=ToolApprovalType.OAUTH,
-                            source_id=payload.source_id,
-                            source_type=payload.source_type,
-                            provider=payload.provider,
-                            oauth_start_url=payload.oauth_start_url,
-                        )
-                        if tool_results:
-                            tool_result_message = MessageParam(
-                                role="user", content=tool_results
-                            )
-                            conversation_messages.append(tool_result_message)
-                            for tool_result in tool_results:
-                                yield (
-                                    f"event: message\ndata: "
-                                    f"{json.dumps(tool_result)}\n\n"
-                                )
-                            yield (
-                                f"event: save_message\ndata: "
-                                f"{json.dumps(tool_result_message)}\n\n"
-                            )
-                        for aid in completed_approval_ids:
-                            await approvals_repo.update_status(
-                                aid, ToolApprovalStatus.COMPLETED, chat_user_id
-                            )
-                        yield (
-                            f"event: oauth_required\ndata: "
-                            f"{json.dumps(oauth_event(tool_call['id'], tool_call['name'], payload.source_id, payload.source_type, payload.provider, payload.oauth_start_url))}\n\n"
-                        )
-                        yield end_of_stream(
-                            EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
-                        )
-                        return
+            return
 
-                    tool_result = ToolResultBlockParam(
-                        type="tool_result",
-                        tool_use_id=tool_call["id"],
-                        content=result.content,
-                        is_error=result.is_error,
-                    )
-                    if approval:
-                        completed_approval_ids.append(approval.id)
+        blocked_oauth = next(
+            (
+                approval
+                for tool_call_id, approval in oauth_interventions_by_tool_call_id.items()
+                if tool_call_id in unanswered_ids
+                and approval.status == ToolApprovalStatus.PENDING
+            ),
+            None,
+        )
+        if blocked_oauth is not None:
+            yield sse_event("oauth_required", oauth_event_from_approval(blocked_oauth))
+            yield end_of_stream(
+                EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+            )
+            return
 
-                tool_results.append(tool_result)
-                yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
-
-            if tool_results:
-                tool_result_message = MessageParam(role="user", content=tool_results)
-                conversation_messages.append(tool_result_message)
-                yield (
-                    f"event: save_message\ndata: "
-                    f"{json.dumps(tool_result_message)}\n\n"
-                )
-            for aid in completed_approval_ids:
-                await approvals_repo.update_status(
-                    aid, ToolApprovalStatus.COMPLETED, chat_user_id
-                )
+        intervention_tool_call_ids = set(normal_interventions_by_tool_call_id) | set(
+            oauth_interventions_by_tool_call_id
+        )
+        resumable_batch_ids = latest_intervention_tool_batch_ids(
+            conversation_messages, intervention_tool_call_ids
+        )
+        resumable_tool_calls = [
+            tool_call
+            for tool_call in unanswered_calls
+            if tool_call["id"] in resumable_batch_ids
+        ]
 
         logger.info(
             f"Starting conversation with {len(conversation_messages)} initial messages"
@@ -625,256 +511,330 @@ async def stream_generator(
             skip_permission_check=tool_skip_perm,
         )
 
-        usage_repo = UsageRepository()
+        if approvals_repo is None:
+            raise ValueError("Tool approvals repository is required")
+
         assistant_message: MessageParam | None = None
 
         # ----- Main agent loop -------------------------------------------------
-        for iteration in range(AGENT_MAX_ITERATIONS):
+        model_iteration = 0
+        loop_passes = AGENT_MAX_ITERATIONS + (1 if resumable_tool_calls else 0)
+        for _ in range(loop_passes):
             if await is_run_cancelled(redis_client, chat_id):
                 logger.info(f"Run cancelled, stopping stream for chat {chat_id}")
                 break
 
-            logger.info(f"Iteration {iteration + 1}/{AGENT_MAX_ITERATIONS}")
             content_blocks = []
             content_blocks_finalized = False
-            provider_extras = llm_provider.PERSISTED_BLOCK_EXTRAS
+            parse_errors_by_tool_call_id: dict[str, ToolResultBlockParam] = {}
+            if resumable_tool_calls:
+                tool_calls = resumable_tool_calls
+                resumable_tool_calls = []
+                logger.info("Processing %s resumed tool calls", len(tool_calls))
+            else:
+                model_iteration += 1
+                logger.info(
+                    "Model iteration %s/%s", model_iteration, AGENT_MAX_ITERATIONS
+                )
+                conversation_messages = coalesce_adjacent_tool_result_messages(
+                    conversation_messages
+                )
+                provider_extras = llm_provider.PERSISTED_BLOCK_EXTRAS
 
-            turn_tools = build_turn_tools(
-                always_on_handlers,
-                connector_handler,
-                loaded_toolsets,
-            )
+                turn_tools = build_turn_tools(
+                    always_on_handlers,
+                    connector_handler,
+                    loaded_toolsets,
+                )
 
-            logger.info("Sending request to LLM provider")
+                logger.info("Sending request to LLM provider")
 
-            stream = event_stream_with_context_retry(
-                turn_tools,
-                conversation_messages,
-                llm_provider,
-                chat_user_id,
-                chat_id,
-                system_prompt,
-                compactor,
-                latest_compaction_summary,
-                summarizer_context_window_tokens,
-            )
+                stream = event_stream_with_context_retry(
+                    turn_tools,
+                    conversation_messages,
+                    llm_provider,
+                    chat_user_id,
+                    chat_id,
+                    system_prompt,
+                    compactor,
+                    latest_compaction_summary,
+                    summarizer_context_window_tokens,
+                )
 
-            event_index = 0
-            message_stop_received = False
-            cancelled = False
-            last_cancel_check_at = 0.0
-            async for event in stream:
-                logger.debug(f"Received event: {event} (index: {event_index})")
-                event_index += 1
+                event_index = 0
+                message_stop_received = False
+                cancelled = False
+                last_cancel_check_at = 0.0
+                async for event in stream:
+                    logger.debug(f"Received event: {event} (index: {event_index})")
+                    event_index += 1
 
-                now = asyncio.get_running_loop().time()
-                if now - last_cancel_check_at >= _CANCEL_CHECK_INTERVAL_SECONDS:
-                    last_cancel_check_at = now
-                    if await is_run_cancelled(redis_client, chat_id):
-                        cancelled = True
+                    now = asyncio.get_running_loop().time()
+                    if now - last_cancel_check_at >= _CANCEL_CHECK_INTERVAL_SECONDS:
+                        last_cancel_check_at = now
+                        if await is_run_cancelled(redis_client, chat_id):
+                            cancelled = True
+                            break
+
+                    if event.type == "message_start":
+                        logger.info("Message start received.")
+
+                    if event.type == "content_block_delta":
+                        logger.debug(
+                            f"Content block delta received at index {event.index}: {event.delta}"
+                        )
+                        if event.delta.type == "text_delta":
+                            if event.index >= len(content_blocks):
+                                logger.warning(
+                                    f"Received text delta for unknown content block index {event.index}, creating new text block"
+                                )
+                                content_blocks.append(TextBlockParam(type="text", text=""))
+                            text_block = cast(TextBlockParam, content_blocks[event.index])
+                            text_block["text"] += event.delta.text
+                        elif event.delta.type == "input_json_delta":
+                            if event.index >= len(content_blocks):
+                                logger.warning(
+                                    f"Received input JSON delta for unknown content block index {event.index}, creating new tool use block"
+                                )
+                                content_blocks.append(
+                                    ToolUseBlockParam(
+                                        type="tool_use", id="", name="", input=""
+                                    )
+                                )
+                            tool_use_block = cast(
+                                ToolUseBlockParam, content_blocks[event.index]
+                            )
+                            tool_use_block["input"] = (
+                                cast(str, tool_use_block["input"])
+                                + event.delta.partial_json
+                            )
+                        elif event.delta.type == "citations_delta":
+                            if event.index >= len(content_blocks):
+                                logger.warning(
+                                    f"Received citations delta for unknown content block index {event.index}, creating new citations block"
+                                )
+                                content_blocks.append(
+                                    TextBlockParam(type="text", text="", citations=[])
+                                )
+                            text_block = cast(TextBlockParam, content_blocks[event.index])
+                            if "citations" not in text_block or not text_block["citations"]:
+                                text_block["citations"] = []
+                            citations = cast(
+                                list[TextCitationParam], text_block["citations"]
+                            )
+                            citations.append(convert_citation_to_param(event.delta))
+
+                    elif event.type == "content_block_start":
+                        if event.content_block.type == "text":
+                            logger.info(f"Text block start: {event.content_block.text}")
+                            text_block: TextBlockParam = TextBlockParam(
+                                type="text", text=event.content_block.text
+                            )
+                            _copy_provider_extras(
+                                event.content_block, text_block, provider_extras
+                            )
+                            content_blocks.append(text_block)
+                        elif event.content_block.type == "tool_use":
+                            logger.info(
+                                f"Tool use block start: {event.content_block.name} (id: {event.content_block.id})"
+                            )
+                            tool_block: ToolUseBlockParam = ToolUseBlockParam(
+                                type="tool_use",
+                                id=event.content_block.id,
+                                name=event.content_block.name,
+                                input="",
+                            )
+                            _copy_provider_extras(
+                                event.content_block, tool_block, provider_extras
+                            )
+                            content_blocks.append(tool_block)
+
+                    elif event.type == "citation":
+                        logger.info(f"Citation received: {event.citation}")
+                    elif event.type == "message_stop":
+                        logger.info("Message stop received.")
+                        message_stop_received = True
+
+                    logger.debug(f"Yielding event to client: {event.to_json(indent=None)}")
+                    yield f"event: message\ndata: {event.to_json(indent=None)}\n\n"
+
+                    if message_stop_received:
                         break
 
-                if event.type == "message_start":
-                    logger.info("Message start received.")
-
-                if event.type == "content_block_delta":
-                    logger.debug(
-                        f"Content block delta received at index {event.index}: {event.delta}"
-                    )
-                    if event.delta.type == "text_delta":
-                        if event.index >= len(content_blocks):
-                            logger.warning(
-                                f"Received text delta for unknown content block index {event.index}, creating new text block"
-                            )
-                            content_blocks.append(TextBlockParam(type="text", text=""))
-                        text_block = cast(TextBlockParam, content_blocks[event.index])
-                        text_block["text"] += event.delta.text
-                    elif event.delta.type == "input_json_delta":
-                        if event.index >= len(content_blocks):
-                            logger.warning(
-                                f"Received input JSON delta for unknown content block index {event.index}, creating new tool use block"
-                            )
-                            content_blocks.append(
-                                ToolUseBlockParam(
-                                    type="tool_use", id="", name="", input=""
-                                )
-                            )
-                        tool_use_block = cast(
-                            ToolUseBlockParam, content_blocks[event.index]
-                        )
-                        tool_use_block["input"] = (
-                            cast(str, tool_use_block["input"])
-                            + event.delta.partial_json
-                        )
-                    elif event.delta.type == "citations_delta":
-                        if event.index >= len(content_blocks):
-                            logger.warning(
-                                f"Received citations delta for unknown content block index {event.index}, creating new citations block"
-                            )
-                            content_blocks.append(
-                                TextBlockParam(type="text", text="", citations=[])
-                            )
-                        text_block = cast(TextBlockParam, content_blocks[event.index])
-                        if "citations" not in text_block or not text_block["citations"]:
-                            text_block["citations"] = []
-                        citations = cast(
-                            list[TextCitationParam], text_block["citations"]
-                        )
-                        citations.append(convert_citation_to_param(event.delta))
-
-                elif event.type == "content_block_start":
-                    if event.content_block.type == "text":
-                        logger.info(f"Text block start: {event.content_block.text}")
-                        text_block: TextBlockParam = TextBlockParam(
-                            type="text", text=event.content_block.text
-                        )
-                        _copy_provider_extras(
-                            event.content_block, text_block, provider_extras
-                        )
-                        content_blocks.append(text_block)
-                    elif event.content_block.type == "tool_use":
-                        logger.info(
-                            f"Tool use block start: {event.content_block.name} (id: {event.content_block.id})"
-                        )
-                        tool_block: ToolUseBlockParam = ToolUseBlockParam(
-                            type="tool_use",
-                            id=event.content_block.id,
-                            name=event.content_block.name,
-                            input="",
-                        )
-                        _copy_provider_extras(
-                            event.content_block, tool_block, provider_extras
-                        )
-                        content_blocks.append(tool_block)
-
-                elif event.type == "citation":
-                    logger.info(f"Citation received: {event.citation}")
-                elif event.type == "message_stop":
-                    logger.info("Message stop received.")
-                    message_stop_received = True
-
-                logger.debug(f"Yielding event to client: {event.to_json(indent=None)}")
-                yield f"event: message\ndata: {event.to_json(indent=None)}\n\n"
-
-                if message_stop_received:
+                # ----- Per-iteration post-processing --------------------------------
+                if cancelled:
+                    assistant_message = partial_assistant_message(content_blocks)
+                    if assistant_message is not None:
+                        conversation_messages.append(assistant_message)
+                        yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
                     break
 
-            # ----- Per-iteration post-processing --------------------------------
-            if cancelled:
-                assistant_message = partial_assistant_message(content_blocks)
-                if assistant_message is not None:
-                    conversation_messages.append(assistant_message)
-                    yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
-                break
-
-            tool_calls = [b for b in content_blocks if b["type"] == "tool_use"]
-            parse_errors = parse_tool_call_inputs(
-                cast(list[ToolUseBlockParam], tool_calls)
-            )
-
-            assistant_message = MessageParam(role="assistant", content=content_blocks)
-            conversation_messages.append(assistant_message)
-            yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
-            content_blocks_finalized = True
-
-            if parse_errors:
-                tool_result_message = MessageParam(role="user", content=parse_errors)
-                conversation_messages.append(tool_result_message)
-                for pe in parse_errors:
-                    yield f"event: message\ndata: {json.dumps(pe)}\n\n"
-                yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
-                continue
-
-            if not tool_calls:
-                logger.info(
-                    f"No tool calls in iteration {iteration + 1}, completing response"
+                tool_calls = [b for b in content_blocks if b["type"] == "tool_use"]
+                parse_errors = parse_tool_call_inputs(
+                    cast(list[ToolUseBlockParam], tool_calls)
                 )
-                break
+                parse_errors_by_tool_call_id = {
+                    error["tool_use_id"]: error for error in parse_errors
+                }
 
-            logger.info(f"Processing {len(tool_calls)} tool calls")
+                assistant_message = MessageParam(role="assistant", content=content_blocks)
+                conversation_messages.append(assistant_message)
+                yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
+                content_blocks_finalized = True
+
+                if not tool_calls:
+                    logger.info(
+                        f"No tool calls in iteration {model_iteration}, completing response"
+                    )
+                    break
+
+                logger.info(f"Processing {len(tool_calls)} tool calls")
 
             if await is_run_cancelled(redis_client, chat_id):
                 logger.info(f"Run cancelled before tool execution for chat {chat_id}")
                 break
 
-            # ----- Approval checks before tool execution ------------------------
+            # Preflight the whole batch before executing any tool. Existing
+            # approved/denied interventions are reused on resume.
             approval_required: list[ToolApproval] = []
             for tool_call in tool_calls:
-                tool_name = tool_call["name"]
-                tool_input = tool_call["input"]
-                if registry.requires_approval(tool_name):
-                    logger.info(f"Tool {tool_name} requires approval")
+                if tool_call["id"] in parse_errors_by_tool_call_id:
+                    continue
+                if not registry.requires_approval(tool_call["name"]):
+                    continue
+                approval = normal_interventions_by_tool_call_id.get(tool_call["id"])
+                if approval is None:
+                    tool_input = tool_call["input"]
                     approval = await approvals_repo.create_pending(
                         chat_id=chat_id,
                         user_id=chat_user_id,
-                        tool_name=tool_name,
+                        tool_name=tool_call["name"],
                         tool_input=tool_input,
                         tool_call_id=tool_call["id"],
                         approval_type=ToolApprovalType.APPROVAL,
                         source_id=tool_input.get("source_id"),
                         source_type=tool_input.get("source_type"),
                     )
-                    logger.info(
-                        f"Saved pending approval {approval.id} for chat {chat_id}"
-                    )
+                    normal_interventions_by_tool_call_id[tool_call["id"]] = approval
+                if approval.status == ToolApprovalStatus.PENDING:
                     approval_required.append(approval)
 
+            tool_results: list[ToolResultBlockParam] = []
+            oauth_required: list[ToolApproval] = []
+            completed_intervention_ids: set[str] = set()
+            for tool_call in tool_calls:
+                parse_error = parse_errors_by_tool_call_id.get(tool_call["id"])
+                if parse_error is not None:
+                    tool_results.append(parse_error)
+                    continue
+                normal_intervention = normal_interventions_by_tool_call_id.get(
+                    tool_call["id"]
+                )
+                if (
+                    normal_intervention is not None
+                    and normal_intervention.status == ToolApprovalStatus.PENDING
+                ):
+                    continue
+                if (
+                    normal_intervention is not None
+                    and normal_intervention.status == ToolApprovalStatus.DENIED
+                ):
+                    tool_results.append(
+                        ToolResultBlockParam(
+                            type="tool_result",
+                            tool_use_id=tool_call["id"],
+                            content=[
+                                {
+                                    "type": "text",
+                                    "text": "The user denied approval for this tool call.",
+                                }
+                            ],
+                            is_error=True,
+                        )
+                    )
+                    completed_intervention_ids.add(normal_intervention.id)
+                    continue
+
+                result = await registry.execute(
+                    tool_call["name"], tool_call["input"], context
+                )
+                if result.oauth_required is not None:
+                    payload = result.oauth_required
+                    oauth_intervention = oauth_interventions_by_tool_call_id.get(
+                        tool_call["id"]
+                    )
+                    if oauth_intervention is None:
+                        oauth_intervention = await approvals_repo.create_pending(
+                            chat_id=chat_id,
+                            user_id=chat_user_id,
+                            tool_name=tool_call["name"],
+                            tool_input=tool_call["input"],
+                            tool_call_id=tool_call["id"],
+                            approval_type=ToolApprovalType.OAUTH,
+                            source_id=payload.source_id,
+                            source_type=payload.source_type,
+                            provider=payload.provider,
+                            oauth_start_url=payload.oauth_start_url,
+                        )
+                        oauth_interventions_by_tool_call_id[tool_call["id"]] = (
+                            oauth_intervention
+                        )
+                    elif oauth_intervention.status == ToolApprovalStatus.APPROVED:
+                        await approvals_repo.update_status(
+                            oauth_intervention.id,
+                            ToolApprovalStatus.PENDING,
+                            chat_user_id,
+                        )
+
+                    oauth_required.append(oauth_intervention)
+                    continue
+
+                tool_results.append(
+                    ToolResultBlockParam(
+                        type="tool_result",
+                        tool_use_id=tool_call["id"],
+                        content=result.content,
+                        is_error=result.is_error,
+                    )
+                )
+                if normal_intervention is not None:
+                    completed_intervention_ids.add(normal_intervention.id)
+                oauth_intervention = oauth_interventions_by_tool_call_id.get(
+                    tool_call["id"]
+                )
+                if oauth_intervention is not None:
+                    completed_intervention_ids.add(oauth_intervention.id)
+
+            if tool_results:
+                tool_result_message = MessageParam(role="user", content=tool_results)
+                conversation_messages.append(tool_result_message)
+                for tool_result in tool_results:
+                    yield sse_event("message", tool_result)
+                yield sse_event("save_message", tool_result_message)
+                for approval_id in completed_intervention_ids:
+                    await approvals_repo.update_status(
+                        approval_id, ToolApprovalStatus.COMPLETED, chat_user_id
+                    )
+
             if approval_required:
-                logger.info(
-                    f"Pausing stream for {len(approval_required)} approval-required tool call(s)"
+                yield sse_event(
+                    "approval_required",
+                    approval_required_event(approval_required, tool_use_blocks),
                 )
-                yield (
-                    f"event: approval_required\ndata: "
-                    f"{json.dumps(approval_required_event(approval_required, tool_use_blocks))}\n\n"
+            for oauth_intervention in oauth_required:
+                yield sse_event(
+                    "oauth_required", oauth_event_from_approval(oauth_intervention)
                 )
+            if oauth_required:
+                yield end_of_stream(
+                    EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                )
+                return
+            if approval_required:
                 yield end_of_stream(
                     EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
                 )
                 return
-
-            # ----- Execute tools -----------------------------------------------
-            tool_results = []
-            for tool_call in tool_calls:
-                tool_name = tool_call["name"]
-                tool_input = tool_call["input"]
-
-                result = await registry.execute(tool_name, tool_input, context)
-                if result.oauth_required is not None:
-                    payload = result.oauth_required
-                    await approvals_repo.create_pending(
-                        chat_id=chat_id,
-                        user_id=chat_user_id,
-                        tool_name=tool_name,
-                        tool_input=tool_input,
-                        tool_call_id=tool_call["id"],
-                        approval_type=ToolApprovalType.OAUTH,
-                        source_id=payload.source_id,
-                        source_type=payload.source_type,
-                        provider=payload.provider,
-                        oauth_start_url=payload.oauth_start_url,
-                    )
-                    logger.info(f"Saved pending oauth approval for chat {chat_id}")
-                    yield (
-                        f"event: oauth_required\ndata: "
-                        f"{json.dumps(oauth_event(tool_call['id'], tool_name, payload.source_id, payload.source_type, payload.provider, payload.oauth_start_url))}\n\n"
-                    )
-                    yield end_of_stream(
-                        EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
-                    )
-                    return
-
-                tool_result = ToolResultBlockParam(
-                    type="tool_result",
-                    tool_use_id=tool_call["id"],
-                    content=result.content,
-                    is_error=result.is_error,
-                )
-                tool_results.append(tool_result)
-                yield f"event: message\ndata: {json.dumps(tool_result)}\n\n"
-
-            tool_result_message = MessageParam(role="user", content=tool_results)
-            conversation_messages.append(tool_result_message)
-            yield f"event: save_message\ndata: {json.dumps(tool_result_message)}\n\n"
 
         # ----- Memory write (fire-and-forget) ----------------------------------
         if (

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -407,8 +407,7 @@ async def stream_generator(
     memory_write_key: str | None = None,
     effective_mode=MemoryMode.OFF,
     approvals_repo=None,
-    pending: list | None = None,
-    pending_oauth: list | None = None,
+    pending_interventions: list[ToolApproval] | None = None,
     original_user_query: str | None = None,
 ) -> AsyncIterator[str]:
     """Core agent loop: yields SSE event strings.
@@ -422,22 +421,24 @@ async def stream_generator(
         content_blocks: list[TextBlockParam | ToolUseBlockParam] = []
         content_blocks_finalized = False
 
-        normal_interventions_by_tool_call_id = {
+        approval_interventions_by_tool_call_id = {
             approval.tool_call_id: approval
-            for approval in pending or []
+            for approval in pending_interventions or []
             if approval.tool_call_id is not None
+            and approval.approval_type == ToolApprovalType.APPROVAL
         }
         oauth_interventions_by_tool_call_id = {
             approval.tool_call_id: approval
-            for approval in pending_oauth or []
+            for approval in pending_interventions or []
             if approval.tool_call_id is not None
+            and approval.approval_type == ToolApprovalType.OAUTH
         }
         unanswered_calls = unanswered_tool_calls(conversation_messages)
         unanswered_ids = {tool_call["id"] for tool_call in unanswered_calls}
 
         blocked_approvals = [
             approval
-            for tool_call_id, approval in normal_interventions_by_tool_call_id.items()
+            for tool_call_id, approval in approval_interventions_by_tool_call_id.items()
             if tool_call_id in unanswered_ids
             and approval.status == ToolApprovalStatus.PENDING
         ]
@@ -467,7 +468,7 @@ async def stream_generator(
             )
             return
 
-        intervention_tool_call_ids = set(normal_interventions_by_tool_call_id) | set(
+        intervention_tool_call_ids = set(approval_interventions_by_tool_call_id) | set(
             oauth_interventions_by_tool_call_id
         )
         resumable_batch_ids = latest_intervention_tool_batch_ids(
@@ -588,8 +589,12 @@ async def stream_generator(
                                 logger.warning(
                                     f"Received text delta for unknown content block index {event.index}, creating new text block"
                                 )
-                                content_blocks.append(TextBlockParam(type="text", text=""))
-                            text_block = cast(TextBlockParam, content_blocks[event.index])
+                                content_blocks.append(
+                                    TextBlockParam(type="text", text="")
+                                )
+                            text_block = cast(
+                                TextBlockParam, content_blocks[event.index]
+                            )
                             text_block["text"] += event.delta.text
                         elif event.delta.type == "input_json_delta":
                             if event.index >= len(content_blocks):
@@ -616,8 +621,13 @@ async def stream_generator(
                                 content_blocks.append(
                                     TextBlockParam(type="text", text="", citations=[])
                                 )
-                            text_block = cast(TextBlockParam, content_blocks[event.index])
-                            if "citations" not in text_block or not text_block["citations"]:
+                            text_block = cast(
+                                TextBlockParam, content_blocks[event.index]
+                            )
+                            if (
+                                "citations" not in text_block
+                                or not text_block["citations"]
+                            ):
                                 text_block["citations"] = []
                             citations = cast(
                                 list[TextCitationParam], text_block["citations"]
@@ -655,7 +665,9 @@ async def stream_generator(
                         logger.info("Message stop received.")
                         message_stop_received = True
 
-                    logger.debug(f"Yielding event to client: {event.to_json(indent=None)}")
+                    logger.debug(
+                        f"Yielding event to client: {event.to_json(indent=None)}"
+                    )
                     yield f"event: message\ndata: {event.to_json(indent=None)}\n\n"
 
                     if message_stop_received:
@@ -677,7 +689,9 @@ async def stream_generator(
                     error["tool_use_id"]: error for error in parse_errors
                 }
 
-                assistant_message = MessageParam(role="assistant", content=content_blocks)
+                assistant_message = MessageParam(
+                    role="assistant", content=content_blocks
+                )
                 conversation_messages.append(assistant_message)
                 yield f"event: save_message\ndata: {json.dumps(assistant_message)}\n\n"
                 content_blocks_finalized = True
@@ -702,7 +716,7 @@ async def stream_generator(
                     continue
                 if not registry.requires_approval(tool_call["name"]):
                     continue
-                approval = normal_interventions_by_tool_call_id.get(tool_call["id"])
+                approval = approval_interventions_by_tool_call_id.get(tool_call["id"])
                 if approval is None:
                     tool_input = tool_call["input"]
                     approval = await approvals_repo.create_pending(
@@ -715,7 +729,7 @@ async def stream_generator(
                         source_id=tool_input.get("source_id"),
                         source_type=tool_input.get("source_type"),
                     )
-                    normal_interventions_by_tool_call_id[tool_call["id"]] = approval
+                    approval_interventions_by_tool_call_id[tool_call["id"]] = approval
                 if approval.status == ToolApprovalStatus.PENDING:
                     approval_required.append(approval)
 
@@ -727,7 +741,7 @@ async def stream_generator(
                 if parse_error is not None:
                     tool_results.append(parse_error)
                     continue
-                normal_intervention = normal_interventions_by_tool_call_id.get(
+                normal_intervention = approval_interventions_by_tool_call_id.get(
                     tool_call["id"]
                 )
                 if (

--- a/services/ai/streaming/persist.py
+++ b/services/ai/streaming/persist.py
@@ -80,6 +80,7 @@ class StreamErrorEvent(TypedDict):
 
 
 class OAuthRequiredEvent(TypedDict):
+    approval_id: str
     tool_call_id: str
     tool_name: str
     source_id: str
@@ -145,6 +146,7 @@ def end_of_stream(reason: EndOfStreamReason, *, message: str | None = None) -> s
 
 
 def oauth_event(
+    approval_id: str,
     tool_call_id: str,
     tool_name: str,
     source_id: str,
@@ -153,6 +155,7 @@ def oauth_event(
     oauth_start_url: str,
 ) -> OAuthRequiredEvent:
     return {
+        "approval_id": approval_id,
         "tool_call_id": tool_call_id,
         "tool_name": tool_name,
         "source_id": source_id,

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -9,25 +9,23 @@ import json
 from typing import Any
 from unittest.mock import AsyncMock
 
-from ulid import ULID
-
 from anthropic.types import (
-    RawMessageStartEvent,
-    RawContentBlockStartEvent,
-    RawContentBlockDeltaEvent,
-    RawContentBlockStopEvent,
-    RawMessageStopEvent,
-    RawMessageDeltaEvent,
-    Message,
-    Usage,
-    TextBlock,
-    ToolUseBlock,
     InputJSONDelta,
-    TextDelta,
+    Message,
     MessageDeltaUsage,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+    Usage,
 )
 from anthropic.types.raw_message_delta_event import Delta
-
+from ulid import ULID
 
 # =============================================================================
 # DB data factories
@@ -199,6 +197,37 @@ def tool_call_events(
         ),
     )
     yield RawContentBlockStopEvent(type="content_block_stop", index=0)
+    yield RawMessageDeltaEvent(
+        type="message_delta",
+        delta=Delta(stop_reason="tool_use", stop_sequence=None),
+        usage=MessageDeltaUsage(output_tokens=30),
+    )
+    yield RawMessageStopEvent(type="message_stop")
+
+
+def multi_tool_call_events(tool_calls: list[dict[str, Any]]):
+    """Yield one assistant turn containing multiple parallel tool calls."""
+    yield message_start_event()
+    for index, tool_call in enumerate(tool_calls):
+        yield RawContentBlockStartEvent(
+            type="content_block_start",
+            index=index,
+            content_block=ToolUseBlock(
+                type="tool_use",
+                id=tool_call["id"],
+                name=tool_call["name"],
+                input={},
+            ),
+        )
+        yield RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=index,
+            delta=InputJSONDelta(
+                type="input_json_delta",
+                partial_json=json.dumps(tool_call["input"]),
+            ),
+        )
+        yield RawContentBlockStopEvent(type="content_block_stop", index=index)
     yield RawMessageDeltaEvent(
         type="message_delta",
         delta=Delta(stop_reason="tool_use", stop_sequence=None),
@@ -484,6 +513,11 @@ class GatedRecordingLLM:
                 yield event
                 if self._inter_event_delay:
                     await asyncio.sleep(self._inter_event_delay)
+        elif kind == "tool_calls":
+            for event in multi_tool_call_events(payload):
+                yield event
+                if self._inter_event_delay:
+                    await asyncio.sleep(self._inter_event_delay)
         else:
             for event in text_response_events(payload):
                 yield event
@@ -499,7 +533,7 @@ class GatedRecordingLLM:
         return True
 
     async def get_context_window_tokens(self):
-        from providers import ContextWindowInfo, SAFE_DEFAULT_CONTEXT_WINDOW_TOKENS
+        from providers import SAFE_DEFAULT_CONTEXT_WINDOW_TOKENS, ContextWindowInfo
 
         return ContextWindowInfo(
             tokens=SAFE_DEFAULT_CONTEXT_WINDOW_TOKENS, source="safe_default"

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -18,34 +18,33 @@ from __future__ import annotations
 
 import asyncio
 import json
+from unittest.mock import AsyncMock
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from ulid import ULID
 
-from unittest.mock import AsyncMock
-
+import db.connection
+import routers.chat as chat_module
 from db import ChatsRepository, MessagesRepository, UsersRepository
 from db.tool_approvals import (
+    ToolApprovalsRepository,
     ToolApprovalStatus,
     ToolApprovalType,
-    ToolApprovalsRepository,
 )
-import db.connection
 from routers import chat_router
 from state import AppState
-from tools import SearchResponse, SearchResult
-from tools.searcher_client import Document
-from tools.searcher_tool import SearcherTool
 from tests.helpers import (
     GatedRecordingLLM,
     assert_sse_wire,
     collect_sse_events,
     stream_sse,
 )
-
-import routers.chat as chat_module
+from tools import SearchResponse, SearchResult, ToolRegistry, ToolResult
+from tools.omni_tool_result import OAuthRequiredPayload
+from tools.searcher_client import Document
+from tools.searcher_tool import SearcherTool
 
 pytestmark = pytest.mark.integration
 
@@ -183,6 +182,96 @@ async def redis_keys(redis_client) -> None:
 
 def _client(app: FastAPI) -> AsyncClient:
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+class ScriptedActionHandler:
+    def __init__(
+        self,
+        *,
+        requires_approval: bool,
+        results: list[ToolResult],
+        tool_name: str = "gmail__send_email",
+    ) -> None:
+        self.tool_name = tool_name
+        self._requires_approval = requires_approval
+        self._results = results
+        self.executions: list[dict] = []
+
+    def get_tools(self):
+        return [
+            {
+                "name": self.tool_name,
+                "description": "Test connector action",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ]
+
+    def can_handle(self, tool_name: str) -> bool:
+        return tool_name == self.tool_name
+
+    def requires_approval(self, tool_name: str) -> bool:
+        return self._requires_approval and self.can_handle(tool_name)
+
+    async def execute(self, tool_name: str, tool_input: dict, _context) -> ToolResult:
+        self.executions.append(tool_input)
+        result_index = min(len(self.executions) - 1, len(self._results) - 1)
+        return self._results[result_index]
+
+
+class MultiActionHandler:
+    def __init__(self, tool_names: set[str], approval_tool_names: set[str]) -> None:
+        self.tool_names = tool_names
+        self.approval_tool_names = approval_tool_names
+        self.executions: list[str] = []
+
+    def get_tools(self):
+        return [
+            {
+                "name": tool_name,
+                "description": "Test connector action",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+            for tool_name in sorted(self.tool_names)
+        ]
+
+    def can_handle(self, tool_name: str) -> bool:
+        return tool_name in self.tool_names
+
+    def requires_approval(self, tool_name: str) -> bool:
+        return tool_name in self.approval_tool_names
+
+    async def execute(self, tool_name: str, _tool_input: dict, _context) -> ToolResult:
+        self.executions.append(tool_name)
+        return ToolResult(content=[{"type": "text", "text": f"{tool_name} completed"}])
+
+
+def _install_scripted_registry(monkeypatch, handler) -> None:
+    registry = ToolRegistry()
+    registry.register(handler)
+
+    async def build_registry(*_args, **_kwargs):
+        return chat_module.RegistryResult(
+            registry=registry,
+            always_on_handlers=[handler],
+            connector_handler=None,
+            toolsets=[],
+            sources=[],
+            search_operators=[],
+        )
+
+    monkeypatch.setattr(chat_module, "_build_registry", build_registry)
+
+
+async def _interventions(
+    chat_id: str,
+    approval_type: ToolApprovalType,
+    statuses: set[ToolApprovalStatus],
+):
+    return await ToolApprovalsRepository().list_for_chat(
+        chat_id=chat_id,
+        approval_type=approval_type,
+        statuses=statuses,
+    )
 
 
 # =============================================================================
@@ -1573,6 +1662,398 @@ class TestMultiTurn:
             "No user message with tool_result found. "
             "Tool was not executed."
         )
+
+
+# =============================================================================
+# Approval and OAuth intervention resume
+# =============================================================================
+
+
+class TestInterventionResume:
+    @pytest.mark.asyncio
+    async def test_approved_action_executes_once_and_completes_intervention(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        handler = ScriptedActionHandler(
+            requires_approval=True,
+            results=[
+                ToolResult(
+                    content=[{"type": "text", "text": "Email sent"}],
+                    is_error=False,
+                )
+            ],
+        )
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": handler.tool_name,
+                        "input": {"to": "person@example.com"},
+                        "id": "toolu_approval",
+                    },
+                ),
+                ("text", "The email was sent."),
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            paused_events = await collect_sse_events(client, chat_id)
+            assert any(event_type == "approval_required" for event_type, _, _ in paused_events)
+            assert handler.executions == []
+
+            approvals = await _interventions(
+                chat_id,
+                ToolApprovalType.APPROVAL,
+                {ToolApprovalStatus.PENDING},
+            )
+            assert len(approvals) == 1
+            await ToolApprovalsRepository().update_status(
+                approvals[0].id, ToolApprovalStatus.APPROVED, user_id
+            )
+
+            resumed_events = await collect_sse_events(client, chat_id)
+
+        assert handler.executions == [{"to": "person@example.com"}]
+        assert any(event_type == "end_of_stream" for event_type, _, _ in resumed_events)
+        completed = await _interventions(
+            chat_id,
+            ToolApprovalType.APPROVAL,
+            {ToolApprovalStatus.COMPLETED},
+        )
+        assert [approval.id for approval in completed] == [approvals[0].id]
+
+        active_path = await MessagesRepository().get_active_path(chat_id)
+        tool_result_messages = [
+            message
+            for message in active_path
+            if message.message["role"] == "user"
+            and isinstance(message.message.get("content"), list)
+            and any(
+                block.get("type") == "tool_result"
+                for block in message.message["content"]
+            )
+        ]
+        assert len(tool_result_messages) == 1
+        assert len(llm.calls) == 2
+        assert llm.calls[1]["messages"][-1] == tool_result_messages[0].message
+
+    @pytest.mark.asyncio
+    async def test_denied_action_is_persisted_without_execution(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        handler = ScriptedActionHandler(
+            requires_approval=True,
+            results=[ToolResult(content=[{"type": "text", "text": "unexpected"}])],
+        )
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": handler.tool_name,
+                        "input": {"to": "person@example.com"},
+                        "id": "toolu_denied",
+                    },
+                ),
+                ("text", "The email was not sent."),
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            await collect_sse_events(client, chat_id)
+            approvals = await _interventions(
+                chat_id,
+                ToolApprovalType.APPROVAL,
+                {ToolApprovalStatus.PENDING},
+            )
+            await ToolApprovalsRepository().update_status(
+                approvals[0].id, ToolApprovalStatus.DENIED, user_id
+            )
+            await collect_sse_events(client, chat_id)
+
+        assert handler.executions == []
+        completed = await _interventions(
+            chat_id,
+            ToolApprovalType.APPROVAL,
+            {ToolApprovalStatus.COMPLETED},
+        )
+        assert [approval.id for approval in completed] == [approvals[0].id]
+        last_model_message = llm.calls[1]["messages"][-1]
+        denial = last_model_message["content"][0]
+        assert denial["type"] == "tool_result"
+        assert denial["tool_use_id"] == "toolu_denied"
+        assert denial["is_error"] is True
+        assert "denied" in denial["content"][0]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_approved_oauth_executes_once_then_completes_intervention(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        oauth_payload = OAuthRequiredPayload(
+            source_id="source-1",
+            source_type="gmail",
+            provider="google",
+            oauth_start_url="/api/oauth/start?source_id=source-1",
+        )
+        handler = ScriptedActionHandler(
+            requires_approval=False,
+            results=[
+                ToolResult(content=[], oauth_required=oauth_payload),
+                ToolResult(content=[{"type": "text", "text": "Email sent"}]),
+            ],
+        )
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": handler.tool_name,
+                        "input": {"to": "person@example.com"},
+                        "id": "toolu_oauth",
+                    },
+                ),
+                ("text", "The email was sent."),
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            paused_events = await collect_sse_events(client, chat_id)
+            oauth_events = [
+                json.loads(data)
+                for event_type, data, _ in paused_events
+                if event_type == "oauth_required"
+            ]
+            oauth_rows = await _interventions(
+                chat_id,
+                ToolApprovalType.OAUTH,
+                {ToolApprovalStatus.PENDING},
+            )
+            assert len(oauth_rows) == 1
+            assert oauth_events[0]["approval_id"] == oauth_rows[0].id
+            await ToolApprovalsRepository().update_status(
+                oauth_rows[0].id, ToolApprovalStatus.APPROVED, user_id
+            )
+
+            await collect_sse_events(client, chat_id)
+
+        assert handler.executions == [
+            {"to": "person@example.com"},
+            {"to": "person@example.com"},
+        ]
+        completed = await _interventions(
+            chat_id,
+            ToolApprovalType.OAUTH,
+            {ToolApprovalStatus.COMPLETED},
+        )
+        assert [approval.id for approval in completed] == [oauth_rows[0].id]
+        assert len(llm.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_oauth_still_required_reuses_the_existing_row(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        oauth_payload = OAuthRequiredPayload(
+            source_id="source-1",
+            source_type="gmail",
+            provider="google",
+            oauth_start_url="/api/oauth/start?source_id=source-1",
+        )
+        handler = ScriptedActionHandler(
+            requires_approval=False,
+            results=[ToolResult(content=[], oauth_required=oauth_payload)],
+        )
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": handler.tool_name,
+                        "input": {"to": "person@example.com"},
+                        "id": "toolu_oauth_repeat",
+                    },
+                )
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            await collect_sse_events(client, chat_id)
+            oauth_rows = await _interventions(
+                chat_id,
+                ToolApprovalType.OAUTH,
+                {ToolApprovalStatus.PENDING},
+            )
+            await ToolApprovalsRepository().update_status(
+                oauth_rows[0].id, ToolApprovalStatus.APPROVED, user_id
+            )
+            resumed_events = await collect_sse_events(client, chat_id)
+
+        oauth_events = [
+            json.loads(data)
+            for event_type, data, _ in resumed_events
+            if event_type == "oauth_required"
+        ]
+        assert oauth_events[0]["approval_id"] == oauth_rows[0].id
+        all_oauth_rows = await _interventions(
+            chat_id,
+            ToolApprovalType.OAUTH,
+            {ToolApprovalStatus.PENDING, ToolApprovalStatus.APPROVED},
+        )
+        assert [approval.id for approval in all_oauth_rows] == [oauth_rows[0].id]
+        assert len(handler.executions) == 2
+        assert len(llm.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_multi_tool_batch_persists_unblocked_results_then_resumes_only_blocker(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        tool_names = {"test__a", "test__b", "test__c"}
+        handler = MultiActionHandler(tool_names, {"test__b"})
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_calls",
+                    [
+                        {"name": "test__a", "input": {"value": "a"}, "id": "toolu_a"},
+                        {"name": "test__b", "input": {"value": "b"}, "id": "toolu_b"},
+                        {"name": "test__c", "input": {"value": "c"}, "id": "toolu_c"},
+                    ],
+                ),
+                ("text", "All requested actions are complete."),
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            paused_events = await collect_sse_events(client, chat_id)
+            assert any(event_type == "approval_required" for event_type, _, _ in paused_events)
+            assert handler.executions == ["test__a", "test__c"]
+
+            active_path = await MessagesRepository().get_active_path(chat_id)
+            partial_results = [
+                block
+                for message in active_path
+                if message.message["role"] == "user"
+                and isinstance(message.message.get("content"), list)
+                for block in message.message["content"]
+                if block.get("type") == "tool_result"
+            ]
+            assert {result["tool_use_id"] for result in partial_results} == {
+                "toolu_a",
+                "toolu_c",
+            }
+
+            approvals = await _interventions(
+                chat_id,
+                ToolApprovalType.APPROVAL,
+                {ToolApprovalStatus.PENDING},
+            )
+            assert [approval.tool_call_id for approval in approvals] == ["toolu_b"]
+            await ToolApprovalsRepository().update_status(
+                approvals[0].id, ToolApprovalStatus.APPROVED, user_id
+            )
+            await collect_sse_events(client, chat_id)
+
+        assert handler.executions == ["test__a", "test__c", "test__b"]
+        assert len(llm.calls) == 2
+        logical_result_turn = llm.calls[1]["messages"][-1]
+        assert logical_result_turn["role"] == "user"
+        assert {
+            block["tool_use_id"]
+            for block in logical_result_turn["content"]
+            if block.get("type") == "tool_result"
+        } == {"toolu_a", "toolu_b", "toolu_c"}
+
+    @pytest.mark.asyncio
+    async def test_resume_repairs_unrelated_abandoned_call_instead_of_executing_it(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        messages_repo = MessagesRepository()
+        active_path = await messages_repo.get_active_path(chat_id)
+        abandoned = await messages_repo.create(
+            chat_id,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_abandoned",
+                        "name": "test__abandoned",
+                        "input": {},
+                    }
+                ],
+            },
+            parent_id=active_path[-1].id,
+        )
+        await messages_repo.create(
+            chat_id,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_intervention",
+                        "name": "test__intervention",
+                        "input": {},
+                    }
+                ],
+            },
+            parent_id=abandoned.id,
+        )
+        approval = await ToolApprovalsRepository().create_pending(
+            chat_id=chat_id,
+            user_id=user_id,
+            tool_name="test__intervention",
+            tool_input={},
+            tool_call_id="toolu_intervention",
+        )
+        await ToolApprovalsRepository().update_status(
+            approval.id, ToolApprovalStatus.APPROVED, user_id
+        )
+
+        handler = MultiActionHandler(
+            {"test__abandoned", "test__intervention"}, {"test__intervention"}
+        )
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM([("text", "Intervention completed.")], model_id)
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            await collect_sse_events(client, chat_id)
+
+        assert handler.executions == ["test__intervention"]
+        model_blocks = [
+            block
+            for message in llm.calls[0]["messages"]
+            if message["role"] == "user" and isinstance(message.get("content"), list)
+            for block in message["content"]
+            if block.get("type") == "tool_result"
+        ]
+        abandoned_result = next(
+            block for block in model_blocks if block["tool_use_id"] == "toolu_abandoned"
+        )
+        assert abandoned_result["is_error"] is True
+        assert "interrupted" in abandoned_result["content"][0]["text"].lower()
 
 
 # =============================================================================

--- a/web/src/lib/components/oauth-integrations/oauth-required-card.svelte
+++ b/web/src/lib/components/oauth-integrations/oauth-required-card.svelte
@@ -62,7 +62,8 @@
                     typeof data === 'object' &&
                     data.type === 'omni:user-auth-result' &&
                     data.ok === true &&
-                    data.sourceId === oauthRequired.sourceId
+                    data.sourceId === oauthRequired.sourceId &&
+                    data.approvalId === oauthRequired.approvalId
                 ) {
                     onComplete()
                 }
@@ -77,10 +78,13 @@
     })
 
     function startConnect() {
-        const popup = window.open(oauthRequired.oauthStartUrl, 'omni_oauth', 'width=560,height=720')
+        const url = new URL(oauthRequired.oauthStartUrl, window.location.origin)
+        url.searchParams.set('approval_id', oauthRequired.approvalId)
+        url.searchParams.set('chat_id', oauthRequired.chatId)
+        const popup = window.open(url.toString(), 'omni_oauth', 'width=560,height=720')
         if (!popup) {
             // Popup blocked — fall back to full-page redirect.
-            window.location.href = oauthRequired.oauthStartUrl
+            window.location.href = url.toString()
         }
     }
 </script>

--- a/web/src/lib/server/db/tool-approvals.test.ts
+++ b/web/src/lib/server/db/tool-approvals.test.ts
@@ -26,6 +26,73 @@ beforeEach(async () => {
 })
 
 describe('ToolApprovalRepository', () => {
+    it('finds only the exact pending OAuth approval correlation', async () => {
+        const approvalId = ulid()
+        const sourceId = ulid()
+        const sourceType = 'gmail'
+        const provider = 'google'
+        const approval = await repo.createWithId(
+            approvalId,
+            chatId,
+            userId,
+            'gmail__send_email',
+            { to: 'person@example.com' },
+            {
+                approvalType: 'oauth',
+                toolCallId: 'toolu_oauth',
+                sourceId,
+                sourceType,
+                provider,
+                oauthStartUrl: `/api/oauth/start?source_id=${sourceId}`,
+            },
+        )
+
+        await expect(
+            repo.getPendingOAuthForUserAndSource(
+                approvalId,
+                userId,
+                chatId,
+                sourceId,
+                sourceType,
+                provider,
+            ),
+        ).resolves.toEqual(approval)
+
+        const otherUserId = await createTestUser(db)
+        const otherChatId = await createTestChat(db, userId)
+        const mismatches: Parameters<ToolApprovalRepository['getPendingOAuthForUserAndSource']>[] =
+            [
+                [approvalId, otherUserId, chatId, sourceId, sourceType, provider],
+                [approvalId, userId, otherChatId, sourceId, sourceType, provider],
+                [approvalId, userId, chatId, ulid(), sourceType, provider],
+                [approvalId, userId, chatId, sourceId, 'google_drive', provider],
+                [approvalId, userId, chatId, sourceId, sourceType, 'microsoft'],
+            ]
+        for (const args of mismatches) {
+            await expect(repo.getPendingOAuthForUserAndSource(...args)).resolves.toBeNull()
+        }
+
+        const approved = await repo.approvePendingOAuth(
+            approvalId,
+            userId,
+            chatId,
+            sourceId,
+            sourceType,
+            provider,
+        )
+        expect(approved?.status).toBe('approved')
+        await expect(
+            repo.getPendingOAuthForUserAndSource(
+                approvalId,
+                userId,
+                chatId,
+                sourceId,
+                sourceType,
+                provider,
+            ),
+        ).resolves.toBeNull()
+    })
+
     it('createWithId is idempotent for replayed approval_required events', async () => {
         const approvalId = ulid()
         const toolInput = {

--- a/web/src/lib/server/db/tool-approvals.ts
+++ b/web/src/lib/server/db/tool-approvals.ts
@@ -1,4 +1,4 @@
-import { eq, and, asc, desc } from 'drizzle-orm'
+import { eq, and, asc, desc, inArray } from 'drizzle-orm'
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
 import { db } from './index'
 import { toolApprovals } from './schema'
@@ -78,6 +78,64 @@ export class ToolApprovalRepository {
         return approval || null
     }
 
+    async getPendingOAuthForUserAndSource(
+        approvalId: string,
+        userId: string,
+        chatId: string,
+        sourceId: string,
+        sourceType: string,
+        provider: string,
+    ): Promise<ToolApproval | null> {
+        const [approval] = await this.db
+            .select()
+            .from(toolApprovals)
+            .where(
+                and(
+                    eq(toolApprovals.id, approvalId),
+                    eq(toolApprovals.userId, userId),
+                    eq(toolApprovals.chatId, chatId),
+                    eq(toolApprovals.approvalType, 'oauth'),
+                    eq(toolApprovals.status, 'pending'),
+                    eq(toolApprovals.sourceId, sourceId),
+                    eq(toolApprovals.sourceType, sourceType),
+                    eq(toolApprovals.provider, provider),
+                ),
+            )
+            .limit(1)
+        return approval || null
+    }
+
+    async approvePendingOAuth(
+        approvalId: string,
+        userId: string,
+        chatId: string,
+        sourceId: string,
+        sourceType: string,
+        provider: string,
+    ): Promise<ToolApproval | null> {
+        const [approval] = await this.db
+            .update(toolApprovals)
+            .set({
+                status: 'approved',
+                resolvedAt: new Date(),
+                resolvedBy: userId,
+            })
+            .where(
+                and(
+                    eq(toolApprovals.id, approvalId),
+                    eq(toolApprovals.userId, userId),
+                    eq(toolApprovals.chatId, chatId),
+                    eq(toolApprovals.approvalType, 'oauth'),
+                    eq(toolApprovals.status, 'pending'),
+                    eq(toolApprovals.sourceId, sourceId),
+                    eq(toolApprovals.sourceType, sourceType),
+                    eq(toolApprovals.provider, provider),
+                ),
+            )
+            .returning()
+        return approval || null
+    }
+
     async resolve(
         approvalId: string,
         status: 'approved' | 'denied',
@@ -132,7 +190,15 @@ export class ToolApprovalRepository {
         chatId: string,
         approvalType?: 'approval' | 'oauth',
     ): Promise<ToolApproval[]> {
-        const filters = [eq(toolApprovals.chatId, chatId), eq(toolApprovals.status, 'pending')]
+        return this.getForChatAll(chatId, ['pending'], approvalType)
+    }
+
+    async getForChatAll(
+        chatId: string,
+        statuses: Array<'pending' | 'approved' | 'denied' | 'completed' | 'expired'>,
+        approvalType?: 'approval' | 'oauth',
+    ): Promise<ToolApproval[]> {
+        const filters = [eq(toolApprovals.chatId, chatId), inArray(toolApprovals.status, statuses)]
         if (approvalType) {
             filters.push(eq(toolApprovals.approvalType, approvalType))
         }

--- a/web/src/lib/server/oauth/connectorOAuth.test.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.test.ts
@@ -1,10 +1,21 @@
-import { describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { OAuthStateManager } from './state'
 import {
     isAutoManagedOAuthProvider,
     isClientConfigComplete,
     tokenEndpointAuthMethodForConfig,
     type OAuthManifestConfig,
 } from './connectorOAuth'
+
+const { redisMock } = vi.hoisted(() => ({
+    redisMock: {
+        getDel: vi.fn(),
+    },
+}))
+
+vi.mock('../redis', () => ({
+    getRedisClient: vi.fn().mockResolvedValue(redisMock),
+}))
 
 const baseManifest: OAuthManifestConfig = {
     provider: 'example',
@@ -20,6 +31,22 @@ const baseManifest: OAuthManifestConfig = {
 }
 
 describe('OAuth connector helpers', () => {
+    beforeEach(() => {
+        vi.clearAllMocks()
+    })
+
+    it('atomically consumes OAuth state with GETDEL', async () => {
+        redisMock.getDel.mockResolvedValueOnce(
+            JSON.stringify({ id: 'state-1', state_token: 'state-1', provider: 'example' }),
+        )
+
+        await expect(OAuthStateManager.validateAndConsumeState('state-1')).resolves.toMatchObject({
+            state_token: 'state-1',
+        })
+        expect(redisMock.getDel).toHaveBeenCalledOnce()
+        expect(redisMock.getDel).toHaveBeenCalledWith('oauth_state:state-1')
+    })
+
     it('infers auto-managed dynamic client registration providers from manifest fields', () => {
         expect(
             isAutoManagedOAuthProvider({

--- a/web/src/lib/server/oauth/connectorOAuth.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.ts
@@ -43,7 +43,14 @@ export type OAuthFlow =
     /// User attaches per-user read creds to a specific org source.
     | { type: 'user_read'; sourceId: string; returnTo?: string }
     /// User attaches per-user read/write action creds to a specific org source.
-    | { type: 'user_write'; sourceId: string; returnTo?: string }
+    | {
+          type: 'user_write'
+          sourceId: string
+          sourceType?: string
+          returnTo?: string
+          approvalId?: string
+          approvalChatId?: string
+      }
 
 export interface ManifestOAuthState {
     user_id?: string
@@ -318,6 +325,8 @@ async function generateAuthUrlForExistingSourceUserFlow(args: {
     sourceType: string
     userId: string
     returnTo?: string
+    approvalId?: string
+    approvalChatId?: string
     mode: 'read' | 'write'
 }): Promise<{ url: string; requiredScopes: string[] }> {
     const manifestConfig = await getOAuthManifestForSourceType(args.sourceType)
@@ -346,7 +355,12 @@ async function generateAuthUrlForExistingSourceUserFlow(args: {
     const flow: OAuthFlow = {
         type: args.mode === 'write' ? 'user_write' : 'user_read',
         sourceId: args.sourceId,
+        ...(args.mode === 'write' ? { sourceType: args.sourceType } : {}),
         returnTo: args.returnTo,
+        ...(args.mode === 'write' && args.approvalId ? { approvalId: args.approvalId } : {}),
+        ...(args.mode === 'write' && args.approvalChatId
+            ? { approvalChatId: args.approvalChatId }
+            : {}),
     }
 
     const pkce = pkceForConfig(manifestConfig)
@@ -387,6 +401,8 @@ export async function generateAuthUrlForUserWrite(args: {
     sourceType: string
     userId: string
     returnTo?: string
+    approvalId?: string
+    approvalChatId?: string
 }): Promise<{ url: string; requiredScopes: string[] }> {
     return generateAuthUrlForExistingSourceUserFlow({ ...args, mode: 'write' })
 }

--- a/web/src/lib/server/oauth/state.ts
+++ b/web/src/lib/server/oauth/state.ts
@@ -53,14 +53,7 @@ export class OAuthStateManager {
         const redis = await getRedisClient()
         const key = `${STATE_PREFIX}:${stateToken}`
 
-        const data = await redis.get(key)
-        if (!data) {
-            return null
-        }
-
-        // Delete immediately to prevent replay attacks
-        await redis.del(key)
-
-        return JSON.parse(data) as OAuthState
+        const data = await redis.getDel(key)
+        return data ? (JSON.parse(data) as OAuthState) : null
     }
 }

--- a/web/src/lib/types/message.ts
+++ b/web/src/lib/types/message.ts
@@ -28,6 +28,8 @@ export type ToolApproval = {
 export type OAuthRequiredStatus = 'pending' | 'completed' | 'cancelled'
 
 export type OAuthRequired = {
+    approvalId: string
+    chatId: string
     sourceId: string
     sourceType: string
     sourceDisplayName: string
@@ -81,6 +83,7 @@ export type ApprovalRequiredEvent = ApprovalRequiredItem & {
 // Wire shape emitted by the AI service before the web layer enriches it
 // with provider_configured / source_display_name.
 export type OAuthRequiredAIEvent = {
+    approval_id: string
     tool_call_id: string
     tool_name: string
     source_id: string

--- a/web/src/routes/(app)/chat/[chatId]/+page.server.ts
+++ b/web/src/routes/(app)/chat/[chatId]/+page.server.ts
@@ -5,18 +5,21 @@ import { toolApprovalRepository } from '$lib/server/db/tool-approvals.js'
 import { error } from '@sveltejs/kit'
 import type { ChatMessage } from '$lib/server/db/schema.js'
 
-function collectActivePathToolCallIds(messages: ChatMessage[]): Set<string> {
-    const ids = new Set<string>()
+function collectActiveUnansweredToolCallIds(messages: ChatMessage[]): Set<string> {
+    const toolCallIds = new Set<string>()
+    const answeredIds = new Set<string>()
     for (const msg of messages) {
         const content = msg.message.content
         if (!Array.isArray(content)) continue
         for (const block of content) {
             if (block.type === 'tool_use') {
-                ids.add(block.id)
+                toolCallIds.add(block.id)
+            } else if (block.type === 'tool_result') {
+                answeredIds.add(block.tool_use_id)
             }
         }
     }
-    return ids
+    return new Set([...toolCallIds].filter((toolCallId) => !answeredIds.has(toolCallId)))
 }
 
 type OmniUploadSource = {
@@ -102,7 +105,7 @@ export const load = async ({ params, locals, fetch, depends }) => {
     const uploadIds = collectUploadIds(messages)
     const uploadFilenames = await resolveUploadFilenames(uploadIds, fetch)
     const activePathMessages = await chatMessageRepository.getActivePath(chat.id)
-    const activePathToolCallIds = collectActivePathToolCallIds(activePathMessages)
+    const activePathToolCallIds = collectActiveUnansweredToolCallIds(activePathMessages)
     const allPendingApprovals = await toolApprovalRepository.getPendingForChatAll(
         chat.id,
         'approval',
@@ -111,12 +114,17 @@ export const load = async ({ params, locals, fetch, depends }) => {
         (approval) =>
             approval.toolCallId !== null && activePathToolCallIds.has(approval.toolCallId),
     )
-    const allPendingOAuth = await toolApprovalRepository.getPendingForChatAll(chat.id, 'oauth')
-    const pendingOAuth =
-        allPendingOAuth.find(
-            (approval) =>
-                approval.toolCallId !== null && activePathToolCallIds.has(approval.toolCallId),
-        ) ?? null
+    const resumableOAuth = await toolApprovalRepository.getForChatAll(
+        chat.id,
+        ['pending', 'approved'],
+        'oauth',
+    )
+    const activeOAuth = resumableOAuth.filter(
+        (approval) =>
+            approval.toolCallId !== null && activePathToolCallIds.has(approval.toolCallId),
+    )
+    const pendingOAuth = activeOAuth.find((approval) => approval.status === 'pending') ?? null
+    const approvedOAuth = activeOAuth.find((approval) => approval.status === 'approved') ?? null
 
     return {
         user: locals.user!,
@@ -127,5 +135,6 @@ export const load = async ({ params, locals, fetch, depends }) => {
         uploadFilenames,
         pendingApprovals,
         pendingOAuth,
+        approvedOAuth,
     }
 }

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -454,6 +454,8 @@
 
     function oauthRequiredFromEvent(event: OAuthRequiredEvent): OAuthRequired {
         return {
+            approvalId: event.approval_id,
+            chatId: data.chat.id,
             sourceId: event.source_id,
             sourceType: event.source_type,
             sourceDisplayName:
@@ -1098,6 +1100,8 @@
                                 data.pendingOAuth.oauthStartUrl
                             ) {
                                 toolMsgContent.oauthRequired = {
+                                    approvalId: data.pendingOAuth.id,
+                                    chatId: data.chat.id,
                                     sourceId: data.pendingOAuth.sourceId,
                                     sourceType: data.pendingOAuth.sourceType,
                                     sourceDisplayName:
@@ -1146,28 +1150,34 @@
                                     envelope.omni_kind === OmniToolResultKind.OauthRequired
                                 ) {
                                     const live = oauthEventByToolCallId[toolUseId]
-                                    updateOAuthRequired(
-                                        toolUseId,
-                                        live
-                                            ? oauthRequiredFromEvent(live)
-                                            : {
-                                                  sourceId: envelope.payload.source_id,
-                                                  sourceType: envelope.payload.source_type,
-                                                  sourceDisplayName:
-                                                      getSourceDisplayName(
-                                                          envelope.payload
-                                                              .source_type as SourceType,
-                                                      ) ?? envelope.payload.source_type,
-                                                  provider: envelope.payload.provider,
-                                                  // Optimistic default on refresh; corrected by
-                                                  // the live SSE event when present, and the
-                                                  // card itself can re-check via /api/oauth/provider-status.
-                                                  providerConfigured: true,
-                                                  oauthStartUrl: envelope.payload.oauth_start_url,
-                                                  status: 'pending',
-                                              },
-                                    )
-                                    promptHandled = true
+                                    const persistedApprovalId =
+                                        data.pendingOAuth?.toolCallId === toolUseId
+                                            ? data.pendingOAuth.id
+                                            : null
+                                    const approvalId = live?.approval_id ?? persistedApprovalId
+                                    if (live) {
+                                        updateOAuthRequired(toolUseId, oauthRequiredFromEvent(live))
+                                        promptHandled = true
+                                    } else if (approvalId) {
+                                        updateOAuthRequired(toolUseId, {
+                                            approvalId,
+                                            chatId: data.chat.id,
+                                            sourceId: envelope.payload.source_id,
+                                            sourceType: envelope.payload.source_type,
+                                            sourceDisplayName:
+                                                getSourceDisplayName(
+                                                    envelope.payload.source_type as SourceType,
+                                                ) ?? envelope.payload.source_type,
+                                            provider: envelope.payload.provider,
+                                            // Optimistic default on refresh; corrected by
+                                            // the live SSE event when present, and the
+                                            // card itself can re-check via /api/oauth/provider-status.
+                                            providerConfigured: true,
+                                            oauthStartUrl: envelope.payload.oauth_start_url,
+                                            status: 'pending',
+                                        })
+                                        promptHandled = true
+                                    }
                                 } else if (
                                     envelope &&
                                     envelope.omni_kind === OmniToolResultKind.ApprovalRequired
@@ -1261,7 +1271,7 @@
     // This will trigger the streaming of AI response when the component is mounted
     // If no response is currently being streamed, nothing happens
     onMount(() => {
-        if ((page.state as any).stream) {
+        if ((page.state as any).stream || data.approvedOAuth) {
             streamResponse(data.chat.id)
         } else {
             void resumeActiveStreamIfNeeded()

--- a/web/src/routes/api/oauth/callback/+server.ts
+++ b/web/src/routes/api/oauth/callback/+server.ts
@@ -10,6 +10,7 @@ import { decryptConfig } from '$lib/server/crypto/encryption'
 import { logger } from '$lib/server/logger'
 import { getConfig } from '$lib/server/config'
 import { getSourceById, getSourcesByType } from '$lib/server/db/sources'
+import { toolApprovalRepository } from '$lib/server/db/tool-approvals'
 import { getSourceDisplayName } from '$lib/utils/icons'
 import { SourceType } from '$lib/types'
 
@@ -203,11 +204,28 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
             config: { granted_scopes: storedGrantedScopes },
             expiresAt,
         })
+        if (flow.type === 'user_write' && flow.approvalId) {
+            if (!flow.approvalChatId || !flow.sourceType) {
+                throw error(400, 'OAuth approval state is incomplete')
+            }
+            const approval = await toolApprovalRepository.approvePendingOAuth(
+                flow.approvalId,
+                user.id,
+                flow.approvalChatId,
+                flow.sourceId,
+                flow.sourceType,
+                config.provider,
+            )
+            if (!approval) throw error(400, 'OAuth approval is no longer pending')
+        }
         await notifyOAuthCredentialReady(flow.sourceId, user.id)
-        if (flow.returnTo) {
+        if (flow.returnTo && !(flow.type === 'user_write' && flow.approvalId)) {
             throw redirect(302, flow.returnTo)
         }
         const params = new URLSearchParams({ ok: 'true', sourceId: flow.sourceId })
+        if (flow.type === 'user_write' && flow.approvalId) {
+            params.set('approvalId', flow.approvalId)
+        }
         throw redirect(302, `/oauth/done?${params}`)
     }
 

--- a/web/src/routes/api/oauth/start/+server.ts
+++ b/web/src/routes/api/oauth/start/+server.ts
@@ -1,6 +1,7 @@
 import { redirect, error } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
 import { getSourceById } from '$lib/server/db/sources'
+import { toolApprovalRepository } from '$lib/server/db/tool-approvals'
 import {
     generateAuthUrl,
     generateAuthUrlForOrgSource,
@@ -32,6 +33,8 @@ export const GET: RequestHandler = async ({ url, locals }) => {
     const flow = url.searchParams.get('flow') ?? 'user_write'
     const sourceTypesParam = url.searchParams.get('source_types')
     const returnTo = url.searchParams.get('return_to') ?? undefined
+    const approvalId = url.searchParams.get('approval_id') ?? undefined
+    const approvalChatId = url.searchParams.get('chat_id') ?? undefined
 
     if (sourceId) {
         if (flow !== 'org_source' && flow !== 'user_read' && flow !== 'user_write') {
@@ -59,6 +62,24 @@ export const GET: RequestHandler = async ({ url, locals }) => {
             throw error(412, oauthClientNotConfiguredMessage(config.provider))
         }
 
+        if (approvalId || approvalChatId) {
+            if (!approvalId || !approvalChatId) {
+                throw error(400, 'approval_id and chat_id must be provided together')
+            }
+            if (flow !== 'user_write') {
+                throw error(400, 'OAuth approval requires user_write flow')
+            }
+            const approval = await toolApprovalRepository.getPendingOAuthForUserAndSource(
+                approvalId,
+                locals.user.id,
+                approvalChatId,
+                sourceId,
+                source.sourceType,
+                config.provider,
+            )
+            if (!approval) throw error(400, 'Invalid OAuth approval')
+        }
+
         if (flow === 'org_source') {
             if (locals.user.role !== 'admin') {
                 throw error(403, 'Admin access required')
@@ -79,6 +100,8 @@ export const GET: RequestHandler = async ({ url, locals }) => {
             sourceType: source.sourceType,
             userId: locals.user.id,
             returnTo,
+            approvalId,
+            approvalChatId,
         })
         throw redirect(302, authUrl)
     }

--- a/web/src/routes/oauth/done/+page.svelte
+++ b/web/src/routes/oauth/done/+page.svelte
@@ -10,6 +10,7 @@
                 type: 'omni:user-auth-result',
                 ok: data.ok,
                 sourceId: data.sourceId,
+                approvalId: data.approvalId,
                 message: data.message,
             })
             ch.close()

--- a/web/src/routes/oauth/done/+page.ts
+++ b/web/src/routes/oauth/done/+page.ts
@@ -4,6 +4,7 @@ export const load: PageLoad = ({ url }) => {
     return {
         ok: url.searchParams.get('ok') === 'true',
         sourceId: url.searchParams.get('sourceId'),
+        approvalId: url.searchParams.get('approvalId'),
         message: url.searchParams.get('message'),
     }
 }


### PR DESCRIPTION
- Unify fresh and resumed tool-call execution through one path.
- Persist unblocked tool results before approval/OAuth pauses.
- Correlate OAuth approval IDs across stream, card, start, and callback.
- Repair unrelated abandoned tool calls instead of re-running them.
- Add focused AI streaming and web OAuth tests.