### PR TITLE
fix: simplify chat history and show compaction status

### DIFF
--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -11,6 +11,7 @@ import asyncio
 import json
 import logging
 import pathlib
+from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -75,6 +76,8 @@ from streaming.persist import (
     EndOfStreamReason,
     end_of_stream,
     persist_and_transform,
+    sse_event,
+    stream_error_sse,
 )
 from streaming.run import (
     SSE_HEADERS,
@@ -941,76 +944,132 @@ class StreamChatHandler:
             loaded_toolsets,
         )
 
-        prepared = await compactor.prepare_chat_conversation(
-            chat_id=chat_id,
-            chat_messages=chat_messages,
-            messages=messages,
-            compactions_repo=CompactionsRepository(),
-            target_provider=llm_provider,
-            tools=initial_tools,
-            system_prompt=system_prompt,
-            max_output_tokens=DEFAULT_MAX_TOKENS,
-        )
-        messages = prepared.messages
-        latest_compaction = prepared.latest_compaction
-        summarizer_context = prepared.summarizer_context
-        logger.info(
-            "Resolved context windows for chat %s: model=%s (%s), summarizer=%s (%s)",
-            chat_id,
-            prepared.model_context.tokens,
-            prepared.model_context.source,
-            summarizer_context.tokens,
-            summarizer_context.source,
-        )
-
-        # Extract first user message for caching
-        original_user_query = None
-        for msg in messages:
-            if msg.get("role") == "user":
-                content = msg.get("content", "")
-                if isinstance(content, str):
-                    original_user_query = content
-                    break
-                elif isinstance(content, list):
-                    text_parts = [
-                        block.get("text", "")
-                        for block in content
-                        if isinstance(block, dict) and block.get("type") == "text"
-                    ]
-                    if text_parts:
-                        original_user_query = " ".join(text_parts)
-                        break
-
         parent_id = chat_messages[-1].id if chat_messages else None
 
