### PR TITLE
Harden OAuth-backed remote MCP actions

### DIFF
--- a/connectors/atlassian/src/connector.rs
+++ b/connectors/atlassian/src/connector.rs
@@ -75,6 +75,7 @@ impl Connector for AtlassianConnector {
                 "required": ["type"]
             }),
             mode: ActionMode::Read,
+            required_scopes: None,
             source_types: Vec::new(),
             admin_only: true,
             hidden: false,

--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -1280,6 +1280,7 @@ fn action(
         description: description.to_string(),
         input_schema,
         mode,
+        required_scopes: None,
         source_types: source_types.to_vec(),
         admin_only,
         hidden: false,

--- a/connectors/filesystem/src/connector.rs
+++ b/connectors/filesystem/src/connector.rs
@@ -64,6 +64,7 @@ impl Connector for FileSystemConnector {
                 },
                 "required": ["base_path"]
             }),
+            required_scopes: None,
             source_types: Vec::new(),
             admin_only: false,
             hidden: false,

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -938,6 +938,7 @@ impl Connector for GoogleConnector {
                     },
                     "required": ["file_id"]
                 }),
+                required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive, SourceType::Gmail],
                 admin_only: false,
                 hidden: false,
@@ -955,6 +956,7 @@ impl Connector for GoogleConnector {
                     },
                     "required": []
                 }),
+                required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive, SourceType::GoogleChat],
                 admin_only: true,
                 hidden: false,
@@ -979,6 +981,7 @@ impl Connector for GoogleConnector {
                     },
                     "required": ["schema"]
                 }),
+                required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive, SourceType::Gmail],
                 admin_only: false,
                 hidden: false,
@@ -1046,6 +1049,7 @@ impl Connector for GoogleConnector {
                     },
                     "required": ["service", "resource", "method"]
                 }),
+                required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive, SourceType::Gmail],
                 admin_only: false,
                 hidden: false,

