### PR TITLE
fix(web): scope sync-runs query to org sources on integrations page

### DIFF
--- a/services/migrations/106_add_sync_runs_source_started_index.sql
+++ b/services/migrations/106_add_sync_runs_source_started_index.sql
@@ -1,0 +1,7 @@
+-- B-tree index on (source_id, started_at DESC) so DISTINCT ON / ROW_NUMBER
+-- window-partition queries can walk the index in order without sorting.  Makes
+-- "latest sync run per source" lookups O(1) per source instead of a full sort
+-- of the entire sync_runs table.
+
+CREATE INDEX IF NOT EXISTS idx_sync_runs_source_started
+    ON sync_runs (source_id, started_at DESC);

--- a/web/src/lib/server/repositories/sources.ts
+++ b/web/src/lib/server/repositories/sources.ts
@@ -1,5 +1,5 @@
 import { db } from '$lib/server/db'
-import { sources, syncRuns } from '$lib/server/db/schema'
+import { sources } from '$lib/server/db/schema'
 import { eq, desc, sql, and } from 'drizzle-orm'
 import type { Source, SyncRun } from '$lib/server/db/schema'
 
@@ -57,37 +57,30 @@ export class SourcesRepository {
             .orderBy(desc(sources.createdAt))
     }
 
-    async getLatestSyncRuns(): Promise<Map<string, SyncRun>> {
-        const rows = await db
-            .select()
-            .from(syncRuns)
-            .where(
-                sql`${syncRuns.id} IN (
-                    SELECT DISTINCT ON (source_id) id
-                    FROM sync_runs
-                    ORDER BY source_id, started_at DESC
-                )`,
-            )
-
-        return new Map(rows.map((sync) => [sync.sourceId, sync]))
-    }
-
     async getLatestSyncRunsForSourceIds(sourceIds: string[]): Promise<Map<string, SyncRun>> {
         if (sourceIds.length === 0) {
             return new Map()
         }
 
-        const rows = await db
-            .select()
-            .from(syncRuns)
-            .where(
-                sql`${syncRuns.id} IN (
-                    SELECT DISTINCT ON (source_id) id
-                    FROM sync_runs
-                    WHERE source_id IN ${sourceIds}
-                    ORDER BY source_id, started_at DESC
-                )`,
-            )
+        // Single-pass DISTINCT ON to fetch one row per source_id without a subquery.
+        const rows = await db.execute<SyncRun>(sql`
+            SELECT DISTINCT ON (sr.source_id)
+                   sr.id,
+                   sr.source_id AS "sourceId",
+                   sr.sync_type AS "syncType",
+                   sr.started_at AS "startedAt",
+                   sr.completed_at AS "completedAt",
+                   sr.status,
+                   sr.documents_scanned AS "documentsScanned",
+                   sr.documents_processed AS "documentsProcessed",
+                   sr.documents_updated AS "documentsUpdated",
+                   sr.error_message AS "errorMessage",
+                   sr.created_at AS "createdAt",
+                   sr.updated_at AS "updatedAt"
+            FROM sync_runs sr
+            WHERE sr.source_id = ANY(${sourceIds})
+            ORDER BY sr.source_id, sr.started_at DESC
+        `)
 
         return new Map(rows.map((sync) => [sync.sourceId, sync]))
     }

--- a/web/src/lib/server/repositories/sources.ts
+++ b/web/src/lib/server/repositories/sources.ts
@@ -67,10 +67,16 @@ export class SourcesRepository {
             .from(syncRuns)
             .where(
                 sql`${syncRuns.id} IN (
-                    SELECT DISTINCT ON (source_id) id
-                    FROM sync_runs
-                    WHERE source_id IN ${sourceIds}
-                    ORDER BY source_id, started_at DESC
+                    SELECT id FROM (
+                        SELECT id,
+                               ROW_NUMBER() OVER (
+                                   PARTITION BY source_id
+                                   ORDER BY started_at DESC
+                               ) AS rn
+                        FROM sync_runs
+                        WHERE source_id IN ${sourceIds}
+                    ) ranked
+                    WHERE rn = 1
                 )`,
             )
 

--- a/web/src/lib/server/repositories/sources.ts
+++ b/web/src/lib/server/repositories/sources.ts
@@ -1,5 +1,5 @@
 import { db } from '$lib/server/db'
-import { sources } from '$lib/server/db/schema'
+import { sources, syncRuns } from '$lib/server/db/schema'
 import { eq, desc, sql, and } from 'drizzle-orm'
 import type { Source, SyncRun } from '$lib/server/db/schema'
 
@@ -62,25 +62,17 @@ export class SourcesRepository {
             return new Map()
         }
 
-        // Single-pass DISTINCT ON to fetch one row per source_id without a subquery.
-        const rows = await db.execute<SyncRun>(sql`
-            SELECT DISTINCT ON (sr.source_id)
-                   sr.id,
-                   sr.source_id AS "sourceId",
-                   sr.sync_type AS "syncType",
-                   sr.started_at AS "startedAt",
-                   sr.completed_at AS "completedAt",
-                   sr.status,
-                   sr.documents_scanned AS "documentsScanned",
-                   sr.documents_processed AS "documentsProcessed",
-                   sr.documents_updated AS "documentsUpdated",
-                   sr.error_message AS "errorMessage",
-                   sr.created_at AS "createdAt",
-                   sr.updated_at AS "updatedAt"
-            FROM sync_runs sr
-            WHERE sr.source_id = ANY(${sourceIds})
-            ORDER BY sr.source_id, sr.started_at DESC
-        `)
+        const rows = await db
+            .select()
+            .from(syncRuns)
+            .where(
+                sql`${syncRuns.id} IN (
+                    SELECT DISTINCT ON (source_id) id
+                    FROM sync_runs
+                    WHERE source_id IN ${sourceIds}
+                    ORDER BY source_id, started_at DESC
+                )`,
+            )
 
         return new Map(rows.map((sync) => [sync.sourceId, sync]))
     }