-        # ---- Build and run the generator ----
-        gen = stream_generator(
-            chat_id,
-            redis_client,
-            messages,
-            llm_provider,
-            chat.user_id,
-            tool_user_id=tool_user_id,
-            user_email=user_email,
-            user_configuration=user_configuration,
-            tool_skip_perm=tool_skip_perm,
-            system_prompt=system_prompt,
-            registry=registry,
-            always_on_handlers=build_result.always_on_handlers,
-            connector_handler=build_result.connector_handler,
-            loaded_toolsets=loaded_toolsets,
-            compactor=compactor,
-            latest_compaction_summary=(
-                latest_compaction.summary if latest_compaction else None
-            ),
-            summarizer_context_window_tokens=summarizer_context.tokens,
-            memory_provider=memory_provider,
-            memory_write_key=memory_write_key,
-            effective_mode=effective_mode,
-            approvals_repo=approvals_repo,
-            pending_interventions=pending_interventions,
-            original_user_query=original_user_query,
-        )
+        async def generate_stream() -> AsyncIterator[str]:
+            compaction_started = asyncio.Event()
+            continue_compaction = asyncio.Event()
+            prepare_task: asyncio.Task | None = None
+            start_wait_task: asyncio.Task | None = None
+
+            async def on_compaction_start() -> None:
+                compaction_started.set()
+                # Do not call the summarizer until the start event has reached
+                # the stream transport and can be rendered by the client.
+                await continue_compaction.wait()
+
+            try:
+                prepare_task = asyncio.create_task(
+                    compactor.prepare_chat_conversation(
+                        chat_id=chat_id,
+                        chat_messages=chat_messages,
+                        messages=messages,
+                        compactions_repo=CompactionsRepository(),
+                        target_provider=llm_provider,
+                        tools=initial_tools,
+                        system_prompt=system_prompt,
+                        max_output_tokens=DEFAULT_MAX_TOKENS,
+                        on_compaction_start=on_compaction_start,
+                    )
+                )
+                start_wait_task = asyncio.create_task(compaction_started.wait())
+                completed, _ = await asyncio.wait(
+                    {prepare_task, start_wait_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+
+                if start_wait_task in completed:
+                    try:
+                        yield sse_event("compaction_start", {})
+                    finally:
+                        continue_compaction.set()
+                else:
+                    start_wait_task.cancel()
+                    await asyncio.gather(start_wait_task, return_exceptions=True)
+                    start_wait_task = None
+
+                prepared = await prepare_task
+                prepare_task = None
+                prepared_messages = prepared.messages
+                latest_compaction = prepared.latest_compaction
+                summarizer_context = prepared.summarizer_context
+                logger.info(
+                    "Resolved context windows for chat %s: model=%s (%s), summarizer=%s (%s)",
+                    chat_id,
+                    prepared.model_context.tokens,
+                    prepared.model_context.source,
+                    summarizer_context.tokens,
+                    summarizer_context.source,
+                )
+
+                original_user_query = None
+                for msg in prepared_messages:
+                    if msg.get("role") == "user":
+                        content = msg.get("content", "")
+                        if isinstance(content, str):
+                            original_user_query = content
+                            break
+                        if isinstance(content, list):
+                            text_parts = [
+                                block.get("text", "")
+                                for block in content
+                                if isinstance(block, dict) and block.get("type") == "text"
+                            ]
+                            if text_parts:
+                                original_user_query = " ".join(text_parts)
+                                break
+
+                async for event in stream_generator(
+                    chat_id,
+                    redis_client,
+                    prepared_messages,
+                    llm_provider,
+                    chat.user_id,
+                    tool_user_id=tool_user_id,
+                    user_email=user_email,
+                    user_configuration=user_configuration,
+                    tool_skip_perm=tool_skip_perm,
+                    system_prompt=system_prompt,
+                    registry=registry,
+                    always_on_handlers=build_result.always_on_handlers,
+                    connector_handler=build_result.connector_handler,
+                    loaded_toolsets=loaded_toolsets,
+                    compactor=compactor,
+                    latest_compaction_summary=(
+                        latest_compaction.summary if latest_compaction else None
+                    ),
+                    summarizer_context_window_tokens=summarizer_context.tokens,
+                    memory_provider=memory_provider,
+                    memory_write_key=memory_write_key,
+                    effective_mode=effective_mode,
+                    approvals_repo=approvals_repo,
+                    pending_interventions=pending_interventions,
+                    original_user_query=original_user_query,
+                ):
+                    yield event
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:
+                logger.error(
+                    "Failed to prepare conversation for chat %s: %s",
+                    chat_id,
+                    exc,
+                    exc_info=True,
+                )
+                yield stream_error_sse(exc)
+            finally:
+                continue_compaction.set()
+                pending_tasks = [
+                    task
+                    for task in (prepare_task, start_wait_task)
+                    if task is not None and not task.done()
+                ]
+                for task in pending_tasks:
+                    task.cancel()
+                if pending_tasks:
+                    await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+        gen = generate_stream()
 
         if redis_client is None:
             return StreamingResponse(

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -11,7 +11,6 @@ import asyncio
 import json
 import logging
 import pathlib
-from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import Any, cast
 
@@ -39,14 +38,14 @@ from config import (
     SANDBOX_URL,
 )
 from db import ChatsRepository, CompactionsRepository, MessagesRepository, SkillsRepository
-from db.documents import DocumentsRepository
 from db.configuration import ConfigurationRepository
+from db.documents import DocumentsRepository
 from db.models import Chat, Source, UserConfiguration
 from db.tool_approvals import (
     ToolApproval,
+    ToolApprovalsRepository,
     ToolApprovalStatus,
     ToolApprovalType,
-    ToolApprovalsRepository,
 )
 from db.uploads import UploadsRepository
 from db.usage import UsageRepository
@@ -68,21 +67,19 @@ from streaming.generate import (
     drop_empty_assistant_messages,
     latest_intervention_tool_batch_ids,
     message_content_blocks,
+    prepare_and_stream_chat,
     repair_interrupted_tool_calls,
-    stream_generator,
     unanswered_tool_calls,
 )
 from streaming.persist import (
     EndOfStreamReason,
     end_of_stream,
     persist_and_transform,
-    sse_event,
-    stream_error_sse,
 )
 from streaming.run import (
-    SSE_HEADERS,
     _CANCEL_TTL,
     _RUN_LOCK_TTL,
+    SSE_HEADERS,
     _run_tasks_by_chat,
     cancel_key,
     clear_producer_task,
@@ -97,18 +94,18 @@ from tools import (
     DocumentToolHandler,
     PeopleSearchHandler,
     SearchToolHandler,
-    WebToolHandler,
     ToolContext,
     ToolHandler,
     ToolRegistry,
+    WebToolHandler,
 )
 from tools.connector_handler import (
     SearchOperator,
     ToolsetSummary,
     sources_from_sync_overview_response,
 )
-from tools.meta_handler import MetaToolHandler, OnLoad
 from tools.mcp_capability_handler import McpCapabilityHandler
+from tools.meta_handler import MetaToolHandler, OnLoad
 from tools.omni_tool_result import OAuthRequiredPayload
 from tools.sandbox_handler import SandboxToolHandler
 from tools.search_handler import fetch_operator_values
@@ -945,131 +942,33 @@ class StreamChatHandler:
         )
 
         parent_id = chat_messages[-1].id if chat_messages else None
-
-        async def generate_stream() -> AsyncIterator[str]:
-            compaction_started = asyncio.Event()
-            continue_compaction = asyncio.Event()
-            prepare_task: asyncio.Task | None = None
-            start_wait_task: asyncio.Task | None = None
-
-            async def on_compaction_start() -> None:
-                compaction_started.set()
-                # Do not call the summarizer until the start event has reached
-                # the stream transport and can be rendered by the client.
-                await continue_compaction.wait()
-
-            try:
-                prepare_task = asyncio.create_task(
-                    compactor.prepare_chat_conversation(
-                        chat_id=chat_id,
-                        chat_messages=chat_messages,
-                        messages=messages,
-                        compactions_repo=CompactionsRepository(),
-                        target_provider=llm_provider,
-                        tools=initial_tools,
-                        system_prompt=system_prompt,
-                        max_output_tokens=DEFAULT_MAX_TOKENS,
-                        on_compaction_start=on_compaction_start,
-                    )
-                )
-                start_wait_task = asyncio.create_task(compaction_started.wait())
-                completed, _ = await asyncio.wait(
-                    {prepare_task, start_wait_task},
-                    return_when=asyncio.FIRST_COMPLETED,
-                )
-
-                if start_wait_task in completed:
-                    try:
-                        yield sse_event("compaction_start", {})
-                    finally:
-                        continue_compaction.set()
-                else:
-                    start_wait_task.cancel()
-                    await asyncio.gather(start_wait_task, return_exceptions=True)
-                    start_wait_task = None
-
-                prepared = await prepare_task
-                prepare_task = None
-                prepared_messages = prepared.messages
-                latest_compaction = prepared.latest_compaction
-                summarizer_context = prepared.summarizer_context
-                logger.info(
-                    "Resolved context windows for chat %s: model=%s (%s), summarizer=%s (%s)",
-                    chat_id,
-                    prepared.model_context.tokens,
-                    prepared.model_context.source,
-                    summarizer_context.tokens,
-                    summarizer_context.source,
-                )
-
-                original_user_query = None
-                for msg in prepared_messages:
-                    if msg.get("role") == "user":
-                        content = msg.get("content", "")
-                        if isinstance(content, str):
-                            original_user_query = content
-                            break
-                        if isinstance(content, list):
-                            text_parts = [
-                                block.get("text", "")
-                                for block in content
-                                if isinstance(block, dict) and block.get("type") == "text"
-                            ]
-                            if text_parts:
-                                original_user_query = " ".join(text_parts)
-                                break
-
-                async for event in stream_generator(
-                    chat_id,
-                    redis_client,
-                    prepared_messages,
-                    llm_provider,
-                    chat.user_id,
-                    tool_user_id=tool_user_id,
-                    user_email=user_email,
-                    user_configuration=user_configuration,
-                    tool_skip_perm=tool_skip_perm,
-                    system_prompt=system_prompt,
-                    registry=registry,
-                    always_on_handlers=build_result.always_on_handlers,
-                    connector_handler=build_result.connector_handler,
-                    loaded_toolsets=loaded_toolsets,
-                    compactor=compactor,
-                    latest_compaction_summary=(
-                        latest_compaction.summary if latest_compaction else None
-                    ),
-                    summarizer_context_window_tokens=summarizer_context.tokens,
-                    memory_provider=memory_provider,
-                    memory_write_key=memory_write_key,
-                    effective_mode=effective_mode,
-                    approvals_repo=approvals_repo,
-                    pending_interventions=pending_interventions,
-                    original_user_query=original_user_query,
-                ):
-                    yield event
-            except asyncio.CancelledError:
-                raise
-            except Exception as exc:
-                logger.error(
-                    "Failed to prepare conversation for chat %s: %s",
-                    chat_id,
-                    exc,
-                    exc_info=True,
-                )
-                yield stream_error_sse(exc)
-            finally:
-                continue_compaction.set()
-                pending_tasks = [
-                    task
-                    for task in (prepare_task, start_wait_task)
-                    if task is not None and not task.done()
-                ]
-                for task in pending_tasks:
-                    task.cancel()
-                if pending_tasks:
-                    await asyncio.gather(*pending_tasks, return_exceptions=True)
-
-        gen = generate_stream()
+        gen = prepare_and_stream_chat(
+            chat_id=chat_id,
+            redis_client=redis_client,
+            chat_messages=chat_messages,
+            messages=messages,
+            compactor=compactor,
+            compactions_repo=CompactionsRepository(),
+            target_provider=llm_provider,
+            initial_tools=initial_tools,
+            llm_provider=llm_provider,
+            chat_user_id=chat.user_id,
+            tool_user_id=tool_user_id,
+            user_email=user_email,
+            user_configuration=user_configuration,
+            tool_skip_perm=tool_skip_perm,
+            system_prompt=system_prompt,
+            registry=registry,
+            always_on_handlers=build_result.always_on_handlers,
+            connector_handler=build_result.connector_handler,
+            loaded_toolsets=loaded_toolsets,
+            memory_provider=memory_provider,
+            memory_write_key=memory_write_key,
+            effective_mode=effective_mode,
+            approvals_repo=approvals_repo,
+            pending_interventions=pending_interventions,
+            max_output_tokens=DEFAULT_MAX_TOKENS,
+        )
 
         if redis_client is None:
             return StreamingResponse(

--- a/services/ai/services/compaction.py
+++ b/services/ai/services/compaction.py
@@ -719,6 +719,17 @@ Summary:"""
             summarizer_context=summarizer_context,
         )
 
+    def select_legacy_compaction_split(
+        self, messages: list[MessageParam]
+    ) -> CompactionSplit | None:
+        if not ENABLE_CONVERSATION_COMPACTION:
+            return None
+
+        split = self.select_compaction_split(messages)
+        if not split.old_messages:
+            return None
+        return split
+
     async def compact_conversation(
         self,
         chat_id: str,
@@ -732,11 +743,8 @@ Summary:"""
         `create_summary_result`, and `make_summary_message` so they can store the
         returned summary and anchor in Postgres.
         """
-        if not ENABLE_CONVERSATION_COMPACTION:
-            return messages
-
-        split = self.select_compaction_split(messages)
-        if not split.old_messages:
+        split = self.select_legacy_compaction_split(messages)
+        if split is None:
             return messages
 
         result = await self.create_summary_result(

--- a/services/ai/services/compaction.py
+++ b/services/ai/services/compaction.py
@@ -7,7 +7,7 @@ callers in durable compaction tables.
 
 import json
 import logging
-from collections.abc import Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -525,6 +525,7 @@ Summary:"""
         tools: list[ToolParam],
         system_prompt: str,
         max_output_tokens: int,
+        on_compaction_start: Callable[[], Awaitable[None]] | None = None,
     ) -> PreparedConversation:
         model_context = await target_provider.get_context_window_tokens()
         summarizer_context = await self.llm_provider.get_context_window_tokens()
@@ -590,6 +591,8 @@ Summary:"""
             )
 
         anchor_row = segment_rows[split.anchor_index]
+        if on_compaction_start is not None:
+            await on_compaction_start()
         summary_result = await self.create_summary_result(
             split.old_messages,
             previous_summary=(latest_compaction.summary if has_prior_summary else None),

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -10,6 +10,7 @@ import asyncio
 import json
 import logging
 from collections.abc import AsyncIterator, Iterable
+from dataclasses import dataclass
 from typing import cast
 
 from anthropic import MessageStreamEvent
@@ -68,6 +69,11 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
+@dataclass(frozen=True)
+class CompactionStart:
+    """Internal marker emitted before a forced compaction retry."""
+
+
 async def event_stream_with_context_retry(
     turn_tools: list[dict],
     conversation_messages: list[MessageParam],
@@ -78,7 +84,7 @@ async def event_stream_with_context_retry(
     compactor: ConversationCompactor,
     latest_compaction_summary: str | None,
     summarizer_context_window_tokens: int,
-) -> AsyncIterator[MessageStreamEvent]:
+) -> AsyncIterator[MessageStreamEvent | CompactionStart]:
     """Stream events from the LLM provider with one automatic compaction retry
     on context-overflow errors.
 
@@ -136,6 +142,7 @@ async def event_stream_with_context_retry(
                     "Chat %s hit provider context limit; retrying once after forced compaction",
                     chat_id,
                 )
+                yield CompactionStart()
                 conversation_messages[:] = await compactor.compact_conversation(
                     chat_id,
                     conversation_messages,
@@ -541,6 +548,10 @@ async def stream_generator(
                 cancelled = False
                 last_cancel_check_at = 0.0
                 async for event in stream:
+                    if isinstance(event, CompactionStart):
+                        yield sse_event("compaction_start", {})
+                        continue
+
                     logger.debug(f"Received event: {event} (index: {event_index})")
                     event_index += 1
 

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -19,6 +19,7 @@ from anthropic.types import (
     MessageParam,
     TextBlockParam,
     TextCitationParam,
+    ToolParam,
     ToolResultBlockParam,
     ToolUseBlockParam,
 )
@@ -29,6 +30,8 @@ from config import (
     DEFAULT_TEMPERATURE,
     DEFAULT_TOP_P,
 )
+from db.compactions import CompactionsRepository
+from db.models import ChatMessage, UserConfiguration
 from db.tool_approvals import ToolApproval, ToolApprovalStatus, ToolApprovalType
 from db.usage import UsageRepository
 from memory import MemoryMode
@@ -71,7 +74,12 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class CompactionStart:
-    """Internal marker emitted before a forced compaction retry."""
+    """Internal marker emitted before a compaction pass starts."""
+
+
+@dataclass(frozen=True)
+class CompactionEnd:
+    """Internal marker emitted after a compaction pass finishes."""
 
 
 async def event_stream_with_context_retry(
@@ -84,7 +92,7 @@ async def event_stream_with_context_retry(
     compactor: ConversationCompactor,
     latest_compaction_summary: str | None,
     summarizer_context_window_tokens: int,
-) -> AsyncIterator[MessageStreamEvent | CompactionStart]:
+) -> AsyncIterator[MessageStreamEvent | CompactionStart | CompactionEnd]:
     """Stream events from the LLM provider with one automatic compaction retry
     on context-overflow errors.
 
@@ -142,13 +150,20 @@ async def event_stream_with_context_retry(
                     "Chat %s hit provider context limit; retrying once after forced compaction",
                     chat_id,
                 )
-                yield CompactionStart()
+                should_emit_progress = (
+                    compactor.select_legacy_compaction_split(conversation_messages)
+                    is not None
+                )
+                if should_emit_progress:
+                    yield CompactionStart()
                 conversation_messages[:] = await compactor.compact_conversation(
                     chat_id,
                     conversation_messages,
                     previous_summary=latest_compaction_summary,
                     summarizer_context_window_tokens=summarizer_context_window_tokens,
                 )
+                if should_emit_progress:
+                    yield CompactionEnd()
                 continue
             raise
 
@@ -353,6 +368,164 @@ def oauth_event_from_approval(approval: ToolApproval) -> OAuthRequiredEvent:
 
 
 # ---------------------------------------------------------------------------
+# Prepared chat stream helper
+# ---------------------------------------------------------------------------
+
+
+async def prepare_and_stream_chat(
+    *,
+    chat_id: str,
+    redis_client,
+    chat_messages: list[ChatMessage],
+    messages: list[MessageParam],
+    compactor: ConversationCompactor,
+    compactions_repo: CompactionsRepository,
+    target_provider: LLMProvider,
+    initial_tools: list[ToolParam],
+    llm_provider: LLMProvider,
+    chat_user_id: str,
+    tool_user_id: str | None = None,
+    user_email: str | None = None,
+    user_configuration: UserConfiguration | None = None,
+    tool_skip_perm: bool = False,
+    system_prompt: str,
+    registry: ToolRegistry,
+    always_on_handlers: list[ToolHandler],
+    connector_handler: ConnectorToolHandler | None,
+    loaded_toolsets: set[str],
+    memory_provider=None,
+    memory_write_key: str | None = None,
+    effective_mode=MemoryMode.OFF,
+    approvals_repo=None,
+    pending_interventions: list[ToolApproval] | None = None,
+    max_output_tokens: int = DEFAULT_MAX_TOKENS,
+) -> AsyncIterator[str]:
+    compaction_started = asyncio.Event()
+    continue_compaction = asyncio.Event()
+    prepare_task: asyncio.Task | None = None
+    start_wait_task: asyncio.Task | None = None
+    emitted_compaction_start = False
+
+    async def on_compaction_start() -> None:
+        compaction_started.set()
+        await continue_compaction.wait()
+
+    try:
+        prepare_task = asyncio.create_task(
+            compactor.prepare_chat_conversation(
+                chat_id=chat_id,
+                chat_messages=chat_messages,
+                messages=messages,
+                compactions_repo=compactions_repo,
+                target_provider=target_provider,
+                tools=initial_tools,
+                system_prompt=system_prompt,
+                max_output_tokens=max_output_tokens,
+                on_compaction_start=on_compaction_start,
+            )
+        )
+        start_wait_task = asyncio.create_task(compaction_started.wait())
+        completed, _ = await asyncio.wait(
+            {prepare_task, start_wait_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+
+        if start_wait_task in completed:
+            emitted_compaction_start = True
+            try:
+                yield sse_event("compaction_start", {})
+            finally:
+                continue_compaction.set()
+        else:
+            start_wait_task.cancel()
+            await asyncio.gather(start_wait_task, return_exceptions=True)
+            start_wait_task = None
+
+        prepared = await prepare_task
+        prepare_task = None
+        if emitted_compaction_start:
+            yield sse_event("compaction_end", {})
+        prepared_messages = prepared.messages
+        latest_compaction = prepared.latest_compaction
+        summarizer_context = prepared.summarizer_context
+        logger.info(
+            "Resolved context windows for chat %s: model=%s (%s), summarizer=%s (%s)",
+            chat_id,
+            prepared.model_context.tokens,
+            prepared.model_context.source,
+            summarizer_context.tokens,
+            summarizer_context.source,
+        )
+
+        original_user_query = None
+        for msg in prepared_messages:
+            if msg.get("role") == "user":
+                content = msg.get("content", "")
+                if isinstance(content, str):
+                    original_user_query = content
+                    break
+                if isinstance(content, list):
+                    text_parts = [
+                        block.get("text", "")
+                        for block in content
+                        if isinstance(block, dict) and block.get("type") == "text"
+                    ]
+                    if text_parts:
+                        original_user_query = " ".join(text_parts)
+                        break
+
+        async for event in stream_generator(
+            chat_id,
+            redis_client,
+            prepared_messages,
+            llm_provider,
+            chat_user_id,
+            tool_user_id=tool_user_id,
+            user_email=user_email,
+            user_configuration=user_configuration,
+            tool_skip_perm=tool_skip_perm,
+            system_prompt=system_prompt,
+            registry=registry,
+            always_on_handlers=always_on_handlers,
+            connector_handler=connector_handler,
+            loaded_toolsets=loaded_toolsets,
+            compactor=compactor,
+            latest_compaction_summary=(
+                latest_compaction.summary if latest_compaction else None
+            ),
+            summarizer_context_window_tokens=summarizer_context.tokens,
+            memory_provider=memory_provider,
+            memory_write_key=memory_write_key,
+            effective_mode=effective_mode,
+            approvals_repo=approvals_repo,
+            pending_interventions=pending_interventions,
+            original_user_query=original_user_query,
+        ):
+            yield event
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:
+        logger.error(
+            "Failed to prepare conversation for chat %s: %s",
+            chat_id,
+            exc,
+            exc_info=True,
+        )
+        yield stream_error_sse(exc)
+    finally:
+        continue_compaction.set()
+        pending_tasks = [
+            task
+            for task in (prepare_task, start_wait_task)
+            if task is not None and not task.done()
+        ]
+        for task in pending_tasks:
+            task.cancel()
+        if pending_tasks:
+            await asyncio.gather(*pending_tasks, return_exceptions=True)
+
+
+# ---------------------------------------------------------------------------
 # The main generator
 # ---------------------------------------------------------------------------
 
@@ -550,6 +723,9 @@ async def stream_generator(
                 async for event in stream:
                     if isinstance(event, CompactionStart):
                         yield sse_event("compaction_start", {})
+                        continue
+                    if isinstance(event, CompactionEnd):
+                        yield sse_event("compaction_end", {})
                         continue
 
                     logger.debug(f"Received event: {event} (index: {event_index})")

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -2498,6 +2498,7 @@ class TestStandaloneEndpoints:
         assert any(
             et in ("end_of_stream", "stream_error") for et, _, _ in events
         ), "No terminal event after context-overflow retry"
+        assert any(et == "compaction_start" for et, _, _ in events)
 
         # The LLM should have been called twice: first fails, second succeeds
         assert (

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -2498,7 +2498,7 @@ class TestStandaloneEndpoints:
         assert any(
             et in ("end_of_stream", "stream_error") for et, _, _ in events
         ), "No terminal event after context-overflow retry"
-        assert any(et == "compaction_start" for et, _, _ in events)
+        assert not any(et == "compaction_start" for et, _, _ in events)
 
         # The LLM should have been called twice: first fails, second succeeds
         assert (

--- a/services/ai/tests/integration/test_compaction_durable.py
+++ b/services/ai/tests/integration/test_compaction_durable.py
@@ -726,7 +726,11 @@ async def test_chat_stream_api_runs_compaction_before_provider_call(db_pool):
     assert response.status_code == 200
     assert "api chat response" in response.text
     assert "event: compaction_start" in response.text
+    assert "event: compaction_end" in response.text
     assert response.text.index("event: compaction_start") < response.text.index(
+        "event: compaction_end"
+    )
+    assert response.text.index("event: compaction_end") < response.text.index(
         "event: message\n"
     )
     assert len(target_provider.recorded_messages) == 1

--- a/services/ai/tests/integration/test_compaction_durable.py
+++ b/services/ai/tests/integration/test_compaction_durable.py
@@ -725,6 +725,10 @@ async def test_chat_stream_api_runs_compaction_before_provider_call(db_pool):
 
     assert response.status_code == 200
     assert "api chat response" in response.text
+    assert "event: compaction_start" in response.text
+    assert response.text.index("event: compaction_start") < response.text.index(
+        "event: message\n"
+    )
     assert len(target_provider.recorded_messages) == 1
     provider_messages = target_provider.recorded_messages[0]
     assert "api-chat-summary" in _summary_text(provider_messages[0])

--- a/web/e2e/chat-stream.spec.ts
+++ b/web/e2e/chat-stream.spec.ts
@@ -1195,6 +1195,84 @@ test('chat keeps prior messages visible when reloaded during an active stream', 
     }
 })
 
+test('chat keeps compaction indicator visible after reload during compaction', async ({ page }) => {
+    let seeded: SeededChat | null = null
+    const fixtureName = `reload-compaction-stream-${ulid()}.sse`
+    const fixturePath = new URL(`./fixtures/${fixtureName}`, import.meta.url)
+
+    try {
+        seeded = await seedChat()
+        await authenticate(page, seeded)
+        await selectReplayFixture(page, fixtureName)
+        await writeFile(
+            fixturePath,
+            ['event: compaction_start\ndata: {}\n\n', 'event: test_sleep\ndata: 15000\n\n'].join(
+                '',
+            ),
+        )
+
+        let streamActive = false
+        await page.route(`**/api/chat/${seeded.chatId}/stream/status`, async (route) => {
+            await route.fulfill({
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({
+                    active: streamActive,
+                    running: streamActive,
+                    resumable: false,
+                    pendingApproval: false,
+                    pendingOAuth: false,
+                }),
+            })
+        })
+
+        await page.route(`**/api/chat/${seeded.chatId}/messages`, async (route) => {
+            const requestBody = (await route.request().postDataJSON()) as {
+                content: string
+                parentId?: string
+            }
+            const messageId = ulid()
+            const sql = postgres(dbConfig)
+            await sql`
+                INSERT INTO chat_messages (id, chat_id, parent_id, message_seq_num, message, content_text)
+                VALUES (
+                    ${messageId},
+                    ${seeded!.chatId},
+                    ${requestBody.parentId ?? null},
+                    2,
+                    ${sql.json({ role: 'user', content: requestBody.content })},
+                    ${requestBody.content}
+                )
+            `
+            await sql.end()
+            streamActive = true
+            await route.fulfill({
+                status: 200,
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ messageId }),
+            })
+        })
+
+        await page.goto(`/chat/${seeded.chatId}`)
+        await page.getByRole('main').getByRole('textbox').fill('Reload during compaction')
+        await page.keyboard.press('Enter')
+
+        await expect(page.getByText('Reload during compaction')).toBeVisible()
+        await expect(page.getByText('Summarizing conversation...')).toBeVisible()
+
+        await page.reload({ waitUntil: 'domcontentloaded' })
+
+        await expect(page.getByText('What tools can you use?')).toBeVisible()
+        await expect(page.getByText('Reload during compaction')).toBeVisible()
+        await expect(page.getByText('Summarizing conversation...')).toBeVisible()
+        await expect(page.locator('.omni-composer-send.rounded-full')).toBeVisible()
+        streamActive = false
+    } finally {
+        await unlink(fixturePath).catch(() => undefined)
+        await cleanupChat(seeded)
+    }
+})
+
 test('approval card can be approved after reload', async ({ page }) => {
     let seeded: SeededChat | null = null
     const fixtureName = `approval-reload-${ulid()}.sse`

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -49,7 +49,6 @@
     import { themeStore } from '$lib/themes/store.svelte'
     import { applyTheme } from '$lib/themes/engine'
     import ThemePicker from '$lib/components/theme-picker.svelte'
-    import { formatDate } from '$lib/utils/datetime'
 
     interface Props {
         data: LayoutData
@@ -58,7 +57,6 @@
 
     let { data, children }: Props = $props()
 
-    type ChatDateGroup = { key: string; label: string; items: Chat[] }
     type SerializedChat = Omit<Chat, 'createdAt' | 'updatedAt'> & {
         createdAt: string
         updatedAt: string
@@ -99,46 +97,6 @@
     )
     let recentChats = $derived<Chat[]>([...data.recentChats, ...additionalRecentChats])
     let recentHasMore = $derived(additionalRecentHasMore ?? data.recentChatsHasMore)
-    let recentChatGroups = $derived(groupChatsByDate(recentChats, data.user.configuration.timezone))
-
-    function dayKey(date: Date, zone?: string | null): string {
-        const parts = new Intl.DateTimeFormat('en-US', {
-            year: 'numeric',
-            month: '2-digit',
-            day: '2-digit',
-            timeZone: zone || undefined,
-        }).formatToParts(date)
-        const get = (type: string) => parts.find((part) => part.type === type)?.value ?? ''
-        return `${get('year')}-${get('month')}-${get('day')}`
-    }
-
-    function groupLabel(date: Date, zone?: string | null): string {
-        const today = new Date()
-        const yesterday = new Date(today)
-        yesterday.setDate(today.getDate() - 1)
-
-        const key = dayKey(date, zone)
-        if (key === dayKey(today, zone)) return 'Today'
-        if (key === dayKey(yesterday, zone)) return 'Yesterday'
-        return formatDate(date, zone)
-    }
-
-    function groupChatsByDate(items: Chat[], zone?: string | null): ChatDateGroup[] {
-        const groups: ChatDateGroup[] = []
-
-        for (const chat of items) {
-            const date = chat.updatedAt
-            const key = dayKey(date, zone)
-            let group = groups[groups.length - 1]
-            if (!group || group.key !== key) {
-                group = { key, label: groupLabel(date, zone), items: [] }
-                groups.push(group)
-            }
-            group.items.push(chat)
-        }
-
-        return groups
-    }
 
     function deserializeChat(chat: SerializedChat): Chat {
         return {
@@ -428,7 +386,7 @@
                     <!-- Starred chats -->
                     {#if data.starredChats.length > 0}
                         <p
-                            class="text-muted-foreground mt-2 p-1.5 text-xs group-data-[collapsible=icon]:hidden">
+                            class="text-muted-foreground mt-2 p-1.5 text-xs font-semibold group-data-[collapsible=icon]:hidden">
                             Starred
                         </p>
                         <SidebarMenu class="gap-1 group-data-[collapsible=icon]:hidden">
@@ -444,17 +402,11 @@
                         Recent chats
                     </p>
                     {#if recentChats.length > 0}
-                        {#each recentChatGroups as group (group.key)}
-                            <p
-                                class="text-muted-foreground mt-2 p-1.5 text-xs group-data-[collapsible=icon]:hidden">
-                                {group.label}
-                            </p>
-                            <SidebarMenu class="gap-1 group-data-[collapsible=icon]:hidden">
-                                {#each group.items as chat (chat.id)}
-                                    {@render chatItem(chat)}
-                                {/each}
-                            </SidebarMenu>
-                        {/each}
+                        <SidebarMenu class="gap-1 group-data-[collapsible=icon]:hidden">
+                            {#each recentChats as chat (chat.id)}
+                                {@render chatItem(chat)}
+                            {/each}
+                        </SidebarMenu>
                         {#if recentHasMore}
                             <Button
                                 variant="ghost"

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -288,6 +288,7 @@
     }
 
     let thinkingText = $state(defaultVerbs[0])
+    let isCompacting = $state(false)
     let thinkingVerbIndex = 0
     let thinkingRotateInterval: ReturnType<typeof setInterval> | null = null
     let thinkingSlowTimer: ReturnType<typeof setTimeout> | null = null
@@ -331,6 +332,7 @@
     }
 
     function startThinkingText() {
+        isCompacting = false
         lastToolContext = null
         thinkingVerbIndex = Math.floor(Math.random() * defaultVerbs.length)
         thinkingText = defaultVerbs[thinkingVerbIndex]
@@ -347,6 +349,7 @@
     }
 
     function stopThinkingText() {
+        isCompacting = false
         if (thinkingRotateInterval) {
             clearInterval(thinkingRotateInterval)
             thinkingRotateInterval = null
@@ -1570,6 +1573,17 @@
                 reconnectAttempts = 0
             })
 
+            eventSource.addEventListener('compaction_start', (event) => {
+                if (!isCurrentStream()) return
+                streamLastEventId = event.lastEventId || streamLastEventId
+                lastStreamEventAt = Date.now()
+                reconnectAttempts = 0
+                stopThinkingText()
+                isCompacting = true
+                thinkingText = 'Summarizing conversation'
+                updateScrollState()
+            })
+
             eventSource.addEventListener('message', (event) => {
                 if (!isCurrentStream()) return
                 streamLastEventId = event.lastEventId || streamLastEventId
@@ -1578,6 +1592,7 @@
                 try {
                     const data: MessageStreamEvent | ToolResultBlockParam = JSON.parse(event.data)
                     if (data.type === 'message_start') {
+                        if (isCompacting) startThinkingText()
                         const messageId = data.message.id
                         if (!messageId) {
                             missingStreamMessageId('message_start')

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -1584,6 +1584,15 @@
                 updateScrollState()
             })
 
+            eventSource.addEventListener('compaction_end', (event) => {
+                if (!isCurrentStream()) return
+                streamLastEventId = event.lastEventId || streamLastEventId
+                lastStreamEventAt = Date.now()
+                reconnectAttempts = 0
+                if (isCompacting) startThinkingText()
+                updateScrollState()
+            })
+
             eventSource.addEventListener('message', (event) => {
                 if (!isCurrentStream()) return
                 streamLastEventId = event.lastEventId || streamLastEventId

--- a/web/src/routes/api/chat/[chatId]/stream/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/stream/+server.ts
@@ -131,6 +131,13 @@ function replayStreamResponse(sampleStream: string, chatId: string): Response {
                 for (const event of events) {
                     if (cancelled) return
                     let eventToSend = event
+                    if (event.startsWith('event: test_sleep')) {
+                        const durationMs = Number.parseInt(eventData(event) ?? '0', 10)
+                        for (let elapsed = 0; elapsed < durationMs && !cancelled; elapsed += 100) {
+                            await sleep(Math.min(100, durationMs - elapsed))
+                        }
+                        continue
+                    }
                     if (event.startsWith('event: message_id')) {
                         eventToSend = `event: message_id\ndata: sample-${runId}-${messageIdCounter++}`
                     } else if (event.startsWith('event: save_message')) {
@@ -492,7 +499,7 @@ export const GET: RequestHandler = async ({ params, locals, cookies, request, ur
                                         controller.enqueue(encoder.encode(redactedEvent))
                                         continue
                                     }
-                                } catch (parseError) {
+                                } catch {
                                     // If parsing fails, forward as-is
                                 }
                             }


### PR DESCRIPTION
- Restore a simple newest-first chat history, keeping starred chats separately ordered above recent chats.
- Emit compaction status events so long-running conversation summarization no longer appears idle.
- Show “Summarizing conversation...” during compaction and resume the normal activity indicator afterward.
- Add integration coverage for proactive and context-overflow compaction events.