### PR TITLE
feat(skills): add user skill library

### DIFF
--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -43,7 +43,7 @@ from config import (
     DEFAULT_TOP_P,
     SANDBOX_URL,
 )
-from db import CompactionsRepository
+from db import CompactionsRepository, SkillsRepository
 from db.configuration import ConfigurationRepository
 from db.documents import DocumentsRepository
 from db.models import Source, UserConfiguration
@@ -290,7 +290,10 @@ async def _build_agent_registry(
         skills_dir=skills_dir,
         searcher_client=app_state.searcher_tool.client,
         connector_manager_url=CONNECTOR_MANAGER_URL,
+        skills_repository=SkillsRepository(),
+        skill_user_id=agent.user_id,
     )
+    await skill_handler.refresh_library_skills()
     await skill_handler.refresh_connector_skills()
     if skill_handler.has_skills():
         await skill_handler.publish_skill_capabilities()

--- a/services/ai/db/__init__.py
+++ b/services/ai/db/__init__.py
@@ -1,29 +1,25 @@
-from .connection import get_db_pool, close_db_pool
-from .models import User, Chat, ChatMessage
-from .users import UsersRepository
 from .chats import ChatsRepository
-from .messages import MessagesRepository
-from .embedding_providers import EmbeddingProvidersRepository, EmbeddingProviderRecord
-from .documents import DocumentsRepository, Document, ContentBlob
-from .embedding_queue import EmbeddingQueueRepository, EmbeddingQueueItem, QueueStatus
-from .embeddings import EmbeddingsRepository, Embedding
-from .model_providers import (
-    ModelProvidersRepository,
-    ModelProviderRecord,
-    ModelsRepository,
-)
-from .models import ModelRecord, Source
-from .usage import UsageRepository, UsageSummary
+from .compactions import AgentRunCompaction, ChatCompaction, CompactionsRepository
 from .configuration import ConfigurationRepository
-from .compactions import CompactionsRepository, ChatCompaction, AgentRunCompaction
-from .web_search_providers import WebSearchProvidersRepository, WebSearchProviderRecord
-from .web_fetch_providers import WebFetchProvidersRepository, WebFetchProviderRecord
+from .connection import close_db_pool, get_db_pool
+from .documents import ContentBlob, Document, DocumentsRepository
+from .embedding_providers import EmbeddingProviderRecord, EmbeddingProvidersRepository
+from .embedding_queue import EmbeddingQueueItem, EmbeddingQueueRepository, QueueStatus
+from .embeddings import Embedding, EmbeddingsRepository
+from .messages import MessagesRepository
+from .model_providers import ModelProviderRecord, ModelProvidersRepository, ModelsRepository
+from .models import Chat, ChatMessage, ModelRecord, Source, User
+from .skills import Skill, SkillsRepository
 from .tool_approvals import (
     ToolApproval,
     ToolApprovalStatus,
     ToolApprovalType,
     ToolApprovalsRepository,
 )