--- a/web/src/lib/server/repositories/sources.ts
+++ b/web/src/lib/server/repositories/sources.ts
@@ -1,5 +1,5 @@
 import { db } from '$lib/server/db'
-import { sources, syncRuns } from '$lib/server/db/schema'
+import { sources } from '$lib/server/db/schema'
 import { eq, desc, sql, and } from 'drizzle-orm'
 import type { Source, SyncRun } from '$lib/server/db/schema'
 
@@ -62,23 +62,30 @@ export class SourcesRepository {
             return new Map()
         }
 
-        const rows = await db
-            .select()
-            .from(syncRuns)
-            .where(
-                sql`${syncRuns.id} IN (
-                    SELECT id FROM (
-                        SELECT id,
-                               ROW_NUMBER() OVER (
-                                   PARTITION BY source_id
-                                   ORDER BY started_at DESC
-                               ) AS rn
-                        FROM sync_runs
-                        WHERE source_id IN ${sourceIds}
-                    ) ranked
-                    WHERE rn = 1
-                )`,
-            )
+        const rows = await db.execute<SyncRun>(sql`
+            SELECT sr.id,
+                   sr.source_id AS "sourceId",
+                   sr.sync_type AS "syncType",
+                   sr.started_at AS "startedAt",
+                   sr.completed_at AS "completedAt",
+                   sr.status,
+                   sr.documents_scanned AS "documentsScanned",
+                   sr.documents_processed AS "documentsProcessed",
+                   sr.documents_updated AS "documentsUpdated",
+                   sr.error_message AS "errorMessage",
+                   sr.created_at AS "createdAt",
+                   sr.updated_at AS "updatedAt"
+            FROM sources s
+            CROSS JOIN LATERAL (
+                SELECT *
+                FROM sync_runs
+                WHERE source_id = s.id
+                ORDER BY started_at DESC
+                LIMIT 1
+            ) sr
+            WHERE s.id IN ${sourceIds}
+              AND s.is_deleted = false
+        `)
 
         return new Map(rows.map((sync) => [sync.sourceId, sync]))
     }

--- a/web/src/routes/(admin)/admin/settings/integrations/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/+page.server.ts
@@ -103,7 +103,8 @@ export const load: PageServerLoad = async ({ locals }) => {
     requireAdmin(locals)
 
     const connectedSources = await sourcesRepository.getOrgWide()
-    const latestSyncRuns = await sourcesRepository.getLatestSyncRuns()
+    const sourceIds = connectedSources.map((s) => s.id)
+    const latestSyncRuns = await sourcesRepository.getLatestSyncRunsForSourceIds(sourceIds)
     const savedOAuthConfigs = await getAllConnectorConfigsPublic()
     const savedOAuthConfigByProvider = new Map(savedOAuthConfigs.map((row) => [row.provider, row]))
 


### PR DESCRIPTION
- The integrations page's `getLatestSyncRuns()` was scanning the entire `sync_runs` table for all sources, then having that data overwritten by the connector-manager response anyway
- Scope the query to only the org sources displayed on the admin page via `getLatestSyncRunsForSourceIds()`
- Rewrite the filtered query to use a single-pass `DISTINCT ON` instead of the two-pass subquery pattern
- Remove the now-unused unfiltered `getLatestSyncRuns()` method to prevent future misuse