### PR TITLE
fix(ai): handle multi-tool OAuth resumes

### DIFF
--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -716,7 +716,56 @@ async def stream_generator(
                 logger.info(f"Run cancelled before tool execution for chat {chat_id}")
                 break
 
-            # Preflight the whole batch before executing any tool. Existing
+            # Preflight credentials before asking for user approval. This keeps
+            # blocked write tools from showing an approval card before the user
+            # has connected the OAuth credential needed to run them.
+            oauth_required: list[ToolApproval] = []
+            for tool_call in tool_calls:
+                if tool_call["id"] in parse_errors_by_tool_call_id:
+                    continue
+                payload = await registry.check_oauth_required(
+                    tool_call["name"], tool_call["input"], context
+                )
+                if payload is None:
+                    continue
+                oauth_intervention = oauth_interventions_by_tool_call_id.get(
+                    tool_call["id"]
+                )
+                if oauth_intervention is None:
+                    oauth_intervention = await approvals_repo.create_pending(
+                        chat_id=chat_id,
+                        user_id=chat_user_id,
+                        tool_name=tool_call["name"],
+                        tool_input=tool_call["input"],
+                        tool_call_id=tool_call["id"],
+                        approval_type=ToolApprovalType.OAUTH,
+                        source_id=payload.source_id,
+                        source_type=payload.source_type,
+                        provider=payload.provider,
+                        oauth_start_url=payload.oauth_start_url,
+                    )
+                    oauth_interventions_by_tool_call_id[tool_call["id"]] = (
+                        oauth_intervention
+                    )
+                elif oauth_intervention.status == ToolApprovalStatus.APPROVED:
+                    await approvals_repo.update_status(
+                        oauth_intervention.id,
+                        ToolApprovalStatus.PENDING,
+                        chat_user_id,
+                    )
+                oauth_required.append(oauth_intervention)
+
+            if oauth_required:
+                for oauth_intervention in oauth_required:
+                    yield sse_event(
+                        "oauth_required", oauth_event_from_approval(oauth_intervention)
+                    )
+                yield end_of_stream(
+                    EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+                )
+                return
+
+            # Preflight approval for credentials-ready tools. Existing
             # approved/denied interventions are reused on resume.
             approval_required: list[ToolApproval] = []
             for tool_call in tool_calls:
@@ -742,7 +791,7 @@ async def stream_generator(
                     approval_required.append(approval)
 
             tool_results: list[ToolResultBlockParam] = []
-            oauth_required: list[ToolApproval] = []
+            oauth_required = []
             completed_intervention_ids: set[str] = set()
             for tool_call in tool_calls:
                 parse_error = parse_errors_by_tool_call_id.get(tool_call["id"])

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -436,22 +436,6 @@ async def stream_generator(
         unanswered_calls = unanswered_tool_calls(conversation_messages)
         unanswered_ids = {tool_call["id"] for tool_call in unanswered_calls}
 
-        blocked_approvals = [
-            approval
-            for tool_call_id, approval in approval_interventions_by_tool_call_id.items()
-            if tool_call_id in unanswered_ids
-            and approval.status == ToolApprovalStatus.PENDING
-        ]
-        if blocked_approvals:
-            yield sse_event(
-                "approval_required",
-                approval_required_event(blocked_approvals, tool_use_blocks),
-            )
-            yield end_of_stream(
-                EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
-            )
-            return
-
         approved_oauth_keys = {
             (approval.source_id, approval.source_type, approval.provider)
             for tool_call_id, approval in oauth_interventions_by_tool_call_id.items()
@@ -473,6 +457,22 @@ async def stream_generator(
             yield sse_event("oauth_required", oauth_event_from_approval(blocked_oauth))
             yield end_of_stream(
                 EndOfStreamReason.OAUTH_REQUIRED, message="OAuth required"
+            )
+            return
+
+        blocked_approvals = [
+            approval
+            for tool_call_id, approval in approval_interventions_by_tool_call_id.items()
+            if tool_call_id in unanswered_ids
+            and approval.status == ToolApprovalStatus.PENDING
+        ]
+        if blocked_approvals:
+            yield sse_event(
+                "approval_required",
+                approval_required_event(blocked_approvals, tool_use_blocks),
+            )
+            yield end_of_stream(
+                EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
             )
             return
 
@@ -838,11 +838,6 @@ async def stream_generator(
                         approval_id, ToolApprovalStatus.COMPLETED, chat_user_id
                     )
 
-            if approval_required:
-                yield sse_event(
-                    "approval_required",
-                    approval_required_event(approval_required, tool_use_blocks),
-                )
             for oauth_intervention in oauth_required:
                 yield sse_event(
                     "oauth_required", oauth_event_from_approval(oauth_intervention)
@@ -853,6 +848,10 @@ async def stream_generator(
                 )
                 return
             if approval_required:
+                yield sse_event(
+                    "approval_required",
+                    approval_required_event(approval_required, tool_use_blocks),
+                )
                 yield end_of_stream(
                     EndOfStreamReason.APPROVAL_REQUIRED, message="Approval required"
                 )

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -452,12 +452,20 @@ async def stream_generator(
             )
             return
 
+        approved_oauth_keys = {
+            (approval.source_id, approval.source_type, approval.provider)
+            for tool_call_id, approval in oauth_interventions_by_tool_call_id.items()
+            if tool_call_id in unanswered_ids
+            and approval.status == ToolApprovalStatus.APPROVED
+        }
         blocked_oauth = next(
             (
                 approval
                 for tool_call_id, approval in oauth_interventions_by_tool_call_id.items()
                 if tool_call_id in unanswered_ids
                 and approval.status == ToolApprovalStatus.PENDING
+                and (approval.source_id, approval.source_type, approval.provider)
+                not in approved_oauth_keys
             ),
             None,
         )

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -1862,6 +1862,110 @@ class TestInterventionResume:
         assert len(llm.calls) == 2
 
     @pytest.mark.asyncio
+    async def test_approved_oauth_unblocks_pending_sibling_for_same_source(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        oauth_payload = OAuthRequiredPayload(
+            source_id="source-1",
+            source_type="google_drive",
+            provider="google",
+            oauth_start_url="/api/oauth/start?source_id=source-1",
+        )
+
+        class MultiOAuthHandler:
+            def __init__(self) -> None:
+                self.tool_names = {"google_drive__create", "google_drive__batch_update"}
+                self.executions: list[str] = []
+
+            def get_tools(self):
+                return [
+                    {
+                        "name": tool_name,
+                        "description": "Test OAuth connector action",
+                        "input_schema": {"type": "object", "properties": {}},
+                    }
+                    for tool_name in sorted(self.tool_names)
+                ]
+
+            def can_handle(self, tool_name: str) -> bool:
+                return tool_name in self.tool_names
+
+            def requires_approval(self, tool_name: str) -> bool:
+                return False
+
+            async def execute(self, tool_name: str, _tool_input: dict, _context) -> ToolResult:
+                self.executions.append(tool_name)
+                if len(self.executions) <= 2:
+                    return ToolResult(content=[], oauth_required=oauth_payload)
+                return ToolResult(
+                    content=[{"type": "text", "text": f"{tool_name} completed"}]
+                )
+
+        handler = MultiOAuthHandler()
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_calls",
+                    [
+                        {
+                            "name": "google_drive__create",
+                            "input": {"title": "Pie chart"},
+                            "id": "toolu_create",
+                        },
+                        {
+                            "name": "google_drive__batch_update",
+                            "input": {"spreadsheet_id": "sheet-1"},
+                            "id": "toolu_batch_update",
+                        },
+                    ],
+                ),
+                ("text", "The spreadsheet is ready."),
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            paused_events = await collect_sse_events(client, chat_id)
+            oauth_events = [
+                json.loads(data)
+                for event_type, data, _ in paused_events
+                if event_type == "oauth_required"
+            ]
+            assert len(oauth_events) == 2
+            oauth_rows = await _interventions(
+                chat_id,
+                ToolApprovalType.OAUTH,
+                {ToolApprovalStatus.PENDING},
+            )
+            assert [row.tool_call_id for row in oauth_rows] == [
+                "toolu_create",
+                "toolu_batch_update",
+            ]
+
+            await ToolApprovalsRepository().update_status(
+                oauth_rows[0].id, ToolApprovalStatus.APPROVED, user_id
+            )
+            resumed_events = await collect_sse_events(client, chat_id)
+
+        assert not any(event_type == "oauth_required" for event_type, _, _ in resumed_events)
+        assert handler.executions == [
+            "google_drive__create",
+            "google_drive__batch_update",
+            "google_drive__create",
+            "google_drive__batch_update",
+        ]
+        completed = await _interventions(
+            chat_id,
+            ToolApprovalType.OAUTH,
+            {ToolApprovalStatus.COMPLETED},
+        )
+        assert [row.id for row in completed] == [row.id for row in oauth_rows]
+        assert len(llm.calls) == 2
+
+    @pytest.mark.asyncio
     async def test_oauth_still_required_reuses_the_existing_row(
         self, seeded_chat, redis_client, redis_keys, monkeypatch
     ):

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -53,9 +53,9 @@ pytestmark = pytest.mark.integration
 # Timing constants — patched short for fast tests
 # =============================================================================
 
-_FAST_LOCK_TTL = 30         # seconds (was 300)
-_FAST_HEARTBEAT_MS = 1000   # ms (was 15000)
-_FAST_TTL = 10              # stream TTL seconds (was 300)
+_FAST_LOCK_TTL = 30  # seconds (was 300)
+_FAST_HEARTBEAT_MS = 1000  # ms (was 15000)
+_FAST_TTL = 10  # stream TTL seconds (was 300)
 
 
 @pytest.fixture
@@ -114,7 +114,9 @@ def _patch_chat_config(monkeypatch):
 
 
 @pytest.fixture
-async def seeded_chat(db_pool, _patch_db_pool, _patch_chat_config, _patch_timing) -> tuple[str, str, str]:
+async def seeded_chat(
+    db_pool, _patch_db_pool, _patch_chat_config, _patch_timing
+) -> tuple[str, str, str]:
     """Create a user, model, chat, and first user message.
 
     Returns ``(chat_id, user_id, model_id)``.  Cleans up DB rows on teardown.
@@ -283,7 +285,9 @@ class TestBaseline:
     """Happy-path assertions on the decoupled producer/consumer."""
 
     @pytest.mark.asyncio
-    async def test_happy_path_streams_text_and_persists_assistant(self, seeded_chat, redis_client, redis_keys):
+    async def test_happy_path_streams_text_and_persists_assistant(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """E2E: stream a text response → DB has persisted assistant row;
         consumer events have strictly increasing ``id:`` lines; no duplicate
         writes."""
@@ -294,9 +298,13 @@ class TestBaseline:
         async with _client(app) as client:
             events = await collect_sse_events(client, chat_id)
 
-        terminal = [(e[0], e[1]) for e in events if e[0] in ("end_of_stream", "stream_error")]
+        terminal = [
+            (e[0], e[1]) for e in events if e[0] in ("end_of_stream", "stream_error")
+        ]
         assert terminal, "Expected a terminal event"
-        assert terminal[-1][0] == "end_of_stream", f"Unexpected terminal: {terminal[-1]}"
+        assert (
+            terminal[-1][0] == "end_of_stream"
+        ), f"Unexpected terminal: {terminal[-1]}"
 
         msg_events = [e for e in events if e[0] == "message"]
         assert msg_events, "No message (SDK) events in stream"
@@ -308,7 +316,9 @@ class TestBaseline:
         assert db_msgs[-1].message["role"] == "assistant"
         assistant_text = db_msgs[-1].message["content"]
         if isinstance(assistant_text, list):
-            text = " ".join(b.get("text", "") for b in assistant_text if b.get("type") == "text")
+            text = " ".join(
+                b.get("text", "") for b in assistant_text if b.get("type") == "text"
+            )
         else:
             text = str(assistant_text)
         assert "This is a test response." in text
@@ -342,9 +352,9 @@ class TestBaseline:
         db_msgs = await MessagesRepository().get_active_path(chat_id)
         assistant_rows = [m for m in db_msgs if m.message["role"] == "assistant"]
         assert assistant_rows, "No assistant message in DB"
-        assert assistant_rows[-1].id == msg_start_id, (
-            f"message_start id {msg_start_id} != DB id {assistant_rows[-1].id}"
-        )
+        assert (
+            assistant_rows[-1].id == msg_start_id
+        ), f"message_start id {msg_start_id} != DB id {assistant_rows[-1].id}"
 
 
 # =============================================================================
@@ -356,11 +366,15 @@ class TestResume:
     """Tests for the ``Last-Event-ID`` resume/reconnect logic."""
 
     @pytest.mark.asyncio
-    async def test_resume_from_last_event_id_yields_suffix_only(self, seeded_chat, redis_client, redis_keys):
+    async def test_resume_from_last_event_id_yields_suffix_only(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """Drop connection at ``id: k``, reconnect with ``Last-Event-ID: k`` →
         suffix events only, no duplicates."""
         chat_id, _user_id, model_id = seeded_chat
-        llm = GatedRecordingLLM([("text", "First part. Second part. Final part.")], model_id)
+        llm = GatedRecordingLLM(
+            [("text", "First part. Second part. Final part.")], model_id
+        )
 
         app = _build_chat_app(llm, redis_client, model_id)
         async with _client(app) as client:
@@ -380,18 +394,21 @@ class TestResume:
             )
 
         suffix_ids = [sid for _et, _d, sid in suffix_events if sid is not None]
-        assert all(sid > last_sse_id for sid in suffix_ids), (
-            f"Suffix events include ids ≤ {last_sse_id}: {suffix_ids}"
-        )
+        assert all(
+            sid > last_sse_id for sid in suffix_ids
+        ), f"Suffix events include ids ≤ {last_sse_id}: {suffix_ids}"
 
         suffix_terminals = [
-            et for et, _d, _sid in suffix_events
+            et
+            for et, _d, _sid in suffix_events
             if et in ("end_of_stream", "stream_error", "not_resumable")
         ]
         assert suffix_terminals, "No terminal event in suffix"
 
     @pytest.mark.asyncio
-    async def test_reconnect_after_run_replays_suffix(self, seeded_chat, redis_client, redis_keys):
+    async def test_reconnect_after_run_replays_suffix(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """Reconnect after run finished, within ``_STREAM_TTL``, with a
         ``Last-Event-ID`` → replays from that offset, then buffered
         ``end_of_stream``."""
@@ -412,15 +429,17 @@ class TestResume:
             )
 
         suffix_ids = [sid for _et, _d, sid in suffix if sid is not None]
-        assert all(sid > checkpoint_id for sid in suffix_ids), (
-            f"Suffix ids not all > {checkpoint_id}: {suffix_ids}"
-        )
+        assert all(
+            sid > checkpoint_id for sid in suffix_ids
+        ), f"Suffix ids not all > {checkpoint_id}: {suffix_ids}"
         assert any(
             et in ("end_of_stream", "stream_error") for et, _d, _ in suffix
         ), "No terminal event in suffix"
 
     @pytest.mark.asyncio
-    async def test_reconnect_after_ttl_returns_not_resumable(self, seeded_chat, redis_client, redis_keys):
+    async def test_reconnect_after_ttl_returns_not_resumable(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """Reconnect after ``_STREAM_TTL`` expired with a ``Last-Event-ID`` →
         ``event: not_resumable`` and no fresh generation."""
         # _STREAM_TTL is already 10s from _patch_timing; the run completes
@@ -442,13 +461,11 @@ class TestResume:
             )
 
         event_types = [et for et, _d, _sid in events]
-        assert "not_resumable" in event_types, (
-            f"Expected not_resumable, got {event_types}"
-        )
+        assert (
+            "not_resumable" in event_types
+        ), f"Expected not_resumable, got {event_types}"
         msg_events = [et for et, _d, _sid in events if et == "message"]
-        assert not msg_events, (
-            f"Got message events after TTL expired: {msg_events}"
-        )
+        assert not msg_events, f"Got message events after TTL expired: {msg_events}"
 
 
 # =============================================================================
@@ -460,7 +477,9 @@ class TestCancel:
     """Graceful stop via the Redis cancel flag."""
 
     @pytest.mark.asyncio
-    async def test_cancel_during_text_stream(self, seeded_chat, redis_client, redis_keys):
+    async def test_cancel_during_text_stream(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """Cancel (cross‑worker style via the Redis flag) during a text
         response → consumer sees terminal event; ``stream/status`` later
         shows ``running=false``."""
@@ -469,9 +488,7 @@ class TestCancel:
 
         app = _build_chat_app(llm, redis_client, model_id)
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Let the run start and write at least the first event
             await asyncio.sleep(0.3)
@@ -486,7 +503,9 @@ class TestCancel:
 
             events = await stream_task
 
-        terminal = [(et, d) for et, d, _ in events if et in ("end_of_stream", "stream_error")]
+        terminal = [
+            (et, d) for et, d, _ in events if et in ("end_of_stream", "stream_error")
+        ]
         assert terminal, "No terminal event after cancel"
 
         async with _client(app) as status_client:
@@ -510,7 +529,9 @@ class TestCancel:
         async with _client(app) as client:
             events = await collect_sse_events(client, chat_id)
 
-        terminal = [et for et, _d, _ in events if et in ("end_of_stream", "stream_error")]
+        terminal = [
+            et for et, _d, _ in events if et in ("end_of_stream", "stream_error")
+        ]
         assert terminal, "No terminal event"
 
         cancel_key = f"chat:cancel:{chat_id}"
@@ -540,9 +561,7 @@ class TestCancel:
 
         app = _build_chat_app(llm, redis_client, model_id)
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Wait for the LLM to yield text_delta (content accumulated)
             # With inter_event_delay=0.3:
@@ -570,12 +589,13 @@ class TestCancel:
         )
         latest_asst = assistant_msgs[-1].message
         content = latest_asst["content"]
-        text_blocks = [b for b in content if isinstance(b, dict) and b.get("type") == "text"]
+        text_blocks = [
+            b for b in content if isinstance(b, dict) and b.get("type") == "text"
+        ]
         assert text_blocks, "No text block in persisted assistant message"
         text = " ".join(b["text"] for b in text_blocks)
         assert "Partial content" in text, (
-            f"Partial assistant text missing after task.cancel(). "
-            f"Got: {text!r}"
+            f"Partial assistant text missing after task.cancel(). " f"Got: {text!r}"
         )
 
     @pytest.mark.asyncio
@@ -601,17 +621,13 @@ class TestCancel:
 
         app = _build_chat_app(llm, redis_client, model_id)
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Wait for text_delta to be processed (content_blocks accumulates)
             await asyncio.sleep(0.8)
 
             # Set the Redis cancel flag (simulates cross-worker Stop)
-            await redis_client.set(
-                f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL
-            )
+            await redis_client.set(f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL)
 
             events = await stream_task
 
@@ -630,14 +646,12 @@ class TestCancel:
         latest_asst = assistant_msgs[-1].message
         content = latest_asst["content"]
         text_blocks = [
-            b for b in content
-            if isinstance(b, dict) and b.get("type") == "text"
+            b for b in content if isinstance(b, dict) and b.get("type") == "text"
         ]
         assert text_blocks, "No text block in persisted assistant message"
         text = " ".join(b["text"] for b in text_blocks)
         assert "Partial content" in text, (
-            f"Partial assistant text missing after Redis-flag cancel. "
-            f"Got: {text!r}"
+            f"Partial assistant text missing after Redis-flag cancel. " f"Got: {text!r}"
         )
 
 
@@ -650,7 +664,9 @@ class TestStreamStatus:
     """Correctness of the ``stream/status`` endpoint at each lifecycle phase."""
 
     @pytest.mark.asyncio
-    async def test_status_idle_all_flags_false(self, seeded_chat, redis_client, redis_keys):
+    async def test_status_idle_all_flags_false(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """Idle (no run active, no buffer) → all flags false."""
         chat_id, _user_id, _model_id = seeded_chat
         app = FastAPI()
@@ -668,7 +684,9 @@ class TestStreamStatus:
             assert status["pending_oauth"] is False
 
     @pytest.mark.asyncio
-    async def test_status_running_true_during_run_then_false_after(self, seeded_chat, redis_client, redis_keys):
+    async def test_status_running_true_during_run_then_false_after(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """During a run → ``running=True``, then after the run completes →
         ``running=False, resumable=True``.
 
@@ -685,9 +703,7 @@ class TestStreamStatus:
         app = _build_chat_app(llm, redis_client, model_id)
         # Separate clients: one for the long-lived stream, one for status
         async with _client(app) as stream_cl, _client(app) as status_cl:
-            stream_task = asyncio.create_task(
-                collect_sse_events(stream_cl, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(stream_cl, chat_id))
 
             # Poll for running=True (the route handler sets the lock before
             # returning; polling handles any startup delay).
@@ -726,7 +742,9 @@ class TestLockAndHeartbeat:
     """Lock refresh, heartbeat emission, and vanished-producer detection."""
 
     @pytest.mark.asyncio
-    async def test_consumer_emits_heartbeat_when_idle(self, seeded_chat, redis_client, redis_keys):
+    async def test_consumer_emits_heartbeat_when_idle(
+        self, seeded_chat, redis_client, redis_keys
+    ):
         """Consumer emits a ``heartbeat`` after ``_STREAM_HEARTBEAT_MS`` of
         idleness.  We make the LLM take a while to produce its first event
         (via a ``pre`` gate released after the heartbeat interval), so the
@@ -738,9 +756,7 @@ class TestLockAndHeartbeat:
 
         app = _build_chat_app(llm, redis_client, model_id)
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Wait > heartbeat interval while LLM is gated and stream is
             # empty.  During this time the consumer should fire a heartbeat.
@@ -753,7 +769,9 @@ class TestLockAndHeartbeat:
             events = await stream_task
 
         event_types = [et for et, _d, _sid in events]
-        assert "heartbeat" in event_types, f"No heartbeat found in events: {event_types}"
+        assert (
+            "heartbeat" in event_types
+        ), f"No heartbeat found in events: {event_types}"
 
     @pytest.mark.asyncio
     async def test_lock_refresh_keeps_lock_alive_past_ttl(
@@ -780,9 +798,7 @@ class TestLockAndHeartbeat:
         lock_key = f"chat:runlock:{chat_id}"
 
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Wait for the lock to be acquired
             await asyncio.sleep(0.3)
@@ -831,9 +847,9 @@ class TestLockAndHeartbeat:
                 pass
 
         event_types = [et for et, _d, _sid in events]
-        assert "stream_error" in event_types, (
-            f"Expected stream_error, got events: {event_types}"
-        )
+        assert (
+            "stream_error" in event_types
+        ), f"Expected stream_error, got events: {event_types}"
 
         # Lock should be cleaned up after the crash
         exists = await redis_client.exists(lock_key)
@@ -936,9 +952,9 @@ class TestStreamStatusPending:
             resp = await client.get(f"/chat/{chat_id}/stream/status")
             assert resp.status_code == 200
             status = resp.json()
-            assert status["pending_approval"] is True, (
-                f"Expected pending_approval=True, got {status}"
-            )
+            assert (
+                status["pending_approval"] is True
+            ), f"Expected pending_approval=True, got {status}"
             assert status["pending_oauth"] is False
             assert status["resumable"] is False
 
@@ -954,7 +970,9 @@ class TestPartialAssistant:
     def test_partial_assistant_strips_empty_text_blocks(self):
         """Empty text blocks are removed; non-empty text blocks are kept.
         Tool inputs with string JSON are parsed to dict."""
-        from streaming.persist import partial_assistant_message as _partial_assistant_message
+        from streaming.persist import (
+            partial_assistant_message as _partial_assistant_message,
+        )
         from anthropic.types import TextBlockParam, ToolUseBlockParam
 
         blocks: list[TextBlockParam | ToolUseBlockParam] = [
@@ -978,28 +996,36 @@ class TestPartialAssistant:
 
     def test_partial_assistant_returns_none_when_all_blocks_empty(self):
         """All-empty blocks → returns None."""
-        from streaming.persist import partial_assistant_message as _partial_assistant_message
+        from streaming.persist import (
+            partial_assistant_message as _partial_assistant_message,
+        )
         from anthropic.types import TextBlockParam
 
-        result = _partial_assistant_message([
-            TextBlockParam(type="text", text=""),
-            TextBlockParam(type="text", text="   "),
-        ])
+        result = _partial_assistant_message(
+            [
+                TextBlockParam(type="text", text=""),
+                TextBlockParam(type="text", text="   "),
+            ]
+        )
         assert result is None
 
     def test_partial_assistant_parses_empty_tool_input(self):
         """Empty string tool input becomes empty dict."""
-        from streaming.persist import partial_assistant_message as _partial_assistant_message
+        from streaming.persist import (
+            partial_assistant_message as _partial_assistant_message,
+        )
         from anthropic.types import ToolUseBlockParam
 
-        result = _partial_assistant_message([
-            ToolUseBlockParam(
-                type="tool_use",
-                id="toolu_empty",
-                name="empty_tool",
-                input="",
-            ),
-        ])
+        result = _partial_assistant_message(
+            [
+                ToolUseBlockParam(
+                    type="tool_use",
+                    id="toolu_empty",
+                    name="empty_tool",
+                    input="",
+                ),
+            ]
+        )
         assert result is not None
         assert result["content"][0]["input"] == {}
 
@@ -1047,8 +1073,7 @@ class TestDropEmpty:
         msgs_for_llm = llm.calls[0]["messages"]
         roles = [m["role"] for m in msgs_for_llm]
         assert roles == ["user", "user"], (
-            f"Expected [user, user], got {roles}. "
-            "Empty assistant was not dropped."
+            f"Expected [user, user], got {roles}. " "Empty assistant was not dropped."
         )
 
 
@@ -1064,8 +1089,11 @@ class TestReconnectActive:
         results=[
             SearchResult(
                 document=Document(
-                    id="doc_1", title="Result", content_type="text",
-                    url="", source_type="test",
+                    id="doc_1",
+                    title="Result",
+                    content_type="text",
+                    url="",
+                    source_type="test",
                 ),
                 highlights=["test highlight"],
                 source_type="test",
@@ -1123,9 +1151,7 @@ class TestReconnectActive:
 
         async with _client(app) as stream_cl, _client(app) as ctrl_cl:
             # Phase 1: start the stream in a background task
-            stream_task = asyncio.create_task(
-                collect_sse_events(stream_cl, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(stream_cl, chat_id))
 
             # Wait for the producer to write the tool-call events and
             # block on the searcher gate
@@ -1143,8 +1169,7 @@ class TestReconnectActive:
         reload_msg = [et for et, _d, _sid in reload_events if et == "message"]
         assert reload_msg, "No message events in reload stream"
         assert any(
-            et in ("end_of_stream", "stream_error")
-            for et, _d, _ in reload_events
+            et in ("end_of_stream", "stream_error") for et, _d, _ in reload_events
         ), "No terminal event in reload"
 
 
@@ -1190,9 +1215,7 @@ class TestCancelEarly:
 
         app = _build_chat_app(llm, redis_client, model_id)
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Wait for the LLM to start producing events (message_start
             # through part of the tool_use content blocks)
@@ -1200,27 +1223,22 @@ class TestCancelEarly:
 
             # Set cancel flag — the next cancel check inside the event
             # loop will detect it and break before tool execution.
-            await redis_client.set(
-                f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL
-            )
+            await redis_client.set(f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL)
 
             events = await stream_task
 
         # Should have received the tool_use events and a terminal
-        msg_events = [
-            json.loads(d) for et, d, _ in events
-            if et == "message" and d
-        ]
+        msg_events = [json.loads(d) for et, d, _ in events if et == "message" and d]
         tool_use_events = [
-            e for e in msg_events
+            e
+            for e in msg_events
             if e.get("type") == "content_block_start"
             and e.get("content_block", {}).get("type") == "tool_use"
         ]
         assert tool_use_events, "No tool_use content_block_start in events"
 
         terminal = [
-            et for et, _d, _ in events
-            if et in ("end_of_stream", "stream_error")
+            et for et, _d, _ in events if et in ("end_of_stream", "stream_error")
         ]
         assert terminal, "No terminal event after cancel"
 
@@ -1241,9 +1259,9 @@ class TestCancelEarly:
             blocks = um.message.get("content", [])
             if isinstance(blocks, list):
                 for b in blocks:
-                    assert b.get("type") != "tool_result", (
-                        "tool_result found in user message despite cancel before execution"
-                    )
+                    assert (
+                        b.get("type") != "tool_result"
+                    ), "tool_result found in user message despite cancel before execution"
 
 
 # =============================================================================
@@ -1263,8 +1281,11 @@ class TestCancelMidToolCall:
         results=[
             SearchResult(
                 document=Document(
-                    id="doc_1", title="Result", content_type="text",
-                    url="", source_type="test",
+                    id="doc_1",
+                    title="Result",
+                    content_type="text",
+                    url="",
+                    source_type="test",
                 ),
                 highlights=["test highlight"],
                 source_type="test",
@@ -1320,9 +1341,7 @@ class TestCancelMidToolCall:
         app.state.searcher_tool = gated_searcher
 
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Wait for the LLM to emit tool_use and the router to start
             # executing the tool (which blocks on searcher_gate)
@@ -1349,18 +1368,17 @@ class TestCancelMidToolCall:
         # The prior turn's assistant message with tool_use is persisted
         db_msgs = await MessagesRepository().get_active_path(chat_id)
         assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
-        assert assistant_msgs, (
-            "No assistant message persisted after mid-tool-call cancel."
-        )
+        assert (
+            assistant_msgs
+        ), "No assistant message persisted after mid-tool-call cancel."
         latest_asst = assistant_msgs[-1].message
         blocks = latest_asst.get("content", [])
         tool_use_blocks = [
-            b for b in blocks
-            if isinstance(b, dict) and b.get("type") == "tool_use"
+            b for b in blocks if isinstance(b, dict) and b.get("type") == "tool_use"
         ]
-        assert tool_use_blocks, (
-            "Prior turn's tool_use was not persisted after mid-tool-call cancel."
-        )
+        assert (
+            tool_use_blocks
+        ), "Prior turn's tool_use was not persisted after mid-tool-call cancel."
 
         # Exactly one assistant message — no duplicate rows from a
         # late CancelledError handler re-saving the same content_blocks.
@@ -1404,9 +1422,7 @@ class TestRacingConnect:
 
         async with _client(app) as client1, _client(app) as client2:
             # Stream 1: will acquire the lock and become producer
-            stream1_task = asyncio.create_task(
-                collect_sse_events(client1, chat_id)
-            )
+            stream1_task = asyncio.create_task(collect_sse_events(client1, chat_id))
 
             # Wait for lock acquisition
             import time
@@ -1419,9 +1435,7 @@ class TestRacingConnect:
             assert await redis_client.exists(lock_key), "Lock not acquired"
 
             # Stream 2: should detect ``run_active`` and attach as consumer
-            stream2_task = asyncio.create_task(
-                collect_sse_events(client2, chat_id)
-            )
+            stream2_task = asyncio.create_task(collect_sse_events(client2, chat_id))
 
             # Let stream 2 attach before releasing
             await asyncio.sleep(0.3)
@@ -1471,15 +1485,11 @@ class TestEmptyRowDelete:
         # cancel check fires between message_start and content_block_start.
         # Since the check runs BEFORE processing the event, content_blocks
         # stays empty and _partial_assistant_message returns None.
-        llm = GatedRecordingLLM(
-            [("text", "X.")], model_id, inter_event_delay=0.55
-        )
+        llm = GatedRecordingLLM([("text", "X.")], model_id, inter_event_delay=0.55)
 
         app = _build_chat_app(llm, redis_client, model_id)
         async with _client(app) as client:
-            stream_task = asyncio.create_task(
-                collect_sse_events(client, chat_id)
-            )
+            stream_task = asyncio.create_task(collect_sse_events(client, chat_id))
 
             # Wait for ``message_start`` to be processed
             await asyncio.sleep(0.2)
@@ -1487,9 +1497,7 @@ class TestEmptyRowDelete:
             # Set cancel flag — the cancel check will fire when
             # content_block_start arrives (0.55s after message_start),
             # detect the flag, and break before processing the event.
-            await redis_client.set(
-                f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL
-            )
+            await redis_client.set(f"chat:cancel:{chat_id}", "1", ex=_FAST_LOCK_TTL)
 
             events = await stream_task
 
@@ -1576,13 +1584,12 @@ class TestInterruptedToolCall:
             content = [{"type": "text", "text": content}]
         tool_results = [b for b in content if b.get("type") == "tool_result"]
         assert tool_results, (
-            "No tool_result injected by repair path. "
-            f"Content: {content}"
+            "No tool_result injected by repair path. " f"Content: {content}"
         )
         assert tool_results[0]["tool_use_id"] == tool_use_id
-        assert tool_results[0]["is_error"] is True, (
-            "Repair tool_result should have is_error=True"
-        )
+        assert (
+            tool_results[0]["is_error"] is True
+        ), "Repair tool_result should have is_error=True"
 
 
 # =============================================================================
@@ -1659,8 +1666,7 @@ class TestMultiTurn:
                     user_with_tool_result = um
                     break
         assert user_with_tool_result is not None, (
-            "No user message with tool_result found. "
-            "Tool was not executed."
+            "No user message with tool_result found. " "Tool was not executed."
         )
 
 
@@ -1703,7 +1709,9 @@ class TestInterventionResume:
 
         async with _client(app) as client:
             paused_events = await collect_sse_events(client, chat_id)
-            assert any(event_type == "approval_required" for event_type, _, _ in paused_events)
+            assert any(
+                event_type == "approval_required" for event_type, _, _ in paused_events
+            )
             assert handler.executions == []
 
             approvals = await _interventions(
@@ -1894,7 +1902,9 @@ class TestInterventionResume:
             def requires_approval(self, tool_name: str) -> bool:
                 return False
 
-            async def execute(self, tool_name: str, _tool_input: dict, _context) -> ToolResult:
+            async def execute(
+                self, tool_name: str, _tool_input: dict, _context
+            ) -> ToolResult:
                 self.executions.append(tool_name)
                 if len(self.executions) <= 2:
                     return ToolResult(content=[], oauth_required=oauth_payload)
@@ -1950,7 +1960,9 @@ class TestInterventionResume:
             )
             resumed_events = await collect_sse_events(client, chat_id)
 
-        assert not any(event_type == "oauth_required" for event_type, _, _ in resumed_events)
+        assert not any(
+            event_type == "oauth_required" for event_type, _, _ in resumed_events
+        )
         assert handler.executions == [
             "google_drive__create",
             "google_drive__batch_update",
@@ -1964,6 +1976,102 @@ class TestInterventionResume:
         )
         assert [row.id for row in completed] == [row.id for row in oauth_rows]
         assert len(llm.calls) == 2
+
+    @pytest.mark.asyncio
+    async def test_oauth_preflight_runs_before_approval_for_same_tool(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        oauth_payload = OAuthRequiredPayload(
+            source_id="source-1",
+            source_type="google_drive",
+            provider="google",
+            oauth_start_url="/api/oauth/start?source_id=source-1",
+        )
+
+        class OAuthBeforeApprovalHandler:
+            def __init__(self) -> None:
+                self.tool_name = "google_drive__google_workspace_call"
+                self.oauth_connected = False
+                self.executions: list[dict] = []
+
+            def get_tools(self):
+                return [
+                    {
+                        "name": self.tool_name,
+                        "description": "Test connector action",
+                        "input_schema": {"type": "object", "properties": {}},
+                    }
+                ]
+
+            def can_handle(self, tool_name: str) -> bool:
+                return tool_name == self.tool_name
+
+            def requires_approval(self, tool_name: str) -> bool:
+                return self.can_handle(tool_name)
+
+            async def check_oauth_required(
+                self, tool_name: str, _tool_input: dict, _context
+            ) -> OAuthRequiredPayload | None:
+                if self.can_handle(tool_name) and not self.oauth_connected:
+                    return oauth_payload
+                return None
+
+            async def execute(
+                self, _tool_name: str, tool_input: dict, _context
+            ) -> ToolResult:
+                self.executions.append(tool_input)
+                return ToolResult(content=[{"type": "text", "text": "created"}])
+
+        handler = OAuthBeforeApprovalHandler()
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": handler.tool_name,
+                        "input": {"title": "Pie chart"},
+                        "id": "toolu_create",
+                    },
+                ),
+                ("text", "Done."),
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            paused_events = await collect_sse_events(client, chat_id)
+            event_types = [event_type for event_type, _, _ in paused_events]
+            assert "oauth_required" in event_types
+            assert "approval_required" not in event_types
+            assert handler.executions == []
+
+            approval_rows = await _interventions(
+                chat_id,
+                ToolApprovalType.APPROVAL,
+                {ToolApprovalStatus.PENDING},
+            )
+            assert approval_rows == []
+
+            oauth_rows = await _interventions(
+                chat_id,
+                ToolApprovalType.OAUTH,
+                {ToolApprovalStatus.PENDING},
+            )
+            assert [row.tool_call_id for row in oauth_rows] == ["toolu_create"]
+            await ToolApprovalsRepository().update_status(
+                oauth_rows[0].id, ToolApprovalStatus.APPROVED, user_id
+            )
+            handler.oauth_connected = True
+
+            resumed_events = await collect_sse_events(client, chat_id)
+
+        resumed_event_types = [event_type for event_type, _, _ in resumed_events]
+        assert "approval_required" in resumed_event_types
+        assert "oauth_required" not in resumed_event_types
+        assert handler.executions == []
 
     @pytest.mark.asyncio
     async def test_oauth_required_defers_approval_prompt_in_same_batch(
@@ -1998,7 +2106,9 @@ class TestInterventionResume:
             def requires_approval(self, tool_name: str) -> bool:
                 return tool_name == "google_drive__share"
 
-            async def execute(self, tool_name: str, _tool_input: dict, _context) -> ToolResult:
+            async def execute(
+                self, tool_name: str, _tool_input: dict, _context
+            ) -> ToolResult:
                 self.executions.append(tool_name)
                 if tool_name == "google_drive__create":
                     return ToolResult(content=[], oauth_required=oauth_payload)
@@ -2142,7 +2252,9 @@ class TestInterventionResume:
 
         async with _client(app) as client:
             paused_events = await collect_sse_events(client, chat_id)
-            assert any(event_type == "approval_required" for event_type, _, _ in paused_events)
+            assert any(
+                event_type == "approval_required" for event_type, _, _ in paused_events
+            )
             assert handler.executions == ["test__a", "test__c"]
 
             active_path = await MessagesRepository().get_active_path(chat_id)
@@ -2317,9 +2429,9 @@ class TestAgentChat:
         # The LLM's system prompt should contain agent instructions
         assert len(llm.calls) == 1, f"Expected 1 LLM call, got {len(llm.calls)}"
         system_prompt = llm.calls[0].get("system_prompt", "")
-        assert "Test Agent" in system_prompt or "test agent" in system_prompt, (
-            f"Agent instructions not found in system prompt: {system_prompt[:200]}"
-        )
+        assert (
+            "Test Agent" in system_prompt or "test agent" in system_prompt
+        ), f"Agent instructions not found in system prompt: {system_prompt[:200]}"
 
 
 # =============================================================================
@@ -2352,9 +2464,9 @@ class TestStandaloneEndpoints:
 
         # Verify the side effect: the Redis cancel flag was actually set,
         # not just an HTTP 200 returned.
-        assert await redis_client.exists(f"chat:cancel:{chat_id}"), (
-            "Cancel flag was not set in Redis"
-        )
+        assert await redis_client.exists(
+            f"chat:cancel:{chat_id}"
+        ), "Cancel flag was not set in Redis"
 
     @pytest.mark.asyncio
     async def test_context_overflow_triggers_compaction_retry(
@@ -2388,9 +2500,9 @@ class TestStandaloneEndpoints:
         ), "No terminal event after context-overflow retry"
 
         # The LLM should have been called twice: first fails, second succeeds
-        assert len(llm.calls) >= 2, (
-            f"Expected ≥2 LLM calls for retry, got {len(llm.calls)}"
-        )
+        assert (
+            len(llm.calls) >= 2
+        ), f"Expected ≥2 LLM calls for retry, got {len(llm.calls)}"
 
         db_msgs = await MessagesRepository().get_active_path(chat_id)
         assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -1966,6 +1966,99 @@ class TestInterventionResume:
         assert len(llm.calls) == 2
 
     @pytest.mark.asyncio
+    async def test_oauth_required_defers_approval_prompt_in_same_batch(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        chat_id, user_id, model_id = seeded_chat
+        oauth_payload = OAuthRequiredPayload(
+            source_id="source-1",
+            source_type="google_drive",
+            provider="google",
+            oauth_start_url="/api/oauth/start?source_id=source-1",
+        )
+
+        class MixedInterventionHandler:
+            def __init__(self) -> None:
+                self.tool_names = {"google_drive__create", "google_drive__share"}
+                self.executions: list[str] = []
+
+            def get_tools(self):
+                return [
+                    {
+                        "name": tool_name,
+                        "description": "Test connector action",
+                        "input_schema": {"type": "object", "properties": {}},
+                    }
+                    for tool_name in sorted(self.tool_names)
+                ]
+
+            def can_handle(self, tool_name: str) -> bool:
+                return tool_name in self.tool_names
+
+            def requires_approval(self, tool_name: str) -> bool:
+                return tool_name == "google_drive__share"
+
+            async def execute(self, tool_name: str, _tool_input: dict, _context) -> ToolResult:
+                self.executions.append(tool_name)
+                if tool_name == "google_drive__create":
+                    return ToolResult(content=[], oauth_required=oauth_payload)
+                return ToolResult(content=[{"type": "text", "text": "shared"}])
+
+        handler = MixedInterventionHandler()
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_calls",
+                    [
+                        {
+                            "name": "google_drive__create",
+                            "input": {"title": "Pie chart"},
+                            "id": "toolu_create",
+                        },
+                        {
+                            "name": "google_drive__share",
+                            "input": {"spreadsheet_id": "sheet-1"},
+                            "id": "toolu_share",
+                        },
+                    ],
+                ),
+                ("text", "Done."),
+            ],
+            model_id,
+        )
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            paused_events = await collect_sse_events(client, chat_id)
+            event_types = [event_type for event_type, _, _ in paused_events]
+            assert "oauth_required" in event_types
+            assert "approval_required" not in event_types
+
+            oauth_rows = await _interventions(
+                chat_id,
+                ToolApprovalType.OAUTH,
+                {ToolApprovalStatus.PENDING},
+            )
+            approval_rows = await _interventions(
+                chat_id,
+                ToolApprovalType.APPROVAL,
+                {ToolApprovalStatus.PENDING},
+            )
+            assert [row.tool_call_id for row in oauth_rows] == ["toolu_create"]
+            assert [row.tool_call_id for row in approval_rows] == ["toolu_share"]
+
+            await ToolApprovalsRepository().update_status(
+                oauth_rows[0].id, ToolApprovalStatus.APPROVED, user_id
+            )
+            resumed_events = await collect_sse_events(client, chat_id)
+
+        resumed_event_types = [event_type for event_type, _, _ in resumed_events]
+        assert "approval_required" in resumed_event_types
+        assert "oauth_required" not in resumed_event_types
+        assert handler.executions == ["google_drive__create"]
+
+    @pytest.mark.asyncio
     async def test_oauth_still_required_reuses_the_existing_row(
         self, seeded_chat, redis_client, redis_keys, monkeypatch
     ):

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -13,6 +13,7 @@ import httpx
 import redis.asyncio as aioredis
 from anthropic.types import ToolParam
 
+from db.connection import get_db_pool
 from db.documents import DocumentsRepository
 from db.models import Source
 from tools.omni_tool_result import OAuthRequiredPayload, encode_oauth_required
@@ -355,6 +356,57 @@ class ConnectorToolHandler:
             return True
         return action.mode == "write"
 
+    async def check_oauth_required(
+        self, tool_name: str, _tool_input: dict, context: ToolContext
+    ) -> OAuthRequiredPayload | None:
+        action = self._actions.get(tool_name)
+        if (
+            action is None
+            or action.admin_only
+            or context.user_id is None
+            or context.skip_permission_check
+        ):
+            return None
+
+        pool = await get_db_pool()
+        async with pool.acquire() as conn:
+            user_credential = await conn.fetchrow(
+                """
+                SELECT id
+                FROM service_credentials
+                WHERE source_id = $1 AND user_id = $2
+                LIMIT 1
+                """,
+                action.source_id,
+                context.user_id,
+            )
+            if user_credential is not None:
+                return None
+
+            org_credential = await conn.fetchrow(
+                """
+                SELECT provider
+                FROM service_credentials
+                WHERE source_id = $1 AND user_id IS NULL
+                LIMIT 1
+                """,
+                action.source_id,
+            )
+
+        if org_credential is None:
+            return None
+
+        provider = org_credential["provider"]
+        if not provider:
+            return None
+
+        return OAuthRequiredPayload(
+            source_id=action.source_id,
+            source_type=action.source_type,
+            provider=provider,
+            oauth_start_url=f"/api/oauth/start?source_id={action.source_id}",
+        )
+
     async def execute(
         self, tool_name: str, tool_input: dict, context: ToolContext
     ) -> ToolResult:
@@ -442,8 +494,13 @@ class ConnectorToolHandler:
                 content_type = response.headers.get("content-type", "")
 
                 if "application/json" not in content_type:
-                    content_disposition = response.headers.get("content-disposition", "")
-                    if is_textual_content_type(content_type) and not content_disposition:
+                    content_disposition = response.headers.get(
+                        "content-disposition", ""
+                    )
+                    if (
+                        is_textual_content_type(content_type)
+                        and not content_disposition
+                    ):
                         return await text_result_or_sandbox(
                             text=response.text,
                             sandbox_url=self._sandbox_url,
@@ -522,4 +579,3 @@ def _action_result_file_name(action_name: str, *, extension: str) -> str:
     if not safe_name:
         safe_name = "connector_action_result"
     return f"{safe_name}_result.{extension}"
-

--- a/services/ai/tools/registry.py
+++ b/services/ai/tools/registry.py
@@ -85,6 +85,18 @@ class ToolRegistry:
                 return handler.requires_approval(tool_name)
         return True  # Unknown tools require approval by default
 
+    async def check_oauth_required(
+        self, tool_name: str, tool_input: dict, context: ToolContext
+    ) -> OAuthRequiredPayload | None:
+        """Check whether a tool needs OAuth before any approval/execution."""
+        for handler in self._handlers:
+            if handler.can_handle(tool_name):
+                checker = getattr(handler, "check_oauth_required", None)
+                if checker is None:
+                    return None
+                return await checker(tool_name, tool_input, context)
+        return None
+
     async def execute(
         self, tool_name: str, tool_input: dict, context: ToolContext
     ) -> ToolResult:

--- a/web/src/lib/components/tool-calls-group.svelte
+++ b/web/src/lib/components/tool-calls-group.svelte
@@ -100,9 +100,11 @@
         <div class="mb-3 max-h-64 overflow-y-auto pr-1 opacity-80">
             {#each earlierBlocks as block (blockRenderKey(block))}
                 {#if block.type === 'text'}
-                    <MarkdownMessage
-                        content={stripThinkingContent(block.text, 'thinking')}
-                        citations={block.citations} />
+                    <div class="min-w-0 overflow-x-auto">
+                        <MarkdownMessage
+                            content={stripThinkingContent(block.text, 'thinking')}
+                            citations={block.citations} />
+                    </div>
                 {:else if block.type === 'tool'}
                     <div class="mb-1">
                         <ToolMessage
@@ -129,9 +131,11 @@
 <!-- Recent blocks: always visible -->
 {#each recentBlocks as block (blockRenderKey(block))}
     {#if block.type === 'text'}
-        <MarkdownMessage
-            content={stripThinkingContent(block.text, 'thinking')}
-            citations={block.citations} />
+        <div class="min-w-0 overflow-x-auto">
+            <MarkdownMessage
+                content={stripThinkingContent(block.text, 'thinking')}
+                citations={block.citations} />
+        </div>
     {:else if block.type === 'tool'}
         <div in:fly={{ y: 4, duration: 300 }} class="mb-1">
             <ToolMessage message={block} {isAdmin} {onOAuthComplete} showOAuthCard={false} />

--- a/web/src/lib/components/tool-calls-group.svelte
+++ b/web/src/lib/components/tool-calls-group.svelte
@@ -1,7 +1,8 @@
 <script lang="ts">
-    import type { MessageContent, TextMessageContent, ToolMessageContent } from '$lib/types/message'
+    import type { MessageContent, OAuthRequired, ToolMessageContent } from '$lib/types/message'
     import ToolMessage from './tool-message.svelte'
     import MarkdownMessage from './markdown-message.svelte'
+    import OAuthRequiredCard from '$lib/components/oauth-integrations/oauth-required-card.svelte'
     import { ChevronRight } from '@lucide/svelte'
     import { fly } from 'svelte/transition'
 
@@ -15,6 +16,12 @@
 
     const MAX_VISIBLE_TOOLS = 4
 
+    type OAuthCardEntry = {
+        key: string
+        toolName: string
+        oauthRequired: OAuthRequired
+    }
+
     let {
         content,
         isStreaming,
@@ -24,26 +31,7 @@
     }: Props = $props()
     let expanded = $state(false)
 
-    // When the model fans out parallel tool calls against the same source and
-    // they all surface oauth_required, we only want one Connect card per source.
-    // Hide the duplicates here; on resume the AI service replaces every
-    // placeholder so the hidden blocks become real tool results naturally.
-    let skippedOAuthBlockIds = $derived.by(() => {
-        const seen = new Set<string>()
-        const skip = new Set<number>()
-        for (const block of content) {
-            if (block.type === 'tool' && block.oauthRequired) {
-                const key = block.oauthRequired.sourceId
-                if (seen.has(key)) skip.add(block.id)
-                else seen.add(key)
-            }
-        }
-        return skip
-    })
-
-    let visibleBlocks = $derived(
-        content.filter((b) => !(b.type === 'tool' && skippedOAuthBlockIds.has(b.id))),
-    )
+    let visibleBlocks = $derived(content)
     let toolBlocks = $derived(
         visibleBlocks.filter((b): b is ToolMessageContent => b.type === 'tool'),
     )
@@ -70,6 +58,23 @@
         }
 
         return `${block.type}:${block.id}`
+    }
+
+    function oauthCardEntries(blocks: MessageContent): OAuthCardEntry[] {
+        const seen = new Set<string>()
+        const entries: OAuthCardEntry[] = []
+        for (const block of blocks) {
+            if (block.type !== 'tool' || !block.oauthRequired) continue
+            const key = `${block.oauthRequired.sourceId}:${block.oauthRequired.provider}`
+            if (seen.has(key)) continue
+            seen.add(key)
+            entries.push({
+                key,
+                toolName: block.toolUse.name,
+                oauthRequired: block.oauthRequired,
+            })
+        }
+        return entries
     }
 </script>
 
@@ -100,9 +105,22 @@
                         citations={block.citations} />
                 {:else if block.type === 'tool'}
                     <div class="mb-1">
-                        <ToolMessage message={block} {isAdmin} {onOAuthComplete} />
+                        <ToolMessage
+                            message={block}
+                            {isAdmin}
+                            {onOAuthComplete}
+                            showOAuthCard={false} />
                     </div>
                 {/if}
+            {/each}
+            {#each oauthCardEntries(earlierBlocks) as entry (`oauth:${entry.key}`)}
+                <div class="mt-2 mb-1">
+                    <OAuthRequiredCard
+                        oauthRequired={entry.oauthRequired}
+                        toolName={entry.toolName}
+                        {isAdmin}
+                        onComplete={onOAuthComplete} />
+                </div>
             {/each}
         </div>
     </div>
@@ -116,7 +134,16 @@
             citations={block.citations} />
     {:else if block.type === 'tool'}
         <div in:fly={{ y: 4, duration: 300 }} class="mb-1">
-            <ToolMessage message={block} {isAdmin} {onOAuthComplete} />
+            <ToolMessage message={block} {isAdmin} {onOAuthComplete} showOAuthCard={false} />
         </div>
     {/if}
+{/each}
+{#each oauthCardEntries(recentBlocks) as entry (`oauth:${entry.key}`)}
+    <div in:fly={{ y: 4, duration: 300 }} class="mt-2 mb-1">
+        <OAuthRequiredCard
+            oauthRequired={entry.oauthRequired}
+            toolName={entry.toolName}
+            {isAdmin}
+            onComplete={onOAuthComplete} />
+    </div>
 {/each}

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -31,6 +31,7 @@
         message: ToolMessageContent
         isAdmin?: boolean
         onOAuthComplete?: () => void
+        showOAuthCard?: boolean
     }
 
     const ToolIndicators: Record<string, { loading: string; loaded: string }> = {
@@ -139,7 +140,12 @@
         },
     }
 
-    let { message, isAdmin = false, onOAuthComplete = () => {} }: Props = $props()
+    let {
+        message,
+        isAdmin = false,
+        onOAuthComplete = () => {},
+        showOAuthCard = true,
+    }: Props = $props()
     let toolName = $derived(message.toolUse.name as ToolName)
 
     // Determine if this is a connector action (contains __)
@@ -352,7 +358,7 @@
             {/if}
         </div>
     </div>
-    {#if message.oauthRequired}
+    {#if showOAuthCard && message.oauthRequired}
         <div class="mt-2">
             <OAuthRequiredCard
                 oauthRequired={message.oauthRequired}

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -2454,7 +2454,7 @@
                             data-testid={`chat-message-${message.origMessageId}`}
                             class="group mt-8 flex w-full min-w-0 flex-col gap-1">
                             <div
-                                class="prose prose-sm md:prose-base prose-p:my-3 prose-headings:text-foreground prose-p:text-foreground prose-li:text-foreground prose-strong:text-foreground prose-code:text-foreground prose-a:text-primary dark:prose-invert max-w-none min-w-0 overflow-x-auto">
+                                class="prose prose-sm md:prose-base prose-p:my-3 prose-headings:text-foreground prose-p:text-foreground prose-li:text-foreground prose-strong:text-foreground prose-code:text-foreground prose-a:text-primary dark:prose-invert max-w-none min-w-0 overflow-visible">
                                 {#key `${message.renderKey}:${messageContentRenderKey(message.content)}`}
                                     <ToolCallsGroup
                                         content={message.content}

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -114,6 +114,7 @@
             uploadFilenames = { ...data.uploadFilenames }
             pendingApproval = pendingApprovalFromData()
             oauthEventByToolCallId = {}
+            oauthBlockerActive = data.pendingOAuth !== null
         }
     })
 
@@ -451,6 +452,7 @@
     // source display name; the persisted envelope on its own can render the
     // card in degraded mode (provider treated as "configured" optimistically).
     let oauthEventByToolCallId = $state<Record<string, OAuthRequiredEvent>>({})
+    let oauthBlockerActive = $state(data.pendingOAuth !== null)
 
     function oauthRequiredFromEvent(event: OAuthRequiredEvent): OAuthRequired {
         return {
@@ -809,6 +811,7 @@
         clearDownstreamSelections(messageId)
         pendingApproval = null
         oauthEventByToolCallId = {}
+        oauthBlockerActive = false
 
         streamResponse(data.chat.id)
     }
@@ -1321,6 +1324,7 @@
         error = null
         errorDetail = null
         startThinkingText()
+        oauthBlockerActive = false
 
         const toolUseStateByIndex = new Map<
             number,
@@ -1733,6 +1737,8 @@
                         ...oauthEventByToolCallId,
                         [oauthData.tool_call_id]: oauthData,
                     }
+                    oauthBlockerActive = true
+                    pendingApproval = null
                     isStreaming = false
                     stopInProgress = false
                     activeStreamingMessageId = null
@@ -2470,7 +2476,7 @@
                                     </Alert.Root>
                                 </div>
                             {/if}
-                            {#if pendingApproval && i === processedMessages.length - 1}
+                            {#if pendingApproval && !oauthBlockerActive && i === processedMessages.length - 1}
                                 {@const connectorName = pendingApproval.tool_name.split('__')[0]}
                                 {@const actionName = pendingApproval.tool_name
                                     .split('__')
@@ -2630,7 +2636,7 @@
                     {/if}
                 {/each}
 
-                {#if pendingApproval && processedMessages[processedMessages.length - 1]?.role !== 'assistant'}
+                {#if pendingApproval && !oauthBlockerActive && processedMessages[processedMessages.length - 1]?.role !== 'assistant'}
                     {@const connectorName = pendingApproval.tool_name.split('__')[0]}
                     {@const actionName = pendingApproval.tool_name.split('__').slice(1).join('__')}
                     {@const connectorIcon = getSourceIconPath(connectorName)}


### PR DESCRIPTION
- Prevent repeated OAuth prompts when multiple tool calls in the same batch need the same source/provider credential.
- Check connector OAuth readiness before creating tool approval prompts so users connect credentials before approving writes.
- Defer approval prompts while OAuth is blocking a tool batch to avoid showing competing intervention cards.
- Render OAuth cards after grouped tool rows and avoid clipping card rings in chat UI.