+from .usage import UsageRepository, UsageSummary
+from .users import UsersRepository
+from .web_fetch_providers import WebFetchProviderRecord, WebFetchProvidersRepository
+from .web_search_providers import WebSearchProviderRecord, WebSearchProvidersRepository
 
 __all__ = [
     "get_db_pool",
@@ -63,4 +59,6 @@ __all__ = [
     "ToolApprovalStatus",
     "ToolApprovalType",
     "ToolApprovalsRepository",
+    "SkillsRepository",
+    "Skill",
 ]

--- a/services/ai/db/skills.py
+++ b/services/ai/db/skills.py
@@ -24,6 +24,7 @@ class Skill:
     id: str
     owner_id: str
     name: str
+    description: str
     instructions: str
     visibility: Literal["private", "public"]
     created_at: datetime
@@ -46,7 +47,7 @@ class SkillsRepository:
         pool = await self._get_pool()
         rows = await pool.fetch(
             """
-            SELECT id, owner_id, name, instructions, visibility,
+            SELECT id, owner_id, name, description, instructions, visibility,
                    created_at, updated_at
             FROM skills
             WHERE owner_id = $1 OR visibility = 'public'
@@ -61,7 +62,7 @@ class SkillsRepository:
         pool = await self._get_pool()
         row = await pool.fetchrow(
             """
-            SELECT id, owner_id, name, instructions, visibility,
+            SELECT id, owner_id, name, description, instructions, visibility,
                    created_at, updated_at
             FROM skills
             WHERE id = $1

--- a/services/ai/db/skills.py
+++ b/services/ai/db/skills.py
@@ -1,0 +1,73 @@
+"""Read-only repository for user-created library skills.
+
+Only the omni-web service writes to the skills table. This repository
+provides read-only access for the AI service to discover skills visible
+to a given user (public skills + the user's own private skills).
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Literal
+
+from asyncpg import Pool
+
+from .connection import get_db_pool
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class Skill:
+    id: str
+    owner_id: str
+    name: str
+    instructions: str
+    visibility: Literal["private", "public"]
+    created_at: datetime
+    updated_at: datetime
+
+
+class SkillsRepository:
+    """Read-only access to user-created library skills."""
+
+    def __init__(self, pool: Pool | None = None):
+        self.pool = pool
+
+    async def _get_pool(self) -> Pool:
+        if self.pool:
+            return self.pool
+        return await get_db_pool()
+
+    async def list_visible(self, user_id: str) -> list[Skill]:
+        """Return skills visible to the given user: public + user's own private."""
+        pool = await self._get_pool()
+        rows = await pool.fetch(
+            """
+            SELECT id, owner_id, name, instructions, visibility,
+                   created_at, updated_at
+            FROM skills
+            WHERE owner_id = $1 OR visibility = 'public'
+            ORDER BY updated_at DESC
+            """,
+            user_id,
+        )
+        return [Skill(**dict(row)) for row in rows]
+
+    async def get_visible_by_id(self, skill_id: str, user_id: str) -> Skill | None:
+        """Get a single skill if visible to the given user."""
+        pool = await self._get_pool()
+        row = await pool.fetchrow(
+            """
+            SELECT id, owner_id, name, instructions, visibility,
+                   created_at, updated_at
+            FROM skills
+            WHERE id = $1
+              AND (owner_id = $2 OR visibility = 'public')
+            """,
+            skill_id,
+            user_id,
+        )
+        return Skill(**dict(row)) if row else None

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -37,7 +37,7 @@ from config import (
     DEFAULT_TOP_P,
     SANDBOX_URL,
 )
-from db import ChatsRepository, CompactionsRepository, MessagesRepository
+from db import ChatsRepository, CompactionsRepository, MessagesRepository, SkillsRepository
 from db.documents import DocumentsRepository
 from db.configuration import ConfigurationRepository
 from db.models import Chat, Source, UserConfiguration
@@ -348,7 +348,10 @@ async def _build_registry(
         skills_dir=skills_dir,
         searcher_client=request.app.state.searcher_tool.client,
         connector_manager_url=CONNECTOR_MANAGER_URL,
+        skills_repository=SkillsRepository(),
+        skill_user_id=chat.user_id,
     )
+    await skill_handler.refresh_library_skills()
     await skill_handler.refresh_connector_skills()
     if skill_handler.has_skills():
         await skill_handler.publish_skill_capabilities()
@@ -453,7 +456,10 @@ async def _build_agent_chat_registry(
         skills_dir=skills_dir,
         searcher_client=request.app.state.searcher_tool.client,
         connector_manager_url=CONNECTOR_MANAGER_URL,
+        skills_repository=SkillsRepository(),
+        skill_user_id=agent.user_id,
     )
+    await skill_handler.refresh_library_skills()
     await skill_handler.refresh_connector_skills()
     if skill_handler.has_skills():
         await skill_handler.publish_skill_capabilities()

--- a/services/ai/tests/integration/test_compaction_durable.py
+++ b/services/ai/tests/integration/test_compaction_durable.py
@@ -199,6 +199,9 @@ class _DummySearcherClient:
     async def upsert_capabilities(self, request):
         return None
 
+    async def sync_capabilities(self, request):
+        return None
+
     async def search_capabilities(self, request):
         return SimpleNamespace(results=[])
 

--- a/services/ai/tests/integration/test_dynamic_sources.py
+++ b/services/ai/tests/integration/test_dynamic_sources.py
@@ -221,6 +221,18 @@ class _FakeCapabilitySearcherClient:
         self.capabilities = list(by_id.values())
         return type("Resp", (), {"upserted": len(request.capabilities)})()
 
+    async def sync_capabilities(self, request):
+        by_id = {
+            capability.id: capability
+            for capability in self.capabilities
+            if capability.publisher_id != request.publisher_id
+            or capability.capability_type != request.capability_type
+        }
+        for capability in request.capabilities:
+            by_id[capability.id] = capability
+        self.capabilities = list(by_id.values())
+        return type("Resp", (), {"upserted": len(request.capabilities), "deleted": 0})()
+
     async def search_capabilities(self, request):
         query = request.query.lower()
         results = []

--- a/services/ai/tests/integration/test_model_prompt_and_tools.py
+++ b/services/ai/tests/integration/test_model_prompt_and_tools.py
@@ -50,6 +50,10 @@ class _RecordingSearcherClient:
         self.upsert_calls.append(request)
         return await self.inner.upsert_capabilities(request)
 
+    async def sync_capabilities(self, request):
+        self.upsert_calls.append(request)
+        return await self.inner.sync_capabilities(request)
+
     async def search_capabilities(self, request):
         self.search_calls.append(request)
         try:

--- a/services/ai/tests/integration/test_skills_repository.py
+++ b/services/ai/tests/integration/test_skills_repository.py
@@ -1,0 +1,99 @@
+"""Integration tests for AI read-only SkillsRepository."""
+
+from __future__ import annotations
+
+import pytest
+from ulid import ULID
+
+from db.skills import SkillsRepository
+from tests.helpers import create_test_user
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.mark.asyncio
+async def test_list_visible_returns_own_private_and_public_skills(db_pool):
+    user1, _ = await create_test_user(db_pool)
+    user2, _ = await create_test_user(db_pool)
+
+    # Seed skills directly (web service normally owns writes)
+    async with db_pool.acquire() as conn:
+        # user1 private skill
+        p1 = str(ULID())
+        await conn.execute(
+            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
+               VALUES ($1, $2, 'User1 Private', 'Only user1', 'private')""",
+            p1, user1,
+        )
+        # user1 public skill
+        pub1 = str(ULID())
+        await conn.execute(
+            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
+               VALUES ($1, $2, 'User1 Public', 'Everyone sees this', 'public')""",
+            pub1, user1,
+        )
+        # user2 public skill
+        pub2 = str(ULID())
+        await conn.execute(
+            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
+               VALUES ($1, $2, 'User2 Public', 'Also public', 'public')""",
+            pub2, user2,
+        )
+        # user2 private skill
+        p2 = str(ULID())
+        await conn.execute(
+            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
+               VALUES ($1, $2, 'User2 Private', 'Only user2', 'private')""",
+            p2, user2,
+        )
+
+    repo = SkillsRepository(pool=db_pool)
+
+    # user1 sees: own private, own public, user2's public (3 skills)
+    visible1 = await repo.list_visible(user1)
+    names1 = sorted(s.name for s in visible1)
+    assert names1 == ['User1 Private', 'User1 Public', 'User2 Public']
+
+    # user2 sees: own private, own public, user1's public (3 skills)
+    visible2 = await repo.list_visible(user2)
+    names2 = sorted(s.name for s in visible2)
+    assert names2 == ['User2 Private', 'User2 Public', 'User1 Public']
+
+
+@pytest.mark.asyncio
+async def test_get_visible_by_id_respects_visibility(db_pool):
+    user1, _ = await create_test_user(db_pool)
+    user2, _ = await create_test_user(db_pool)
+
+    async with db_pool.acquire() as conn:
+        private_id = str(ULID())
+        await conn.execute(
+            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
+               VALUES ($1, $2, 'Secret', 'Shhh', 'private')""",
+            private_id, user1,
+        )
+        public_id = str(ULID())
+        await conn.execute(
+            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
+               VALUES ($1, $2, 'Open', 'Available', 'public')""",
+            public_id, user1,
+        )
+
+    repo = SkillsRepository(pool=db_pool)
+
+    # Owner can see both
+    assert await repo.get_visible_by_id(private_id, user1) is not None
+    assert await repo.get_visible_by_id(public_id, user1) is not None
+
+    # Other user can only see public
+    assert await repo.get_visible_by_id(private_id, user2) is None
+    assert await repo.get_visible_by_id(public_id, user2) is not None
+
+
+@pytest.mark.asyncio
+async def test_get_visible_by_id_returns_none_for_nonexistent(db_pool):
+    user1, _ = await create_test_user(db_pool)
+    repo = SkillsRepository(pool=db_pool)
+
+    result = await repo.get_visible_by_id(str(ULID()), user1)
+    assert result is None

--- a/services/ai/tests/integration/test_skills_repository.py
+++ b/services/ai/tests/integration/test_skills_repository.py
@@ -21,29 +21,29 @@ async def test_list_visible_returns_own_private_and_public_skills(db_pool):
         # user1 private skill
         p1 = str(ULID())
         await conn.execute(
-            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
-               VALUES ($1, $2, 'User1 Private', 'Only user1', 'private')""",
+            """INSERT INTO skills (id, owner_id, name, description, instructions, visibility)
+               VALUES ($1, $2, 'User1 Private', 'Only user1', 'Only user1', 'private')""",
             p1, user1,
         )
         # user1 public skill
         pub1 = str(ULID())
         await conn.execute(
-            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
-               VALUES ($1, $2, 'User1 Public', 'Everyone sees this', 'public')""",
+            """INSERT INTO skills (id, owner_id, name, description, instructions, visibility)
+               VALUES ($1, $2, 'User1 Public', 'Everyone sees this', 'Everyone sees this', 'public')""",
             pub1, user1,
         )
         # user2 public skill
         pub2 = str(ULID())
         await conn.execute(
-            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
-               VALUES ($1, $2, 'User2 Public', 'Also public', 'public')""",
+            """INSERT INTO skills (id, owner_id, name, description, instructions, visibility)
+               VALUES ($1, $2, 'User2 Public', 'Also public', 'Also public', 'public')""",
             pub2, user2,
         )
         # user2 private skill
         p2 = str(ULID())
         await conn.execute(
-            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
-               VALUES ($1, $2, 'User2 Private', 'Only user2', 'private')""",
+            """INSERT INTO skills (id, owner_id, name, description, instructions, visibility)
+               VALUES ($1, $2, 'User2 Private', 'Only user2', 'Only user2', 'private')""",
             p2, user2,
         )
 
@@ -53,6 +53,9 @@ async def test_list_visible_returns_own_private_and_public_skills(db_pool):
     visible1 = await repo.list_visible(user1)
     names1 = sorted(s.name for s in visible1)
     assert names1 == ['User1 Private', 'User1 Public', 'User2 Public']
+    descriptions1 = {skill.name: skill.description for skill in visible1}
+    assert descriptions1["User1 Private"] == "Only user1"
+    assert descriptions1["User2 Public"] == "Also public"
 
     # user2 sees: own private, own public, user1's public (3 skills)
     visible2 = await repo.list_visible(user2)
@@ -68,22 +71,26 @@ async def test_get_visible_by_id_respects_visibility(db_pool):
     async with db_pool.acquire() as conn:
         private_id = str(ULID())
         await conn.execute(
-            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
-               VALUES ($1, $2, 'Secret', 'Shhh', 'private')""",
+            """INSERT INTO skills (id, owner_id, name, description, instructions, visibility)
+               VALUES ($1, $2, 'Secret', 'Shhh', 'Shhh', 'private')""",
             private_id, user1,
         )
         public_id = str(ULID())
         await conn.execute(
-            """INSERT INTO skills (id, owner_id, name, instructions, visibility)
-               VALUES ($1, $2, 'Open', 'Available', 'public')""",
+            """INSERT INTO skills (id, owner_id, name, description, instructions, visibility)
+               VALUES ($1, $2, 'Open', 'Available', 'Available', 'public')""",
             public_id, user1,
         )
 
     repo = SkillsRepository(pool=db_pool)
 
     # Owner can see both
-    assert await repo.get_visible_by_id(private_id, user1) is not None
-    assert await repo.get_visible_by_id(public_id, user1) is not None
+    private_skill = await repo.get_visible_by_id(private_id, user1)
+    public_skill = await repo.get_visible_by_id(public_id, user1)
+    assert private_skill is not None
+    assert private_skill.description == "Shhh"
+    assert public_skill is not None
+    assert public_skill.description == "Available"
 
     # Other user can only see public
     assert await repo.get_visible_by_id(private_id, user2) is None

--- a/services/ai/tests/unit/test_mcp_capability_handler.py
+++ b/services/ai/tests/unit/test_mcp_capability_handler.py
@@ -22,6 +22,10 @@ class _FakeSearcherClient:
         self.upserts.append(request)
         return type("Resp", (), {"upserted": len(request.capabilities)})()
 
+    async def sync_capabilities(self, request):
+        self.upserts.append(request)
+        return type("Resp", (), {"upserted": len(request.capabilities), "deleted": 0})()
+
     async def search_capabilities(self, request):
         self.searches.append(request)
         results = [

--- a/services/ai/tests/unit/test_meta_handler.py
+++ b/services/ai/tests/unit/test_meta_handler.py
@@ -60,6 +60,10 @@ class _FakeSearcherClient:
         self.upserts.append(request)
         return type("Resp", (), {"upserted": len(request.capabilities)})()
 
+    async def sync_capabilities(self, request):
+        self.upserts.append(request)
+        return type("Resp", (), {"upserted": len(request.capabilities), "deleted": 0})()
+
     async def search_capabilities(self, request):
         self.searches.append(request)
         return CapabilitySearchResponse(

--- a/services/ai/tests/unit/test_skill_handler.py
+++ b/services/ai/tests/unit/test_skill_handler.py
@@ -25,6 +25,10 @@ class _FakeSearcherClient:
         self.upserts.append(request)
         return type("Resp", (), {"upserted": len(request.capabilities)})()
 
+    async def sync_capabilities(self, request):
+        self.upserts.append(request)
+        return type("Resp", (), {"upserted": len(request.capabilities), "deleted": 0})()
+
     async def search_capabilities(self, request):
         self.searches.append(request)
         results = []

--- a/services/ai/tests/unit/test_skill_handler.py
+++ b/services/ai/tests/unit/test_skill_handler.py
@@ -233,9 +233,11 @@ def test_google_workspace_connector_skills_do_not_instruct_local_gws_auth_or_ins
 @dataclass
 class _FakeSkill:
     """Minimal stand-in matching the fields SkillHandler reads from Skill."""
+
     id: str
     owner_id: str
     name: str
+    description: str
     instructions: str
     visibility: str
     created_at: datetime.datetime
@@ -273,6 +275,7 @@ async def test_library_skill_loads_via_namespaced_id(tmp_path):
         id=skill_id,
         owner_id="user-1",
         name="My Library Skill",
+        description="Do the thing quickly.",
         instructions="# Library Skill\n\nDo the thing.",
         visibility="public",
         created_at=datetime.datetime.now(),
@@ -306,6 +309,7 @@ async def test_library_skill_not_loadable_by_non_owner_when_private(tmp_path):
         id="01J00000000000000000000001",
         owner_id="user-1",
         name="Private Skill",
+        description="Secret description.",
         instructions="Secret instructions",
         visibility="private",
         created_at=datetime.datetime.now(),
@@ -340,6 +344,7 @@ async def test_library_skills_included_in_search_allowed_ids(tmp_path):
         id="01J00000000000000000000002",
         owner_id="user-1",
         name="Public Library Skill",
+        description="Public library description.",
         instructions="Public library instructions",
         visibility="public",
         created_at=datetime.datetime.now(),
@@ -376,6 +381,7 @@ async def test_library_skills_published_as_capabilities(tmp_path):
         id="01J00000000000000000000003",
         owner_id="user-1",
         name="Lib Skill",
+        description="Lib description.",
         instructions="Lib instructions",
         visibility="public",
         created_at=datetime.datetime.now(),
@@ -409,6 +415,7 @@ async def test_library_skill_search_returns_exact_library_id(tmp_path):
                 id=skill_id,
                 owner_id="user-1",
                 name="PR Review",
+                description="Review pull requests with a checklist.",
                 instructions="Review pull requests with a checklist.",
                 visibility="public",
                 created_at=datetime.datetime.now(),
@@ -445,6 +452,7 @@ async def test_library_skill_uses_configured_owner_when_context_has_no_user(tmp_
                 id=skill_id,
                 owner_id="agent-owner",
                 name="Owner Private Skill",
+                description="Private owner description.",
                 instructions="Private owner instructions.",
                 visibility="private",
                 created_at=datetime.datetime.now(),
@@ -467,3 +475,74 @@ async def test_library_skill_uses_configured_owner_when_context_has_no_user(tmp_
 
     assert not result.is_error
     assert result.content[0]["text"] == "Private owner instructions."
+
+
+@pytest.mark.asyncio
+async def test_library_skill_capability_uses_explicit_description(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    searcher = _FakeSearcherClient(include_excel=False)
+    skill_id = "01J00000000000000000000006"
+    lib_skill = _FakeSkill(
+        id=skill_id,
+        owner_id="user-1",
+        name="Explicit Desc Skill",
+        description="Explicit short description for this skill.",
+        instructions="# Detailed Instructions\n\nStep-by-step guide.",
+        visibility="public",
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+    fake_repo = _FakeSkillsRepository(skills=[lib_skill])
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=searcher,
+        skills_repository=fake_repo,
+        skill_user_id="user-1",
+    )
+
+    await handler.publish_skill_capabilities()
+
+    assert searcher.upserts
+    cap = next(c for c in searcher.upserts[0].capabilities if c.id == f"skill:library:{skill_id}")
+    assert cap.description == "Explicit short description for this skill."
+    assert cap.data["description"] == "Explicit short description for this skill."
+    assert "Explicit short description for this skill." in cap.search_text
+    assert "# Detailed Instructions" not in cap.description
+
+
+@pytest.mark.asyncio
+async def test_library_skill_search_snippet_prefers_description(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    searcher = _FakeSearcherClient(include_excel=False)
+    skill_id = "01J00000000000000000000007"
+    lib_skill = _FakeSkill(
+        id=skill_id,
+        owner_id="user-1",
+        name="Snippet Skill",
+        description="Snippet description content.",
+        instructions="Long body content that should not appear in snippet when description is available.",
+        visibility="public",
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+    fake_repo = _FakeSkillsRepository(skills=[lib_skill])
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=searcher,
+        skills_repository=fake_repo,
+        skill_user_id="user-1",
+    )
+
+    await handler.publish_skill_capabilities()
+    result = await handler.execute(
+        "skill_search",
+        {"query": "snippet"},
+        ToolContext(chat_id="c1", user_id="user-1"),
+    )
+
+    assert not result.is_error
+    text = result.content[0]["text"]
+    assert "Snippet description content." in text
+    assert "Long body content that should not appear" not in text

--- a/services/ai/tests/unit/test_skill_handler.py
+++ b/services/ai/tests/unit/test_skill_handler.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+import datetime
+from dataclasses import dataclass
 from pathlib import Path
 
 import pytest
@@ -26,7 +28,9 @@ class _FakeSearcherClient:
     async def search_capabilities(self, request):
         self.searches.append(request)
         results = []
-        if self.include_excel:
+        query = request.query.lower()
+        allowed_ids = set(request.allowed_ids or [])
+        if self.include_excel and (not allowed_ids or "skill:excel" in allowed_ids):
             results.append(
                 CapabilitySearchResult(
                     id="skill:excel",
@@ -43,7 +47,25 @@ class _FakeSearcherClient:
                     score=4.2,
                 )
             )
-        return CapabilitySearchResponse(results=results)
+        for upsert in self.upserts:
+            for capability in upsert.capabilities:
+                if allowed_ids and capability.id not in allowed_ids:
+                    continue
+                searchable = f"{capability.id} {capability.name} {capability.search_text}".lower()
+                if query not in searchable:
+                    continue
+                results.append(
+                    CapabilitySearchResult(
+                        id=capability.id,
+                        capability_type=capability.capability_type,
+                        name=capability.name,
+                        description=capability.description,
+                        search_text=capability.search_text,
+                        data=capability.data,
+                        score=3.0,
+                    )
+                )
+        return CapabilitySearchResponse(results=results[: request.limit])
 
 
 def _ctx() -> ToolContext:
@@ -197,3 +219,247 @@ def test_google_workspace_connector_skills_do_not_instruct_local_gws_auth_or_ins
         for phrase in forbidden:
             assert phrase not in text
         assert "Do not run local `gws` commands" in text
+
+
+# =============================================================================
+# Library skill tests
+# =============================================================================
+
+
+@dataclass
+class _FakeSkill:
+    """Minimal stand-in matching the fields SkillHandler reads from Skill."""
+    id: str
+    owner_id: str
+    name: str
+    instructions: str
+    visibility: str
+    created_at: datetime.datetime
+    updated_at: datetime.datetime
+
+
+class _FakeSkillsRepository:
+    """In-memory SkillsRepository that returns pre-configured library skill records."""
+
+    def __init__(self, skills: list | None = None):
+        self.skills = skills or []
+
+    async def list_visible(self, user_id: str) -> list:
+        return [
+            s for s in self.skills
+            if s.owner_id == user_id or s.visibility == "public"
+        ]
+
+    async def get_visible_by_id(self, skill_id: str, user_id: str):
+        for s in self.skills:
+            if s.id == skill_id and (s.owner_id == user_id or s.visibility == "public"):
+                return s
+        return None
+
+
+@pytest.mark.asyncio
+async def test_library_skill_loads_via_namespaced_id(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    searcher = _FakeSearcherClient()
+
+    skill_id = "01J00000000000000000000000"
+    assert len(skill_id) == 26
+    lib_skill = _FakeSkill(
+        id=skill_id,
+        owner_id="user-1",
+        name="My Library Skill",
+        instructions="# Library Skill\n\nDo the thing.",
+        visibility="public",
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+    fake_repo = _FakeSkillsRepository(skills=[lib_skill])
+
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=searcher,
+        skills_repository=fake_repo,
+    )
+
+    result = await handler.execute(
+        "load_skill",
+        {"skill": f"library:{skill_id}"},
+        ToolContext(chat_id="c1", user_id="user-1"),
+    )
+
+    assert not result.is_error
+    assert result.content[0]["text"] == "# Library Skill\n\nDo the thing."
+
+
+@pytest.mark.asyncio
+async def test_library_skill_not_loadable_by_non_owner_when_private(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    searcher = _FakeSearcherClient()
+
+    lib_skill = _FakeSkill(
+        id="01J00000000000000000000001",
+        owner_id="user-1",
+        name="Private Skill",
+        instructions="Secret instructions",
+        visibility="private",
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+    fake_repo = _FakeSkillsRepository(skills=[lib_skill])
+
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=searcher,
+        skills_repository=fake_repo,
+    )
+
+    # Non-owner user-2 tries to load user-1's private skill
+    result = await handler.execute(
+        "load_skill",
+        {"skill": "library:01J00000000000000000000001"},
+        ToolContext(chat_id="c1", user_id="user-2"),
+    )
+
+    assert result.is_error
+    assert "Unknown skill" in result.content[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_library_skills_included_in_search_allowed_ids(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    (skills_dir / "excel.md").write_text("# Excel Skill\n\nInspect spreadsheets.")
+
+    lib_skill = _FakeSkill(
+        id="01J00000000000000000000002",
+        owner_id="user-1",
+        name="Public Library Skill",
+        instructions="Public library instructions",
+        visibility="public",
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+    fake_repo = _FakeSkillsRepository(skills=[lib_skill])
+
+    searcher = _FakeSearcherClient()
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=searcher,
+        skills_repository=fake_repo,
+    )
+
+    await handler.execute(
+        "skill_search",
+        {"query": "spreadsheet"},
+        ToolContext(chat_id="c1", user_id="user-1"),
+    )
+
+    # The library skills should be in the allowed_ids
+    assert len(searcher.searches) >= 1
+    allowed_ids = searcher.searches[0].allowed_ids
+    assert "skill:library:01J00000000000000000000002" in allowed_ids
+
+
+@pytest.mark.asyncio
+async def test_library_skills_published_as_capabilities(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    searcher = _FakeSearcherClient()
+
+    lib_skill = _FakeSkill(
+        id="01J00000000000000000000003",
+        owner_id="user-1",
+        name="Lib Skill",
+        instructions="Lib instructions",
+        visibility="public",
+        created_at=datetime.datetime.now(),
+        updated_at=datetime.datetime.now(),
+    )
+    fake_repo = _FakeSkillsRepository(skills=[lib_skill])
+
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=searcher,
+        skills_repository=fake_repo,
+    )
+
+    await handler.refresh_library_skills("user-1")
+    await handler.publish_skill_capabilities()
+
+    assert searcher.upserts
+    capability_ids = {c.id for c in searcher.upserts[0].capabilities}
+    assert "skill:library:01J00000000000000000000003" in capability_ids
+
+
+@pytest.mark.asyncio
+async def test_library_skill_search_returns_exact_library_id(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    searcher = _FakeSearcherClient(include_excel=False)
+    skill_id = "01J00000000000000000000004"
+    fake_repo = _FakeSkillsRepository(
+        skills=[
+            _FakeSkill(
+                id=skill_id,
+                owner_id="user-1",
+                name="PR Review",
+                instructions="Review pull requests with a checklist.",
+                visibility="public",
+                created_at=datetime.datetime.now(),
+                updated_at=datetime.datetime.now(),
+            )
+        ]
+    )
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=searcher,
+        skills_repository=fake_repo,
+        skill_user_id="user-1",
+    )
+
+    await handler.publish_skill_capabilities()
+    result = await handler.execute(
+        "skill_search",
+        {"query": f"library:{skill_id}"},
+        ToolContext(chat_id="c1", user_id="user-1"),
+    )
+
+    assert not result.is_error
+    assert f"library:{skill_id} — PR Review" in result.content[0]["text"]
+
+
+@pytest.mark.asyncio
+async def test_library_skill_uses_configured_owner_when_context_has_no_user(tmp_path):
+    skills_dir = tmp_path / "skills"
+    skills_dir.mkdir()
+    skill_id = "01J00000000000000000000005"
+    fake_repo = _FakeSkillsRepository(
+        skills=[
+            _FakeSkill(
+                id=skill_id,
+                owner_id="agent-owner",
+                name="Owner Private Skill",
+                instructions="Private owner instructions.",
+                visibility="private",
+                created_at=datetime.datetime.now(),
+                updated_at=datetime.datetime.now(),
+            )
+        ]
+    )
+    handler = SkillHandler(
+        skills_dir,
+        searcher_client=_FakeSearcherClient(include_excel=False),
+        skills_repository=fake_repo,
+        skill_user_id="agent-owner",
+    )
+
+    result = await handler.execute(
+        "load_skill",
+        {"skill": f"library:{skill_id}"},
+        ToolContext(chat_id="agent-run", user_id=None, skip_permission_check=True),
+    )
+
+    assert not result.is_error
+    assert result.content[0]["text"] == "Private owner instructions."

--- a/services/ai/tools/mcp_capability_handler.py
+++ b/services/ai/tools/mcp_capability_handler.py
@@ -18,7 +18,7 @@ from db.models import Source
 from tools.connector_handler import SourceFilter, sources_from_sync_overview_response
 from tools.registry import ToolContext, ToolResult
 from tools.searcher_client import (
-    CapabilitiesUpsertRequest,
+    CapabilitiesSyncRequest,
     CapabilitySearchRequest,
     CapabilityUpsert,
     SearcherClient,
@@ -29,7 +29,6 @@ logger = logging.getLogger(__name__)
 _TOOL_NAMES = {"resource_search", "load_resource", "prompt_search", "load_prompt"}
 _DEFAULT_LIMIT = 10
 _MAX_LIMIT = 25
-_CAPABILITY_UPSERT_BATCH_SIZE = 500
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 _RESOURCE_INLINE_MAX_BYTES = 24_000
 _RESOURCE_PREVIEW_MAX_LINES = 80
@@ -359,12 +358,19 @@ class McpCapabilityHandler:
             if publish_key in self._published_capability_keys:
                 return
             try:
-                for start in range(0, len(capabilities), _CAPABILITY_UPSERT_BATCH_SIZE):
-                    await self._searcher_client.upsert_capabilities(
-                        CapabilitiesUpsertRequest(
-                            capabilities=capabilities[
-                                start : start + _CAPABILITY_UPSERT_BATCH_SIZE
-                            ]
+                grouped: dict[tuple[str, str], list[CapabilityUpsert]] = {}
+                for capability in capabilities:
+                    if not capability.source_id:
+                        continue
+                    grouped.setdefault((capability.source_id, capability.capability_type), []).append(
+                        capability
+                    )
+                for (publisher_id, capability_type), group in grouped.items():
+                    await self._searcher_client.sync_capabilities(
+                        CapabilitiesSyncRequest(
+                            publisher_id=publisher_id,
+                            capability_type=capability_type,
+                            capabilities=group,
                         )
                     )
             except Exception as e:
@@ -586,6 +592,7 @@ class McpCapabilityHandler:
                     capability_type="resource",
                     name=record.name,
                     description=record.description,
+                    publisher_id=record.source_id,
                     source_id=record.source_id,
                     source_type=record.source_type,
                     search_text=(
@@ -611,6 +618,7 @@ class McpCapabilityHandler:
                     capability_type="prompt",
                     name=record.name,
                     description=record.description,
+                    publisher_id=record.source_id,
                     source_id=record.source_id,
                     source_type=record.source_type,
                     search_text=(

--- a/services/ai/tools/meta_handler.py
+++ b/services/ai/tools/meta_handler.py
@@ -20,7 +20,7 @@ from anthropic.types import ToolParam
 from tools.connector_handler import ConnectorAction, ConnectorToolHandler
 from tools.registry import ToolContext, ToolResult
 from tools.searcher_client import (
-    CapabilitiesUpsertRequest,
+    CapabilitiesSyncRequest,
     CapabilitySearchRequest,
     CapabilityUpsert,
     SearcherClient,
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 _TOOL_NAMES = {"tool_search", "load_tool", "load_tool_set"}
 _DEFAULT_LIMIT = 10
 _MAX_LIMIT = 25
-_CAPABILITY_UPSERT_BATCH_SIZE = 500
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 OnLoad = Callable[[set[str]], Awaitable[None]]
 
@@ -239,12 +238,17 @@ class MetaToolHandler:
             if publish_key in self._published_capability_keys:
                 return
             try:
-                for start in range(0, len(capabilities), _CAPABILITY_UPSERT_BATCH_SIZE):
-                    await self._searcher_client.upsert_capabilities(
-                        CapabilitiesUpsertRequest(
-                            capabilities=capabilities[
-                                start : start + _CAPABILITY_UPSERT_BATCH_SIZE
-                            ]
+                grouped: dict[str, list[CapabilityUpsert]] = {}
+                for capability in capabilities:
+                    if not capability.source_id:
+                        continue
+                    grouped.setdefault(capability.source_id, []).append(capability)
+                for publisher_id, group in grouped.items():
+                    await self._searcher_client.sync_capabilities(
+                        CapabilitiesSyncRequest(
+                            publisher_id=publisher_id,
+                            capability_type="tool",
+                            capabilities=group,
                         )
                     )
             except Exception as e:
@@ -261,6 +265,7 @@ class MetaToolHandler:
                     capability_type="tool",
                     name=tool_name,
                     description=action.description or "",
+                    publisher_id=action.source_id,
                     source_id=action.source_id,
                     source_type=action.source_type,
                     search_text=(

--- a/services/ai/tools/searcher_client.py
+++ b/services/ai/tools/searcher_client.py
@@ -93,6 +93,7 @@ class CapabilityUpsert(BaseModel):
     search_text: str
     data: JsonObject
     description: str = ""
+    publisher_id: str | None = None
     user_id: str | None = None
     source_id: str | None = None
     source_type: str | None = None
@@ -102,8 +103,19 @@ class CapabilitiesUpsertRequest(BaseModel):
     capabilities: list[CapabilityUpsert]
 
 
+class CapabilitiesSyncRequest(BaseModel):
+    publisher_id: str
+    capability_type: str
+    capabilities: list[CapabilityUpsert]
+
+
 class CapabilitiesUpsertResponse(BaseModel):
     upserted: int
+
+
+class CapabilitiesSyncResponse(BaseModel):
+    upserted: int
+    deleted: int
 
 
 class CapabilitySearchRequest(BaseModel):
@@ -225,6 +237,25 @@ class SearcherClient:
         )
         raise SearcherError(
             message=f"Capability upsert failed: {response.status_code} {response.text}",
+            request=response.request,
+            response=response,
+        )
+
+    async def sync_capabilities(
+        self, request: CapabilitiesSyncRequest
+    ) -> CapabilitiesSyncResponse:
+        """Atomically replace one publisher's capabilities of a single type."""
+        response = await self.client.post(
+            f"{self.searcher_url}/capabilities/sync",
+            json=request.model_dump(),
+        )
+        if response.status_code == 200:
+            return CapabilitiesSyncResponse.model_validate(response.json())
+        logger.error(
+            f"Capability sync error: {response.status_code} - {response.text}"
+        )
+        raise SearcherError(
+            message=f"Capability sync failed: {response.status_code} {response.text}",
             request=response.request,
             response=response,
         )

--- a/services/ai/tools/skill_handler.py
+++ b/services/ai/tools/skill_handler.py
@@ -397,8 +397,12 @@ class SkillHandler:
             if skill_id not in all_ids:
                 continue
             title = result.data.get("title") or skill_id
-            body = result.data.get("body") or result.data.get("description") or ""
-            matches.append((skill_id, title, self._snippet(body)))
+            snippet_text = (
+                result.data.get("description")
+                or result.data.get("body")
+                or ""
+            )
+            matches.append((skill_id, title, self._snippet(snippet_text)))
         return matches
 
     async def publish_skill_capabilities(self) -> None:
@@ -488,19 +492,20 @@ class SkillHandler:
             )
         for lib_id, lib_skill in self._library_skills.items():
             body = lib_skill.instructions
+            description = lib_skill.description
             capabilities.append(
                 CapabilityUpsert(
                     id=f"skill:{lib_id}",
                     capability_type="skill",
                     name=lib_id,
-                    description=self._snippet(body, max_chars=240),
+                    description=description,
                     publisher_id=f"omni:skill-library:{lib_skill.id}",
-                    search_text=f"{lib_id} {lib_skill.name}\n{body}",
+                    search_text=f"{lib_id} {lib_skill.name} {description}\n{body}",
                     user_id=lib_skill.owner_id,
                     data={
                         "skill_id": lib_id,
                         "title": lib_skill.name,
-                        "description": self._snippet(body, max_chars=240),
+                        "description": description,
                         "body": body,
                         "user_id": lib_skill.owner_id,
                     },

--- a/services/ai/tools/skill_handler.py
+++ b/services/ai/tools/skill_handler.py
@@ -16,7 +16,7 @@ from anthropic.types import ToolParam
 from db.skills import Skill, SkillsRepository
 from tools.registry import ToolContext, ToolResult
 from tools.searcher_client import (
-    CapabilitiesUpsertRequest,
+    CapabilitiesSyncRequest,
     CapabilitySearchRequest,
     CapabilityUpsert,
     SearcherClient,
@@ -28,7 +28,7 @@ _TOOL_NAMES = {"skill_search", "load_skill"}
 _SKILL_FILENAME = "SKILL.md"
 _DEFAULT_LIMIT = 10
 _MAX_LIMIT = 25
-_CAPABILITY_UPSERT_BATCH_SIZE = 500
+_BUILTIN_SKILLS_PUBLISHER_ID = "omni:skills"
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 
 
@@ -324,7 +324,11 @@ class SkillHandler:
         return request
 
     def _all_skill_ids(self) -> set[str]:
-        return set(self._available) | set(self._connector_skills) | set(self._library_skills)
+        return (
+            set(self._available)
+            | set(self._connector_skills)
+            | set(self._library_skills)
+        )
 
     async def _skill_search(self, tool_input: dict) -> ToolResult:
         await self.refresh_connector_skills()
@@ -417,12 +421,20 @@ class SkillHandler:
             if publish_key in self._published_capability_keys:
                 return
             try:
-                for start in range(0, len(capabilities), _CAPABILITY_UPSERT_BATCH_SIZE):
-                    await self._searcher_client.upsert_capabilities(
-                        CapabilitiesUpsertRequest(
-                            capabilities=capabilities[
-                                start : start + _CAPABILITY_UPSERT_BATCH_SIZE
-                            ]
+                grouped: dict[tuple[str, str], list[CapabilityUpsert]] = {}
+                for capability in capabilities:
+                    publisher_id = (
+                        capability.publisher_id or _BUILTIN_SKILLS_PUBLISHER_ID
+                    )
+                    grouped.setdefault(
+                        (publisher_id, capability.capability_type), []
+                    ).append(capability)
+                for (publisher_id, capability_type), group in grouped.items():
+                    await self._searcher_client.sync_capabilities(
+                        CapabilitiesSyncRequest(
+                            publisher_id=publisher_id,
+                            capability_type=capability_type,
+                            capabilities=group,
                         )
                     )
             except Exception as e:
@@ -441,6 +453,7 @@ class SkillHandler:
                     capability_type="skill",
                     name=skill_id,
                     description=self._snippet(content, max_chars=240),
+                    publisher_id=_BUILTIN_SKILLS_PUBLISHER_ID,
                     search_text=f"{skill_id} {title}\n{content}",
                     data={
                         "skill_id": skill_id,
@@ -460,6 +473,8 @@ class SkillHandler:
                     capability_type="skill",
                     name=skill_id,
                     description=skill.description or self._snippet(body, max_chars=240),
+                    publisher_id=skill.source_id
+                    or f"connector:{skill.source_type or skill_id}",
                     search_text=f"{skill_id} {skill.title}\n{body}",
                     data={
                         "skill_id": skill_id,
@@ -479,6 +494,7 @@ class SkillHandler:
                     capability_type="skill",
                     name=lib_id,
                     description=self._snippet(body, max_chars=240),
+                    publisher_id=f"omni:skill-library:{lib_skill.id}",
                     search_text=f"{lib_id} {lib_skill.name}\n{body}",
                     user_id=lib_skill.owner_id,
                     data={

--- a/services/ai/tools/skill_handler.py
+++ b/services/ai/tools/skill_handler.py
@@ -13,6 +13,7 @@ from pathlib import Path
 import httpx
 from anthropic.types import ToolParam
 
+from db.skills import Skill, SkillsRepository
 from tools.registry import ToolContext, ToolResult
 from tools.searcher_client import (
     CapabilitiesUpsertRequest,
@@ -62,6 +63,8 @@ class SkillHandler:
         skills_dir: Path,
         searcher_client: SearcherClient | None = None,
         connector_manager_url: str | None = None,
+        skills_repository: SkillsRepository | None = None,
+        skill_user_id: str | None = None,
     ) -> None:
         self._skills_dir = skills_dir
         self._searcher_client = searcher_client
@@ -71,6 +74,9 @@ class SkillHandler:
         self._available: dict[str, Path] = {}
         self._connector_skills: dict[str, ConnectorSkill] = {}
         self._connector_skills_loaded = False
+        self._library_skills: dict[str, Skill] = {}
+        self._skills_repository = skills_repository
+        self._skill_user_id = skill_user_id
         self._discover_skills()
 
     def _discover_skills(self) -> None:
@@ -130,8 +136,26 @@ class SkillHandler:
         self._connector_skills = skills
         self._connector_skills_loaded = True
 
+    async def refresh_library_skills(self, user_id: str | None = None) -> None:
+        """Fetch library skills visible to the configured skill-library user."""
+        if self._skills_repository is None:
+            self._library_skills = {}
+            return
+        if user_id and self._skill_user_id is None:
+            self._skill_user_id = user_id
+        visibility_user_id = self._skill_user_id
+        if not visibility_user_id:
+            self._library_skills = {}
+            return
+        try:
+            skills = await self._skills_repository.list_visible(visibility_user_id)
+            self._library_skills = {f"library:{skill.id}": skill for skill in skills}
+        except Exception as e:
+            logger.warning(f"Failed to refresh library skills: {e}")
+            self._library_skills = {}
+
     def has_skills(self) -> bool:
-        return bool(self._available or self._connector_skills)
+        return bool(self._available or self._connector_skills or self._library_skills)
 
     def get_tools(self) -> list[ToolParam]:
         return [
@@ -188,6 +212,8 @@ class SkillHandler:
     async def execute(
         self, tool_name: str, tool_input: dict, context: ToolContext
     ) -> ToolResult:
+        await self.refresh_library_skills(context.user_id)
+
         if tool_name == "skill_search":
             return await self._skill_search(tool_input)
         if tool_name != "load_skill":
@@ -215,6 +241,12 @@ class SkillHandler:
 
         if skill in self._connector_skills:
             return await self._load_connector_skill(skill)
+
+        if skill in self._library_skills:
+            lib_skill = self._library_skills[skill]
+            return ToolResult(
+                content=[{"type": "text", "text": lib_skill.instructions}]
+            )
 
         available = ", ".join(sorted(self._all_skill_ids()))
         return ToolResult(
@@ -292,7 +324,7 @@ class SkillHandler:
         return request
 
     def _all_skill_ids(self) -> set[str]:
-        return set(self._available) | set(self._connector_skills)
+        return set(self._available) | set(self._connector_skills) | set(self._library_skills)
 
     async def _skill_search(self, tool_input: dict) -> ToolResult:
         await self.refresh_connector_skills()
@@ -344,18 +376,21 @@ class SkillHandler:
         if self._searcher_client is None:
             raise RuntimeError("skill_search requires a searcher client")
 
+        allowed_ids = [f"skill:{skill_id}" for skill_id in self._all_skill_ids()]
+
         response = await self._searcher_client.search_capabilities(
             CapabilitySearchRequest(
                 capability_type="skill",
                 query=query,
                 limit=limit,
-                allowed_ids=[f"skill:{skill_id}" for skill_id in self._all_skill_ids()],
+                allowed_ids=allowed_ids,
             )
         )
+        all_ids = self._all_skill_ids() | set(self._library_skills)
         matches: list[tuple[str, str, str]] = []
         for result in response.results:
             skill_id = result.data["skill_id"]
-            if skill_id not in self._all_skill_ids():
+            if skill_id not in all_ids:
                 continue
             title = result.data.get("title") or skill_id
             body = result.data.get("body") or result.data.get("description") or ""
@@ -364,7 +399,10 @@ class SkillHandler:
 
     async def publish_skill_capabilities(self) -> None:
         await self.refresh_connector_skills()
-        if self._searcher_client is None or not self._all_skill_ids():
+        await self.refresh_library_skills()
+        if self._searcher_client is None:
+            return
+        if not self._all_skill_ids() and not self._library_skills:
             return
 
         capabilities = await self._skill_capabilities()
@@ -430,6 +468,25 @@ class SkillHandler:
                         "body": body,
                         "source_type": skill.source_type,
                         "source_id": skill.source_id,
+                    },
+                )
+            )
+        for lib_id, lib_skill in self._library_skills.items():
+            body = lib_skill.instructions
+            capabilities.append(
+                CapabilityUpsert(
+                    id=f"skill:{lib_id}",
+                    capability_type="skill",
+                    name=lib_id,
+                    description=self._snippet(body, max_chars=240),
+                    search_text=f"{lib_id} {lib_skill.name}\n{body}",
+                    user_id=lib_skill.owner_id,
+                    data={
+                        "skill_id": lib_id,
+                        "title": lib_skill.name,
+                        "description": self._snippet(body, max_chars=240),
+                        "body": body,
+                        "user_id": lib_skill.owner_id,
                     },
                 )
             )

--- a/services/migrations/105_create_skills_table.sql
+++ b/services/migrations/105_create_skills_table.sql
@@ -26,3 +26,12 @@ CREATE TRIGGER update_skills_updated_at BEFORE UPDATE ON skills
 
 COMMENT ON TABLE skills IS
     'User-created skill library entries only. Built-in and connector skills remain sourced from static Markdown files and are indexed/cached separately.';
+
+ALTER TABLE agent_capabilities
+    ADD COLUMN IF NOT EXISTS publisher_id TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_agent_capabilities_publisher_type
+    ON agent_capabilities(publisher_id, capability_type);
+
+COMMENT ON COLUMN agent_capabilities.publisher_id IS
+    'Stable owner of this capability projection. Publishers sync their own capabilities atomically and prune stale rows.';

--- a/services/migrations/105_create_skills_table.sql
+++ b/services/migrations/105_create_skills_table.sql
@@ -1,0 +1,28 @@
+-- User-created skill library entries only. Built-in and connector skills remain
+-- sourced from static Markdown files and are indexed/cached separately.
+
+CREATE TABLE IF NOT EXISTS skills (
+    id CHAR(26) PRIMARY KEY,
+    owner_id CHAR(26) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    instructions TEXT NOT NULL,
+    visibility TEXT NOT NULL DEFAULT 'private',
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT skills_name_not_blank CHECK (btrim(name) <> ''),
+    CONSTRAINT skills_instructions_not_blank CHECK (btrim(instructions) <> ''),
+    CONSTRAINT skills_visibility_check CHECK (visibility IN ('private', 'public'))
+);
+
+CREATE INDEX IF NOT EXISTS idx_skills_owner_updated
+    ON skills (owner_id, updated_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_skills_public_updated
+    ON skills (updated_at DESC)
+    WHERE visibility = 'public';
+
+CREATE TRIGGER update_skills_updated_at BEFORE UPDATE ON skills
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+COMMENT ON TABLE skills IS
+    'User-created skill library entries only. Built-in and connector skills remain sourced from static Markdown files and are indexed/cached separately.';

--- a/services/migrations/105_create_skills_table.sql
+++ b/services/migrations/105_create_skills_table.sql
@@ -5,11 +5,14 @@ CREATE TABLE IF NOT EXISTS skills (
     id CHAR(26) PRIMARY KEY,
     owner_id CHAR(26) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
     name TEXT NOT NULL,
+    description TEXT NOT NULL,
     instructions TEXT NOT NULL,
     visibility TEXT NOT NULL DEFAULT 'private',
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
     CONSTRAINT skills_name_not_blank CHECK (btrim(name) <> ''),
+    CONSTRAINT skills_description_not_blank CHECK (btrim(description) <> ''),
+    CONSTRAINT skills_description_max_length CHECK (char_length(description) <= 500),
     CONSTRAINT skills_instructions_not_blank CHECK (btrim(instructions) <> ''),
     CONSTRAINT skills_visibility_check CHECK (visibility IN ('private', 'public'))
 );

--- a/services/searcher/src/capabilities_repository.rs
+++ b/services/searcher/src/capabilities_repository.rs
@@ -1,6 +1,6 @@
 use crate::models::{CapabilitySearchResult, CapabilityUpsert};
 use shared::db::error::DatabaseError;
-use sqlx::{FromRow, PgPool};
+use sqlx::{FromRow, PgPool, Postgres, Transaction};
 
 #[derive(FromRow)]
 struct CapabilityHit {
@@ -30,11 +30,58 @@ impl AgentCapabilitiesRepository {
             return Ok(());
         }
 
+        let mut tx = self.pool.begin().await?;
+        Self::upsert_many_in_tx(&mut tx, items, None).await?;
+        tx.commit().await?;
+        Ok(())
+    }
+
+    pub async fn sync_publisher(
+        &self,
+        publisher_id: &str,
+        capability_type: &str,
+        items: &[CapabilityUpsert],
+    ) -> Result<u64, DatabaseError> {
+        let mut tx = self.pool.begin().await?;
+        Self::upsert_many_in_tx(&mut tx, items, Some(publisher_id)).await?;
+
+        let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
+        let result = sqlx::query(
+            r#"
+            DELETE FROM agent_capabilities
+            WHERE publisher_id = $1
+              AND capability_type = $2
+              AND NOT (id = ANY($3::text[]))
+            "#,
+        )
+        .bind(publisher_id)
+        .bind(capability_type)
+        .bind(ids)
+        .execute(&mut *tx)
+        .await?;
+
+        tx.commit().await?;
+        Ok(result.rows_affected())
+    }
+
+    async fn upsert_many_in_tx(
+        tx: &mut Transaction<'_, Postgres>,
+        items: &[CapabilityUpsert],
+        publisher_override: Option<&str>,
+    ) -> Result<(), DatabaseError> {
+        if items.is_empty() {
+            return Ok(());
+        }
+
         let ids: Vec<&str> = items.iter().map(|i| i.id.as_str()).collect();
         let capability_types: Vec<&str> =
             items.iter().map(|i| i.capability_type.as_str()).collect();
         let names: Vec<&str> = items.iter().map(|i| i.name.as_str()).collect();
         let descriptions: Vec<&str> = items.iter().map(|i| i.description.as_str()).collect();
+        let publisher_ids: Vec<Option<&str>> = items
+            .iter()
+            .map(|i| publisher_override.or(i.publisher_id.as_deref()))
+            .collect();
         let user_ids: Vec<Option<&str>> = items.iter().map(|i| i.user_id.as_deref()).collect();
         let source_ids: Vec<Option<&str>> = items.iter().map(|i| i.source_id.as_deref()).collect();
         let source_types: Vec<Option<&str>> =
@@ -45,20 +92,21 @@ impl AgentCapabilitiesRepository {
         sqlx::query(
             r#"
             INSERT INTO agent_capabilities (
-                id, capability_type, name, description, user_id, source_id, source_type,
-                search_text, data, created_at, updated_at
+                id, capability_type, name, description, publisher_id, user_id,
+                source_id, source_type, search_text, data, created_at, updated_at
             )
-            SELECT u.id, u.capability_type, u.name, u.description, u.user_id,
-                   u.source_id, u.source_type, u.search_text, u.data, NOW(), NOW()
+            SELECT u.id, u.capability_type, u.name, u.description, u.publisher_id,
+                   u.user_id, u.source_id, u.source_type, u.search_text, u.data, NOW(), NOW()
             FROM UNNEST(
                 $1::varchar[], $2::text[], $3::text[], $4::text[], $5::text[],
-                $6::text[], $7::text[], $8::text[], $9::jsonb[]
-            ) AS u(id, capability_type, name, description, user_id, source_id,
-                   source_type, search_text, data)
+                $6::text[], $7::text[], $8::text[], $9::text[], $10::jsonb[]
+            ) AS u(id, capability_type, name, description, publisher_id, user_id,
+                   source_id, source_type, search_text, data)
             ON CONFLICT (id) DO UPDATE SET
                 capability_type = EXCLUDED.capability_type,
                 name = EXCLUDED.name,
                 description = EXCLUDED.description,
+                publisher_id = EXCLUDED.publisher_id,
                 user_id = EXCLUDED.user_id,
                 source_id = EXCLUDED.source_id,
                 source_type = EXCLUDED.source_type,
@@ -71,12 +119,13 @@ impl AgentCapabilitiesRepository {
         .bind(capability_types)
         .bind(names)
         .bind(descriptions)
+        .bind(&publisher_ids)
         .bind(user_ids)
         .bind(source_ids)
         .bind(source_types)
         .bind(search_texts)
         .bind(data)
-        .execute(&self.pool)
+        .execute(&mut **tx)
         .await?;
 
         Ok(())

--- a/services/searcher/src/handlers.rs
+++ b/services/searcher/src/handlers.rs
@@ -1,9 +1,10 @@
 use crate::capabilities_repository::AgentCapabilitiesRepository;
 use crate::models::{
-    AttributeValuesResponse, CapabilitiesUpsertRequest, CapabilitiesUpsertResponse,
-    CapabilitySearchRequest, CapabilitySearchResponse, PeopleSearchResponse, PersonResult,
-    RecentSearchesRequest, SearchRequest, SuggestedQuestionsRequest, SuggestedQuestionsResponse,
-    TypeaheadQuery, TypeaheadResponse,
+    AttributeValuesResponse, CapabilitiesSyncRequest, CapabilitiesSyncResponse,
+    CapabilitiesUpsertRequest, CapabilitiesUpsertResponse, CapabilitySearchRequest,
+    CapabilitySearchResponse, PeopleSearchResponse, PersonResult, RecentSearchesRequest,
+    SearchRequest, SuggestedQuestionsRequest, SuggestedQuestionsResponse, TypeaheadQuery,
+    TypeaheadResponse,
 };
 use crate::search::SearchEngine;
 use crate::search_repository::SearchDocumentRepository;
@@ -17,10 +18,10 @@ use axum::{
 };
 use futures_util::Stream;
 use redis::AsyncCommands;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use shared::{
-    ConfigurationRepository, PersonRepository, Repository, UserRepository,
-    models::UserConfiguration,
+    models::UserConfiguration, ConfigurationRepository, PersonRepository, Repository,
+    UserRepository,
 };
 use sqlx::types::time::OffsetDateTime;
 use std::pin::Pin;
@@ -412,16 +413,13 @@ pub async fn attribute_values(
     Ok(Json(AttributeValuesResponse { attributes }))
 }
 
-pub async fn capabilities_upsert(
-    State(state): State<AppState>,
-    Json(request): Json<CapabilitiesUpsertRequest>,
-) -> SearcherResult<Json<CapabilitiesUpsertResponse>> {
-    if request.capabilities.len() > 500 {
+fn validate_capabilities(capabilities: &[crate::models::CapabilityUpsert]) -> SearcherResult<()> {
+    if capabilities.len() > 500 {
         return Err(SearcherError::BadRequest(
             "capabilities batch is limited to 500 items".to_string(),
         ));
     }
-    if request.capabilities.iter().any(|capability| {
+    if capabilities.iter().any(|capability| {
         capability.id.trim().is_empty()
             || capability.capability_type.trim().is_empty()
             || capability.name.trim().is_empty()
@@ -431,6 +429,14 @@ pub async fn capabilities_upsert(
             "capability id, capability_type, name, and search_text are required".to_string(),
         ));
     }
+    Ok(())
+}
+
+pub async fn capabilities_upsert(
+    State(state): State<AppState>,
+    Json(request): Json<CapabilitiesUpsertRequest>,
+) -> SearcherResult<Json<CapabilitiesUpsertResponse>> {
+    validate_capabilities(&request.capabilities)?;
 
     let repo = AgentCapabilitiesRepository::new(state.db_pool.pool());
     repo.upsert_many(&request.capabilities)
@@ -439,6 +445,42 @@ pub async fn capabilities_upsert(
 
     Ok(Json(CapabilitiesUpsertResponse {
         upserted: request.capabilities.len(),
+    }))
+}
+
+pub async fn capabilities_sync(
+    State(state): State<AppState>,
+    Json(request): Json<CapabilitiesSyncRequest>,
+) -> SearcherResult<Json<CapabilitiesSyncResponse>> {
+    if request.publisher_id.trim().is_empty() || request.capability_type.trim().is_empty() {
+        return Err(SearcherError::BadRequest(
+            "publisher_id and capability_type are required".to_string(),
+        ));
+    }
+    validate_capabilities(&request.capabilities)?;
+    if request
+        .capabilities
+        .iter()
+        .any(|capability| capability.capability_type != request.capability_type)
+    {
+        return Err(SearcherError::BadRequest(
+            "all capabilities must match request capability_type".to_string(),
+        ));
+    }
+
+    let repo = AgentCapabilitiesRepository::new(state.db_pool.pool());
+    let deleted = repo
+        .sync_publisher(
+            &request.publisher_id,
+            &request.capability_type,
+            &request.capabilities,
+        )
+        .await
+        .map_err(|e| SearcherError::Internal(anyhow!("Capability sync failed: {}", e)))?;
+
+    Ok(Json(CapabilitiesSyncResponse {
+        upserted: request.capabilities.len(),
+        deleted,
     }))
 }
 

--- a/services/searcher/src/lib.rs
+++ b/services/searcher/src/lib.rs
@@ -10,13 +10,14 @@ pub mod typeahead;
 
 use anyhow::Result as AnyhowResult;
 use axum::{
-    Router, middleware,
+    middleware,
     routing::{get, post},
+    Router,
 };
 use redis::Client as RedisClient;
 use shared::{
-    AIClient, DatabasePool, ObjectStorage, SearcherConfig, StorageFactory,
     telemetry::{self, TelemetryConfig},
+    AIClient, DatabasePool, ObjectStorage, SearcherConfig, StorageFactory,
 };
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -98,6 +99,7 @@ pub fn create_app(state: AppState) -> Router {
         .route("/typeahead", get(handlers::typeahead))
         .route("/people/search", get(handlers::people_search))
         .route("/capabilities/upsert", post(handlers::capabilities_upsert))
+        .route("/capabilities/sync", post(handlers::capabilities_sync))
         .route("/capabilities/search", post(handlers::capabilities_search))
         .route("/suggested-questions", post(handlers::suggested_questions))
         .route("/attributes/values", get(handlers::attribute_values))

--- a/services/searcher/src/models.rs
+++ b/services/searcher/src/models.rs
@@ -1,7 +1,7 @@
 use serde::{Deserialize, Deserializer, Serialize};
 use shared::{
-    SourceType,
     models::{AttributeFilter, DateFilter, Document, Facet, UserConfiguration},
+    SourceType,
 };
 use std::collections::HashMap;
 
@@ -198,6 +198,8 @@ pub struct CapabilityUpsert {
     #[serde(default)]
     pub description: String,
     #[serde(default)]
+    pub publisher_id: Option<String>,
+    #[serde(default)]
     pub user_id: Option<String>,
     #[serde(default)]
     pub source_id: Option<String>,
@@ -212,9 +214,22 @@ pub struct CapabilitiesUpsertRequest {
     pub capabilities: Vec<CapabilityUpsert>,
 }
 
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct CapabilitiesSyncRequest {
+    pub publisher_id: String,
+    pub capability_type: String,
+    pub capabilities: Vec<CapabilityUpsert>,
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct CapabilitiesUpsertResponse {
     pub upserted: usize,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct CapabilitiesSyncResponse {
+    pub upserted: usize,
+    pub deleted: u64,
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]

--- a/services/searcher/tests/integration_tests.rs
+++ b/services/searcher/tests/integration_tests.rs
@@ -6,7 +6,7 @@ use axum::{
     http::{Method, Request, StatusCode},
 };
 use common::SearcherTestFixture;
-use serde_json::{Value, json};
+use serde_json::{json, Value};
 use shared::db::repositories::{GroupRepository, PersonRepository, PersonUpsert};
 use shared::models::DocumentPermissions;
 use tower::ServiceExt;
@@ -188,6 +188,91 @@ async fn test_capability_search_indexes_search_text() -> Result<()> {
         .is_empty());
 
     Ok(())
+}
+
+#[tokio::test]
+async fn test_capability_sync_prunes_stale_rows_for_publisher_and_type() -> Result<()> {
+    let fixture = SearcherTestFixture::new().await?;
+
+    let first_sync = json!({
+        "publisher_id": "src-gmail-1",
+        "capability_type": "tool",
+        "capabilities": [
+            {
+                "id": "tool:gmail__send_email",
+                "capability_type": "tool",
+                "name": "gmail__send_email",
+                "description": "Send email",
+                "source_id": "src-gmail-1",
+                "source_type": "gmail",
+                "search_text": "Gmail send email quokka",
+                "data": { "tool_name": "gmail__send_email" }
+            },
+            {
+                "id": "tool:gmail__old_tool",
+                "capability_type": "tool",
+                "name": "gmail__old_tool",
+                "description": "Old tool",
+                "source_id": "src-gmail-1",
+                "source_type": "gmail",
+                "search_text": "Gmail old tool quokka",
+                "data": { "tool_name": "gmail__old_tool" }
+            }
+        ]
+    });
+    let response = sync_capabilities(&fixture, first_sync).await?;
+    assert_eq!(response["upserted"], 2);
+    assert_eq!(response["deleted"], 0);
+
+    let second_sync = json!({
+        "publisher_id": "src-gmail-1",
+        "capability_type": "tool",
+        "capabilities": [
+            {
+                "id": "tool:gmail__send_email",
+                "capability_type": "tool",
+                "name": "gmail__send_email",
+                "description": "Send email updated",
+                "source_id": "src-gmail-1",
+                "source_type": "gmail",
+                "search_text": "Gmail send email updated quokka",
+                "data": { "tool_name": "gmail__send_email" }
+            }
+        ]
+    });
+    let response = sync_capabilities(&fixture, second_sync).await?;
+    assert_eq!(response["upserted"], 1);
+    assert_eq!(response["deleted"], 1);
+
+    let search_response = search_capabilities(
+        &fixture,
+        json!({
+            "capability_type": "tool",
+            "query": "quokka",
+            "limit": 10
+        }),
+    )
+    .await?;
+    assert_capability_present(&search_response, "tool:gmail__send_email", "quokka");
+    assert!(!search_response["results"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .any(|result| result["id"] == "tool:gmail__old_tool"));
+
+    Ok(())
+}
+
+async fn sync_capabilities(fixture: &SearcherTestFixture, body: Value) -> Result<Value> {
+    let request = Request::builder()
+        .method(Method::POST)
+        .uri("/capabilities/sync")
+        .header("content-type", "application/json")
+        .body(Body::from(body.to_string()))?;
+    let response = fixture.app.clone().oneshot(request).await?;
+    assert_eq!(response.status(), StatusCode::OK);
+    let body = axum::body::to_bytes(response.into_body(), usize::MAX).await?;
+    Ok(serde_json::from_slice(&body)?)
 }
 
 async fn search_capabilities(fixture: &SearcherTestFixture, body: Value) -> Result<Value> {

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -1,4 +1,14 @@
-import { pgTable, text, timestamp, boolean, jsonb, bigint, integer } from 'drizzle-orm/pg-core'
+import { sql } from 'drizzle-orm'
+import {
+    pgTable,
+    text,
+    timestamp,
+    boolean,
+    jsonb,
+    bigint,
+    integer,
+    index,
+} from 'drizzle-orm/pg-core'
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages.js'
 
 export const user = pgTable('users', {
@@ -360,6 +370,31 @@ export const compactions = pgTable('compactions', {
     createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 })
 
+export const skills = pgTable(
+    'skills',
+    {
+        id: text('id').primaryKey(),
+        ownerId: text('owner_id')
+            .notNull()
+            .references(() => user.id, { onDelete: 'cascade' }),
+        name: text('name').notNull(),
+        instructions: text('instructions').notNull(),
+        visibility: text('visibility').$type<'private' | 'public'>().notNull().default('private'),
+        createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' })
+            .notNull()
+            .defaultNow(),
+        updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' })
+            .notNull()
+            .defaultNow(),
+    },
+    (table) => [
+        index('idx_skills_owner_updated').on(table.ownerId, table.updatedAt.desc()),
+        index('idx_skills_public_updated')
+            .on(table.updatedAt.desc())
+            .where(sql`${table.visibility} = 'public'`),
+    ],
+)
+
 export const apiKeys = pgTable('api_keys', {
     id: text('id').primaryKey(),
     userId: text('user_id')
@@ -402,4 +437,6 @@ export type WebFetchProvider = typeof webFetchProviders.$inferSelect
 export type Agent = typeof agents.$inferSelect
 export type AgentRun = typeof agentRuns.$inferSelect
 export type AgentRunLog = typeof agentRunLogs.$inferSelect
+export type Skill = typeof skills.$inferSelect
+
 export type ApiKey = typeof apiKeys.$inferSelect

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -378,6 +378,7 @@ export const skills = pgTable(
             .notNull()
             .references(() => user.id, { onDelete: 'cascade' }),
         name: text('name').notNull(),
+        description: text('description').notNull(),
         instructions: text('instructions').notNull(),
         visibility: text('visibility').$type<'private' | 'public'>().notNull().default('private'),
         createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' })

--- a/web/src/lib/server/db/skills.test.ts
+++ b/web/src/lib/server/db/skills.test.ts
@@ -31,12 +31,14 @@ describe('SkillRepository', () => {
         const skill = await repo.create({
             userId: user1Id,
             name: 'PR Review',
+            description: 'Review pull requests for code quality.',
             instructions: 'Review pull requests for code quality.',
         })
 
         expect(skill).toBeDefined()
         expect(skill.ownerId).toBe(user1Id)
         expect(skill.name).toBe('PR Review')
+        expect(skill.description).toBe('Review pull requests for code quality.')
         expect(skill.instructions).toBe('Review pull requests for code quality.')
         expect(skill.visibility).toBe('private')
         expect(skill.id).toBeTruthy()
@@ -48,6 +50,7 @@ describe('SkillRepository', () => {
         const skill = await repo.create({
             userId: user1Id,
             name: 'Public PR Review',
+            description: 'Review pull requests.',
             instructions: 'Review pull requests.',
             visibility: 'public',
         })
@@ -60,6 +63,7 @@ describe('SkillRepository', () => {
         await repo.create({
             userId: user1Id,
             name: 'Private Skill',
+            description: 'Only user1 can see this.',
             instructions: 'Only user1 can see this.',
         })
 
@@ -67,6 +71,7 @@ describe('SkillRepository', () => {
         await repo.create({
             userId: user1Id,
             name: 'Public Skill',
+            description: 'Everyone can see this.',
             instructions: 'Everyone can see this.',
             visibility: 'public',
         })
@@ -75,6 +80,7 @@ describe('SkillRepository', () => {
         await repo.create({
             userId: user2Id,
             name: 'User2 Public',
+            description: 'Also public.',
             instructions: 'Also public.',
             visibility: 'public',
         })
@@ -83,6 +89,7 @@ describe('SkillRepository', () => {
         await repo.create({
             userId: user2Id,
             name: 'User2 Private',
+            description: 'Should be invisible to user1.',
             instructions: 'Should be invisible to user1.',
         })
 
@@ -96,12 +103,14 @@ describe('SkillRepository', () => {
         const privateSkill = await repo.create({
             userId: user1Id,
             name: 'Private',
+            description: 'Secret.',
             instructions: 'Secret.',
         })
 
         const publicSkill = await repo.create({
             userId: user1Id,
             name: 'Public',
+            description: 'Open.',
             instructions: 'Open.',
             visibility: 'public',
         })
@@ -119,6 +128,7 @@ describe('SkillRepository', () => {
         const skill = await repo.create({
             userId: user1Id,
             name: 'My Skill',
+            description: 'Original desc.',
             instructions: 'Original.',
         })
 
@@ -131,11 +141,13 @@ describe('SkillRepository', () => {
         // Owner can update
         const updated = await repo.update(skill.id, user1Id, {
             name: 'Updated',
+            description: 'New description.',
             instructions: 'New instructions.',
             visibility: 'public',
         })
         expect(updated).toBeDefined()
         expect(updated!.name).toBe('Updated')
+        expect(updated!.description).toBe('New description.')
         expect(updated!.instructions).toBe('New instructions.')
         expect(updated!.visibility).toBe('public')
         expect(updated!.updatedAt.getTime()).toBeGreaterThanOrEqual(skill.updatedAt.getTime())
@@ -145,6 +157,7 @@ describe('SkillRepository', () => {
         const skill = await repo.create({
             userId: user1Id,
             name: 'To Delete',
+            description: 'Delete me.',
             instructions: 'Delete me.',
         })
 
@@ -165,6 +178,7 @@ describe('SkillRepository', () => {
         const source = await repo.create({
             userId: user1Id,
             name: 'Source Skill',
+            description: 'Original description.',
             instructions: 'Original instructions.',
             visibility: 'public',
         })
@@ -175,6 +189,7 @@ describe('SkillRepository', () => {
         expect(cloned!.id).not.toBe(source.id)
         expect(cloned!.ownerId).toBe(user2Id)
         expect(cloned!.name).toBe('Source Skill')
+        expect(cloned!.description).toBe('Original description.')
         expect(cloned!.instructions).toBe('Original instructions.')
         expect(cloned!.visibility).toBe('private')
 
@@ -188,6 +203,7 @@ describe('SkillRepository', () => {
         const privateSkill = await repo.create({
             userId: user1Id,
             name: 'Secret',
+            description: 'Shhh.',
             instructions: 'Shhh.',
         })
 
@@ -199,12 +215,14 @@ describe('SkillRepository', () => {
         const first = await repo.create({
             userId: user1Id,
             name: 'PR Review',
+            description: 'First description.',
             instructions: 'First instructions.',
             visibility: 'public',
         })
         const second = await repo.create({
             userId: user2Id,
             name: 'PR Review',
+            description: 'Second description.',
             instructions: 'Second instructions.',
             visibility: 'public',
         })
@@ -214,17 +232,44 @@ describe('SkillRepository', () => {
         expect(duplicates.map((skill) => skill.id).sort()).toEqual([first.id, second.id].sort())
     })
 
-    it('database constraints reject blank names, blank instructions, and invalid visibility', async () => {
+    it('database constraints reject blank names, blank instructions, blank description, and invalid visibility', async () => {
         await expect(
-            repo.create({ userId: user1Id, name: '   ', instructions: 'Do it.' }),
-        ).rejects.toThrow()
-        await expect(
-            repo.create({ userId: user1Id, name: 'Name', instructions: '   ' }),
+            repo.create({
+                userId: user1Id,
+                name: '   ',
+                description: 'Desc.',
+                instructions: 'Do it.',
+            }),
         ).rejects.toThrow()
         await expect(
             repo.create({
                 userId: user1Id,
                 name: 'Name',
+                description: '   ',
+                instructions: 'Do it.',
+            }),
+        ).rejects.toThrow()
+        await expect(
+            repo.create({
+                userId: user1Id,
+                name: 'Name',
+                description: 'Desc.',
+                instructions: '   ',
+            }),
+        ).rejects.toThrow()
+        await expect(
+            repo.create({
+                userId: user1Id,
+                name: 'Name',
+                description: 'x'.repeat(501),
+                instructions: 'Do it.',
+            }),
+        ).rejects.toThrow()
+        await expect(
+            repo.create({
+                userId: user1Id,
+                name: 'Name',
+                description: 'Desc.',
                 instructions: 'Do it.',
                 visibility: 'team' as 'private',
             }),
@@ -235,6 +280,7 @@ describe('SkillRepository', () => {
         const skill = await repo.create({
             userId: user1Id,
             name: 'Cascade',
+            description: 'Owned by user1.',
             instructions: 'Owned by user1.',
         })
 
@@ -247,6 +293,7 @@ describe('SkillRepository', () => {
         const skill = await repo.create({
             userId: user1Id,
             name: 'Trigger',
+            description: 'Original desc.',
             instructions: 'Original.',
         })
 

--- a/web/src/lib/server/db/skills.test.ts
+++ b/web/src/lib/server/db/skills.test.ts
@@ -1,0 +1,259 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import { eq } from 'drizzle-orm'
+import { startTestDb, stopTestDb, createTestUser } from './test-setup'
+import { SkillRepository } from './skills'
+import * as schema from './schema'
+
+let db: PostgresJsDatabase<typeof schema>
+let repo: SkillRepository
+let user1Id: string
+let user2Id: string
+
+beforeAll(async () => {
+    db = await startTestDb()
+    repo = new SkillRepository(db)
+})
+
+afterAll(async () => {
+    await stopTestDb()
+})
+
+beforeEach(async () => {
+    // Clean up any skills left by previous tests
+    await db.delete(schema.skills)
+    user1Id = await createTestUser(db)
+    user2Id = await createTestUser(db)
+})
+
+describe('SkillRepository', () => {
+    it('creates a skill with default private visibility', async () => {
+        const skill = await repo.create({
+            userId: user1Id,
+            name: 'PR Review',
+            instructions: 'Review pull requests for code quality.',
+        })
+
+        expect(skill).toBeDefined()
+        expect(skill.ownerId).toBe(user1Id)
+        expect(skill.name).toBe('PR Review')
+        expect(skill.instructions).toBe('Review pull requests for code quality.')
+        expect(skill.visibility).toBe('private')
+        expect(skill.id).toBeTruthy()
+        expect(skill.createdAt).toBeInstanceOf(Date)
+        expect(skill.updatedAt).toBeInstanceOf(Date)
+    })
+
+    it('creates a skill with public visibility', async () => {
+        const skill = await repo.create({
+            userId: user1Id,
+            name: 'Public PR Review',
+            instructions: 'Review pull requests.',
+            visibility: 'public',
+        })
+
+        expect(skill.visibility).toBe('public')
+    })
+
+    it('listVisible returns own private and all public skills', async () => {
+        // user1 creates a private skill
+        await repo.create({
+            userId: user1Id,
+            name: 'Private Skill',
+            instructions: 'Only user1 can see this.',
+        })
+
+        // user1 creates a public skill
+        await repo.create({
+            userId: user1Id,
+            name: 'Public Skill',
+            instructions: 'Everyone can see this.',
+            visibility: 'public',
+        })
+
+        // user2 creates a public skill
+        await repo.create({
+            userId: user2Id,
+            name: 'User2 Public',
+            instructions: 'Also public.',
+            visibility: 'public',
+        })
+
+        // user2 creates a private skill
+        await repo.create({
+            userId: user2Id,
+            name: 'User2 Private',
+            instructions: 'Should be invisible to user1.',
+        })
+
+        // user1 sees: own private, own public, user2's public (but NOT user2's private)
+        const visible = await repo.listVisible(user1Id)
+        const names = visible.map((s) => s.name).sort()
+        expect(names).toEqual(['Private Skill', 'Public Skill', 'User2 Public'])
+    })
+
+    it('getVisibleById respects visibility', async () => {
+        const privateSkill = await repo.create({
+            userId: user1Id,
+            name: 'Private',
+            instructions: 'Secret.',
+        })
+
+        const publicSkill = await repo.create({
+            userId: user1Id,
+            name: 'Public',
+            instructions: 'Open.',
+            visibility: 'public',
+        })
+
+        // user1 can see both
+        expect(await repo.getVisibleById(privateSkill.id, user1Id)).toBeDefined()
+        expect(await repo.getVisibleById(publicSkill.id, user1Id)).toBeDefined()
+
+        // user2 can only see public
+        expect(await repo.getVisibleById(privateSkill.id, user2Id)).toBeNull()
+        expect(await repo.getVisibleById(publicSkill.id, user2Id)).toBeDefined()
+    })
+
+    it('update only works for the owner', async () => {
+        const skill = await repo.create({
+            userId: user1Id,
+            name: 'My Skill',
+            instructions: 'Original.',
+        })
+
+        // Non-owner cannot update
+        const notUpdated = await repo.update(skill.id, user2Id, {
+            name: 'Hacked',
+        })
+        expect(notUpdated).toBeNull()
+
+        // Owner can update
+        const updated = await repo.update(skill.id, user1Id, {
+            name: 'Updated',
+            instructions: 'New instructions.',
+            visibility: 'public',
+        })
+        expect(updated).toBeDefined()
+        expect(updated!.name).toBe('Updated')
+        expect(updated!.instructions).toBe('New instructions.')
+        expect(updated!.visibility).toBe('public')
+        expect(updated!.updatedAt.getTime()).toBeGreaterThanOrEqual(skill.updatedAt.getTime())
+    })
+
+    it('delete only works for the owner', async () => {
+        const skill = await repo.create({
+            userId: user1Id,
+            name: 'To Delete',
+            instructions: 'Delete me.',
+        })
+
+        // Non-owner cannot delete
+        const notDeleted = await repo.delete(skill.id, user2Id)
+        expect(notDeleted).toBeNull()
+
+        // Owner can delete
+        const deleted = await repo.delete(skill.id, user1Id)
+        expect(deleted).toBeDefined()
+        expect(deleted!.id).toBe(skill.id)
+
+        // Verify it's gone
+        expect(await repo.getVisibleById(skill.id, user1Id)).toBeNull()
+    })
+
+    it('clone creates an independent private copy', async () => {
+        const source = await repo.create({
+            userId: user1Id,
+            name: 'Source Skill',
+            instructions: 'Original instructions.',
+            visibility: 'public',
+        })
+
+        const cloned = await repo.clone(source.id, user2Id)
+
+        expect(cloned).toBeDefined()
+        expect(cloned!.id).not.toBe(source.id)
+        expect(cloned!.ownerId).toBe(user2Id)
+        expect(cloned!.name).toBe('Source Skill')
+        expect(cloned!.instructions).toBe('Original instructions.')
+        expect(cloned!.visibility).toBe('private')
+
+        // Cloned skill is independent: original can be deleted
+        await repo.delete(source.id, user1Id)
+        expect(await repo.getVisibleById(source.id, user1Id)).toBeNull()
+        expect(await repo.getVisibleById(cloned!.id, user2Id)).toBeDefined()
+    })
+
+    it('clone returns null for private skills, including owned private skills', async () => {
+        const privateSkill = await repo.create({
+            userId: user1Id,
+            name: 'Secret',
+            instructions: 'Shhh.',
+        })
+
+        await expect(repo.clone(privateSkill.id, user2Id)).resolves.toBeNull()
+        await expect(repo.clone(privateSkill.id, user1Id)).resolves.toBeNull()
+    })
+
+    it('allows duplicate display names across visible skills', async () => {
+        const first = await repo.create({
+            userId: user1Id,
+            name: 'PR Review',
+            instructions: 'First instructions.',
+            visibility: 'public',
+        })
+        const second = await repo.create({
+            userId: user2Id,
+            name: 'PR Review',
+            instructions: 'Second instructions.',
+            visibility: 'public',
+        })
+
+        const visible = await repo.listVisible(user1Id)
+        const duplicates = visible.filter((skill) => skill.name === 'PR Review')
+        expect(duplicates.map((skill) => skill.id).sort()).toEqual([first.id, second.id].sort())
+    })
+
+    it('database constraints reject blank names, blank instructions, and invalid visibility', async () => {
+        await expect(
+            repo.create({ userId: user1Id, name: '   ', instructions: 'Do it.' }),
+        ).rejects.toThrow()
+        await expect(
+            repo.create({ userId: user1Id, name: 'Name', instructions: '   ' }),
+        ).rejects.toThrow()
+        await expect(
+            repo.create({
+                userId: user1Id,
+                name: 'Name',
+                instructions: 'Do it.',
+                visibility: 'team' as 'private',
+            }),
+        ).rejects.toThrow()
+    })
+
+    it('deleting the owner cascades skills', async () => {
+        const skill = await repo.create({
+            userId: user1Id,
+            name: 'Cascade',
+            instructions: 'Owned by user1.',
+        })
+
+        await db.delete(schema.user).where(eq(schema.user.id, user1Id))
+
+        expect(await repo.getVisibleById(skill.id, user1Id)).toBeNull()
+    })
+
+    it('database trigger updates updatedAt on mutation', async () => {
+        const skill = await repo.create({
+            userId: user1Id,
+            name: 'Trigger',
+            instructions: 'Original.',
+        })
+
+        await new Promise((resolve) => setTimeout(resolve, 10))
+        const updated = await repo.update(skill.id, user1Id, { instructions: 'Updated.' })
+
+        expect(updated).not.toBeNull()
+        expect(updated!.updatedAt.getTime()).toBeGreaterThan(skill.updatedAt.getTime())
+    })
+})

--- a/web/src/lib/server/db/skills.ts
+++ b/web/src/lib/server/db/skills.ts
@@ -1,0 +1,125 @@
+import { eq, and, or, desc, sql } from 'drizzle-orm'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import { db } from './index'
+import { skills } from './schema'
+import type { Skill } from './schema'
+import * as schema from './schema'
+import type { SkillVisibility } from '$lib/skills.js'
+import { ulid } from 'ulid'
+
+export class SkillRepository {
+    private db: PostgresJsDatabase<typeof schema>
+
+    constructor(private dbInstance: PostgresJsDatabase<typeof schema> = db) {
+        this.db = dbInstance
+    }
+
+    /**
+     * List skills visible to the given user: public skills + user's own private skills.
+     */
+    async listVisible(userId: string): Promise<Skill[]> {
+        return this.db
+            .select()
+            .from(skills)
+            .where(or(eq(skills.ownerId, userId), eq(skills.visibility, 'public')))
+            .orderBy(desc(skills.updatedAt))
+    }
+
+    /**
+     * Get a single skill by ID if it is visible to the given user.
+     * Returns null if the skill does not exist or is not visible.
+     */
+    async getVisibleById(id: string, userId: string): Promise<Skill | null> {
+        const [row] = await this.db
+            .select()
+            .from(skills)
+            .where(
+                and(
+                    eq(skills.id, id),
+                    or(eq(skills.ownerId, userId), eq(skills.visibility, 'public')),
+                ),
+            )
+            .limit(1)
+        return row || null
+    }
+
+    /**
+     * Create a new skill owned by the given user.
+     */
+    async create(data: {
+        userId: string
+        name: string
+        instructions: string
+        visibility?: SkillVisibility
+    }): Promise<Skill> {
+        const id = ulid()
+        const [row] = await this.db
+            .insert(skills)
+            .values({
+                id,
+                ownerId: data.userId,
+                name: data.name,
+                instructions: data.instructions,
+                visibility: data.visibility || 'private',
+            })
+            .returning()
+        return row
+    }
+
+    /**
+     * Update a skill if the user is the owner.
+     * Returns the updated skill, or null if not found or not owned.
+     */
+    async update(
+        id: string,
+        userId: string,
+        data: Partial<{
+            name: string
+            instructions: string
+            visibility: SkillVisibility
+        }>,
+    ): Promise<Skill | null> {
+        const [row] = await this.db
+            .update(skills)
+            .set(data)
+            .where(and(eq(skills.id, id), eq(skills.ownerId, userId)))
+            .returning()
+        return row || null
+    }
+
+    /**
+     * Delete a skill if the user is the owner.
+     * Returns the deleted skill, or null if not found or not owned.
+     */
+    async delete(id: string, userId: string): Promise<Skill | null> {
+        const [row] = await this.db
+            .delete(skills)
+            .where(and(eq(skills.id, id), eq(skills.ownerId, userId)))
+            .returning()
+        return row || null
+    }
+
+    /**
+     * Clone a public skill into a new private skill owned by the target user.
+     * Returns the new skill, or null if the source is not visible or not public.
+     */
+    async clone(sourceId: string, newOwnerId: string): Promise<Skill | null> {
+        const id = ulid()
+        const rows = await this.db.execute<Skill>(sql`
+            INSERT INTO skills (id, owner_id, name, instructions, visibility)
+            SELECT ${id}, ${newOwnerId}, name, instructions, 'private'
+            FROM skills
+            WHERE id = ${sourceId}
+              AND visibility = 'public'
+            RETURNING
+                id,
+                owner_id AS "ownerId",
+                name,
+                instructions,
+                visibility,
+                created_at AS "createdAt",
+                updated_at AS "updatedAt"
+        `)
+        return rows[0] || null
+    }
+}

--- a/web/src/lib/server/db/skills.ts
+++ b/web/src/lib/server/db/skills.ts
@@ -49,6 +49,7 @@ export class SkillRepository {
     async create(data: {
         userId: string
         name: string
+        description: string
         instructions: string
         visibility?: SkillVisibility
     }): Promise<Skill> {
@@ -59,6 +60,7 @@ export class SkillRepository {
                 id,
                 ownerId: data.userId,
                 name: data.name,
+                description: data.description,
                 instructions: data.instructions,
                 visibility: data.visibility || 'private',
             })
@@ -75,6 +77,7 @@ export class SkillRepository {
         userId: string,
         data: Partial<{
             name: string
+            description: string
             instructions: string
             visibility: SkillVisibility
         }>,
@@ -106,8 +109,8 @@ export class SkillRepository {
     async clone(sourceId: string, newOwnerId: string): Promise<Skill | null> {
         const id = ulid()
         const rows = await this.db.execute<Skill>(sql`
-            INSERT INTO skills (id, owner_id, name, instructions, visibility)
-            SELECT ${id}, ${newOwnerId}, name, instructions, 'private'
+            INSERT INTO skills (id, owner_id, name, description, instructions, visibility)
+            SELECT ${id}, ${newOwnerId}, name, description, instructions, 'private'
             FROM skills
             WHERE id = ${sourceId}
               AND visibility = 'public'
@@ -115,6 +118,7 @@ export class SkillRepository {
                 id,
                 owner_id AS "ownerId",
                 name,
+                description,
                 instructions,
                 visibility,
                 created_at AS "createdAt",

--- a/web/src/lib/skills.test.ts
+++ b/web/src/lib/skills.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { createSkillSchema, updateSkillSchema } from './skills'
+
+describe('skill payload schemas', () => {
+    it('trims valid create payloads', () => {
+        const parsed = createSkillSchema.parse({
+            name: '  PR Review  ',
+            instructions: '  Review carefully.  ',
+            visibility: 'public',
+        })
+
+        expect(parsed).toEqual({
+            name: 'PR Review',
+            instructions: 'Review carefully.',
+            visibility: 'public',
+        })
+    })
+
+    it('rejects whitespace-only create and update payloads', () => {
+        expect(createSkillSchema.safeParse({ name: '   ', instructions: 'Do it.' }).success).toBe(
+            false,
+        )
+        expect(createSkillSchema.safeParse({ name: 'Name', instructions: '   ' }).success).toBe(
+            false,
+        )
+        expect(updateSkillSchema.safeParse({ instructions: '   ' }).success).toBe(false)
+    })
+
+    it('rejects unknown visibility and empty updates', () => {
+        expect(
+            createSkillSchema.safeParse({
+                name: 'Name',
+                instructions: 'Do it.',
+                visibility: 'team',
+            }).success,
+        ).toBe(false)
+        expect(updateSkillSchema.safeParse({}).success).toBe(false)
+    })
+})

--- a/web/src/lib/skills.test.ts
+++ b/web/src/lib/skills.test.ts
@@ -5,31 +5,72 @@ describe('skill payload schemas', () => {
     it('trims valid create payloads', () => {
         const parsed = createSkillSchema.parse({
             name: '  PR Review  ',
+            description: '  Review pull requests.  ',
             instructions: '  Review carefully.  ',
             visibility: 'public',
         })
 
         expect(parsed).toEqual({
             name: 'PR Review',
+            description: 'Review pull requests.',
             instructions: 'Review carefully.',
             visibility: 'public',
         })
     })
 
     it('rejects whitespace-only create and update payloads', () => {
-        expect(createSkillSchema.safeParse({ name: '   ', instructions: 'Do it.' }).success).toBe(
-            false,
-        )
-        expect(createSkillSchema.safeParse({ name: 'Name', instructions: '   ' }).success).toBe(
-            false,
-        )
-        expect(updateSkillSchema.safeParse({ instructions: '   ' }).success).toBe(false)
+        expect(
+            createSkillSchema.safeParse({
+                name: '   ',
+                description: 'Do it.',
+                instructions: 'Do it.',
+            }).success,
+        ).toBe(false)
+        expect(
+            createSkillSchema.safeParse({
+                name: 'Name',
+                description: '   ',
+                instructions: 'Do it.',
+            }).success,
+        ).toBe(false)
+        expect(
+            createSkillSchema.safeParse({
+                name: 'Name',
+                description: 'Desc',
+                instructions: '   ',
+            }).success,
+        ).toBe(false)
+        expect(updateSkillSchema.safeParse({ description: '   ' }).success).toBe(false)
+    })
+
+    it('rejects description over 500 characters', () => {
+        const longDesc = 'x'.repeat(501)
+        expect(
+            createSkillSchema.safeParse({
+                name: 'Name',
+                description: longDesc,
+                instructions: 'Do it.',
+            }).success,
+        ).toBe(false)
+        expect(updateSkillSchema.safeParse({ description: longDesc }).success).toBe(false)
+    })
+
+    it('accepts description exactly 500 characters', () => {
+        const desc500 = 'x'.repeat(500)
+        expect(
+            createSkillSchema.safeParse({
+                name: 'Name',
+                description: desc500,
+                instructions: 'Do it.',
+            }).success,
+        ).toBe(true)
     })
 
     it('rejects unknown visibility and empty updates', () => {
         expect(
             createSkillSchema.safeParse({
                 name: 'Name',
+                description: 'Desc',
                 instructions: 'Do it.',
                 visibility: 'team',
             }).success,

--- a/web/src/lib/skills.ts
+++ b/web/src/lib/skills.ts
@@ -1,0 +1,47 @@
+import { z } from 'zod'
+
+export const SKILL_VISIBILITY_VALUES = ['private', 'public'] as const
+export type SkillVisibility = (typeof SKILL_VISIBILITY_VALUES)[number]
+
+export const createSkillSchema = z
+    .object({
+        name: z.string().trim().min(1, 'Name is required'),
+        instructions: z.string().trim().min(1, 'Instructions are required'),
+        visibility: z.enum(SKILL_VISIBILITY_VALUES).default('private'),
+    })
+    .strict()
+
+export const updateSkillSchema = z
+    .object({
+        name: z.string().trim().min(1, 'Name is required').optional(),
+        instructions: z.string().trim().min(1, 'Instructions are required').optional(),
+        visibility: z.enum(SKILL_VISIBILITY_VALUES).optional(),
+    })
+    .strict()
+    .refine(
+        (data) => Object.keys(data).length > 0,
+        'At least one field must be provided for update',
+    )
+
+export const cloneSkillSchema = z.object({}).strict()
+
+export type CreateSkillInput = z.infer<typeof createSkillSchema>
+export type UpdateSkillInput = z.infer<typeof updateSkillSchema>
+
+export interface SkillResponse {
+    id: string
+    ownerId: string
+    name: string
+    instructions: string
+    visibility: SkillVisibility
+    createdAt: string
+    updatedAt: string
+}
+
+export interface SkillListResponse {
+    skills: SkillResponse[]
+}
+
+export interface SkillErrorResponse {
+    error: string
+}

--- a/web/src/lib/skills.ts
+++ b/web/src/lib/skills.ts
@@ -6,6 +6,11 @@ export type SkillVisibility = (typeof SKILL_VISIBILITY_VALUES)[number]
 export const createSkillSchema = z
     .object({
         name: z.string().trim().min(1, 'Name is required'),
+        description: z
+            .string()
+            .trim()
+            .min(1, 'Description is required')
+            .max(500, 'Description must be 500 characters or less'),
         instructions: z.string().trim().min(1, 'Instructions are required'),
         visibility: z.enum(SKILL_VISIBILITY_VALUES).default('private'),
     })
@@ -14,6 +19,12 @@ export const createSkillSchema = z
 export const updateSkillSchema = z
     .object({
         name: z.string().trim().min(1, 'Name is required').optional(),
+        description: z
+            .string()
+            .trim()
+            .min(1, 'Description is required')
+            .max(500, 'Description must be 500 characters or less')
+            .optional(),
         instructions: z.string().trim().min(1, 'Instructions are required').optional(),
         visibility: z.enum(SKILL_VISIBILITY_VALUES).optional(),
     })
@@ -32,6 +43,7 @@ export interface SkillResponse {
     id: string
     ownerId: string
     name: string
+    description: string
     instructions: string
     visibility: SkillVisibility
     createdAt: string

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -35,6 +35,7 @@
         Pencil,
         Trash2,
         Bot,
+        BookOpen,
     } from '@lucide/svelte'
     import { onMount, type Snippet } from 'svelte'
     import { cn } from '$lib/utils'
@@ -397,8 +398,15 @@
                     <Bot />
                     <span class="group-data-[collapsible=icon]:hidden">Agents</span>
                 </Button>
-                <hr />
             {/if}
+            <Button
+                href="/skills"
+                class="mb-2 flex w-full cursor-pointer items-center justify-start has-[>svg]:px-2"
+                variant="ghost">
+                <BookOpen />
+                <span class="group-data-[collapsible=icon]:hidden">Skills</span>
+            </Button>
+            <hr />
 
             <Button
                 href="/"
@@ -518,6 +526,8 @@
                             Chat
                         {:else if page.url.pathname.startsWith('/agents')}
                             Agents
+                        {:else if page.url.pathname.startsWith('/skills')}
+                            Skills
                         {:else}
                             <!-- empty -->
                         {/if}

--- a/web/src/routes/(app)/skills/+page.server.ts
+++ b/web/src/routes/(app)/skills/+page.server.ts
@@ -1,0 +1,14 @@
+import type { PageServerLoad } from './$types.js'
+import { requireActiveUser } from '$lib/server/authHelpers.js'
+import { SkillRepository } from '$lib/server/db/skills.js'
+
+export const load: PageServerLoad = async ({ locals }) => {
+    const { user } = requireActiveUser(locals)
+    const repo = new SkillRepository()
+    const skills = await repo.listVisible(user.id)
+
+    return {
+        user,
+        skills,
+    }
+}

--- a/web/src/routes/(app)/skills/+page.svelte
+++ b/web/src/routes/(app)/skills/+page.svelte
@@ -4,16 +4,18 @@
     import { Input } from '$lib/components/ui/input/index.js'
     import { Textarea } from '$lib/components/ui/textarea/index.js'
     import { Label } from '$lib/components/ui/label/index.js'
+    import { Switch } from '$lib/components/ui/switch/index.js'
     import * as Tabs from '$lib/components/ui/tabs/index.js'
     import * as Card from '$lib/components/ui/card/index.js'
+    import * as Dialog from '$lib/components/ui/dialog/index.js'
     import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
-    import { Plus, BookOpen, Copy, Pencil, Trash2, Globe, Lock } from '@lucide/svelte'
+    import { Tooltip, TooltipTrigger, TooltipContent } from '$lib/components/ui/tooltip/index.js'
+    import { Plus, BookOpen, Copy, Pencil, Trash2, Globe, Lock, Search } from '@lucide/svelte'
     import { invalidateAll } from '$app/navigation'
     import { toast } from 'svelte-sonner'
     import { formatDateTime } from '$lib/utils/datetime'
     import type { PageData } from './$types.js'
     import type { Skill } from '$lib/server/db/schema.js'
-    import type { SkillVisibility } from '$lib/skills.js'
 
     let { data }: { data: PageData } = $props()
 
@@ -22,7 +24,7 @@
     let showNewForm = $state(false)
     let newName = $state('')
     let newInstructions = $state('')
-    let newVisibility = $state<SkillVisibility>('private')
+    let newIsPublic = $state(false)
     let saving = $state(false)
     let filterQuery = $state('')
 
@@ -30,7 +32,7 @@
     let editingSkill = $state<Skill | null>(null)
     let editName = $state('')
     let editInstructions = $state('')
-    let editVisibility = $state<SkillVisibility>('private')
+    let editIsPublic = $state(false)
 
     let showDeleteConfirm = $state(false)
     let deletingSkill = $state<Skill | null>(null)
@@ -63,14 +65,14 @@
         showNewForm = false
         newName = ''
         newInstructions = ''
-        newVisibility = 'private'
+        newIsPublic = false
     }
 
     function openEdit(skill: Skill) {
         editingSkill = skill
         editName = skill.name
         editInstructions = skill.instructions
-        editVisibility = skill.visibility
+        editIsPublic = skill.visibility === 'public'
         showEditForm = true
     }
 
@@ -92,7 +94,7 @@
                 body: JSON.stringify({
                     name: newName.trim(),
                     instructions: newInstructions.trim(),
-                    visibility: newVisibility,
+                    visibility: newIsPublic ? 'public' : 'private',
                 }),
             })
             if (res.ok) {
@@ -124,7 +126,7 @@
                 body: JSON.stringify({
                     name: editName.trim(),
                     instructions: editInstructions.trim(),
-                    visibility: editVisibility,
+                    visibility: editIsPublic ? 'public' : 'private',
                 }),
             })
             if (res.ok) {
@@ -188,8 +190,7 @@
         <div>
             <h1 class="text-2xl font-bold">Skill Library</h1>
             <p class="text-muted-foreground text-sm">
-                Create and manage workplace skills. Public skills are visible to everyone in your
-                deployment.
+                Create and manage workplace skills. Public skills are visible to everyone.
             </p>
         </div>
         {#if !showNewForm}
@@ -236,30 +237,13 @@
                             placeholder="Describe the task, what tools to use, and how to format the response..."
                             rows={6} />
                     </div>
-                    <div class="space-y-2">
-                        <Label>Visibility</Label>
-                        <div class="flex gap-4">
-                            <label class="flex cursor-pointer items-center gap-2">
-                                <input
-                                    type="radio"
-                                    name="visibility"
-                                    value="private"
-                                    checked={newVisibility === 'private'}
-                                    onchange={() => (newVisibility = 'private')} />
-                                <Lock class="h-4 w-4" />
-                                <span class="text-sm">Private (only you)</span>
-                            </label>
-                            <label class="flex cursor-pointer items-center gap-2">
-                                <input
-                                    type="radio"
-                                    name="visibility"
-                                    value="public"
-                                    checked={newVisibility === 'public'}
-                                    onchange={() => (newVisibility = 'public')} />
-                                <Globe class="h-4 w-4" />
-                                <span class="text-sm">Public (everyone)</span>
-                            </label>
-                        </div>
+                    <div class="flex items-center gap-2">
+                        <Switch
+                            id="new-is-public"
+                            checked={newIsPublic}
+                            onCheckedChange={(v) => (newIsPublic = v)}
+                            class="cursor-pointer" />
+                        <Label for="new-is-public" class="cursor-pointer">Public</Label>
                     </div>
                     <div class="flex gap-2">
                         <Button type="submit" disabled={saving} class="cursor-pointer">
@@ -278,88 +262,83 @@
         </Card.Root>
     {/if}
 
-    <!-- Edit form dialog -->
-    {#if showEditForm && editingSkill}
-        <Card.Root class="mb-6">
-            <Card.Header>
-                <Card.Title>Edit Skill</Card.Title>
-            </Card.Header>
-            <Card.Content>
-                <form
-                    onsubmit={(e) => {
-                        e.preventDefault()
-                        handleUpdate()
-                    }}
-                    class="space-y-4">
-                    <div class="space-y-2">
-                        <Label for="edit-name">Name</Label>
-                        <Input id="edit-name" bind:value={editName} />
-                    </div>
-                    <div class="space-y-2">
-                        <Label for="edit-instructions">Instructions</Label>
-                        <Textarea id="edit-instructions" bind:value={editInstructions} rows={6} />
-                    </div>
-                    <div class="space-y-2">
-                        <Label>Visibility</Label>
-                        <div class="flex gap-4">
-                            <label class="flex cursor-pointer items-center gap-2">
-                                <input
-                                    type="radio"
-                                    name="edit-visibility"
-                                    value="private"
-                                    checked={editVisibility === 'private'}
-                                    onchange={() => (editVisibility = 'private')} />
-                                <Lock class="h-4 w-4" />
-                                <span class="text-sm">Private</span>
-                            </label>
-                            <label class="flex cursor-pointer items-center gap-2">
-                                <input
-                                    type="radio"
-                                    name="edit-visibility"
-                                    value="public"
-                                    checked={editVisibility === 'public'}
-                                    onchange={() => (editVisibility = 'public')} />
-                                <Globe class="h-4 w-4" />
-                                <span class="text-sm">Public</span>
-                            </label>
-                        </div>
-                    </div>
-                    <div class="flex gap-2">
-                        <Button type="submit" disabled={saving} class="cursor-pointer">
-                            {saving ? 'Saving...' : 'Save Changes'}
-                        </Button>
-                        <Button
-                            variant="outline"
-                            class="cursor-pointer"
-                            onclick={() => {
-                                showEditForm = false
-                                editingSkill = null
-                            }}
-                            type="button">
-                            Cancel
-                        </Button>
-                    </div>
-                </form>
-            </Card.Content>
-        </Card.Root>
-    {/if}
+    <!-- Edit skill dialog -->
+    <Dialog.Root
+        open={showEditForm}
+        onOpenChange={(open) => {
+            if (!open) {
+                showEditForm = false
+                editingSkill = null
+            }
+        }}>
+        <Dialog.Content>
+            <Dialog.Header>
+                <Dialog.Title>Edit Skill</Dialog.Title>
+                <Dialog.Description
+                    >Update the skill name, instructions, or visibility.</Dialog.Description>
+            </Dialog.Header>
+            <form
+                onsubmit={(e) => {
+                    e.preventDefault()
+                    handleUpdate()
+                }}
+                class="space-y-4">
+                <div class="space-y-2">
+                    <Label for="edit-name">Name</Label>
+                    <Input id="edit-name" bind:value={editName} />
+                </div>
+                <div class="space-y-2">
+                    <Label for="edit-instructions">Instructions</Label>
+                    <Textarea id="edit-instructions" bind:value={editInstructions} rows={6} />
+                </div>
+                <div class="flex items-center gap-2">
+                    <Switch
+                        id="edit-is-public"
+                        checked={editIsPublic}
+                        onCheckedChange={(v) => (editIsPublic = v)}
+                        class="cursor-pointer" />
+                    <Label for="edit-is-public" class="cursor-pointer">Public</Label>
+                </div>
+                <Dialog.Footer>
+                    <Button
+                        variant="outline"
+                        class="cursor-pointer"
+                        onclick={() => {
+                            showEditForm = false
+                            editingSkill = null
+                        }}
+                        type="button">Cancel</Button>
+                    <Button type="submit" disabled={saving} class="cursor-pointer"
+                        >{saving ? 'Saving...' : 'Save Changes'}</Button>
+                </Dialog.Footer>
+            </form>
+        </Dialog.Content>
+    </Dialog.Root>
 
     <div class="mb-4">
         <Label for="skill-filter">Filter skills</Label>
-        <Input
-            id="skill-filter"
-            bind:value={filterQuery}
-            placeholder="Search by name, instructions, or library:<id>"
-            class="mt-2" />
+        <div class="relative mt-2">
+            <Search
+                class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+            <Input
+                id="skill-filter"
+                bind:value={filterQuery}
+                placeholder="Search by name, instructions, or library:<id>"
+                class="pl-9" />
+        </div>
     </div>
 
     <!-- Tabs -->
     <Tabs.Root value={tab} onValueChange={(v) => (tab = v)} class="w-full">
         <Tabs.List class="mb-4">
-            <Tabs.Trigger value="mine" class="cursor-pointer">
+            <Tabs.Trigger
+                value="mine"
+                class="data-[state=active]:bg-background data-[state=active]:text-foreground cursor-pointer data-[state=active]:shadow-sm">
                 My Skills ({mySkills.length})
             </Tabs.Trigger>
-            <Tabs.Trigger value="public" class="cursor-pointer">
+            <Tabs.Trigger
+                value="public"
+                class="data-[state=active]:bg-background data-[state=active]:text-foreground cursor-pointer data-[state=active]:shadow-sm">
                 Public Library ({publicSkills.length})
             </Tabs.Trigger>
         </Tabs.List>
@@ -385,10 +364,10 @@
                     </Button>
                 </div>
             {:else}
-                <div class="space-y-3">
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     {#each mySkills as skill (skill.id)}
-                        <Card.Root class="hover:bg-muted/50 transition-colors">
-                            <Card.Content class="flex items-start justify-between p-4">
+                        <Card.Root class="group hover:bg-muted/50 transition-colors">
+                            <Card.Content class="flex items-start justify-between">
                                 <div class="min-w-0 flex-1">
                                     <div class="flex items-center gap-2">
                                         <h3 class="font-medium">{skill.name}</h3>
@@ -414,23 +393,32 @@
                                         )}
                                     </p>
                                 </div>
-                                <div class="ml-4 flex shrink-0 items-center gap-1">
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        class="cursor-pointer"
-                                        onclick={() => openEdit(skill)}
-                                        title="Edit">
-                                        <Pencil class="h-4 w-4" />
-                                    </Button>
-                                    <Button
-                                        variant="ghost"
-                                        size="icon"
-                                        class="cursor-pointer text-red-500 hover:text-red-600"
-                                        onclick={() => openDelete(skill)}
-                                        title="Delete">
-                                        <Trash2 class="h-4 w-4" />
-                                    </Button>
+                                <div
+                                    class="invisible ml-4 flex shrink-0 items-center gap-1 group-hover:visible">
+                                    <Tooltip>
+                                        <TooltipTrigger>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                class="cursor-pointer"
+                                                onclick={() => openEdit(skill)}>
+                                                <Pencil class="h-4 w-4" />
+                                            </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Edit</TooltipContent>
+                                    </Tooltip>
+                                    <Tooltip>
+                                        <TooltipTrigger>
+                                            <Button
+                                                variant="ghost"
+                                                size="icon"
+                                                class="cursor-pointer text-red-500 hover:text-red-600"
+                                                onclick={() => openDelete(skill)}>
+                                                <Trash2 class="h-4 w-4" />
+                                            </Button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>Delete</TooltipContent>
+                                    </Tooltip>
                                 </div>
                             </Card.Content>
                         </Card.Root>
@@ -452,10 +440,10 @@
                     </p>
                 </div>
             {:else}
-                <div class="space-y-3">
+                <div class="grid grid-cols-1 gap-3 sm:grid-cols-2">
                     {#each publicSkills as skill (skill.id)}
-                        <Card.Root class="hover:bg-muted/50 transition-colors">
-                            <Card.Content class="flex items-start justify-between p-4">
+                        <Card.Root class="group hover:bg-muted/50 transition-colors">
+                            <Card.Content class="flex items-start justify-between">
                                 <div class="min-w-0 flex-1">
                                     <div class="flex items-center gap-2">
                                         <h3 class="font-medium">{skill.name}</h3>
@@ -472,7 +460,7 @@
                                         ID: library:{skill.id}
                                     </p>
                                 </div>
-                                <div class="ml-4 shrink-0">
+                                <div class="invisible ml-4 shrink-0 group-hover:visible">
                                     <Button
                                         variant="outline"
                                         size="sm"

--- a/web/src/routes/(app)/skills/+page.svelte
+++ b/web/src/routes/(app)/skills/+page.svelte
@@ -2,7 +2,6 @@
     import { Button } from '$lib/components/ui/button/index.js'
     import { Badge } from '$lib/components/ui/badge/index.js'
     import { Input } from '$lib/components/ui/input/index.js'
-    import { Textarea } from '$lib/components/ui/textarea/index.js'
     import { Label } from '$lib/components/ui/label/index.js'
     import { Switch } from '$lib/components/ui/switch/index.js'
     import * as Tabs from '$lib/components/ui/tabs/index.js'
@@ -33,7 +32,6 @@
     let editName = $state('')
     let editInstructions = $state('')
     let editIsPublic = $state(false)
-
     let showDeleteConfirm = $state(false)
     let deletingSkill = $state<Skill | null>(null)
 
@@ -62,7 +60,6 @@
     )
 
     function resetNewForm() {
-        showNewForm = false
         newName = ''
         newInstructions = ''
         newIsPublic = false
@@ -98,7 +95,7 @@
                 }),
             })
             if (res.ok) {
-                resetNewForm()
+                showNewForm = false
                 toast.success('Skill created')
                 invalidateAll()
             } else {
@@ -193,85 +190,81 @@
                 Create and manage workplace skills. Public skills are visible to everyone.
             </p>
         </div>
-        {#if !showNewForm}
-            <Button
-                class="cursor-pointer"
-                onclick={() => {
-                    resetNewForm()
-                    showNewForm = true
-                }}>
-                <Plus class="mr-2 h-4 w-4" />
-                New Skill
-            </Button>
-        {/if}
+        <Button
+            class="cursor-pointer"
+            onclick={() => {
+                resetNewForm()
+                showNewForm = true
+            }}>
+            <Plus class="mr-2 h-4 w-4" />
+            New Skill
+        </Button>
     </div>
 
-    <!-- Create form -->
-    {#if showNewForm}
-        <Card.Root class="mb-6">
-            <Card.Header>
-                <Card.Title>Create Skill</Card.Title>
-                <Card.Description>
+    <!-- Create skill dialog -->
+    <Dialog.Root bind:open={showNewForm}>
+        <Dialog.Content
+            class="flex h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] flex-col sm:max-w-3xl lg:max-w-4xl">
+            <Dialog.Header>
+                <Dialog.Title>Create Skill</Dialog.Title>
+                <Dialog.Description>
                     Write instructions that the AI will use when this skill is loaded.
-                </Card.Description>
-            </Card.Header>
-            <Card.Content>
-                <form
-                    onsubmit={(e) => {
-                        e.preventDefault()
-                        handleCreate()
-                    }}
-                    class="space-y-4">
-                    <div class="space-y-2">
-                        <Label for="new-name">Name</Label>
-                        <Input
-                            id="new-name"
-                            bind:value={newName}
-                            placeholder="e.g., PR Review Checklist" />
+                </Dialog.Description>
+            </Dialog.Header>
+            <form
+                onsubmit={(e) => {
+                    e.preventDefault()
+                    handleCreate()
+                }}
+                class="flex min-h-0 flex-1 flex-col gap-4">
+                <div class="space-y-2">
+                    <Label for="new-name">Name</Label>
+                    <Input
+                        id="new-name"
+                        bind:value={newName}
+                        placeholder="e.g., PR Review Checklist" />
+                </div>
+                <div class="flex min-h-0 flex-1 flex-col space-y-2">
+                    <Label for="new-instructions">Instructions</Label>
+                    <div
+                        id="new-instructions"
+                        bind:innerText={newInstructions}
+                        class="before:text-muted-foreground border-input focus-visible:border-ring focus-visible:ring-ring/50 relative min-h-0 flex-1 cursor-text overflow-y-auto rounded-md border bg-transparent px-3 py-2 text-base break-words whitespace-pre-wrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] md:text-sm"
+                        class:before:content-[attr(data-placeholder)]={!newInstructions.trim()}
+                        class:before:content-none={newInstructions.trim()}
+                        contenteditable="plaintext-only"
+                        role="textbox"
+                        aria-multiline="true"
+                        data-placeholder="Describe the task, what tools to use, and how to format the response...">
                     </div>
-                    <div class="space-y-2">
-                        <Label for="new-instructions">Instructions</Label>
-                        <Textarea
-                            id="new-instructions"
-                            bind:value={newInstructions}
-                            placeholder="Describe the task, what tools to use, and how to format the response..."
-                            rows={6} />
-                    </div>
-                    <div class="flex items-center gap-2">
-                        <Switch
-                            id="new-is-public"
-                            checked={newIsPublic}
-                            onCheckedChange={(v) => (newIsPublic = v)}
-                            class="cursor-pointer" />
-                        <Label for="new-is-public" class="cursor-pointer">Public</Label>
-                    </div>
-                    <div class="flex gap-2">
-                        <Button type="submit" disabled={saving} class="cursor-pointer">
-                            {saving ? 'Creating...' : 'Create'}
-                        </Button>
-                        <Button
-                            variant="outline"
-                            class="cursor-pointer"
-                            onclick={resetNewForm}
-                            type="button">
-                            Cancel
-                        </Button>
-                    </div>
-                </form>
-            </Card.Content>
-        </Card.Root>
-    {/if}
+                </div>
+                <div class="flex items-center gap-2">
+                    <Switch
+                        id="new-is-public"
+                        checked={newIsPublic}
+                        onCheckedChange={(v) => (newIsPublic = v)}
+                        class="cursor-pointer" />
+                    <Label for="new-is-public" class="cursor-pointer">Public</Label>
+                </div>
+                <Dialog.Footer>
+                    <Button
+                        variant="outline"
+                        class="cursor-pointer"
+                        onclick={() => {
+                            showNewForm = false
+                        }}
+                        type="button">Cancel</Button>
+                    <Button type="submit" disabled={saving} class="cursor-pointer"
+                        >{saving ? 'Creating...' : 'Create'}</Button>
+                </Dialog.Footer>
+            </form>
+        </Dialog.Content>
+    </Dialog.Root>
 
     <!-- Edit skill dialog -->
-    <Dialog.Root
-        open={showEditForm}
-        onOpenChange={(open) => {
-            if (!open) {
-                showEditForm = false
-                editingSkill = null
-            }
-        }}>
-        <Dialog.Content>
+    <Dialog.Root bind:open={showEditForm}>
+        <Dialog.Content
+            class="flex h-[calc(100dvh-2rem)] max-h-[calc(100dvh-2rem)] flex-col sm:max-w-3xl lg:max-w-4xl">
             <Dialog.Header>
                 <Dialog.Title>Edit Skill</Dialog.Title>
                 <Dialog.Description
@@ -282,14 +275,24 @@
                     e.preventDefault()
                     handleUpdate()
                 }}
-                class="space-y-4">
+                class="flex min-h-0 flex-1 flex-col gap-4">
                 <div class="space-y-2">
                     <Label for="edit-name">Name</Label>
                     <Input id="edit-name" bind:value={editName} />
                 </div>
-                <div class="space-y-2">
+                <div class="flex min-h-0 flex-1 flex-col space-y-2">
                     <Label for="edit-instructions">Instructions</Label>
-                    <Textarea id="edit-instructions" bind:value={editInstructions} rows={6} />
+                    <div
+                        id="edit-instructions"
+                        bind:innerText={editInstructions}
+                        class="before:text-muted-foreground border-input focus-visible:border-ring focus-visible:ring-ring/50 relative min-h-0 flex-1 cursor-text overflow-y-auto rounded-md border bg-transparent px-3 py-2 text-base break-words whitespace-pre-wrap shadow-xs transition-[color,box-shadow] outline-none focus-visible:ring-[3px] md:text-sm"
+                        class:before:content-[attr(data-placeholder)]={!editInstructions.trim()}
+                        class:before:content-none={editInstructions.trim()}
+                        contenteditable="plaintext-only"
+                        role="textbox"
+                        aria-multiline="true"
+                        data-placeholder="Describe the task, what tools to use, and how to format the response...">
+                    </div>
                 </div>
                 <div class="flex items-center gap-2">
                     <Switch
@@ -305,7 +308,6 @@
                         class="cursor-pointer"
                         onclick={() => {
                             showEditForm = false
-                            editingSkill = null
                         }}
                         type="button">Cancel</Button>
                     <Button type="submit" disabled={saving} class="cursor-pointer"

--- a/web/src/routes/(app)/skills/+page.svelte
+++ b/web/src/routes/(app)/skills/+page.svelte
@@ -9,6 +9,7 @@
     import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
     import { Plus, BookOpen, Copy, Pencil, Trash2, Globe, Lock } from '@lucide/svelte'
     import { invalidateAll } from '$app/navigation'
+    import { toast } from 'svelte-sonner'
     import { formatDateTime } from '$lib/utils/datetime'
     import type { PageData } from './$types.js'
     import type { Skill } from '$lib/server/db/schema.js'
@@ -23,8 +24,6 @@
     let newInstructions = $state('')
     let newVisibility = $state<SkillVisibility>('private')
     let saving = $state(false)
-    let error = $state('')
-    let statusMessage = $state('')
     let filterQuery = $state('')
 
     let showEditForm = $state(false)
@@ -65,8 +64,6 @@
         newName = ''
         newInstructions = ''
         newVisibility = 'private'
-        error = ''
-        statusMessage = ''
     }
 
     function openEdit(skill: Skill) {
@@ -75,8 +72,6 @@
         editInstructions = skill.instructions
         editVisibility = skill.visibility
         showEditForm = true
-        error = ''
-        statusMessage = ''
     }
 
     function openDelete(skill: Skill) {
@@ -86,12 +81,10 @@
 
     async function handleCreate() {
         if (!newName.trim() || !newInstructions.trim()) {
-            error = 'Name and instructions are required'
+            toast.error('Name and instructions are required')
             return
         }
         saving = true
-        error = ''
-        statusMessage = ''
         try {
             const res = await fetch('/api/skills', {
                 method: 'POST',
@@ -104,14 +97,14 @@
             })
             if (res.ok) {
                 resetNewForm()
-                statusMessage = 'Skill created.'
+                toast.success('Skill created')
                 invalidateAll()
             } else {
                 const body = await res.json()
-                error = body.error || 'Failed to create skill'
+                toast.error(body.error || 'Failed to create skill')
             }
         } catch {
-            error = 'Failed to create skill'
+            toast.error('Failed to create skill')
         } finally {
             saving = false
         }
@@ -120,12 +113,10 @@
     async function handleUpdate() {
         if (!editingSkill) return
         if (!editName.trim() || !editInstructions.trim()) {
-            error = 'Name and instructions are required'
+            toast.error('Name and instructions are required')
             return
         }
         saving = true
-        error = ''
-        statusMessage = ''
         try {
             const res = await fetch(`/api/skills/${editingSkill.id}`, {
                 method: 'PUT',
@@ -139,14 +130,14 @@
             if (res.ok) {
                 showEditForm = false
                 editingSkill = null
-                statusMessage = 'Skill updated.'
+                toast.success('Skill updated')
                 invalidateAll()
             } else {
                 const body = await res.json()
-                error = body.error || 'Failed to update skill'
+                toast.error(body.error || 'Failed to update skill')
             }
         } catch {
-            error = 'Failed to update skill'
+            toast.error('Failed to update skill')
         } finally {
             saving = false
         }
@@ -162,32 +153,30 @@
             const res = await fetch(`/api/skills/${skillId}`, { method: 'DELETE' })
             if (!res.ok) {
                 const body = await res.json()
-                error = body.error || 'Failed to delete skill'
+                toast.error(body.error || 'Failed to delete skill')
                 return
             }
-            statusMessage = 'Skill deleted.'
+            toast.success('Skill deleted')
             invalidateAll()
         } catch {
-            error = 'Failed to delete skill'
+            toast.error('Failed to delete skill')
         }
     }
 
     async function handleClone(skillId: string) {
         cloningIds = [...cloningIds, skillId]
-        error = ''
-        statusMessage = ''
         try {
             const res = await fetch(`/api/skills/${skillId}/clone`, { method: 'POST' })
             if (res.ok) {
-                statusMessage = 'Skill cloned as a private copy.'
+                toast.success('Skill cloned as a private copy')
                 await invalidateAll()
                 tab = 'mine'
                 return
             }
             const body = await res.json()
-            error = body.error || 'Failed to clone skill'
+            toast.error(body.error || 'Failed to clone skill')
         } catch {
-            error = 'Failed to clone skill'
+            toast.error('Failed to clone skill')
         } finally {
             cloningIds = cloningIds.filter((id) => id !== skillId)
         }
@@ -215,18 +204,6 @@
             </Button>
         {/if}
     </div>
-
-    {#if statusMessage}
-        <p
-            class="mb-4 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
-            {statusMessage}
-        </p>
-    {/if}
-    {#if error && !showNewForm && !showEditForm}
-        <p class="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
-            {error}
-        </p>
-    {/if}
 
     <!-- Create form -->
     {#if showNewForm}
@@ -284,9 +261,6 @@
                             </label>
                         </div>
                     </div>
-                    {#if error}
-                        <p class="text-sm text-red-500">{error}</p>
-                    {/if}
                     <div class="flex gap-2">
                         <Button type="submit" disabled={saving} class="cursor-pointer">
                             {saving ? 'Creating...' : 'Create'}
@@ -350,9 +324,6 @@
                             </label>
                         </div>
                     </div>
-                    {#if error}
-                        <p class="text-sm text-red-500">{error}</p>
-                    {/if}
                     <div class="flex gap-2">
                         <Button type="submit" disabled={saving} class="cursor-pointer">
                             {saving ? 'Saving...' : 'Save Changes'}
@@ -363,7 +334,6 @@
                             onclick={() => {
                                 showEditForm = false
                                 editingSkill = null
-                                error = ''
                             }}
                             type="button">
                             Cancel
@@ -417,52 +387,53 @@
             {:else}
                 <div class="space-y-3">
                     {#each mySkills as skill (skill.id)}
-                        <div
-                            class="hover:bg-muted/50 flex items-start justify-between rounded-lg border p-4 transition-colors">
-                            <div class="min-w-0 flex-1">
-                                <div class="flex items-center gap-2">
-                                    <h3 class="font-medium">{skill.name}</h3>
-                                    {#if skill.visibility === 'public'}
-                                        <Badge variant="outline">
-                                            <Globe class="mr-1 h-3 w-3" />
-                                            Public
-                                        </Badge>
-                                    {:else}
-                                        <Badge variant="secondary">
-                                            <Lock class="mr-1 h-3 w-3" />
-                                            Private
-                                        </Badge>
-                                    {/if}
+                        <Card.Root class="hover:bg-muted/50 transition-colors">
+                            <Card.Content class="flex items-start justify-between p-4">
+                                <div class="min-w-0 flex-1">
+                                    <div class="flex items-center gap-2">
+                                        <h3 class="font-medium">{skill.name}</h3>
+                                        {#if skill.visibility === 'public'}
+                                            <Badge variant="outline">
+                                                <Globe class="mr-1 h-3 w-3" />
+                                                Public
+                                            </Badge>
+                                        {:else}
+                                            <Badge variant="secondary">
+                                                <Lock class="mr-1 h-3 w-3" />
+                                                Private
+                                            </Badge>
+                                        {/if}
+                                    </div>
+                                    <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
+                                        {skill.instructions}
+                                    </p>
+                                    <p class="text-muted-foreground mt-1 text-xs">
+                                        Updated {formatDateTime(
+                                            skill.updatedAt,
+                                            data.user.configuration,
+                                        )}
+                                    </p>
                                 </div>
-                                <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
-                                    {skill.instructions}
-                                </p>
-                                <p class="text-muted-foreground mt-1 text-xs">
-                                    Updated {formatDateTime(
-                                        skill.updatedAt,
-                                        data.user.configuration,
-                                    )}
-                                </p>
-                            </div>
-                            <div class="ml-4 flex shrink-0 items-center gap-1">
-                                <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    class="cursor-pointer"
-                                    onclick={() => openEdit(skill)}
-                                    title="Edit">
-                                    <Pencil class="h-4 w-4" />
-                                </Button>
-                                <Button
-                                    variant="ghost"
-                                    size="icon"
-                                    class="cursor-pointer text-red-500 hover:text-red-600"
-                                    onclick={() => openDelete(skill)}
-                                    title="Delete">
-                                    <Trash2 class="h-4 w-4" />
-                                </Button>
-                            </div>
-                        </div>
+                                <div class="ml-4 flex shrink-0 items-center gap-1">
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        class="cursor-pointer"
+                                        onclick={() => openEdit(skill)}
+                                        title="Edit">
+                                        <Pencil class="h-4 w-4" />
+                                    </Button>
+                                    <Button
+                                        variant="ghost"
+                                        size="icon"
+                                        class="cursor-pointer text-red-500 hover:text-red-600"
+                                        onclick={() => openDelete(skill)}
+                                        title="Delete">
+                                        <Trash2 class="h-4 w-4" />
+                                    </Button>
+                                </div>
+                            </Card.Content>
+                        </Card.Root>
                     {/each}
                 </div>
             {/if}
@@ -483,36 +454,37 @@
             {:else}
                 <div class="space-y-3">
                     {#each publicSkills as skill (skill.id)}
-                        <div
-                            class="hover:bg-muted/50 flex items-start justify-between rounded-lg border p-4 transition-colors">
-                            <div class="min-w-0 flex-1">
-                                <div class="flex items-center gap-2">
-                                    <h3 class="font-medium">{skill.name}</h3>
-                                    <Badge variant="outline">
-                                        <Globe class="mr-1 h-3 w-3" />
-                                        Public
-                                    </Badge>
-                                    <Badge variant="secondary">Shared</Badge>
+                        <Card.Root class="hover:bg-muted/50 transition-colors">
+                            <Card.Content class="flex items-start justify-between p-4">
+                                <div class="min-w-0 flex-1">
+                                    <div class="flex items-center gap-2">
+                                        <h3 class="font-medium">{skill.name}</h3>
+                                        <Badge variant="outline">
+                                            <Globe class="mr-1 h-3 w-3" />
+                                            Public
+                                        </Badge>
+                                        <Badge variant="secondary">Shared</Badge>
+                                    </div>
+                                    <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
+                                        {skill.instructions}
+                                    </p>
+                                    <p class="text-muted-foreground mt-1 text-xs">
+                                        ID: library:{skill.id}
+                                    </p>
                                 </div>
-                                <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
-                                    {skill.instructions}
-                                </p>
-                                <p class="text-muted-foreground mt-1 text-xs">
-                                    ID: library:{skill.id}
-                                </p>
-                            </div>
-                            <div class="ml-4 shrink-0">
-                                <Button
-                                    variant="outline"
-                                    size="sm"
-                                    class="cursor-pointer"
-                                    disabled={cloningIds.includes(skill.id)}
-                                    onclick={() => handleClone(skill.id)}>
-                                    <Copy class="mr-1 h-3 w-3" />
-                                    {cloningIds.includes(skill.id) ? 'Cloning...' : 'Clone'}
-                                </Button>
-                            </div>
-                        </div>
+                                <div class="ml-4 shrink-0">
+                                    <Button
+                                        variant="outline"
+                                        size="sm"
+                                        class="cursor-pointer"
+                                        disabled={cloningIds.includes(skill.id)}
+                                        onclick={() => handleClone(skill.id)}>
+                                        <Copy class="mr-1 h-3 w-3" />
+                                        {cloningIds.includes(skill.id) ? 'Cloning...' : 'Clone'}
+                                    </Button>
+                                </div>
+                            </Card.Content>
+                        </Card.Root>
                     {/each}
                 </div>
             {/if}

--- a/web/src/routes/(app)/skills/+page.svelte
+++ b/web/src/routes/(app)/skills/+page.svelte
@@ -22,6 +22,7 @@
 
     let showNewForm = $state(false)
     let newName = $state('')
+    let newDescription = $state('')
     let newInstructions = $state('')
     let newIsPublic = $state(false)
     let saving = $state(false)
@@ -30,6 +31,7 @@
     let showEditForm = $state(false)
     let editingSkill = $state<Skill | null>(null)
     let editName = $state('')
+    let editDescription = $state('')
     let editInstructions = $state('')
     let editIsPublic = $state(false)
     let showDeleteConfirm = $state(false)
@@ -42,6 +44,7 @@
         if (!query) return true
         return (
             skill.name.toLocaleLowerCase().includes(query) ||
+            skill.description.toLocaleLowerCase().includes(query) ||
             skill.instructions.toLocaleLowerCase().includes(query) ||
             `library:${skill.id}`.toLocaleLowerCase().includes(query)
         )
@@ -61,6 +64,7 @@
 
     function resetNewForm() {
         newName = ''
+        newDescription = ''
         newInstructions = ''
         newIsPublic = false
     }
@@ -68,6 +72,7 @@
     function openEdit(skill: Skill) {
         editingSkill = skill
         editName = skill.name
+        editDescription = skill.description
         editInstructions = skill.instructions
         editIsPublic = skill.visibility === 'public'
         showEditForm = true
@@ -79,8 +84,8 @@
     }
 
     async function handleCreate() {
-        if (!newName.trim() || !newInstructions.trim()) {
-            toast.error('Name and instructions are required')
+        if (!newName.trim() || !newDescription.trim() || !newInstructions.trim()) {
+            toast.error('Name, description, and instructions are required')
             return
         }
         saving = true
@@ -90,6 +95,7 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     name: newName.trim(),
+                    description: newDescription.trim(),
                     instructions: newInstructions.trim(),
                     visibility: newIsPublic ? 'public' : 'private',
                 }),
@@ -111,8 +117,8 @@
 
     async function handleUpdate() {
         if (!editingSkill) return
-        if (!editName.trim() || !editInstructions.trim()) {
-            toast.error('Name and instructions are required')
+        if (!editName.trim() || !editDescription.trim() || !editInstructions.trim()) {
+            toast.error('Name, description, and instructions are required')
             return
         }
         saving = true
@@ -122,6 +128,7 @@
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({
                     name: editName.trim(),
+                    description: editDescription.trim(),
                     instructions: editInstructions.trim(),
                     visibility: editIsPublic ? 'public' : 'private',
                 }),
@@ -224,6 +231,14 @@
                         bind:value={newName}
                         placeholder="e.g., PR Review Checklist" />
                 </div>
+                <div class="space-y-2">
+                    <Label for="new-description">Description</Label>
+                    <Input
+                        id="new-description"
+                        bind:value={newDescription}
+                        maxlength={500}
+                        placeholder="Briefly explain what this skill does and when it should be used..." />
+                </div>
                 <div class="flex min-h-0 flex-1 flex-col space-y-2">
                     <Label for="new-instructions">Instructions</Label>
                     <div
@@ -280,6 +295,14 @@
                     <Label for="edit-name">Name</Label>
                     <Input id="edit-name" bind:value={editName} />
                 </div>
+                <div class="space-y-2">
+                    <Label for="edit-description">Description</Label>
+                    <Input
+                        id="edit-description"
+                        bind:value={editDescription}
+                        maxlength={500}
+                        placeholder="Briefly explain what this skill does and when it should be used..." />
+                </div>
                 <div class="flex min-h-0 flex-1 flex-col space-y-2">
                     <Label for="edit-instructions">Instructions</Label>
                     <div
@@ -325,7 +348,7 @@
             <Input
                 id="skill-filter"
                 bind:value={filterQuery}
-                placeholder="Search by name, instructions, or library:<id>"
+                placeholder="Search by name, description, instructions, or library:<id>"
                 class="pl-9" />
         </div>
     </div>
@@ -386,7 +409,7 @@
                                         {/if}
                                     </div>
                                     <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
-                                        {skill.instructions}
+                                        {skill.description}
                                     </p>
                                     <p class="text-muted-foreground mt-1 text-xs">
                                         Updated {formatDateTime(
@@ -456,7 +479,7 @@
                                         <Badge variant="secondary">Shared</Badge>
                                     </div>
                                     <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
-                                        {skill.instructions}
+                                        {skill.description}
                                     </p>
                                     <p class="text-muted-foreground mt-1 text-xs">
                                         ID: library:{skill.id}

--- a/web/src/routes/(app)/skills/+page.svelte
+++ b/web/src/routes/(app)/skills/+page.svelte
@@ -1,0 +1,544 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button/index.js'
+    import { Badge } from '$lib/components/ui/badge/index.js'
+    import { Input } from '$lib/components/ui/input/index.js'
+    import { Textarea } from '$lib/components/ui/textarea/index.js'
+    import { Label } from '$lib/components/ui/label/index.js'
+    import * as Tabs from '$lib/components/ui/tabs/index.js'
+    import * as Card from '$lib/components/ui/card/index.js'
+    import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
+    import { Plus, BookOpen, Copy, Pencil, Trash2, Globe, Lock } from '@lucide/svelte'
+    import { invalidateAll } from '$app/navigation'
+    import { formatDateTime } from '$lib/utils/datetime'
+    import type { PageData } from './$types.js'
+    import type { Skill } from '$lib/server/db/schema.js'
+    import type { SkillVisibility } from '$lib/skills.js'
+
+    let { data }: { data: PageData } = $props()
+
+    let tab = $state('mine')
+
+    let showNewForm = $state(false)
+    let newName = $state('')
+    let newInstructions = $state('')
+    let newVisibility = $state<SkillVisibility>('private')
+    let saving = $state(false)
+    let error = $state('')
+    let statusMessage = $state('')
+    let filterQuery = $state('')
+
+    let showEditForm = $state(false)
+    let editingSkill = $state<Skill | null>(null)
+    let editName = $state('')
+    let editInstructions = $state('')
+    let editVisibility = $state<SkillVisibility>('private')
+
+    let showDeleteConfirm = $state(false)
+    let deletingSkill = $state<Skill | null>(null)
+
+    let cloningIds = $state<string[]>([])
+
+    function matchesFilter(skill: Skill) {
+        const query = filterQuery.trim().toLocaleLowerCase()
+        if (!query) return true
+        return (
+            skill.name.toLocaleLowerCase().includes(query) ||
+            skill.instructions.toLocaleLowerCase().includes(query) ||
+            `library:${skill.id}`.toLocaleLowerCase().includes(query)
+        )
+    }
+
+    let mySkills = $derived(
+        data.skills.filter((skill) => skill.ownerId === data.user.id && matchesFilter(skill)),
+    )
+    let publicSkills = $derived(
+        data.skills.filter(
+            (skill) =>
+                skill.visibility === 'public' &&
+                skill.ownerId !== data.user.id &&
+                matchesFilter(skill),
+        ),
+    )
+
+    function resetNewForm() {
+        showNewForm = false
+        newName = ''
+        newInstructions = ''
+        newVisibility = 'private'
+        error = ''
+        statusMessage = ''
+    }
+
+    function openEdit(skill: Skill) {
+        editingSkill = skill
+        editName = skill.name
+        editInstructions = skill.instructions
+        editVisibility = skill.visibility
+        showEditForm = true
+        error = ''
+        statusMessage = ''
+    }
+
+    function openDelete(skill: Skill) {
+        deletingSkill = skill
+        showDeleteConfirm = true
+    }
+
+    async function handleCreate() {
+        if (!newName.trim() || !newInstructions.trim()) {
+            error = 'Name and instructions are required'
+            return
+        }
+        saving = true
+        error = ''
+        statusMessage = ''
+        try {
+            const res = await fetch('/api/skills', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: newName.trim(),
+                    instructions: newInstructions.trim(),
+                    visibility: newVisibility,
+                }),
+            })
+            if (res.ok) {
+                resetNewForm()
+                statusMessage = 'Skill created.'
+                invalidateAll()
+            } else {
+                const body = await res.json()
+                error = body.error || 'Failed to create skill'
+            }
+        } catch {
+            error = 'Failed to create skill'
+        } finally {
+            saving = false
+        }
+    }
+
+    async function handleUpdate() {
+        if (!editingSkill) return
+        if (!editName.trim() || !editInstructions.trim()) {
+            error = 'Name and instructions are required'
+            return
+        }
+        saving = true
+        error = ''
+        statusMessage = ''
+        try {
+            const res = await fetch(`/api/skills/${editingSkill.id}`, {
+                method: 'PUT',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: editName.trim(),
+                    instructions: editInstructions.trim(),
+                    visibility: editVisibility,
+                }),
+            })
+            if (res.ok) {
+                showEditForm = false
+                editingSkill = null
+                statusMessage = 'Skill updated.'
+                invalidateAll()
+            } else {
+                const body = await res.json()
+                error = body.error || 'Failed to update skill'
+            }
+        } catch {
+            error = 'Failed to update skill'
+        } finally {
+            saving = false
+        }
+    }
+
+    async function confirmDelete() {
+        if (!deletingSkill) return
+        const skillId = deletingSkill.id
+        deletingSkill = null
+        showDeleteConfirm = false
+
+        try {
+            const res = await fetch(`/api/skills/${skillId}`, { method: 'DELETE' })
+            if (!res.ok) {
+                const body = await res.json()
+                error = body.error || 'Failed to delete skill'
+                return
+            }
+            statusMessage = 'Skill deleted.'
+            invalidateAll()
+        } catch {
+            error = 'Failed to delete skill'
+        }
+    }
+
+    async function handleClone(skillId: string) {
+        cloningIds = [...cloningIds, skillId]
+        error = ''
+        statusMessage = ''
+        try {
+            const res = await fetch(`/api/skills/${skillId}/clone`, { method: 'POST' })
+            if (res.ok) {
+                statusMessage = 'Skill cloned as a private copy.'
+                await invalidateAll()
+                tab = 'mine'
+                return
+            }
+            const body = await res.json()
+            error = body.error || 'Failed to clone skill'
+        } catch {
+            error = 'Failed to clone skill'
+        } finally {
+            cloningIds = cloningIds.filter((id) => id !== skillId)
+        }
+    }
+</script>
+
+<div class="mx-auto max-w-4xl p-6">
+    <div class="mb-6 flex items-center justify-between">
+        <div>
+            <h1 class="text-2xl font-bold">Skill Library</h1>
+            <p class="text-muted-foreground text-sm">
+                Create and manage workplace skills. Public skills are visible to everyone in your
+                deployment.
+            </p>
+        </div>
+        {#if !showNewForm}
+            <Button
+                class="cursor-pointer"
+                onclick={() => {
+                    resetNewForm()
+                    showNewForm = true
+                }}>
+                <Plus class="mr-2 h-4 w-4" />
+                New Skill
+            </Button>
+        {/if}
+    </div>
+
+    {#if statusMessage}
+        <p
+            class="mb-4 rounded-md border border-green-200 bg-green-50 px-3 py-2 text-sm text-green-700">
+            {statusMessage}
+        </p>
+    {/if}
+    {#if error && !showNewForm && !showEditForm}
+        <p class="mb-4 rounded-md border border-red-200 bg-red-50 px-3 py-2 text-sm text-red-700">
+            {error}
+        </p>
+    {/if}
+
+    <!-- Create form -->
+    {#if showNewForm}
+        <Card.Root class="mb-6">
+            <Card.Header>
+                <Card.Title>Create Skill</Card.Title>
+                <Card.Description>
+                    Write instructions that the AI will use when this skill is loaded.
+                </Card.Description>
+            </Card.Header>
+            <Card.Content>
+                <form
+                    onsubmit={(e) => {
+                        e.preventDefault()
+                        handleCreate()
+                    }}
+                    class="space-y-4">
+                    <div class="space-y-2">
+                        <Label for="new-name">Name</Label>
+                        <Input
+                            id="new-name"
+                            bind:value={newName}
+                            placeholder="e.g., PR Review Checklist" />
+                    </div>
+                    <div class="space-y-2">
+                        <Label for="new-instructions">Instructions</Label>
+                        <Textarea
+                            id="new-instructions"
+                            bind:value={newInstructions}
+                            placeholder="Describe the task, what tools to use, and how to format the response..."
+                            rows={6} />
+                    </div>
+                    <div class="space-y-2">
+                        <Label>Visibility</Label>
+                        <div class="flex gap-4">
+                            <label class="flex cursor-pointer items-center gap-2">
+                                <input
+                                    type="radio"
+                                    name="visibility"
+                                    value="private"
+                                    checked={newVisibility === 'private'}
+                                    onchange={() => (newVisibility = 'private')} />
+                                <Lock class="h-4 w-4" />
+                                <span class="text-sm">Private (only you)</span>
+                            </label>
+                            <label class="flex cursor-pointer items-center gap-2">
+                                <input
+                                    type="radio"
+                                    name="visibility"
+                                    value="public"
+                                    checked={newVisibility === 'public'}
+                                    onchange={() => (newVisibility = 'public')} />
+                                <Globe class="h-4 w-4" />
+                                <span class="text-sm">Public (everyone)</span>
+                            </label>
+                        </div>
+                    </div>
+                    {#if error}
+                        <p class="text-sm text-red-500">{error}</p>
+                    {/if}
+                    <div class="flex gap-2">
+                        <Button type="submit" disabled={saving} class="cursor-pointer">
+                            {saving ? 'Creating...' : 'Create'}
+                        </Button>
+                        <Button
+                            variant="outline"
+                            class="cursor-pointer"
+                            onclick={resetNewForm}
+                            type="button">
+                            Cancel
+                        </Button>
+                    </div>
+                </form>
+            </Card.Content>
+        </Card.Root>
+    {/if}
+
+    <!-- Edit form dialog -->
+    {#if showEditForm && editingSkill}
+        <Card.Root class="mb-6">
+            <Card.Header>
+                <Card.Title>Edit Skill</Card.Title>
+            </Card.Header>
+            <Card.Content>
+                <form
+                    onsubmit={(e) => {
+                        e.preventDefault()
+                        handleUpdate()
+                    }}
+                    class="space-y-4">
+                    <div class="space-y-2">
+                        <Label for="edit-name">Name</Label>
+                        <Input id="edit-name" bind:value={editName} />
+                    </div>
+                    <div class="space-y-2">
+                        <Label for="edit-instructions">Instructions</Label>
+                        <Textarea id="edit-instructions" bind:value={editInstructions} rows={6} />
+                    </div>
+                    <div class="space-y-2">
+                        <Label>Visibility</Label>
+                        <div class="flex gap-4">
+                            <label class="flex cursor-pointer items-center gap-2">
+                                <input
+                                    type="radio"
+                                    name="edit-visibility"
+                                    value="private"
+                                    checked={editVisibility === 'private'}
+                                    onchange={() => (editVisibility = 'private')} />
+                                <Lock class="h-4 w-4" />
+                                <span class="text-sm">Private</span>
+                            </label>
+                            <label class="flex cursor-pointer items-center gap-2">
+                                <input
+                                    type="radio"
+                                    name="edit-visibility"
+                                    value="public"
+                                    checked={editVisibility === 'public'}
+                                    onchange={() => (editVisibility = 'public')} />
+                                <Globe class="h-4 w-4" />
+                                <span class="text-sm">Public</span>
+                            </label>
+                        </div>
+                    </div>
+                    {#if error}
+                        <p class="text-sm text-red-500">{error}</p>
+                    {/if}
+                    <div class="flex gap-2">
+                        <Button type="submit" disabled={saving} class="cursor-pointer">
+                            {saving ? 'Saving...' : 'Save Changes'}
+                        </Button>
+                        <Button
+                            variant="outline"
+                            class="cursor-pointer"
+                            onclick={() => {
+                                showEditForm = false
+                                editingSkill = null
+                                error = ''
+                            }}
+                            type="button">
+                            Cancel
+                        </Button>
+                    </div>
+                </form>
+            </Card.Content>
+        </Card.Root>
+    {/if}
+
+    <div class="mb-4">
+        <Label for="skill-filter">Filter skills</Label>
+        <Input
+            id="skill-filter"
+            bind:value={filterQuery}
+            placeholder="Search by name, instructions, or library:<id>"
+            class="mt-2" />
+    </div>
+
+    <!-- Tabs -->
+    <Tabs.Root value={tab} onValueChange={(v) => (tab = v)} class="w-full">
+        <Tabs.List class="mb-4">
+            <Tabs.Trigger value="mine" class="cursor-pointer">
+                My Skills ({mySkills.length})
+            </Tabs.Trigger>
+            <Tabs.Trigger value="public" class="cursor-pointer">
+                Public Library ({publicSkills.length})
+            </Tabs.Trigger>
+        </Tabs.List>
+
+        <!-- My Skills tab -->
+        <Tabs.Content value="mine">
+            {#if mySkills.length === 0}
+                <div
+                    class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+                    <BookOpen class="text-muted-foreground mb-4 h-12 w-12" />
+                    <h3 class="mb-2 text-lg font-medium">No skills yet</h3>
+                    <p class="text-muted-foreground mb-4 text-sm">
+                        Create a skill with reusable instructions for common tasks.
+                    </p>
+                    <Button
+                        class="cursor-pointer"
+                        onclick={() => {
+                            resetNewForm()
+                            showNewForm = true
+                        }}>
+                        <Plus class="mr-2 h-4 w-4" />
+                        Create your first skill
+                    </Button>
+                </div>
+            {:else}
+                <div class="space-y-3">
+                    {#each mySkills as skill (skill.id)}
+                        <div
+                            class="hover:bg-muted/50 flex items-start justify-between rounded-lg border p-4 transition-colors">
+                            <div class="min-w-0 flex-1">
+                                <div class="flex items-center gap-2">
+                                    <h3 class="font-medium">{skill.name}</h3>
+                                    {#if skill.visibility === 'public'}
+                                        <Badge variant="outline">
+                                            <Globe class="mr-1 h-3 w-3" />
+                                            Public
+                                        </Badge>
+                                    {:else}
+                                        <Badge variant="secondary">
+                                            <Lock class="mr-1 h-3 w-3" />
+                                            Private
+                                        </Badge>
+                                    {/if}
+                                </div>
+                                <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
+                                    {skill.instructions}
+                                </p>
+                                <p class="text-muted-foreground mt-1 text-xs">
+                                    Updated {formatDateTime(
+                                        skill.updatedAt,
+                                        data.user.configuration,
+                                    )}
+                                </p>
+                            </div>
+                            <div class="ml-4 flex shrink-0 items-center gap-1">
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    class="cursor-pointer"
+                                    onclick={() => openEdit(skill)}
+                                    title="Edit">
+                                    <Pencil class="h-4 w-4" />
+                                </Button>
+                                <Button
+                                    variant="ghost"
+                                    size="icon"
+                                    class="cursor-pointer text-red-500 hover:text-red-600"
+                                    onclick={() => openDelete(skill)}
+                                    title="Delete">
+                                    <Trash2 class="h-4 w-4" />
+                                </Button>
+                            </div>
+                        </div>
+                    {/each}
+                </div>
+            {/if}
+        </Tabs.Content>
+
+        <!-- Public Library tab -->
+        <Tabs.Content value="public">
+            {#if publicSkills.length === 0}
+                <div
+                    class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+                    <BookOpen class="text-muted-foreground mb-4 h-12 w-12" />
+                    <h3 class="mb-2 text-lg font-medium">No public skills yet</h3>
+                    <p class="text-muted-foreground text-sm">
+                        Public skills created by other users will appear here. You can clone any
+                        public skill to make it your own.
+                    </p>
+                </div>
+            {:else}
+                <div class="space-y-3">
+                    {#each publicSkills as skill (skill.id)}
+                        <div
+                            class="hover:bg-muted/50 flex items-start justify-between rounded-lg border p-4 transition-colors">
+                            <div class="min-w-0 flex-1">
+                                <div class="flex items-center gap-2">
+                                    <h3 class="font-medium">{skill.name}</h3>
+                                    <Badge variant="outline">
+                                        <Globe class="mr-1 h-3 w-3" />
+                                        Public
+                                    </Badge>
+                                    <Badge variant="secondary">Shared</Badge>
+                                </div>
+                                <p class="text-muted-foreground mt-1 line-clamp-2 text-sm">
+                                    {skill.instructions}
+                                </p>
+                                <p class="text-muted-foreground mt-1 text-xs">
+                                    ID: library:{skill.id}
+                                </p>
+                            </div>
+                            <div class="ml-4 shrink-0">
+                                <Button
+                                    variant="outline"
+                                    size="sm"
+                                    class="cursor-pointer"
+                                    disabled={cloningIds.includes(skill.id)}
+                                    onclick={() => handleClone(skill.id)}>
+                                    <Copy class="mr-1 h-3 w-3" />
+                                    {cloningIds.includes(skill.id) ? 'Cloning...' : 'Clone'}
+                                </Button>
+                            </div>
+                        </div>
+                    {/each}
+                </div>
+            {/if}
+        </Tabs.Content>
+    </Tabs.Root>
+</div>
+
+<!-- Delete confirmation dialog -->
+<AlertDialog.Root
+    open={showDeleteConfirm}
+    onOpenChange={(open) => {
+        if (!open) {
+            showDeleteConfirm = false
+            deletingSkill = null
+        }
+    }}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>Delete skill</AlertDialog.Title>
+            <AlertDialog.Description>
+                This will permanently delete "{deletingSkill?.name}". This action cannot be undone.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel>Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action onclick={confirmDelete}>Delete</AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/web/src/routes/api/skills/+server.ts
+++ b/web/src/routes/api/skills/+server.ts
@@ -23,7 +23,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
         parsed = createSkillSchema.parse(await request.json())
     } catch {
         return json(
-            { error: 'Invalid skill payload. name and instructions are required.' },
+            { error: 'Invalid skill payload. name, description, and instructions are required.' },
             { status: 400 },
         )
     }
@@ -33,6 +33,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
         const skill = await repo.create({
             userId: locals.user.id,
             name: parsed.name,
+            description: parsed.description,
             instructions: parsed.instructions,
             visibility: parsed.visibility,
         })

--- a/web/src/routes/api/skills/+server.ts
+++ b/web/src/routes/api/skills/+server.ts
@@ -1,0 +1,43 @@
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types.js'
+import { SkillRepository } from '$lib/server/db/skills.js'
+import { createSkillSchema, type CreateSkillInput } from '$lib/skills.js'
+
+export const GET: RequestHandler = async ({ locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const repo = new SkillRepository()
+    const skills = await repo.listVisible(locals.user.id)
+    return json({ skills })
+}
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    let parsed: CreateSkillInput
+    try {
+        parsed = createSkillSchema.parse(await request.json())
+    } catch {
+        return json(
+            { error: 'Invalid skill payload. name and instructions are required.' },
+            { status: 400 },
+        )
+    }
+
+    try {
+        const repo = new SkillRepository()
+        const skill = await repo.create({
+            userId: locals.user.id,
+            name: parsed.name,
+            instructions: parsed.instructions,
+            visibility: parsed.visibility,
+        })
+        return json(skill, { status: 201 })
+    } catch {
+        return json({ error: 'Failed to create skill' }, { status: 500 })
+    }
+}

--- a/web/src/routes/api/skills/[skillId]/+server.ts
+++ b/web/src/routes/api/skills/[skillId]/+server.ts
@@ -1,0 +1,83 @@
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types.js'
+import { SkillRepository } from '$lib/server/db/skills.js'
+import { updateSkillSchema, type UpdateSkillInput } from '$lib/skills.js'
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const repo = new SkillRepository()
+    const skill = await repo.getVisibleById(params.skillId, locals.user.id)
+    if (!skill) {
+        return json({ error: 'Skill not found' }, { status: 404 })
+    }
+
+    return json(skill)
+}
+
+export const PUT: RequestHandler = async ({ params, request, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const repo = new SkillRepository()
+
+    // Verify visibility first — 404 if invisible
+    const existing = await repo.getVisibleById(params.skillId, locals.user.id)
+    if (!existing) {
+        return json({ error: 'Skill not found' }, { status: 404 })
+    }
+
+    // 403 if visible but not owned
+    if (existing.ownerId !== locals.user.id) {
+        return json({ error: 'Only the owner can update this skill' }, { status: 403 })
+    }
+
+    let parsed: UpdateSkillInput
+    try {
+        parsed = updateSkillSchema.parse(await request.json())
+    } catch {
+        return json(
+            { error: 'Invalid skill payload. Provide at least one field to update.' },
+            { status: 400 },
+        )
+    }
+
+    try {
+        const updated = await repo.update(params.skillId, locals.user.id, parsed)
+        if (!updated) {
+            return json({ error: 'Skill not found' }, { status: 404 })
+        }
+
+        return json(updated)
+    } catch {
+        return json({ error: 'Failed to update skill' }, { status: 500 })
+    }
+}
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const repo = new SkillRepository()
+
+    // Check ownership
+    const existing = await repo.getVisibleById(params.skillId, locals.user.id)
+    if (!existing) {
+        return json({ error: 'Skill not found' }, { status: 404 })
+    }
+
+    if (existing.ownerId !== locals.user.id) {
+        return json({ error: 'Only the owner can delete this skill' }, { status: 403 })
+    }
+
+    const deleted = await repo.delete(params.skillId, locals.user.id)
+    if (!deleted) {
+        return json({ error: 'Skill not found' }, { status: 404 })
+    }
+
+    return json({ success: true })
+}

--- a/web/src/routes/api/skills/[skillId]/+server.ts
+++ b/web/src/routes/api/skills/[skillId]/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types.js'
 import { SkillRepository } from '$lib/server/db/skills.js'
+import { services } from '$lib/server/config.js'
 import { updateSkillSchema, type UpdateSkillInput } from '$lib/skills.js'
 
 export const GET: RequestHandler = async ({ params, locals }) => {
@@ -57,6 +58,28 @@ export const PUT: RequestHandler = async ({ params, request, locals }) => {
     }
 }
 
+async function pruneSkillCapability(skillId: string, logger: App.Locals['logger']) {
+    try {
+        const response = await fetch(`${services.searcherUrl}/capabilities/sync`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                publisher_id: `omni:skill-library:${skillId}`,
+                capability_type: 'skill',
+                capabilities: [],
+            }),
+        })
+        if (!response.ok) {
+            logger.warn('Failed to prune deleted skill capability', undefined, {
+                skillId,
+                status: response.status,
+            })
+        }
+    } catch (error) {
+        logger.warn('Failed to prune deleted skill capability', error as Error, { skillId })
+    }
+}
+
 export const DELETE: RequestHandler = async ({ params, locals }) => {
     if (!locals.user?.id) {
         return json({ error: 'User not authenticated' }, { status: 401 })
@@ -78,6 +101,8 @@ export const DELETE: RequestHandler = async ({ params, locals }) => {
     if (!deleted) {
         return json({ error: 'Skill not found' }, { status: 404 })
     }
+
+    await pruneSkillCapability(params.skillId, locals.logger)
 
     return json({ success: true })
 }

--- a/web/src/routes/api/skills/[skillId]/clone/+server.ts
+++ b/web/src/routes/api/skills/[skillId]/clone/+server.ts
@@ -1,0 +1,29 @@
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types.js'
+import { SkillRepository } from '$lib/server/db/skills.js'
+import { cloneSkillSchema } from '$lib/skills.js'
+
+export const POST: RequestHandler = async ({ params, request, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    let payload: unknown = {}
+    try {
+        payload = await request.json()
+    } catch {
+        payload = {}
+    }
+    if (!cloneSkillSchema.safeParse(payload).success) {
+        return json({ error: 'Invalid clone payload.' }, { status: 400 })
+    }
+
+    const repo = new SkillRepository()
+    const cloned = await repo.clone(params.skillId, locals.user.id)
+
+    if (!cloned) {
+        return json({ error: 'Skill not found or not accessible' }, { status: 404 })
+    }
+
+    return json(cloned, { status: 201 })
+}

--- a/web/src/routes/api/skills/skillsApi.test.ts
+++ b/web/src/routes/api/skills/skillsApi.test.ts
@@ -48,7 +48,8 @@ vi.mock('$lib/server/db/skills.js', () => ({
 }))
 
 function locals(userId: string | null = 'user-1') {
-    return userId ? { user: { id: userId } } : { user: null }
+    const logger = { warn: vi.fn() }
+    return userId ? { user: { id: userId }, logger } : { user: null, logger }
 }
 
 function jsonRequest(body: unknown) {
@@ -98,6 +99,32 @@ describe('skills API routes', () => {
 
         expect(updateResponse.status).toBe(403)
         expect(deleteResponse.status).toBe(403)
+    })
+
+    it('deletes owned skills and prunes their capability publisher', async () => {
+        const fetchMock = vi.fn(async () => new Response('{}', { status: 200 }))
+        vi.stubGlobal('fetch', fetchMock)
+        repo.delete.mockClear()
+
+        const response = await DELETE({
+            locals: locals(),
+            params: { skillId: ownedSkill.id },
+        } as never)
+
+        expect(response.status).toBe(200)
+        expect(repo.delete).toHaveBeenCalledWith(ownedSkill.id, 'user-1')
+        expect(fetchMock).toHaveBeenCalledWith(
+            expect.stringContaining('/capabilities/sync'),
+            expect.objectContaining({
+                method: 'POST',
+                body: JSON.stringify({
+                    publisher_id: `omni:skill-library:${ownedSkill.id}`,
+                    capability_type: 'skill',
+                    capabilities: [],
+                }),
+            }),
+        )
+        vi.unstubAllGlobals()
     })
 
     it('clones through the server-side repository', async () => {

--- a/web/src/routes/api/skills/skillsApi.test.ts
+++ b/web/src/routes/api/skills/skillsApi.test.ts
@@ -7,6 +7,7 @@ const ownedSkill = {
     id: 'owned-skill',
     ownerId: 'user-1',
     name: 'Owned',
+    description: 'Owner skill description.',
     instructions: 'Owner instructions.',
     visibility: 'private',
     createdAt: new Date(),
@@ -17,6 +18,7 @@ const publicSkill = {
     id: 'public-skill',
     ownerId: 'user-2',
     name: 'Public',
+    description: 'Public skill description.',
     instructions: 'Public instructions.',
     visibility: 'public',
     createdAt: new Date(),
@@ -70,11 +72,64 @@ describe('skills API routes', () => {
         repo.create.mockClear()
         const response = await postCollection({
             locals: locals(),
-            request: jsonRequest({ name: '   ', instructions: 'Do it.' }),
+            request: jsonRequest({
+                name: '   ',
+                description: 'Desc.',
+                instructions: 'Do it.',
+            }),
         } as never)
 
         expect(response.status).toBe(400)
         expect(repo.create).not.toHaveBeenCalled()
+    })
+
+    it('rejects missing description in create payload', async () => {
+        repo.create.mockClear()
+        const response = await postCollection({
+            locals: locals(),
+            request: jsonRequest({
+                name: 'Valid',
+                instructions: 'Do it.',
+            }),
+        } as never)
+
+        expect(response.status).toBe(400)
+        expect(repo.create).not.toHaveBeenCalled()
+    })
+
+    it('passes a trimmed description when creating a skill', async () => {
+        repo.create.mockClear()
+        const response = await postCollection({
+            locals: locals(),
+            request: jsonRequest({
+                name: 'New Skill',
+                description: '  Use this for release notes.  ',
+                instructions: 'Write release notes.',
+            }),
+        } as never)
+
+        expect(response.status).toBe(201)
+        expect(repo.create).toHaveBeenCalledWith({
+            userId: 'user-1',
+            name: 'New Skill',
+            description: 'Use this for release notes.',
+            instructions: 'Write release notes.',
+            visibility: 'private',
+        })
+    })
+
+    it('passes description updates to the owner-scoped repository mutation', async () => {
+        repo.update.mockClear()
+        const response = await PUT({
+            locals: locals(),
+            params: { skillId: ownedSkill.id },
+            request: jsonRequest({ description: '  Use when reviewing pull requests.  ' }),
+        } as never)
+
+        expect(response.status).toBe(200)
+        expect(repo.update).toHaveBeenCalledWith(ownedSkill.id, 'user-1', {
+            description: 'Use when reviewing pull requests.',
+        })
     })
 
     it('returns 404 for invisible skill reads', async () => {

--- a/web/src/routes/api/skills/skillsApi.test.ts
+++ b/web/src/routes/api/skills/skillsApi.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GET as getCollection, POST as postCollection } from './+server'
+import { DELETE, GET as getItem, PUT } from './[skillId]/+server'
+import { POST as postClone } from './[skillId]/clone/+server'
+
+const ownedSkill = {
+    id: 'owned-skill',
+    ownerId: 'user-1',
+    name: 'Owned',
+    instructions: 'Owner instructions.',
+    visibility: 'private',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+}
+
+const publicSkill = {
+    id: 'public-skill',
+    ownerId: 'user-2',
+    name: 'Public',
+    instructions: 'Public instructions.',
+    visibility: 'public',
+    createdAt: new Date(),
+    updatedAt: new Date(),
+}
+
+const repo = {
+    listVisible: vi.fn(async () => [ownedSkill, publicSkill]),
+    getVisibleById: vi.fn(async (id: string) => {
+        if (id === ownedSkill.id) return ownedSkill
+        if (id === publicSkill.id) return publicSkill
+        return null
+    }),
+    create: vi.fn(async (data) => ({ ...ownedSkill, ...data, id: 'created-skill' })),
+    update: vi.fn(async (id: string, _userId: string, data) => ({ ...ownedSkill, id, ...data })),
+    delete: vi.fn(async () => ownedSkill),
+    clone: vi.fn(async () => ({
+        ...publicSkill,
+        id: 'cloned-skill',
+        ownerId: 'user-1',
+        visibility: 'private',
+    })),
+}
+
+vi.mock('$lib/server/db/skills.js', () => ({
+    SkillRepository: vi.fn(function SkillRepository() {
+        return repo
+    }),
+}))
+
+function locals(userId: string | null = 'user-1') {
+    return userId ? { user: { id: userId } } : { user: null }
+}
+
+function jsonRequest(body: unknown) {
+    return new Request('http://localhost/api/skills', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+}
+
+describe('skills API routes', () => {
+    it('requires authentication', async () => {
+        const response = await getCollection({ locals: locals(null) } as never)
+        expect(response.status).toBe(401)
+    })
+
+    it('rejects whitespace-only create payloads before repository calls', async () => {
+        repo.create.mockClear()
+        const response = await postCollection({
+            locals: locals(),
+            request: jsonRequest({ name: '   ', instructions: 'Do it.' }),
+        } as never)
+
+        expect(response.status).toBe(400)
+        expect(repo.create).not.toHaveBeenCalled()
+    })
+
+    it('returns 404 for invisible skill reads', async () => {
+        const response = await getItem({
+            locals: locals(),
+            params: { skillId: 'missing-skill' },
+        } as never)
+
+        expect(response.status).toBe(404)
+    })
+
+    it('returns 403 when a visible non-owner attempts mutation', async () => {
+        const updateResponse = await PUT({
+            locals: locals(),
+            params: { skillId: publicSkill.id },
+            request: jsonRequest({ name: 'Nope' }),
+        } as never)
+        const deleteResponse = await DELETE({
+            locals: locals(),
+            params: { skillId: publicSkill.id },
+        } as never)
+
+        expect(updateResponse.status).toBe(403)
+        expect(deleteResponse.status).toBe(403)
+    })
+
+    it('clones through the server-side repository', async () => {
+        repo.clone.mockClear()
+        const response = await postClone({
+            locals: locals(),
+            params: { skillId: publicSkill.id },
+            request: jsonRequest({}),
+        } as never)
+
+        expect(response.status).toBe(201)
+        expect(repo.clone).toHaveBeenCalledWith(publicSkill.id, 'user-1')
+    })
+})


### PR DESCRIPTION
- Add user-owned skills with private/public visibility so teams can share reusable workplace instructions.
- Add authenticated skill library APIs and UI for creating, editing, deleting, browsing, and cloning public skills.
- Make visible library skills available through existing `skill_search` and `load_skill` using stable `library:<ULID>` identifiers.