--- a/connectors/imap/src/connector.rs
+++ b/connectors/imap/src/connector.rs
@@ -95,6 +95,7 @@ impl Connector for ImapConnector {
                 // Setup/util action with no chat-facing use: hidden from every
                 // chat/MCP tool surface, admins included, but still in the
                 // manifest (Read mode) and dispatchable by name.
+                required_scopes: None,
                 source_types: Vec::new(),
                 admin_only: false,
                 hidden: true,
@@ -115,6 +116,7 @@ impl Connector for ImapConnector {
                 // Setup/util action with no chat-facing use: hidden from every
                 // chat/MCP tool surface, admins included, but still in the
                 // manifest (Read mode) and dispatchable by name.
+                required_scopes: None,
                 source_types: Vec::new(),
                 admin_only: false,
                 hidden: true,

--- a/connectors/nextcloud/src/connector.rs
+++ b/connectors/nextcloud/src/connector.rs
@@ -120,6 +120,7 @@ impl Connector for NextcloudConnector {
                 description: "Verify that the provided Nextcloud credentials are valid".into(),
                 input_schema: json!({}),
                 mode: omni_connector_sdk::ActionMode::Read,
+                required_scopes: None,
                 source_types: Vec::new(),
                 admin_only: false,
                 hidden: false,
@@ -138,6 +139,7 @@ impl Connector for NextcloudConnector {
                     "required": ["file_id"]
                 }),
                 mode: omni_connector_sdk::ActionMode::Read,
+                required_scopes: None,
                 source_types: Vec::new(),
                 // Internal action with no chat-facing use: hidden from every
                 // chat/MCP tool surface, admins included, but still in the

--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -145,6 +145,11 @@ class ActionDefinition(BaseModel):
     # Hidden from every chat/agent tool surface, admins included (unlike
     # admin_only, not bypassed for admin users). Still dispatchable by name.
     hidden: bool = False
+    # OAuth scopes required to invoke this action, when declared by the
+    # connector or its upstream MCP tool metadata.
+    # None means the connector has not declared action-level scopes and
+    # Omni should fall back to the coarse credential-existence check.
+    required_scopes: list[str] | None = None
 
 
 class SearchOperator(BaseModel):

--- a/sdk/rust/src/mcp_adapter.rs
+++ b/sdk/rust/src/mcp_adapter.rs
@@ -442,6 +442,8 @@ async fn fetch_actions(client: &RmcpClient) -> Result<Vec<ActionDefinition>> {
             } else {
                 ActionMode::Write
             },
+            // Rust MCP adapter does not extract tool-level scope metadata yet.
+            required_scopes: None,
             source_types: Vec::new(),
             admin_only: false,
             hidden: false,

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -275,6 +275,22 @@ export class SdkClient {
     return SdkSourceSyncDataSchema.parse(raw);
   }
 
+  async getUserEmailForSource(sourceId: string): Promise<string> {
+    const response = await this.get(`/sdk/source/${sourceId}/user-email`);
+    if (!response.ok) {
+      const text = await response.text();
+      throw new SdkClientError(
+        `Failed to get user email for source: ${response.status} - ${text}`,
+        response.status
+      );
+    }
+    const result = (await response.json()) as { email?: unknown };
+    if (typeof result.email !== 'string' || result.email.length === 0) {
+      throw new SdkClientError('Failed to get user email for source: invalid response');
+    }
+    return result.email;
+  }
+
   private async get(path: string): Promise<Response> {
     const url = `${this.baseUrl}${path}`;
     return fetch(url, {

--- a/sdk/typescript/src/connector.ts
+++ b/sdk/typescript/src/connector.ts
@@ -6,6 +6,7 @@ import type {
   SearchOperator,
   OAuthManifestConfig,
   Source,
+  OAuthCredentialReadyRequest,
 } from './models.js';
 import { ActionResponse } from './models.js';
 import { createServer } from './server.js';
@@ -103,6 +104,21 @@ export abstract class Connector<
     }
   }
 
+  /**
+   * React to a newly stored OAuth credential. MCP-backed connectors use it to
+   * restore their authenticated catalog after OAuth or a connector restart.
+   */
+  async oauthCredentialReady(
+    request: OAuthCredentialReadyRequest
+  ): Promise<boolean> {
+    const adapter = await this.getMcpAdapter();
+    if (!adapter) {
+      return false;
+    }
+    await this.bootstrapMcp(request.credentials as TCredentials);
+    return adapter.hasCachedCatalog();
+  }
+
   prepareMcpAuth(credentials: TCredentials): {
     env?: Record<string, string>;
     headers?: Record<string, string>;
@@ -141,6 +157,7 @@ export abstract class Connector<
       extra_schema: this.extraSchema,
       attributes_schema: this.attributesSchema,
       mcp_enabled: adapter !== undefined,
+      mcp_catalog_loaded: adapter?.hasCachedCatalog() ?? false,
       resources: adapter ? await adapter.getResourceDefinitions() : [],
       prompts: adapter ? await adapter.getPromptDefinitions() : [],
       oauth: this.oauthConfig,

--- a/sdk/typescript/src/context.ts
+++ b/sdk/typescript/src/context.ts
@@ -271,6 +271,11 @@ export class SyncContext {
     return true;
   }
 
+  /** Return the Omni email of the user who owns this source. */
+  async getUserEmailForSource(): Promise<string> {
+    return this.client.getUserEmailForSource(this._sourceId);
+  }
+
   /**
    * Checkpoint state for resumability. Call periodically for long syncs.
    *

--- a/sdk/typescript/src/mcp-adapter.ts
+++ b/sdk/typescript/src/mcp-adapter.ts
@@ -55,6 +55,14 @@ export class McpAdapter {
     this.server = server;
   }
 
+  hasCachedCatalog(): boolean {
+    return (
+      this.cachedActions !== null &&
+      this.cachedResources !== null &&
+      this.cachedPrompts !== null
+    );
+  }
+
   private async withSession<T>(
     env: Record<string, string> | undefined,
     headers: Record<string, string> | undefined,
@@ -292,11 +300,18 @@ export class McpAdapter {
     const actions: ActionDefinition[] = [];
     for (const tool of tools) {
       const isReadOnly = tool.annotations?.readOnlyHint === true;
+      const meta = (tool as { _meta?: Record<string, unknown> })._meta;
+      const requiredScopes = Array.isArray(meta?.required_scopes)
+        ? meta.required_scopes.filter(
+            (scope): scope is string => typeof scope === 'string'
+          )
+        : [];
       actions.push({
         name: tool.name,
         description: tool.description ?? '',
         input_schema: tool.inputSchema ?? { type: 'object', properties: {} },
         mode: isReadOnly ? 'read' : 'write',
+        required_scopes: requiredScopes,
         source_types: [],
         admin_only: false,
       });

--- a/sdk/typescript/src/mcp-adapter.ts
+++ b/sdk/typescript/src/mcp-adapter.ts
@@ -305,7 +305,7 @@ export class McpAdapter {
         ? meta.required_scopes.filter(
             (scope): scope is string => typeof scope === 'string'
           )
-        : [];
+        : undefined;
       actions.push({
         name: tool.name,
         description: tool.description ?? '',

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -73,7 +73,7 @@ export const ActionDefinitionSchema = z.object({
   description: z.string(),
   input_schema: z.record(z.any()).default({ type: 'object', properties: {} }),
   mode: z.enum(['read', 'write']).default('write'),
-  required_scopes: z.array(z.string()).default([]),
+  required_scopes: z.array(z.string()).optional(),
   source_types: z.array(z.string()).default([]),
   admin_only: z.boolean().default(false),
 });

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -73,6 +73,7 @@ export const ActionDefinitionSchema = z.object({
   description: z.string(),
   input_schema: z.record(z.any()).default({ type: 'object', properties: {} }),
   mode: z.enum(['read', 'write']).default('write'),
+  required_scopes: z.array(z.string()).default([]),
   source_types: z.array(z.string()).default([]),
   admin_only: z.boolean().default(false),
 });
@@ -171,6 +172,7 @@ export const ConnectorManifestSchema = z.object({
   extra_schema: z.record(z.unknown()).optional(),
   attributes_schema: z.record(z.unknown()).optional(),
   mcp_enabled: z.boolean().default(false),
+  mcp_catalog_loaded: z.boolean().default(false),
   resources: z.array(McpResourceDefinitionSchema).default([]),
   prompts: z.array(McpPromptDefinitionSchema).default([]),
   oauth: OAuthManifestConfigSchema.nullable().optional(),
@@ -231,6 +233,17 @@ export const ActionRequestSchema = z.object({
   actor_email: z.string().optional(),
 });
 export type ActionRequest = z.infer<typeof ActionRequestSchema>;
+
+export const OAuthCredentialReadyRequestSchema = z.object({
+  source_id: z.string(),
+  user_id: z.string().nullable().optional(),
+  provider: z.string(),
+  flow: z.string(),
+  credentials: z.record(z.unknown()).default({}),
+});
+export type OAuthCredentialReadyRequest = z.infer<
+  typeof OAuthCredentialReadyRequestSchema
+>;
 
 export const ActionResponseSchema = z.object({
   status: z.string(),

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -8,6 +8,7 @@ import {
   SyncRequestSchema,
   CancelRequestSchema,
   ActionRequestSchema,
+  OAuthCredentialReadyRequestSchema,
   ResourceRequestSchema,
   PromptRequestSchema,
   createSyncResponseStarted,
@@ -72,6 +73,28 @@ export function createServer(connector: Connector): Express {
 
   app.get("/manifest", async (_req: Request, res: Response) => {
     const manifest = await connector.getManifest(connectorUrl);
+    res.json(manifest);
+  });
+
+  app.post("/oauth/credential-ready", async (req: Request, res: Response) => {
+    const parseResult = OAuthCredentialReadyRequestSchema.safeParse(req.body);
+    if (!parseResult.success) {
+      res.status(400).json({ error: "Invalid request body" });
+      return;
+    }
+
+    const changed = await connector.oauthCredentialReady(parseResult.data);
+    if (!changed) {
+      res.status(204).send();
+      return;
+    }
+
+    const manifest = await connector.getManifest(connectorUrl);
+    try {
+      await getSdkClient().register(manifest);
+    } catch (err) {
+      logger.warn({ err }, "OAuth credential-ready manifest registration failed");
+    }
     res.json(manifest);
   });
 

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -334,6 +334,34 @@ describe('SdkClient', () => {
     });
   });
 
+  describe('getUserEmailForSource', () => {
+    it('returns the source owner email', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/source/source-123/user-email`, () =>
+          HttpResponse.json({ email: 'owner@example.com' })
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      await expect(client.getUserEmailForSource('source-123')).resolves.toBe(
+        'owner@example.com'
+      );
+    });
+
+    it('rejects an invalid response', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/source/source-123/user-email`, () =>
+          HttpResponse.json({})
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      await expect(client.getUserEmailForSource('source-123')).rejects.toThrow(
+        'invalid response'
+      );
+    });
+  });
+
   describe('error handling', () => {
     it('throws SdkClientError on non-2xx response', async () => {
       server.use(

--- a/sdk/typescript/tests/context.test.ts
+++ b/sdk/typescript/tests/context.test.ts
@@ -209,6 +209,23 @@ describe('SyncContext.shouldIndexUser', () => {
   });
 });
 
+describe('SyncContext.getUserEmailForSource', () => {
+  it('returns the owner email for its source', async () => {
+    server.use(
+      http.get(`${BASE_URL}/sdk/source/source-owner/user-email`, () =>
+        HttpResponse.json({ email: 'owner@example.com' })
+      )
+    );
+    const ctx = new SyncContext(
+      new SdkClient(BASE_URL),
+      'sync-owner',
+      'source-owner'
+    );
+
+    await expect(ctx.getUserEmailForSource()).resolves.toBe('owner@example.com');
+  });
+});
+
 describe('SyncContext.incrementUpdated', () => {
   it('POSTs the count to /sdk/sync/:id/updated', async () => {
     const calls: Array<{ syncRunId: string; count: number }> = [];

--- a/sdk/typescript/tests/fixtures/test-mcp-server.mjs
+++ b/sdk/typescript/tests/fixtures/test-mcp-server.mjs
@@ -21,10 +21,13 @@ function buildServer() {
     })
   );
 
-  server.tool(
+  server.registerTool(
     'add',
-    'Add two numbers',
-    { a: z.number(), b: z.number() },
+    {
+      description: 'Add two numbers',
+      inputSchema: { a: z.number(), b: z.number() },
+      _meta: { required_scopes: ['numbers:write'] },
+    },
     async (args) => ({
       content: [{ type: 'text', text: String(args.a + args.b) }],
     })

--- a/sdk/typescript/tests/fixtures/test-mcp-server.mjs
+++ b/sdk/typescript/tests/fixtures/test-mcp-server.mjs
@@ -33,6 +33,19 @@ function buildServer() {
     })
   );
 
+  server.registerTool(
+    'ping',
+    {
+      description: 'Return pong without requiring OAuth scopes',
+      annotations: { readOnlyHint: true },
+      inputSchema: {},
+      _meta: { required_scopes: [] },
+    },
+    async () => ({
+      content: [{ type: 'text', text: 'pong' }],
+    })
+  );
+
   server.resource(
     'item',
     new ResourceTemplate('test://item/{item_id}', { list: undefined }),

--- a/sdk/typescript/tests/mcp-adapter.test.ts
+++ b/sdk/typescript/tests/mcp-adapter.test.ts
@@ -60,6 +60,7 @@ describe('McpAdapter (stdio)', () => {
     expect(greet.description).toBe('Greet someone by name');
     const add = actions.find((a) => a.name === 'add')!;
     expect(add.mode).toBe('write');
+    expect(add.required_scopes).toEqual(['numbers:write']);
   });
 
   it('lists resources', async () => {
@@ -234,6 +235,7 @@ describe('Connector MCP integration', () => {
     await connector.bootstrapMcp({});
     const manifest: ConnectorManifest = await connector.getManifest('http://test:8000');
     expect(manifest.mcp_enabled).toBe(true);
+    expect(manifest.mcp_catalog_loaded).toBe(true);
     const actionNames = manifest.actions.map((a) => a.name);
     expect(actionNames).toContain('greet');
     expect(actionNames).toContain('add');

--- a/sdk/typescript/tests/mcp-adapter.test.ts
+++ b/sdk/typescript/tests/mcp-adapter.test.ts
@@ -54,13 +54,16 @@ describe('McpAdapter (stdio)', () => {
     const adapter = new McpAdapter(STDIO_SERVER);
     const actions = await adapter.getActionDefinitions({ TEST_MODE: '1' });
     const names = actions.map((a) => a.name).sort();
-    expect(names).toEqual(['add', 'greet']);
+    expect(names).toEqual(['add', 'greet', 'ping']);
     const greet = actions.find((a) => a.name === 'greet')!;
     expect(greet.mode).toBe('read');
     expect(greet.description).toBe('Greet someone by name');
+    expect(greet.required_scopes).toBeUndefined();
     const add = actions.find((a) => a.name === 'add')!;
     expect(add.mode).toBe('write');
     expect(add.required_scopes).toEqual(['numbers:write']);
+    const ping = actions.find((a) => a.name === 'ping')!;
+    expect(ping.required_scopes).toEqual([]);
   });
 
   it('lists resources', async () => {
@@ -118,7 +121,7 @@ describe('McpAdapter (stdio)', () => {
     await adapter.discover({ TEST_MODE: '1' });
     // No env — returns from cache without spawning
     const actions = await adapter.getActionDefinitions();
-    expect(actions.map((a) => a.name).sort()).toEqual(['add', 'greet']);
+    expect(actions.map((a) => a.name).sort()).toEqual(['add', 'greet', 'ping']);
     const resources = await adapter.getResourceDefinitions();
     expect(resources).toHaveLength(1);
     const prompts = await adapter.getPromptDefinitions();
@@ -159,7 +162,7 @@ describe('McpAdapter (Streamable HTTP)', () => {
   it('lists tools', async () => {
     const adapter = new McpAdapter({ transport: 'http', url });
     const actions = await adapter.getActionDefinitions(undefined, { 'X-Test': '1' });
-    expect(actions.map((a) => a.name).sort()).toEqual(['add', 'greet']);
+    expect(actions.map((a) => a.name).sort()).toEqual(['add', 'greet', 'ping']);
   });
 
   it('executes a tool', async () => {
@@ -198,7 +201,7 @@ describe('McpAdapter (Streamable HTTP)', () => {
     await adapter.discover(undefined, { 'X-Test': '1' });
     expect(
       (await adapter.getActionDefinitions()).map((a) => a.name).sort()
-    ).toEqual(['add', 'greet']);
+    ).toEqual(['add', 'greet', 'ping']);
     expect(await adapter.getResourceDefinitions()).toHaveLength(1);
     expect(await adapter.getPromptDefinitions()).toHaveLength(1);
   });
@@ -213,7 +216,7 @@ describe('McpAdapter (Streamable HTTP)', () => {
     const actions = await adapter.getActionDefinitions(undefined, {
       'X-Per-Call': 'yes',
     });
-    expect(actions).toHaveLength(2);
+    expect(actions).toHaveLength(3);
   });
 });
 

--- a/sdk/typescript/tests/models.test.ts
+++ b/sdk/typescript/tests/models.test.ts
@@ -3,6 +3,7 @@ import {
   DocumentMetadataSchema,
   DocumentPermissionsSchema,
   DocumentSchema,
+  ActionDefinitionSchema,
   ConnectorManifestSchema,
   SyncRequestSchema,
   EventType,
@@ -94,6 +95,30 @@ describe('DocumentSchema', () => {
     const doc = { title: 'Missing ID' };
     const result = DocumentSchema.safeParse(doc);
     expect(result.success).toBe(false);
+  });
+});
+
+describe('ActionDefinitionSchema', () => {
+  const action = {
+    name: 'example',
+    description: 'Example action',
+    input_schema: {},
+    mode: 'read' as const,
+  };
+
+  it('keeps omitted required scopes undeclared', () => {
+    const result = ActionDefinitionSchema.parse(action);
+
+    expect(result.required_scopes).toBeUndefined();
+  });
+
+  it('preserves an explicit empty required scope list', () => {
+    const result = ActionDefinitionSchema.parse({
+      ...action,
+      required_scopes: [],
+    });
+
+    expect(result.required_scopes).toEqual([]);
   });
 });
 

--- a/sdk/typescript/tests/server.test.ts
+++ b/sdk/typescript/tests/server.test.ts
@@ -54,6 +54,9 @@ const mockServer = setupServer(
   http.post(`${MANAGER_URL}/sdk/sync/:id/fail`, () =>
     HttpResponse.json({ success: true }),
   ),
+  http.post(`${MANAGER_URL}/sdk/register`, () =>
+    HttpResponse.json({ success: true }),
+  ),
 );
 
 beforeAll(() => {
@@ -103,8 +106,37 @@ describe("Connector Server", () => {
         actions: [],
         search_operators: [],
         mcp_enabled: false,
+        mcp_catalog_loaded: false,
         resources: [],
         prompts: [],
+      });
+    });
+  });
+
+  describe("POST /oauth/credential-ready", () => {
+    it("refreshes and returns a changed connector manifest", async () => {
+      const connector = new MockConnector();
+      const credentialReady = vi
+        .spyOn(connector, "oauthCredentialReady")
+        .mockResolvedValue(true);
+      const app = createServer(connector);
+
+      const response = await request(app).post("/oauth/credential-ready").send({
+        source_id: "source-456",
+        user_id: "user-123",
+        provider: "windshift",
+        flow: "user_write",
+        credentials: { access_token: "token" },
+      });
+
+      expect(response.status).toBe(200);
+      expect(response.body.connector_id).toBe("mock-connector");
+      expect(credentialReady).toHaveBeenCalledWith({
+        source_id: "source-456",
+        user_id: "user-123",
+        provider: "windshift",
+        flow: "user_write",
+        credentials: { access_token: "token" },
       });
     });
   });

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -104,8 +104,8 @@ from tools.connector_handler import (
     ToolsetSummary,
     fetch_active_sources_from_connector_manager,
 )
+from tools.meta_handler import MetaToolHandler, OnLoad, exact_tool_names_for_query
 from tools.mcp_capability_handler import McpCapabilityHandler
-from tools.meta_handler import MetaToolHandler, OnLoad
 from tools.omni_tool_result import OAuthRequiredPayload
 from tools.sandbox_handler import SandboxToolHandler
 from tools.search_handler import fetch_operator_values
@@ -197,6 +197,10 @@ def _loaded_tools_from_meta_call(
     tool_input: dict[str, object],
     connector_handler: ConnectorToolHandler,
 ) -> set[str]:
+    if tool_name == "tool_search":
+        query = tool_input.get("query")
+        if isinstance(query, str):
+            return exact_tool_names_for_query(query, connector_handler.actions)
     if tool_name == "load_tool":
         requested = tool_input.get("tool_name")
         if isinstance(requested, str) and requested in connector_handler.actions:

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -104,8 +104,8 @@ from tools.connector_handler import (
     ToolsetSummary,
     fetch_active_sources_from_connector_manager,
 )
-from tools.meta_handler import MetaToolHandler, OnLoad, exact_tool_names_for_query
 from tools.mcp_capability_handler import McpCapabilityHandler
+from tools.meta_handler import MetaToolHandler, OnLoad, exact_tool_names_for_query
 from tools.omni_tool_result import OAuthRequiredPayload
 from tools.sandbox_handler import SandboxToolHandler
 from tools.search_handler import fetch_operator_values

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -64,6 +64,12 @@ from tools.turn_builder import build_turn_tools
 
 logger = logging.getLogger(__name__)
 
+_EMPTY_RESPONSE_RECOVERY_PROMPT = (
+    "Continue the original request. If the last result discovered or loaded a tool, "
+    "call the appropriate available tool now. Do not stop without either making the "
+    "next tool call or giving the user a clear explanation."
+)
+
 
 # ---------------------------------------------------------------------------
 # Per-iteration event stream provider (with compaction retry)
@@ -682,6 +688,7 @@ async def stream_generator(
 
         # ----- Main agent loop -------------------------------------------------
         model_iteration = 0
+        empty_response_retries = 0
         loop_passes = AGENT_MAX_ITERATIONS + (1 if resumable_tool_calls else 0)
         for _ in range(loop_passes):
             if await is_run_cancelled(redis_client, chat_id):
@@ -729,6 +736,7 @@ async def stream_generator(
 
                 event_index = 0
                 message_stop_received = False
+                pending_message_start_sse: str | None = None
                 cancelled = False
                 last_cancel_check_at = 0.0
                 async for event in stream:
@@ -839,10 +847,22 @@ async def stream_generator(
                         logger.info("Message stop received.")
                         message_stop_received = True
 
-                    logger.debug(
-                        f"Yielding event to client: {event.to_json(indent=None)}"
-                    )
-                    yield f"event: message\ndata: {event.to_json(indent=None)}\n\n"
+                    event_json = event.to_json(indent=None)
+                    event_sse = f"event: message\ndata: {event_json}\n\n"
+                    if event.type == "message_start":
+                        # Hold this until the provider emits actual content. If
+                        # it immediately stops, the retry below stays invisible
+                        # and the persistence wrapper does not create an empty
+                        # assistant row.
+                        pending_message_start_sse = event_sse
+                    elif event.type == "message_stop" and not content_blocks:
+                        pass
+                    else:
+                        if pending_message_start_sse is not None:
+                            yield pending_message_start_sse
+                            pending_message_start_sse = None
+                        logger.debug("Yielding event to client: %s", event_json)
+                        yield event_sse
 
                     if message_stop_received:
                         break
@@ -856,6 +876,23 @@ async def stream_generator(
                     break
 
                 tool_calls = [b for b in content_blocks if b["type"] == "tool_use"]
+                has_text = any(
+                    b["type"] == "text" and str(b.get("text", "")).strip()
+                    for b in content_blocks
+                )
+                if not tool_calls and not has_text and empty_response_retries < 1:
+                    empty_response_retries += 1
+                    logger.warning(
+                        "Provider returned an empty response in iteration %s; "
+                        "retrying once with a continuation prompt",
+                        model_iteration,
+                    )
+                    conversation_messages.append(
+                        MessageParam(
+                            role="user", content=_EMPTY_RESPONSE_RECOVERY_PROMPT
+                        )
+                    )
+                    continue
                 parse_errors = parse_tool_call_inputs(
                     cast(list[ToolUseBlockParam], tool_calls)
                 )

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -296,7 +296,10 @@ def create_mock_llm_multi(
         idx = min(call_count, len(responses) - 1)
         call_count += 1
         kind, data = responses[idx]
-        if kind == "tool_call":
+        if kind == "empty":
+            yield message_start_event()
+            yield RawMessageStopEvent(type="message_stop")
+        elif kind == "tool_call":
             for evt in tool_call_events(data):
                 yield evt
         else:
@@ -433,6 +436,7 @@ class GatedRecordingLLM:
 
     Each response entry follows the same convention as ``create_mock_llm_multi``:
 
+    * ``("empty", None)``
     * ``("text", "response string")``
     * ``("tool_call", {"name": ..., "input": ..., "id": ...})``
 
@@ -451,6 +455,10 @@ class GatedRecordingLLM:
     model_name = "gated-test"
     provider_type = "test"
     supports_citations = False
+
+    @property
+    def supports_citations(self) -> bool:
+        return False
 
     def __init__(
         self,
@@ -506,7 +514,10 @@ class GatedRecordingLLM:
 
         idx = min(call_idx, len(self.responses) - 1)
         kind, payload = self.responses[idx]
-        if kind == "tool_call":
+        if kind == "empty":
+            yield message_start_event()
+            yield RawMessageStopEvent(type="message_stop")
+        elif kind == "tool_call":
             for event in tool_call_events(
                 payload["input"],
                 tool_name=payload.get("name", "search_documents"),

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -17,6 +17,7 @@ which defaults to 15 s.  If the LLM never writes events (e.g. it's gated at
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 from unittest.mock import AsyncMock
 
@@ -863,10 +864,8 @@ class TestLockAndHeartbeat:
         # Wait for the producer task to finish its cleanup
         producer_task = chat_module._run_tasks_by_chat.get(chat_id)
         if producer_task is not None:
-            try:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await asyncio.wait_for(producer_task, timeout=5)
-            except (asyncio.CancelledError, Exception):
-                pass
 
         event_types = [et for et, _d, _sid in events]
         assert (
@@ -937,7 +936,7 @@ class TestStreamStatusPending:
         parent_id = active[-1].id
 
         tool_use_id = "toolu_for_approval"
-        assistant_msg = await msgs_repo.create(
+        await msgs_repo.create(
             chat_id,
             {
                 "role": "assistant",
@@ -992,10 +991,11 @@ class TestPartialAssistant:
     def test_partial_assistant_strips_empty_text_blocks(self):
         """Empty text blocks are removed; non-empty text blocks are kept.
         Tool inputs with string JSON are parsed to dict."""
+        from anthropic.types import TextBlockParam, ToolUseBlockParam
+
         from streaming.persist import (
             partial_assistant_message as _partial_assistant_message,
         )
-        from anthropic.types import TextBlockParam, ToolUseBlockParam
 
         blocks: list[TextBlockParam | ToolUseBlockParam] = [
             TextBlockParam(type="text", text="   "),  # stripped
@@ -1018,10 +1018,11 @@ class TestPartialAssistant:
 
     def test_partial_assistant_returns_none_when_all_blocks_empty(self):
         """All-empty blocks → returns None."""
+        from anthropic.types import TextBlockParam
+
         from streaming.persist import (
             partial_assistant_message as _partial_assistant_message,
         )
-        from anthropic.types import TextBlockParam
 
         result = _partial_assistant_message(
             [
@@ -1033,10 +1034,11 @@ class TestPartialAssistant:
 
     def test_partial_assistant_parses_empty_tool_input(self):
         """Empty string tool input becomes empty dict."""
+        from anthropic.types import ToolUseBlockParam
+
         from streaming.persist import (
             partial_assistant_message as _partial_assistant_message,
         )
-        from anthropic.types import ToolUseBlockParam
 
         result = _partial_assistant_message(
             [
@@ -1492,13 +1494,11 @@ class TestEmptyRowDelete:
     empty assistant row is deleted from the DB."""
 
     @pytest.mark.asyncio
-    async def test_early_cancel_deletes_empty_assistant_row(
+    async def test_early_cancel_does_not_persist_empty_assistant(
         self, seeded_chat, redis_client, redis_keys
     ):
-        """LLM yields ``message_start`` (which triggers an early-persisted
-        assistant row), then cancel fires before any content block.  The
-        empty row should be deleted, leaving zero assistant rows in the DB
-        for this chat."""
+        """Cancel after ``message_start`` but before content leaves no empty
+        assistant event or database row."""
         import routers.chat as chat_module
 
         chat_id, _user_id, model_id = seeded_chat
@@ -1526,16 +1526,14 @@ class TestEmptyRowDelete:
         # Wait for the producer task to finish its cleanup
         producer_task = chat_module._run_tasks_by_chat.get(chat_id)
         if producer_task is not None:
-            try:
+            with contextlib.suppress(asyncio.CancelledError, Exception):
                 await asyncio.wait_for(producer_task, timeout=5)
-            except (asyncio.CancelledError, Exception):
-                pass
 
         event_types = [et for et, _d, _sid in events]
-        # Should only have message_start + end_of_stream, no content
+        # The pending message_start is suppressed because no content arrived.
         msg_count = sum(1 for et, _, _ in events if et == "message")
-        assert msg_count == 1, (
-            f"Expected 1 message event (message_start), got {msg_count}. "
+        assert msg_count == 0, (
+            f"Expected no message events, got {msg_count}. "
             f"Event types: {event_types}"
         )
 
@@ -1683,10 +1681,11 @@ class TestMultiTurn:
         user_with_tool_result = None
         for um in user_msgs:
             content = um.message.get("content", [])
-            if isinstance(content, list):
-                if any(b.get("type") == "tool_result" for b in content):
-                    user_with_tool_result = um
-                    break
+            if isinstance(content, list) and any(
+                b.get("type") == "tool_result" for b in content
+            ):
+                user_with_tool_result = um
+                break
         assert user_with_tool_result is not None, (
             "No user message with tool_result found. " "Tool was not executed."
         )
@@ -2530,6 +2529,44 @@ class TestStandaloneEndpoints:
         db_msgs = await MessagesRepository().get_active_path(chat_id)
         assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
         assert assistant_msgs, "No assistant message persisted after retry"
+
+    @pytest.mark.asyncio
+    async def test_empty_provider_response_retries_once(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Retry a provider turn containing only message_start/message_stop."""
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [("empty", None), ("text", "Recovered after an empty response.")],
+            model_id,
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(et == "end_of_stream" for et, _, _ in events)
+        assert len(llm.calls) == 2
+        retry_messages = llm.calls[1]["messages"]
+        assert retry_messages[-1] == {
+            "role": "user",
+            "content": (
+                "Continue the original request. If the last result discovered or "
+                "loaded a tool, call the appropriate available tool now. Do not stop "
+                "without either making the next tool call or giving the user a clear "
+                "explanation."
+            ),
+        }
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert len(assistant_msgs) == 1
+        text = " ".join(
+            block["text"]
+            for block in assistant_msgs[0].message["content"]
+            if block.get("type") == "text"
+        )
+        assert text == "Recovered after an empty response."
 
 
 # =============================================================================

--- a/services/ai/tests/unit/test_lazy_tool_loading.py
+++ b/services/ai/tests/unit/test_lazy_tool_loading.py
@@ -77,6 +77,91 @@ async def test_chat_resume_restores_loaded_tool_from_successful_tool_call():
 
 
 @pytest.mark.asyncio
+async def test_chat_resume_restores_unique_exact_tool_search_match():
+    connector_handler = _connector_with(
+        [
+            _action("src-windshift-1", "windshift", "add_comment"),
+            _action("src-windshift-1", "windshift", "delete_comment"),
+        ]
+    )
+
+    messages = [
+        MessageParam(
+            role="assistant",
+            content=[
+                ToolUseBlockParam(
+                    type="tool_use",
+                    id="toolu_1",
+                    name="tool_search",
+                    input={"query": "add_comment"},
+                )
+            ],
+        ),
+        MessageParam(
+            role="user",
+            content=[
+                ToolResultBlockParam(
+                    type="tool_result",
+                    tool_use_id="toolu_1",
+                    content=[
+                        {
+                            "type": "text",
+                            "text": (
+                                "Exact match loaded and now callable: "
+                                "windshift__add_comment"
+                            ),
+                        }
+                    ],
+                    is_error=False,
+                )
+            ],
+        ),
+    ]
+
+    loaded = _loaded_tools_from_history(messages, connector_handler)
+
+    assert loaded == {"windshift__add_comment"}
+
+
+@pytest.mark.asyncio
+async def test_chat_resume_restores_tools_from_exact_source_search():
+    connector_handler = _connector_with(
+        [
+            _action("src-windshift-1", "windshift", "add_comment"),
+            _action("src-windshift-1", "windshift", "delete_comment"),
+        ]
+    )
+    messages = [
+        MessageParam(
+            role="assistant",
+            content=[
+                ToolUseBlockParam(
+                    type="tool_use",
+                    id="toolu_1",
+                    name="tool_search",
+                    input={"query": "windshift"},
+                )
+            ],
+        ),
+        MessageParam(
+            role="user",
+            content=[
+                ToolResultBlockParam(
+                    type="tool_result",
+                    tool_use_id="toolu_1",
+                    content=[{"type": "text", "text": "Exact source match loaded."}],
+                    is_error=False,
+                )
+            ],
+        ),
+    ]
+
+    loaded = _loaded_tools_from_history(messages, connector_handler)
+
+    assert loaded == {"windshift__add_comment", "windshift__delete_comment"}
+
+
+@pytest.mark.asyncio
 async def test_chat_resume_restores_loaded_tool_set_from_tool_call():
     connector_handler = _connector_with(
         [

--- a/services/ai/tests/unit/test_meta_handler.py
+++ b/services/ai/tests/unit/test_meta_handler.py
@@ -6,8 +6,8 @@ import pytest
 
 from tools.connector_handler import ConnectorAction, ConnectorToolHandler
 from tools.meta_handler import MetaToolHandler
-from tools.searcher_client import CapabilitySearchResponse, CapabilitySearchResult
 from tools.registry import ToolContext
+from tools.searcher_client import CapabilitySearchResponse, CapabilitySearchResult
 
 
 def _make_action(
@@ -146,6 +146,49 @@ async def test_tool_search_returns_matches_without_loading(actions):
 
 
 @pytest.mark.asyncio
+async def test_tool_search_loads_unique_exact_action_name_match(actions):
+    handler = _make_handler(actions)
+    loaded: set[str] = set()
+    fired: list[set[str]] = []
+
+    async def on_load(newly: set[str]) -> None:
+        fired.append(newly)
+
+    searcher = _FakeSearcherClient(["gmail__list_threads"])
+    meta = MetaToolHandler(handler, loaded, on_load, searcher_client=searcher)
+    result = await meta.execute("tool_search", {"query": "list_threads"}, _ctx())
+
+    assert not result.is_error
+    assert loaded == {"gmail__list_threads"}
+    assert fired == [{"gmail__list_threads"}]
+    assert "Exact match loaded and now callable: gmail__list_threads" in result.content[
+        0
+    ]["text"]
+
+
+@pytest.mark.asyncio
+async def test_tool_search_loads_all_tools_for_exact_source_match(actions):
+    handler = _make_handler(actions)
+    loaded: set[str] = set()
+    fired: list[set[str]] = []
+
+    async def on_load(newly: set[str]) -> None:
+        fired.append(newly)
+
+    searcher = _FakeSearcherClient(["gmail__send_email"])
+    meta = MetaToolHandler(handler, loaded, on_load, searcher_client=searcher)
+    result = await meta.execute("tool_search", {"query": "gmail"}, _ctx())
+
+    gmail_tools = {"gmail__send_email", "gmail__list_threads"}
+    assert not result.is_error
+    assert loaded == gmail_tools
+    assert fired == [gmail_tools]
+    assert "Exact match loaded and now callable: 2 matching source tools" in result.content[
+        0
+    ]["text"]
+
+
+@pytest.mark.asyncio
 async def test_tool_search_uses_searcher_without_loading(actions):
     handler = _make_handler(actions)
     loaded: set[str] = set()
@@ -176,11 +219,17 @@ async def test_publish_tool_capabilities_skips_unchanged_refresh(actions):
     await meta.publish_tool_capabilities()
     await meta.publish_tool_capabilities()
 
-    assert len(searcher.upserts) == 1
+    assert len(searcher.upserts) == 4
+    assert {call.publisher_id for call in searcher.upserts} == {
+        "src-gmail-1",
+        "src-outlook-1",
+        "src-drive-1",
+        "src-slack-1",
+    }
 
 
 @pytest.mark.asyncio
-async def test_publish_tool_capabilities_chunks_large_batches():
+async def test_publish_tool_capabilities_groups_by_publisher():
     many_actions = [
         _make_action(
             f"src-{idx}",
@@ -196,7 +245,8 @@ async def test_publish_tool_capabilities_chunks_large_batches():
 
     await meta.publish_tool_capabilities()
 
-    assert [len(call.capabilities) for call in searcher.upserts] == [500, 1]
+    assert len(searcher.upserts) == 501
+    assert all(len(call.capabilities) == 1 for call in searcher.upserts)
 
 
 @pytest.mark.asyncio

--- a/services/ai/tests/unit/test_oauth_required.py
+++ b/services/ai/tests/unit/test_oauth_required.py
@@ -10,6 +10,7 @@ import pytest
 import respx
 from httpx import Response
 
+import tools.connector_handler as connector_handler_module
 from tools.connector_handler import ConnectorAction, ConnectorToolHandler
 from tools.omni_tool_result import (
     OAuthRequiredPayload,
@@ -17,7 +18,6 @@ from tools.omni_tool_result import (
     encode_oauth_required,
 )
 from tools.registry import ToolContext
-
 
 pytestmark = pytest.mark.unit
 
@@ -36,7 +36,124 @@ def _register_action(handler: ConnectorToolHandler, source_id: str) -> None:
     handler._initialized = True
 
 
+class _CredentialConnection:
+    def __init__(self, credential: dict) -> None:
+        self.credential = credential
+
+    async def fetchrow(self, _query: str, *_args: object) -> dict:
+        return self.credential
+
+
+class _AcquireConnection:
+    def __init__(self, credential: dict) -> None:
+        self.connection = _CredentialConnection(credential)
+
+    async def __aenter__(self) -> _CredentialConnection:
+        return self.connection
+
+    async def __aexit__(self, *_args: object) -> None:
+        return None
+
+
+class _CredentialPool:
+    def __init__(self, credential: dict) -> None:
+        self.credential = credential
+
+    def acquire(self) -> _AcquireConnection:
+        return _AcquireConnection(self.credential)
+
+
 class TestConnectorHandlerOAuthRequired:
+    @pytest.mark.asyncio
+    async def test_existing_credential_missing_action_scope_requires_oauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        handler = ConnectorToolHandler(
+            connector_manager_url="http://cm.test",
+            user_id="user-1",
+        )
+        handler._actions["windshift__add_comment"] = ConnectorAction(
+            source_id="src-1",
+            source_type="windshift",
+            source_name="Windshift",
+            action_name="add_comment",
+            description="Add a comment",
+            input_schema={"type": "object", "properties": {}},
+            mode="write",
+            required_scopes=["items:write"],
+        )
+        handler._initialized = True
+
+        async def fake_get_db_pool() -> _CredentialPool:
+            return _CredentialPool(
+                {
+                    "id": "credential-1",
+                    "provider": "windshift",
+                    "config": json.dumps(
+                        {"granted_scopes": ["mcp:access", "items:read"]}
+                    ),
+                }
+            )
+
+        monkeypatch.setattr(connector_handler_module, "get_db_pool", fake_get_db_pool)
+
+        payload = await handler.check_oauth_required(
+            "windshift__add_comment",
+            {},
+            ToolContext(chat_id="c1", user_id="user-1"),
+        )
+
+        assert payload is not None
+        assert payload.oauth_start_url == (
+            "/api/oauth/start?source_id=src-1&flow=user_write&"
+            "required_scopes=items%3Awrite"
+        )
+
+    @pytest.mark.asyncio
+    async def test_existing_credential_with_action_scope_does_not_require_oauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        handler = ConnectorToolHandler(
+            connector_manager_url="http://cm.test",
+            user_id="user-1",
+        )
+        handler._actions["windshift__add_comment"] = ConnectorAction(
+            source_id="src-1",
+            source_type="windshift",
+            source_name="Windshift",
+            action_name="add_comment",
+            description="Add a comment",
+            input_schema={"type": "object", "properties": {}},
+            mode="write",
+            required_scopes=["items:write"],
+        )
+        handler._initialized = True
+
+        async def fake_get_db_pool() -> _CredentialPool:
+            return _CredentialPool(
+                {
+                    "id": "credential-1",
+                    "provider": "windshift",
+                    "config": {
+                        "granted_scopes": [
+                            "mcp:access",
+                            "items:read",
+                            "items:write",
+                        ]
+                    },
+                }
+            )
+
+        monkeypatch.setattr(connector_handler_module, "get_db_pool", fake_get_db_pool)
+
+        payload = await handler.check_oauth_required(
+            "windshift__add_comment",
+            {},
+            ToolContext(chat_id="c1", user_id="user-1"),
+        )
+
+        assert payload is None
+
     @pytest.mark.asyncio
     async def test_412_response_produces_structured_oauth_required(self):
         """A 412 needs_user_auth response from connector-manager must yield a

--- a/services/ai/tests/unit/test_oauth_required.py
+++ b/services/ai/tests/unit/test_oauth_required.py
@@ -11,6 +11,7 @@ import respx
 from httpx import Response
 
 import tools.connector_handler as connector_handler_module
+from db.models import Source
 from tools.connector_handler import ConnectorAction, ConnectorToolHandler
 from tools.omni_tool_result import (
     OAuthRequiredPayload,
@@ -20,6 +21,49 @@ from tools.omni_tool_result import (
 from tools.registry import ToolContext
 
 pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+async def test_manifest_preserves_undeclared_and_explicit_empty_action_scopes():
+    source = Source(
+        id="src-1",
+        source_type="example",
+        name="Example",
+        is_active=True,
+        is_deleted=False,
+    )
+    handler = ConnectorToolHandler(
+        connector_manager_url="http://cm.test",
+        user_id="user-1",
+        prefetched_sources=[source],
+    )
+    manifest = {
+        "source_type": "example",
+        "healthy": True,
+        "manifest": {
+            "actions": [
+                {
+                    "name": "undeclared",
+                    "description": "No action-level scope metadata",
+                },
+                {
+                    "name": "explicit_empty",
+                    "description": "Explicitly requires no OAuth scopes",
+                    "required_scopes": [],
+                },
+            ]
+        },
+    }
+
+    with respx.mock(assert_all_called=True) as mock:
+        mock.get("http://cm.test/connectors").mock(
+            return_value=Response(200, json=[manifest])
+        )
+        actions = await handler._fetch_actions()
+
+    by_name = {action.action_name: action for action in actions}
+    assert by_name["undeclared"].required_scopes is None
+    assert by_name["explicit_empty"].required_scopes == []
 
 
 def _register_action(handler: ConnectorToolHandler, source_id: str) -> None:

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -272,7 +272,7 @@ class ConnectorToolHandler:
                                 "input_schema", {"type": "object", "properties": {}}
                             ),
                             mode=action_def.get("mode", "write"),
-                            required_scopes=action_def.get("required_scopes", []),
+                            required_scopes=action_def.get("required_scopes"),
                             admin_only=action_def.get("admin_only", False),
                             hidden=action_def.get("hidden", False),
                             integration_type=integration_type,
@@ -421,7 +421,13 @@ class ConnectorToolHandler:
                 context.user_id,
             )
             if user_credential is not None:
-                required_scopes = set(action.required_scopes or [])
+                # None = connector has not declared action-level scopes.
+                # Fall back to original behavior: credential existence is
+                # sufficient and Omni does not attempt incremental consent.
+                if action.required_scopes is None:
+                    return None
+
+                required_scopes = set(action.required_scopes)
                 config = user_credential["config"] or {}
                 if isinstance(config, str):
                     try:

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -8,6 +8,7 @@ import re
 from collections.abc import Mapping
 from dataclasses import asdict, dataclass
 from typing import Literal, TypedDict
+from urllib.parse import urlencode
 
 import httpx
 import redis.asyncio as aioredis
@@ -98,6 +99,7 @@ class ConnectorAction:
     description: str
     input_schema: dict
     mode: SourceMode
+    required_scopes: list[str] | None = None
     admin_only: bool = False
     hidden: bool = False
     integration_type: str = "connector"
@@ -270,6 +272,7 @@ class ConnectorToolHandler:
                                 "input_schema", {"type": "object", "properties": {}}
                             ),
                             mode=action_def.get("mode", "write"),
+                            required_scopes=action_def.get("required_scopes", []),
                             admin_only=action_def.get("admin_only", False),
                             hidden=action_def.get("hidden", False),
                             integration_type=integration_type,
@@ -308,9 +311,11 @@ class ConnectorToolHandler:
             base_tool_name = f"{action.source_type}__{action.action_name}"
 
             # Apply action_whitelist: skip actions not in whitelist
-            if self._action_whitelist is not None:
-                if base_tool_name not in self._action_whitelist:
-                    continue
+            if (
+                self._action_whitelist is not None
+                and base_tool_name not in self._action_whitelist
+            ):
+                continue
 
             occurrence = base_name_counts.get(base_tool_name, 0)
             base_name_counts[base_tool_name] = occurrence + 1
@@ -359,7 +364,7 @@ class ConnectorToolHandler:
         sample_tool_names (up to 3 for the LLM to skim).
         """
         by_source: dict[str, list[ConnectorAction]] = {}
-        for tool_name, action in self._actions.items():
+        for _tool_name, action in self._actions.items():
             by_source.setdefault(action.source_id, []).append(action)
 
         toolsets: list[ToolsetSummary] = []
@@ -407,7 +412,7 @@ class ConnectorToolHandler:
         async with pool.acquire() as conn:
             user_credential = await conn.fetchrow(
                 """
-                SELECT id
+                SELECT id, provider, config
                 FROM service_credentials
                 WHERE source_id = $1 AND user_id = $2
                 LIMIT 1
@@ -416,7 +421,36 @@ class ConnectorToolHandler:
                 context.user_id,
             )
             if user_credential is not None:
-                return None
+                required_scopes = set(action.required_scopes or [])
+                config = user_credential["config"] or {}
+                if isinstance(config, str):
+                    try:
+                        config = json.loads(config)
+                    except json.JSONDecodeError:
+                        config = {}
+                if not isinstance(config, Mapping):
+                    config = {}
+                granted_scopes = set(config.get("granted_scopes") or [])
+                missing_scopes = sorted(required_scopes - granted_scopes)
+                if not missing_scopes:
+                    return None
+
+                provider = user_credential["provider"]
+                if not provider:
+                    return None
+                query = urlencode(
+                    {
+                        "source_id": action.source_id,
+                        "flow": "user_write",
+                        "required_scopes": ",".join(missing_scopes),
+                    }
+                )
+                return OAuthRequiredPayload(
+                    source_id=action.source_id,
+                    source_type=action.source_type,
+                    provider=provider,
+                    oauth_start_url=f"/api/oauth/start?{query}",
+                )
 
             source_row = await conn.fetchrow(
                 """

--- a/services/ai/tools/meta_handler.py
+++ b/services/ai/tools/meta_handler.py
@@ -13,7 +13,7 @@ import hashlib
 import json
 import logging
 import re
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 
 from anthropic.types import ToolParam
 
@@ -33,6 +33,37 @@ _DEFAULT_LIMIT = 10
 _MAX_LIMIT = 25
 _TOKEN_RE = re.compile(r"[a-z0-9]+")
 OnLoad = Callable[[set[str]], Awaitable[None]]
+
+
+def exact_tool_names_for_query(
+    query: str, actions: Mapping[str, ConnectorAction]
+) -> set[str]:
+    """Return a unique exact action or every tool for an exact source query."""
+    query_tokens = set(_TOKEN_RE.findall(query.lower()))
+    if not query_tokens:
+        return set()
+
+    exact_action_matches = {
+        tool_name
+        for tool_name, action in actions.items()
+        if query_tokens
+        in (
+            set(_TOKEN_RE.findall(tool_name.lower())),
+            set(_TOKEN_RE.findall(action.action_name.lower())),
+        )
+    }
+    if len(exact_action_matches) == 1:
+        return exact_action_matches
+
+    return {
+        tool_name
+        for tool_name, action in actions.items()
+        if query_tokens
+        in (
+            set(_TOKEN_RE.findall(action.source_type.lower())),
+            set(_TOKEN_RE.findall(action.source_name.lower())),
+        )
+    }
 
 
 class MetaToolHandler:
@@ -193,7 +224,26 @@ class MetaToolHandler:
                 else ""
             )
             lines.append(f"- {tool_name} — {desc}")
-        lines.append("Call load_tool with the exact tool name for any tools you need.")
+
+        exact_tool_names = exact_tool_names_for_query(query, self._ch.actions)
+        if exact_tool_names:
+            newly_loaded = await self._mark_loaded(exact_tool_names)
+            tool_label = (
+                next(iter(exact_tool_names))
+                if len(exact_tool_names) == 1
+                else f"{len(exact_tool_names)} matching source tools"
+            )
+            if newly_loaded:
+                lines.append(
+                    f"Exact match loaded and now callable: {tool_label}. "
+                    "Call it on your next turn."
+                )
+            else:
+                lines.append(
+                    f"Exact match already loaded and callable: {tool_label}."
+                )
+        else:
+            lines.append("Call load_tool with the exact tool name for any tools you need.")
 
         return ToolResult(content=[{"type": "text", "text": "\n".join(lines)}])
 

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -3132,7 +3132,7 @@ mod tests {
                 description: "Export a database".to_string(),
                 input_schema,
                 mode: ActionMode::Read,
-                required_scopes: Vec::new(),
+                required_scopes: None,
                 source_types: Vec::new(),
                 admin_only: false,
                 hidden: false,

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -3132,6 +3132,7 @@ mod tests {
                 description: "Export a database".to_string(),
                 input_schema,
                 mode: ActionMode::Read,
+                required_scopes: Vec::new(),
                 source_types: Vec::new(),
                 admin_only: false,
                 hidden: false,

--- a/services/indexer/src/queue_processor.rs
+++ b/services/indexer/src/queue_processor.rs
@@ -1,5 +1,5 @@
-use crate::AppState;
 use crate::people_extractor;
+use crate::AppState;
 use anyhow::{Context, Result};
 use shared::db::repositories::{
     DocumentRepository, GroupRepository, PersonRepository, SyncRunRepository,
@@ -14,7 +14,7 @@ use shared::storage::gc::{ContentBlobGC, GCConfig};
 use std::collections::HashMap;
 use std::sync::Arc;
 use tokio::sync::{Mutex, Semaphore};
-use tokio::time::{Duration, MissedTickBehavior, interval};
+use tokio::time::{interval, Duration, MissedTickBehavior};
 use tracing::{debug, error, info, warn};
 
 // Default poll interval for draining the queue. Overridable via INDEXER_POLL_INTERVAL_SECS.
@@ -110,7 +110,9 @@ impl BatchingConfig {
                 SyncType::Realtime => (self.realtime_batch_size, self.realtime_max_age_secs),
             };
 
-            if metrics.count >= size_threshold {
+            if metrics.has_completed_sync {
+                ready.push((sync_type.clone(), format!("{} sync completed", sync_type)));
+            } else if metrics.count >= size_threshold {
                 ready.push((
                     sync_type.clone(),
                     format!(
@@ -168,6 +170,7 @@ struct PendingMetrics {
     count: i64,
     oldest_age_secs: i64,
     size_bytes: i64,
+    has_completed_sync: bool,
 }
 
 type PendingBySyncType = HashMap<SyncType, PendingMetrics>;
@@ -194,6 +197,7 @@ fn summarize_pending(summary: &shared::queue::QueueSummary) -> (PendingBySyncTyp
                         count: entry.count,
                         oldest_age_secs,
                         size_bytes: entry.size_bytes,
+                        has_completed_sync: entry.has_completed_sync,
                     },
                 );
             }
@@ -1363,6 +1367,7 @@ mod tests {
                 count: 2,
                 oldest: Some(chrono::Utc::now()),
                 size_bytes: 150,
+                has_completed_sync: false,
             }],
         };
 
@@ -1381,5 +1386,30 @@ mod tests {
         assert_eq!(ready.len(), 1);
         assert_eq!(ready[0].0, SyncType::Incremental);
         assert!(ready[0].1.contains("pending bytes 150 >= 100"));
+    }
+
+    #[test]
+    fn test_completed_sync_is_ready_below_batch_threshold() {
+        let summary = QueueSummary {
+            entries: vec![QueueSummaryEntry {
+                sync_type: Some(SyncType::Full),
+                status: EventStatus::Pending,
+                count: 4,
+                oldest: Some(chrono::Utc::now()),
+                size_bytes: 100,
+                has_completed_sync: true,
+            }],
+        };
+
+        let (by_sync_type, orphan_count) = summarize_pending(&summary);
+        let ready = BatchingConfig::default().ready_sync_types(
+            &by_sync_type,
+            orphan_count,
+            DEFAULT_BATCH_MAX_BYTES,
+        );
+
+        assert_eq!(ready.len(), 1);
+        assert_eq!(ready[0].0, SyncType::Full);
+        assert!(ready[0].1.contains("sync completed"));
     }
 }

--- a/shared/src/db/repositories/service_credentials.rs
+++ b/shared/src/db/repositories/service_credentials.rs
@@ -1,9 +1,126 @@
-use anyhow::Result;
+use anyhow::{anyhow, Context, Result};
+use serde::Deserialize;
 use serde_json::Value as JsonValue;
 use sqlx::PgPool;
+use time::{Duration, OffsetDateTime};
 
 use crate::encryption::{EncryptedData, EncryptionService};
-use crate::models::{ServiceCredential, Source, SourceScope};
+use crate::models::{AuthType, ServiceCredential, Source, SourceScope};
+
+const OAUTH_REFRESH_SKEW: Duration = Duration::minutes(1);
+
+#[derive(Deserialize)]
+struct OAuthRefreshResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    token_type: Option<String>,
+    expires_in: Option<i64>,
+}
+
+fn oauth_needs_refresh(creds: &ServiceCredential) -> bool {
+    creds.auth_type == AuthType::OAuth
+        && creds
+            .expires_at
+            .is_some_and(|expires_at| expires_at <= OffsetDateTime::now_utc() + OAUTH_REFRESH_SKEW)
+}
+
+fn oauth_is_refreshable(creds: &ServiceCredential) -> bool {
+    let Some(values) = creds.credentials.as_object() else {
+        return false;
+    };
+    ["refresh_token", "client_id", "token_uri"]
+        .iter()
+        .all(|key| {
+            values
+                .get(*key)
+                .and_then(JsonValue::as_str)
+                .is_some_and(|value| !value.is_empty())
+        })
+}
+
+async fn refresh_oauth_tokens(creds: &mut ServiceCredential) -> Result<()> {
+    let values = creds
+        .credentials
+        .as_object_mut()
+        .ok_or_else(|| anyhow!("OAuth credentials must be a JSON object"))?;
+    let string_value = |key: &str| {
+        values
+            .get(key)
+            .and_then(JsonValue::as_str)
+            .filter(|value| !value.is_empty())
+            .map(str::to_owned)
+    };
+    let refresh_token = string_value("refresh_token").context("missing OAuth refresh_token")?;
+    let client_id = string_value("client_id").context("missing OAuth client_id")?;
+    let token_uri = string_value("token_uri").context("missing OAuth token_uri")?;
+    let client_secret = string_value("client_secret");
+    let auth_method = string_value("token_endpoint_auth_method").unwrap_or_else(|| {
+        if client_secret.is_some() {
+            "client_secret_post".to_string()
+        } else {
+            "none".to_string()
+        }
+    });
+
+    let mut form = vec![
+        ("grant_type", "refresh_token".to_string()),
+        ("refresh_token", refresh_token),
+    ];
+    if auth_method != "client_secret_basic" {
+        form.push(("client_id", client_id.clone()));
+    }
+    if let Some(resource) = string_value("resource") {
+        form.push(("resource", resource));
+    }
+    if auth_method == "client_secret_post" {
+        form.push((
+            "client_secret",
+            client_secret
+                .clone()
+                .context("missing OAuth client_secret")?,
+        ));
+    }
+
+    let client = reqwest::Client::new();
+    let mut request = client.post(&token_uri).form(&form);
+    if auth_method == "client_secret_basic" {
+        request = request.basic_auth(
+            client_id,
+            Some(client_secret.context("missing OAuth client_secret")?),
+        );
+    } else if auth_method != "none" && auth_method != "client_secret_post" {
+        return Err(anyhow!("unsupported OAuth token endpoint auth method"));
+    }
+    let response = request
+        .send()
+        .await
+        .context("OAuth token refresh request failed")?;
+    if !response.status().is_success() {
+        return Err(anyhow!(
+            "OAuth token refresh failed with status {}",
+            response.status()
+        ));
+    }
+    let refreshed: OAuthRefreshResponse = response
+        .json()
+        .await
+        .context("invalid OAuth token refresh response")?;
+    let now = OffsetDateTime::now_utc();
+    values.insert("access_token".to_string(), refreshed.access_token.into());
+    if let Some(refresh_token) = refreshed.refresh_token {
+        values.insert("refresh_token".to_string(), refresh_token.into());
+    }
+    if let Some(token_type) = refreshed.token_type {
+        values.insert("token_type".to_string(), token_type.into());
+    }
+    let expires_in = refreshed
+        .expires_in
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(3600);
+    creds.expires_at = Some(now + Duration::seconds(expires_in));
+    creds.last_validated_at = Some(now);
+    Ok(())
+}
 
 /// Service credentials repository with encryption support.
 pub struct ServiceCredentialsRepo {
@@ -49,7 +166,10 @@ impl ServiceCredentialsRepo {
             self.decrypt_credentials_in_place(creds)?;
         }
 
-        Ok(creds)
+        match creds {
+            Some(creds) => Ok(Some(self.refresh_oauth_if_needed(creds).await?)),
+            None => Ok(None),
+        }
     }
 
     /// Fetch the credential row that "owns" a source — the one used for sync
@@ -87,7 +207,10 @@ impl ServiceCredentialsRepo {
             self.decrypt_credentials_in_place(creds)?;
         }
 
-        Ok(creds)
+        match creds {
+            Some(creds) => Ok(Some(self.refresh_oauth_if_needed(creds).await?)),
+            None => Ok(None),
+        }
     }
 
     fn decrypt_credentials_in_place(&self, creds: &mut ServiceCredential) -> Result<()> {
@@ -106,6 +229,51 @@ impl ServiceCredentialsRepo {
             "encrypted_data": encrypted_data,
             "version": 1
         }))
+    }
+
+    async fn refresh_oauth_if_needed(&self, creds: ServiceCredential) -> Result<ServiceCredential> {
+        if !oauth_needs_refresh(&creds) || !oauth_is_refreshable(&creds) {
+            return Ok(creds);
+        }
+        self.refresh_oauth_credential(&creds.id).await
+    }
+
+    async fn refresh_oauth_credential(&self, credential_id: &str) -> Result<ServiceCredential> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
+            .bind(credential_id)
+            .execute(&mut *tx)
+            .await?;
+
+        let mut creds = sqlx::query_as::<_, ServiceCredential>(
+            "SELECT * FROM service_credentials WHERE id = $1 FOR UPDATE",
+        )
+        .bind(credential_id)
+        .fetch_one(&mut *tx)
+        .await?;
+        self.decrypt_credentials_in_place(&mut creds)?;
+
+        // Another request may have refreshed this credential while we waited for
+        // the per-row advisory lock. Recheck under the lock before calling the
+        // provider so rotating refresh tokens are never replayed concurrently.
+        if !oauth_needs_refresh(&creds) || !oauth_is_refreshable(&creds) {
+            tx.commit().await?;
+            return Ok(creds);
+        }
+
+        refresh_oauth_tokens(&mut creds).await?;
+        let encrypted_credentials = self.encrypt_credentials(&creds)?;
+        sqlx::query(
+            "UPDATE service_credentials SET credentials = $2, expires_at = $3, last_validated_at = $4, updated_at = CURRENT_TIMESTAMP WHERE id = $1",
+        )
+        .bind(&creds.id)
+        .bind(encrypted_credentials)
+        .bind(creds.expires_at)
+        .bind(creds.last_validated_at)
+        .execute(&mut *tx)
+        .await?;
+        tx.commit().await?;
+        Ok(creds)
     }
 
     pub async fn create(&self, creds: ServiceCredential) -> Result<ServiceCredential> {
@@ -239,5 +407,125 @@ impl ServiceCredentialsRepo {
         }
 
         Ok(count)
+    }
+}
+
+#[cfg(test)]
+mod oauth_refresh_tests {
+    use std::{collections::HashMap, sync::Arc};
+
+    use axum::{
+        extract::{Form, State},
+        routing::post,
+        Json, Router,
+    };
+    use serde_json::json;
+    use tokio::sync::Mutex;
+
+    use super::*;
+    use crate::models::ServiceProvider;
+
+    fn oauth_credential(
+        credentials: JsonValue,
+        expires_at: Option<OffsetDateTime>,
+    ) -> ServiceCredential {
+        let now = OffsetDateTime::now_utc();
+        ServiceCredential {
+            id: "credential-1".to_string(),
+            source_id: "source-1".to_string(),
+            user_id: None,
+            provider: ServiceProvider::Clickup,
+            auth_type: AuthType::OAuth,
+            principal_email: Some("user@example.com".to_string()),
+            credentials,
+            config: json!({}),
+            expires_at,
+            last_validated_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    #[test]
+    fn refreshes_only_expiring_oauth_credentials_with_refresh_metadata() {
+        let complete = json!({
+            "refresh_token": "refresh-old",
+            "client_id": "client-1",
+            "token_uri": "https://windshift.example/api/oauth/token"
+        });
+        let expiring = oauth_credential(complete.clone(), Some(OffsetDateTime::now_utc()));
+        assert!(oauth_needs_refresh(&expiring));
+        assert!(oauth_is_refreshable(&expiring));
+
+        let valid = oauth_credential(
+            complete,
+            Some(OffsetDateTime::now_utc() + Duration::hours(1)),
+        );
+        assert!(!oauth_needs_refresh(&valid));
+
+        let incomplete = oauth_credential(json!({ "access_token": "token" }), None);
+        assert!(!oauth_is_refreshable(&incomplete));
+    }
+
+    #[tokio::test]
+    async fn refreshes_public_client_tokens_and_preserves_resource_binding() {
+        type CapturedForm = Arc<Mutex<Option<HashMap<String, String>>>>;
+
+        async fn token_endpoint(
+            State(captured): State<CapturedForm>,
+            Form(form): Form<HashMap<String, String>>,
+        ) -> Json<JsonValue> {
+            *captured.lock().await = Some(form);
+            Json(json!({
+                "access_token": "access-new",
+                "refresh_token": "refresh-new",
+                "token_type": "Bearer",
+                "expires_in": 120
+            }))
+        }
+
+        let captured: CapturedForm = Arc::new(Mutex::new(None));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/token", post(token_endpoint))
+            .with_state(captured.clone());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let resource = "https://windshift.example/mcp";
+        let mut credential = oauth_credential(
+            json!({
+                "access_token": "access-old",
+                "refresh_token": "refresh-old",
+                "client_id": "client-1",
+                "token_uri": format!("http://{address}/token"),
+                "token_endpoint_auth_method": "none",
+                "resource": resource
+            }),
+            Some(OffsetDateTime::now_utc()),
+        );
+
+        refresh_oauth_tokens(&mut credential).await.unwrap();
+        server.abort();
+
+        assert_eq!(credential.credentials["access_token"], "access-new");
+        assert_eq!(credential.credentials["refresh_token"], "refresh-new");
+        assert_eq!(credential.credentials["token_type"], "Bearer");
+        assert!(
+            credential.expires_at.unwrap() > OffsetDateTime::now_utc() + Duration::seconds(100)
+        );
+
+        let form = captured.lock().await.clone().unwrap();
+        assert_eq!(
+            form.get("grant_type").map(String::as_str),
+            Some("refresh_token")
+        );
+        assert_eq!(
+            form.get("refresh_token").map(String::as_str),
+            Some("refresh-old")
+        );
+        assert_eq!(form.get("client_id").map(String::as_str), Some("client-1"));
+        assert_eq!(form.get("resource").map(String::as_str), Some(resource));
+        assert!(!form.contains_key("client_secret"));
     }
 }

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -863,6 +863,10 @@ pub struct ActionDefinition {
     pub input_schema: JsonValue,
     #[serde(default)]
     pub mode: ActionMode,
+    /// OAuth scopes required to invoke this action, when declared by the
+    /// connector or its upstream MCP tool metadata.
+    #[serde(default)]
+    pub required_scopes: Vec<String>,
     /// Restrict this action to a subset of the connector's `source_types`.
     /// Empty = applies to all source_types the connector supports.
     #[serde(default)]

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -865,8 +865,10 @@ pub struct ActionDefinition {
     pub mode: ActionMode,
     /// OAuth scopes required to invoke this action, when declared by the
     /// connector or its upstream MCP tool metadata.
+    /// `None` means the connector has not declared action-level scopes and
+    /// Omni should fall back to the coarse credential-existence check.
     #[serde(default)]
-    pub required_scopes: Vec<String>,
+    pub required_scopes: Option<Vec<String>>,
     /// Restrict this action to a subset of the connector's `source_types`.
     /// Empty = applies to all source_types the connector supports.
     #[serde(default)]

--- a/shared/src/queue.rs
+++ b/shared/src/queue.rs
@@ -466,7 +466,8 @@ impl EventQueue {
                 q.status,
                 COUNT(*) as count,
                 MIN(q.created_at) as oldest,
-                COALESCE(SUM(COALESCE(cb.size_bytes, 0)), 0)::BIGINT as size_bytes
+                COALESCE(SUM(COALESCE(cb.size_bytes, 0)), 0)::BIGINT as size_bytes,
+                COALESCE(BOOL_OR(s.status = 'completed'), false) as has_completed_sync
             FROM connector_events_queue q
             LEFT JOIN sync_runs s ON q.sync_run_id = s.id
             LEFT JOIN content_blobs cb ON cb.id = CASE
@@ -488,6 +489,7 @@ impl EventQueue {
             let count: i64 = row.get("count");
             let oldest: Option<chrono::DateTime<chrono::Utc>> = row.get("oldest");
             let size_bytes: i64 = row.get("size_bytes");
+            let has_completed_sync: bool = row.get("has_completed_sync");
 
             let sync_type = match sync_type_str.as_deref() {
                 None => None,
@@ -511,6 +513,7 @@ impl EventQueue {
                 count,
                 oldest,
                 size_bytes,
+                has_completed_sync,
             });
         }
 
@@ -673,6 +676,7 @@ pub struct QueueSummaryEntry {
     pub count: i64,
     pub oldest: Option<chrono::DateTime<chrono::Utc>>,
     pub size_bytes: i64,
+    pub has_completed_sync: bool,
 }
 
 #[derive(Debug)]

--- a/shared/tests/action_definition_test.rs
+++ b/shared/tests/action_definition_test.rs
@@ -1,0 +1,28 @@
+use serde_json::json;
+use shared::models::ActionDefinition;
+
+fn action_json() -> serde_json::Value {
+    json!({
+        "name": "example",
+        "description": "Example action",
+        "input_schema": {},
+        "mode": "read"
+    })
+}
+
+#[test]
+fn omitted_required_scopes_deserializes_as_undeclared() {
+    let action: ActionDefinition = serde_json::from_value(action_json()).unwrap();
+
+    assert_eq!(action.required_scopes, None);
+}
+
+#[test]
+fn explicit_empty_required_scopes_remains_distinct_from_undeclared() {
+    let mut value = action_json();
+    value["required_scopes"] = json!([]);
+
+    let action: ActionDefinition = serde_json::from_value(value).unwrap();
+
+    assert_eq!(action.required_scopes, Some(Vec::new()));
+}

--- a/web/src/lib/server/oauth/connectorOAuth.test.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.test.ts
@@ -3,6 +3,7 @@ import { OAuthStateManager } from './state'
 import {
     isAutoManagedOAuthProvider,
     isClientConfigComplete,
+    scopesForExistingSourceUserFlow,
     tokenEndpointAuthMethodForConfig,
     type OAuthManifestConfig,
 } from './connectorOAuth'
@@ -95,5 +96,27 @@ describe('OAuth connector helpers', () => {
             ),
         ).toBe('client_secret_basic')
         expect(tokenEndpointAuthMethodForConfig(undefined, undefined)).toBe('client_secret_post')
+    })
+
+    it('limits write elevation to the requested connector scopes', () => {
+        const config: OAuthManifestConfig = {
+            ...baseManifest,
+            scopes: {
+                example: {
+                    read: ['mcp:access', 'items:read'],
+                    write: ['mcp:access', 'items:read', 'items:write', 'items:delete'],
+                },
+            },
+        }
+
+        expect(
+            scopesForExistingSourceUserFlow(config, 'example', 'write', ['items:write']),
+        ).toEqual(['mcp:access', 'items:read', 'items:write'])
+    })
+
+    it('rejects requested scopes not declared by the connector', () => {
+        expect(() =>
+            scopesForExistingSourceUserFlow(baseManifest, 'example', 'write', ['unexpected:write']),
+        ).toThrow('Unsupported write scopes')
     })
 })

--- a/web/src/lib/server/oauth/connectorOAuth.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.ts
@@ -328,6 +328,26 @@ function scopesForFlow(
     return [...out]
 }
 
+export function scopesForExistingSourceUserFlow(
+    config: OAuthManifestConfig,
+    sourceType: string,
+    mode: 'read' | 'write',
+    requiredScopes?: string[],
+): string[] {
+    const readScopes = config.scopes[sourceType]?.read ?? []
+    if (mode === 'read') return readScopes
+
+    const writeScopes = config.scopes[sourceType]?.write ?? []
+    const requestedWriteScopes = requiredScopes?.length ? [...new Set(requiredScopes)] : writeScopes
+    const invalidScopes = requestedWriteScopes.filter((scope) => !writeScopes.includes(scope))
+    if (invalidScopes.length > 0) {
+        throw new Error(
+            `Unsupported write scopes for source_type=${sourceType}: ${invalidScopes.join(', ')}`,
+        )
+    }
+    return [...new Set([...readScopes, ...requestedWriteScopes])]
+}
+
 /// Build the authorization URL for a given flow.
 export async function generateAuthUrl(args: {
     flow: Extract<OAuthFlow, { type: 'connect_source' }>
@@ -428,6 +448,7 @@ async function generateAuthUrlForExistingSourceUserFlow(args: {
     approvalId?: string
     approvalChatId?: string
     mode: 'read' | 'write'
+    requiredScopes?: string[]
 }): Promise<{ url: string; requiredScopes: string[] }> {
     const manifestConfig = args.source
         ? await getOAuthConfigForSource(args.source)
@@ -440,10 +461,12 @@ async function generateAuthUrlForExistingSourceUserFlow(args: {
         throw new Error(`OAuth client not configured for provider=${manifestConfig.provider}`)
     }
 
-    const readScopes = manifestConfig.scopes[args.sourceType]?.read ?? []
-    const writeScopes = manifestConfig.scopes[args.sourceType]?.write ?? []
-    const actionScopes =
-        args.mode === 'write' ? [...new Set([...readScopes, ...writeScopes])] : readScopes
+    const actionScopes = scopesForExistingSourceUserFlow(
+        manifestConfig,
+        args.sourceType,
+        args.mode,
+        args.requiredScopes,
+    )
     if (actionScopes.length === 0 && args.source?.integrationType !== IntegrationType.REMOTE_MCP) {
         throw new Error(`No ${args.mode} action scopes declared for source_type=${args.sourceType}`)
     }
@@ -507,6 +530,7 @@ export async function generateAuthUrlForUserWrite(args: {
     returnTo?: string
     approvalId?: string
     approvalChatId?: string
+    requiredScopes?: string[]
 }): Promise<{ url: string; requiredScopes: string[] }> {
     return generateAuthUrlForExistingSourceUserFlow({ ...args, mode: 'write' })
 }

--- a/web/src/routes/api/oauth/callback/+server.ts
+++ b/web/src/routes/api/oauth/callback/+server.ts
@@ -122,6 +122,8 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
         client_id: clientCreds.clientId,
         ...(clientCreds.clientSecret ? { client_secret: clientCreds.clientSecret } : {}),
         token_uri: clientCreds.tokenEndpoint ?? config.token_endpoint,
+        token_endpoint_auth_method: clientCreds.tokenEndpointAuthMethod,
+        ...(config.resource ? { resource: config.resource } : {}),
     })
 
     const notifyOAuthCredentialReady = async (
@@ -263,6 +265,7 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
     // connect_source flow: for each requested source_type, create or refresh this
     // user's personal source. Org-level sources are managed separately under
     // /admin/settings/integrations.
+    const connectedSourceIds: string[] = []
     for (const sourceType of flow.sourceTypes) {
         const sourcesOfType = await getSourcesByType(sourceType)
         const existing = sourcesOfType.find((s) => s.scope === 'user' && s.createdBy === user.id)
@@ -289,6 +292,7 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
                 config: { granted_scopes: effectiveGrantedScopes },
                 expiresAt,
             })
+            connectedSourceIds.push(existing.id)
             continue
         }
 
@@ -315,8 +319,31 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
             config: { granted_scopes: effectiveGrantedScopes },
             expiresAt,
         })
+        connectedSourceIds.push(newSource.id)
 
         logger.info(`Created personal source ${newSource.id} (${sourceType}) for user ${user.id}`)
+    }
+
+    const connectorManagerUrl = getConfig().services.connectorManagerUrl
+    for (const sourceId of connectedSourceIds) {
+        await notifyOAuthCredentialReady(sourceId, user.id)
+        try {
+            const syncResponse = await fetch(`${connectorManagerUrl}/sync/${sourceId}`, {
+                method: 'POST',
+            })
+            if (!syncResponse.ok && syncResponse.status !== 409) {
+                logger.warn('Failed to trigger personal source sync after OAuth', {
+                    sourceId,
+                    status: syncResponse.status,
+                    body: await syncResponse.text(),
+                })
+            }
+        } catch (syncError) {
+            logger.warn('Failed to trigger personal source sync after OAuth', {
+                sourceId,
+                syncError,
+            })
+        }
     }
 
     throw redirect(302, flow.returnTo ?? '/settings/integrations?success=connected')

--- a/web/src/routes/api/oauth/start/+server.ts
+++ b/web/src/routes/api/oauth/start/+server.ts
@@ -36,6 +36,10 @@ export const GET: RequestHandler = async ({ url, locals }) => {
     const returnTo = url.searchParams.get('return_to') ?? undefined
     const approvalId = url.searchParams.get('approval_id') ?? undefined
     const approvalChatId = url.searchParams.get('chat_id') ?? undefined
+    const requiredScopes = (url.searchParams.get('required_scopes') ?? '')
+        .split(',')
+        .map((scope) => scope.trim())
+        .filter(Boolean)
 
     if (sourceId) {
         if (flow !== 'org_source' && flow !== 'user_read' && flow !== 'user_write') {
@@ -105,6 +109,7 @@ export const GET: RequestHandler = async ({ url, locals }) => {
             returnTo,
             approvalId,
             approvalChatId,
+            requiredScopes,
         })
         throw redirect(302, authUrl)
     }


### PR DESCRIPTION
This is the first of two PRs following up on [the remote MCP connector discussion](https://github.com/getomnico/omni/discussions/186).

In that discussion we agreed that connectors should be able to use native Streamable HTTP MCP, and that tool calls should run with the current user's OAuth identity instead of reusing an administrator's source credential. PRs #211 and #212 established that direction. Building the Windshift connector against it exposed a few gaps in the end-to-end flow, which this PR addresses without adding the Windshift source itself.

MCP tools can now declare the OAuth scopes they require. Omni carries those scopes through connector discovery and asks the user only for permissions missing from their existing credential. Stored OAuth credentials retain the metadata needed for refresh and are refreshed safely, including providers that rotate refresh tokens.

The connector SDK can rebuild an authenticated MCP catalog after OAuth completes, and a newly connected personal source starts syncing immediately. Completed syncs are flushed to the index without waiting for a batch threshold. Tool discovery also handles exact matches more reliably and retries once when a model stops immediately after discovering or loading a tool.

The tests in this PR cover the generic SDK, OAuth, indexing, credential-refresh, and lazy-tool behavior. The Windshift connector is kept in the dependent draft #378 so this foundation can be reviewed on its own.

Validation:

- TypeScript connector SDK: 82 tests
- Web OAuth helpers: 6 tests
- AI tool discovery and OAuth handling: 29 unit tests
- Shared OAuth refresh: 2 tests
- Indexer queue behavior: 3 tests
- Connector-manager unit tests: 29 tests
- Standalone Rust compile check for `shared`, `omni-indexer`, and `omni-connector-manager`
