### PR TITLE
feat(darwinbox): harden sync and action security

### DIFF
--- a/connectors/atlassian/src/connector.rs
+++ b/connectors/atlassian/src/connector.rs
@@ -8,7 +8,7 @@ use omni_connector_sdk::{
     ActionDefinition, ActionMode, ActionResponse, Connector, SearchOperator, ServiceCredential,
     Source, SourceType, SyncContext, SyncType,
 };
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 use tracing::info;
 
 use crate::auth::{AtlassianCredentials, AuthManager};
@@ -123,6 +123,8 @@ impl Connector for AtlassianConnector {
         action: &str,
         params: JsonValue,
         credentials: Option<ServiceCredential>,
+        _source: Option<Source>,
+        _actor_email: Option<String>,
     ) -> Result<Response> {
         info!("Action requested: {}", action);
         match action {

--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use axum::response::Response;
 use chrono::{Datelike, Utc};
 use omni_connector_sdk::{
-    ActionContext, ActionDefinition, ActionMode, ActionResponse, ServiceCredential, SourceType,
+    ActionDefinition, ActionMode, ActionResponse, ServiceCredential, Source, SourceType,
 };
 use serde_json::{json, Value as JsonValue};
 
@@ -13,6 +13,267 @@ use crate::client::{
 use crate::config::DarwinboxSourceConfig;
 use crate::credentials::DarwinboxCredentials;
 use crate::models::EmployeeRecord;
+
+/// Action policy table mapping every registered action to its classification.
+pub struct ActionPolicy {
+    pub name: &'static str,
+    pub module: &'static str,
+    pub mode: ActionMode,
+    pub audience: &'static str,
+    pub is_write: bool,
+}
+
+/// All registered actions with their policy metadata.
+pub fn action_policies() -> &'static [ActionPolicy] {
+    &[
+        // Self-service (employee reads)
+        ActionPolicy {
+            name: "get_my_profile",
+            module: "employee_self_service",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_my_leave_balance",
+            module: "employee_self_service",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_holiday_calendar",
+            module: "employee_self_service",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_my_leave_requests",
+            module: "employee_self_service",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_my_attendance",
+            module: "employee_self_service",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_my_timesheet",
+            module: "employee_self_service",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+        },
+        // Self-service (employee writes) — always classified as writes
+        ActionPolicy {
+            name: "apply_my_leave",
+            module: "employee_self_service",
+            mode: ActionMode::Write,
+            audience: "self",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "revoke_my_leave",
+            module: "employee_self_service",
+            mode: ActionMode::Write,
+            audience: "self",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "regularize_my_attendance",
+            module: "employee_self_service",
+            mode: ActionMode::Write,
+            audience: "self",
+            is_write: true,
+        },
+        // Manager reads
+        ActionPolicy {
+            name: "list_pending_leave_approvals",
+            module: "manager_workflows",
+            mode: ActionMode::Read,
+            audience: "manager",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_team_leave_calendar",
+            module: "manager_workflows",
+            mode: ActionMode::Read,
+            audience: "manager",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_team_attendance_exceptions",
+            module: "manager_workflows",
+            mode: ActionMode::Read,
+            audience: "manager",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_direct_report_profile",
+            module: "manager_workflows",
+            mode: ActionMode::Read,
+            audience: "manager",
+            is_write: false,
+        },
+        // Manager writes
+        ActionPolicy {
+            name: "approve_leave_request",
+            module: "manager_workflows",
+            mode: ActionMode::Write,
+            audience: "manager",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "reject_leave_request",
+            module: "manager_workflows",
+            mode: ActionMode::Write,
+            audience: "manager",
+            is_write: true,
+        },
+        // Directory (read-only, not a write)
+        ActionPolicy {
+            name: "find_employee",
+            module: "",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+        },
+        // HR admin reads
+        ActionPolicy {
+            name: "fetch_employee_history",
+            module: "hr_operations",
+            mode: ActionMode::Read,
+            audience: "hr_admin",
+            is_write: false,
+        },
+        // HR admin writes
+        ActionPolicy {
+            name: "add_pending_employee",
+            module: "hr_operations",
+            mode: ActionMode::Write,
+            audience: "hr_admin",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "activate_pending_employee",
+            module: "hr_operations",
+            mode: ActionMode::Write,
+            audience: "hr_admin",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "update_employee_record",
+            module: "hr_operations",
+            mode: ActionMode::Write,
+            audience: "hr_admin",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "update_employment_details",
+            module: "hr_operations",
+            mode: ActionMode::Write,
+            audience: "hr_admin",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "deactivate_employee",
+            module: "hr_operations",
+            mode: ActionMode::Write,
+            audience: "hr_admin",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "reactivate_employee",
+            module: "hr_operations",
+            mode: ActionMode::Write,
+            audience: "hr_admin",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "upload_employee_document",
+            module: "hr_operations",
+            mode: ActionMode::Write,
+            audience: "hr_admin",
+            is_write: true,
+        },
+        // Reports
+        ActionPolicy {
+            name: "fetch_report_ids",
+            module: "reports",
+            mode: ActionMode::Read,
+            audience: "hr_admin",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "run_report",
+            module: "reports",
+            mode: ActionMode::Read,
+            audience: "hr_admin",
+            is_write: false,
+        },
+        // ATS reads
+        ActionPolicy {
+            name: "list_jobs",
+            module: "ats",
+            mode: ActionMode::Read,
+            audience: "recruiter",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_job_detail",
+            module: "ats",
+            mode: ActionMode::Read,
+            audience: "recruiter",
+            is_write: false,
+        },
+        ActionPolicy {
+            name: "get_candidates",
+            module: "ats",
+            mode: ActionMode::Read,
+            audience: "recruiter",
+            is_write: false,
+        },
+        // ATS writes
+        ActionPolicy {
+            name: "tag_candidate",
+            module: "ats",
+            mode: ActionMode::Write,
+            audience: "recruiter",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "reject_candidate",
+            module: "ats",
+            mode: ActionMode::Write,
+            audience: "recruiter",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "create_requisition",
+            module: "ats",
+            mode: ActionMode::Write,
+            audience: "recruiter",
+            is_write: true,
+        },
+        ActionPolicy {
+            name: "archive_requisition",
+            module: "ats",
+            mode: ActionMode::Write,
+            audience: "recruiter",
+            is_write: true,
+        },
+    ]
+}
+
+/// Look up the policy for a given action name.
+pub fn find_action_policy(action: &str) -> Option<&'static ActionPolicy> {
+    action_policies().iter().find(|p| p.name == action)
+}
 
 pub fn action_definitions() -> Vec<ActionDefinition> {
     let source_types = vec![SourceType::Darwinbox];
@@ -222,19 +483,123 @@ pub async fn execute_action(
     action: &str,
     params: JsonValue,
     credentials: Option<ServiceCredential>,
+    source: Option<Source>,
+    actor_email: Option<String>,
 ) -> Result<Response> {
-    let (client, config, params, action_context) = action_runtime(params, credentials)?;
+    // Look up the action policy to determine authorization requirements
+    let policy =
+        find_action_policy(action).ok_or_else(|| anyhow!("unknown Darwinbox action: {action}"))?;
+
+    // Extract source config and actor from trusted context.
+    let trusted_source = source.ok_or_else(|| {
+        anyhow!("Darwinbox actions require a trusted source from connector-manager")
+    })?;
+    let config: DarwinboxSourceConfig = serde_json::from_value(trusted_source.config)
+        .context("failed to deserialize Darwinbox source config from trusted source")?;
+
+    if !config.authorization.actions_enabled {
+        return Err(anyhow!("Darwinbox actions are disabled for this source"));
+    }
+
+    // Extract the authenticated actor identity.
+    let caller_email = actor_email
+        .ok_or_else(|| anyhow!("Darwinbox actions require an interactive authenticated user"))?;
+    if !config.is_action_participant(&caller_email) {
+        return Err(anyhow!(
+            "caller is not an approved Darwinbox action participant"
+        ));
+    }
+    if !config
+        .authorization
+        .allowed_actions
+        .iter()
+        .any(|allowed| allowed == action)
+    {
+        return Err(anyhow!(
+            "action '{action}' is not allowlisted for this source"
+        ));
+    }
+    if policy.is_write && config.read_only {
+        return Err(anyhow!(
+            "action '{action}' is not allowed: source is configured as read-only"
+        ));
+    }
+    // Decode the integration credential only after all policy-only gates.
+    let client = action_client(&config, credentials)?;
+
+    // Module enforcement: check that the action's module is enabled
+    match policy.module {
+        "employee_self_service" => ensure_enabled(
+            config.action_modules.employee_self_service,
+            "employee_self_service",
+        )?,
+        "manager_workflows" => {
+            ensure_enabled(config.action_modules.manager_workflows, "manager_workflows")?
+        }
+        "hr_operations" => ensure_enabled(config.action_modules.hr_operations, "hr_operations")?,
+        "ats" => ensure_enabled(config.action_modules.ats, "ats")?,
+        "reports" => ensure_enabled(config.action_modules.reports, "reports")?,
+        _ => {} // no module requirement
+    }
+
+    // 3. Audience enforcement
+    match policy.audience {
+        "self" => {
+            // Self-service: requires user email context
+            reject_identity_params(&params)?;
+            let _employee = resolve_calling_employee(&client, &caller_email).await?;
+            // (employee is used in the action match below)
+        }
+        "manager" => {
+            // Manager: verify user is a manager (has direct reports)
+            let reports = direct_reports(&client, &caller_email, &config).await?;
+            if reports.is_empty() {
+                return Err(anyhow!("caller has no direct reports"));
+            }
+        }
+        "hr_admin" => {
+            // HR admin: requires explicit email allowlist membership.
+            let email = &caller_email;
+            let is_hr_admin = config
+                .authorization
+                .hr_admin_emails
+                .iter()
+                .any(|e| e.eq_ignore_ascii_case(email));
+            if !is_hr_admin {
+                return Err(anyhow!(
+                    "action '{action}' requires email in hr_admin_emails"
+                ));
+            }
+        }
+        "recruiter" => {
+            // Recruiter: requires email in recruiter_emails list
+            let email = &caller_email;
+            let is_recruiter = config
+                .authorization
+                .recruiter_emails
+                .iter()
+                .any(|e| e.eq_ignore_ascii_case(email));
+            if !is_recruiter {
+                return Err(anyhow!(
+                    "action '{action}' requires recruiter authorization"
+                ));
+            }
+        }
+        _ => {}
+    }
+
     let result = match action {
         "get_my_profile" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
-            json!({ "employee": employee })
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
+            // Sanitized response: include only safe fields
+            json!({ "employee": safe_employee_profile(&employee) })
         }
         "find_employee" => {
             let query = required_str(&params, "query")?.to_ascii_lowercase();
             let employees = client.fetch_employees(None, None).await?.employee_data;
             let matches = employees
                 .into_iter()
+                .filter(|employee| config.is_employee_in_scope(employee))
                 .filter(|employee| {
                     employee
                         .display_name()
@@ -261,17 +626,16 @@ pub async fn execute_action(
                 })
                 .take(20)
                 .collect::<Vec<_>>();
-            json!({ "employees": matches })
+            // Sanitize response
+            json!({ "employees": matches.into_iter().map(|e| safe_employee_profile(&e)).collect::<Vec<_>>() })
         }
         "get_my_leave_balance" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             client.fetch_leave_balance(employee_no).await?
         }
         "get_holiday_calendar" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             let year = params
                 .get("year")
@@ -281,8 +645,7 @@ pub async fn execute_action(
             client.fetch_holiday_list(employee_no, &year).await?
         }
         "apply_my_leave" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             client
                 .apply_leave(ApplyLeaveRequest {
@@ -301,8 +664,7 @@ pub async fn execute_action(
                 .await?
         }
         "revoke_my_leave" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             client
                 .revoke_leave(RevokeLeaveRequest {
@@ -313,8 +675,7 @@ pub async fn execute_action(
                 .await?
         }
         "get_my_leave_requests" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             client
                 .fetch_leave_requests(LeaveRequestsRequest {
@@ -326,8 +687,7 @@ pub async fn execute_action(
                 .await?
         }
         "get_my_attendance" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             let month = optional_str(&params, "month")
                 .map(str::to_string)
@@ -342,8 +702,7 @@ pub async fn execute_action(
                 .await?
         }
         "regularize_my_attendance" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             let attendance = params
                 .get("attendance")
@@ -355,8 +714,7 @@ pub async fn execute_action(
                 .await?
         }
         "get_my_timesheet" => {
-            reject_identity_params(&params)?;
-            let employee = resolve_calling_employee(&client, &action_context).await?;
+            let employee = resolve_calling_employee(&client, &caller_email).await?;
             let employee_no = employee_id(&employee)?;
             client
                 .fetch_timesheet(
@@ -367,7 +725,7 @@ pub async fn execute_action(
                 .await?
         }
         "list_pending_leave_approvals" => {
-            let reports = direct_reports(&client, &action_context).await?;
+            let reports = direct_reports(&client, &caller_email, &config).await?;
             let employee_nos = employee_ids(reports);
             client
                 .fetch_leave_requests(LeaveRequestsRequest {
@@ -380,7 +738,7 @@ pub async fn execute_action(
         }
         "approve_leave_request" | "reject_leave_request" => {
             let employee_no = required_str(&params, "employee_no")?;
-            ensure_direct_report(&client, &action_context, employee_no).await?;
+            ensure_direct_report(&client, &caller_email, &config, employee_no).await?;
             let decision = if action == "approve_leave_request" {
                 LeaveDecision::Approve
             } else {
@@ -396,7 +754,7 @@ pub async fn execute_action(
                 .await?
         }
         "get_team_leave_calendar" => {
-            let reports = direct_reports(&client, &action_context).await?;
+            let reports = direct_reports(&client, &caller_email, &config).await?;
             let employee_nos = employee_ids(reports);
             client
                 .fetch_leave_requests(LeaveRequestsRequest {
@@ -408,7 +766,7 @@ pub async fn execute_action(
                 .await?
         }
         "get_team_attendance_exceptions" => {
-            let reports = direct_reports(&client, &action_context).await?;
+            let reports = direct_reports(&client, &caller_email, &config).await?;
             let employee_nos = employee_ids(reports);
             client
                 .fetch_daily_attendance_roster(
@@ -420,27 +778,24 @@ pub async fn execute_action(
         }
         "get_direct_report_profile" => {
             let employee_no = required_str(&params, "employee_no")?;
-            ensure_direct_report(&client, &action_context, employee_no).await?;
+            ensure_direct_report(&client, &caller_email, &config, employee_no).await?;
             let employee = client
                 .fetch_employees(Some(vec![employee_no.to_string()]), None)
                 .await?
                 .employee_data;
-            json!({ "employees": employee })
+            // Sanitize response
+            json!({ "employees": employee.into_iter().map(|e| safe_employee_profile(&e)).collect::<Vec<_>>() })
         }
         "add_pending_employee" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client.post_json::<JsonValue>("/importapi/add", json!({ "employees": [params.get("employee").cloned().ok_or_else(|| anyhow!("employee is required"))?] }), false).await?
         }
         "activate_pending_employee" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client.post_json::<JsonValue>("/importapi/activate", json!({ "user_ids": params.get("user_ids").cloned().ok_or_else(|| anyhow!("user_ids is required"))? }), false).await?
         }
         "update_employee_record" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client.post_json::<JsonValue>("/importapi/update", json!({ "employees": [params.get("employee").cloned().ok_or_else(|| anyhow!("employee is required"))?] }), false).await?
         }
         "update_employment_details" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client
                 .post_json::<JsonValue>(
                     "/importapi/updateemploymentdetails",
@@ -453,15 +808,12 @@ pub async fn execute_action(
                 .await?
         }
         "deactivate_employee" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client.post_json::<JsonValue>("/importapi/deactivate", json!({ "employees": params.get("employees").cloned().ok_or_else(|| anyhow!("employees is required"))? }), false).await?
         }
         "reactivate_employee" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client.post_json::<JsonValue>("/importapi/undodeactivation", json!({ "employees": params.get("employees").cloned().ok_or_else(|| anyhow!("employees is required"))? }), false).await?
         }
         "upload_employee_document" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client
                 .post_json::<JsonValue>(
                     "/Employeedocs/StandardDoc",
@@ -475,7 +827,6 @@ pub async fn execute_action(
                 .await?
         }
         "fetch_employee_history" => {
-            ensure_enabled(config.action_modules.hr_operations, "hr_operations")?;
             client.post_json::<JsonValue>("/UpdateEmployeeDetails/employeehistory", json!({
                 "from": required_str(&params, "from")?,
                 "to": required_str(&params, "to")?,
@@ -483,13 +834,11 @@ pub async fn execute_action(
             }), false).await?
         }
         "fetch_report_ids" => {
-            ensure_enabled(config.action_modules.reports, "reports")?;
             client
                 .post_json::<JsonValue>("/reportsbuilderapi/reportids", json!({}), false)
                 .await?
         }
         "run_report" => {
-            ensure_enabled(config.action_modules.reports, "reports")?;
             client
                 .post_json::<JsonValue>(
                     "/reportsbuilderapi/reportdatav2",
@@ -499,7 +848,6 @@ pub async fn execute_action(
                 .await?
         }
         "list_jobs" => {
-            ensure_enabled(config.action_modules.ats, "ats")?;
             client
                 .fetch_jobs(
                     params
@@ -509,7 +857,6 @@ pub async fn execute_action(
                 .await?
         }
         "get_job_detail" => {
-            ensure_enabled(config.action_modules.ats, "ats")?;
             client
                 .post_json::<JsonValue>(
                     "/JobsApiv3/Jobdetail",
@@ -519,21 +866,17 @@ pub async fn execute_action(
                 .await?
         }
         "get_candidates" => {
-            ensure_enabled(config.action_modules.ats, "ats")?;
             client
                 .post_json::<JsonValue>("/JobsApiv3/BulkCandidatesData", params.clone(), false)
                 .await?
         }
         "tag_candidate" => {
-            ensure_enabled(config.action_modules.ats, "ats")?;
             client.post_json::<JsonValue>("/JobsApiv2/candidatetag", json!({ "candidate_ids": params.get("candidate_ids").cloned().ok_or_else(|| anyhow!("candidate_ids is required"))?, "tags": params.get("tags").cloned().ok_or_else(|| anyhow!("tags is required"))? }), false).await?
         }
         "reject_candidate" => {
-            ensure_enabled(config.action_modules.ats, "ats")?;
             client.post_json::<JsonValue>("/JobsApiv3/RejectCandidate", json!({ "candidate_ids": params.get("candidate_ids").cloned().ok_or_else(|| anyhow!("candidate_ids is required"))?, "reason": params.get("reason").cloned().unwrap_or(json!("")) }), false).await?
         }
         "create_requisition" => {
-            ensure_enabled(config.action_modules.ats, "ats")?;
             client
                 .post_json::<JsonValue>(
                     "/requisitionApi/createRequisition",
@@ -546,38 +889,136 @@ pub async fn execute_action(
                 .await?
         }
         "archive_requisition" => {
-            ensure_enabled(config.action_modules.ats, "ats")?;
             client.post_json::<JsonValue>("/requisitionApi/archiveRequisition", json!({ "requisition_id": required_str(&params, "requisition_id")?, "employee_id": required_str(&params, "employee_id")?, "reason": params.get("reason").and_then(JsonValue::as_str).unwrap_or("") }), false).await?
         }
         _ => return Ok(ActionResponse::not_supported(action).into_response()),
     };
 
-    Ok(ActionResponse::success(result).into_response())
+    Ok(
+        ActionResponse::success(sanitize_action_response(action, result, policy.is_write))
+            .into_response(),
+    )
 }
 
-fn action_runtime(
-    params: JsonValue,
+/// Build a safe employee profile DTO containing only pre-approved fields.
+fn safe_employee_profile(employee: &EmployeeRecord) -> serde_json::Value {
+    let mut profile = serde_json::Map::new();
+    let name = employee.display_name();
+    profile.insert("display_name".to_string(), json!(name));
+    profile.insert("employee_id".to_string(), json!(employee.employee_id));
+    profile.insert(
+        "company_email_id".to_string(),
+        json!(employee.company_email_id),
+    );
+    profile.insert(
+        "department_name".to_string(),
+        json!(employee.department_name),
+    );
+    profile.insert(
+        "designation_name".to_string(),
+        json!(employee.designation_name),
+    );
+    profile.insert("office_area".to_string(), json!(employee.office_area));
+    profile.insert(
+        "direct_manager_employee_id".to_string(),
+        json!(employee.direct_manager_employee_id),
+    );
+    profile.insert("employee_type".to_string(), json!(employee.employee_type));
+    serde_json::Value::Object(profile)
+}
+
+fn action_client(
+    config: &DarwinboxSourceConfig,
     credentials: Option<ServiceCredential>,
-) -> Result<(
-    DarwinboxClient,
-    DarwinboxSourceConfig,
-    JsonValue,
-    ActionContext,
-)> {
-    let config: DarwinboxSourceConfig = serde_json::from_value(params.clone())
-        .context("Darwinbox source config was not merged into action params")?;
+) -> Result<DarwinboxClient> {
     let creds = credentials.ok_or_else(|| anyhow!("Darwinbox credentials are required"))?;
     let darwinbox_creds: DarwinboxCredentials = serde_json::from_value(creds.credentials)
         .context("failed to decode Darwinbox credentials")?;
-    let context = params
-        .get("_omni_action_context")
-        .cloned()
-        .map(serde_json::from_value::<ActionContext>)
-        .transpose()
-        .context("invalid action context")?
-        .ok_or_else(|| anyhow!("Darwinbox action requires authenticated caller context"))?;
-    let client = DarwinboxClient::new(&config, darwinbox_creds)?;
-    Ok((client, config, params, context))
+    DarwinboxClient::new(config, darwinbox_creds)
+}
+
+fn sanitize_action_response(action: &str, value: JsonValue, is_write: bool) -> JsonValue {
+    if is_write {
+        return json!({ "status": "submitted", "action": action });
+    }
+
+    const SAFE_SCALAR_KEYS: &[&str] = &[
+        "status",
+        "message",
+        "success",
+        "id",
+        "employee_id",
+        "employee_no",
+        "leave_id",
+        "leave_name",
+        "leave_type",
+        "balance",
+        "available_balance",
+        "from",
+        "to",
+        "from_date",
+        "to_date",
+        "date",
+        "year",
+        "month",
+        "attendance_status",
+        "holiday_name",
+        "holiday_date",
+        "display_name",
+        "company_email_id",
+        "department_name",
+        "designation_name",
+        "office_area",
+        "direct_manager_employee_id",
+        "employee_type",
+    ];
+    const SAFE_CONTAINER_KEYS: &[&str] = &[
+        "employees",
+        "employee",
+        "data",
+        "results",
+        "records",
+        "holidays",
+        "leave_requests",
+        "timesheet",
+        "attendance",
+    ];
+
+    fn project_object(value: JsonValue) -> JsonValue {
+        let JsonValue::Object(object) = value else {
+            return JsonValue::Null;
+        };
+        JsonValue::Object(
+            object
+                .into_iter()
+                .filter_map(|(key, value)| {
+                    if SAFE_SCALAR_KEYS.contains(&key.as_str())
+                        && !value.is_array()
+                        && !value.is_object()
+                    {
+                        Some((key, value))
+                    } else if SAFE_CONTAINER_KEYS.contains(&key.as_str()) {
+                        let projected = match value {
+                            JsonValue::Object(_) => project_object(value),
+                            JsonValue::Array(items) => JsonValue::Array(
+                                items
+                                    .into_iter()
+                                    .filter(|item| item.is_object())
+                                    .map(project_object)
+                                    .collect(),
+                            ),
+                            _ => JsonValue::Null,
+                        };
+                        Some((key, projected))
+                    } else {
+                        None
+                    }
+                })
+                .collect(),
+        )
+    }
+
+    project_object(value)
 }
 
 fn ensure_enabled(enabled: bool, module: &str) -> Result<()> {
@@ -633,30 +1074,39 @@ const IDENTITY_PARAM_KEYS: &[&str] = &[
 
 async fn resolve_calling_employee(
     client: &DarwinboxClient,
-    context: &ActionContext,
+    caller_email: &str,
 ) -> Result<EmployeeRecord> {
-    let caller_email = context
-        .user_email()
-        .ok_or_else(|| anyhow!("authenticated caller email is required"))?
-        .to_ascii_lowercase();
-    let employees = client.fetch_employees(None, None).await?.employee_data;
-    employees
+    let caller_email = caller_email.to_ascii_lowercase();
+    let matches = client
+        .fetch_employees(None, None)
+        .await?
+        .employee_data
         .into_iter()
-        .find(|employee| {
+        .filter(|employee| {
             employee
                 .company_email_id
                 .as_deref()
-                .map(|email| email.eq_ignore_ascii_case(&caller_email))
+                .map(|email| email.trim().eq_ignore_ascii_case(&caller_email))
                 .unwrap_or(false)
         })
-        .ok_or_else(|| anyhow!("no Darwinbox employee found for caller email {caller_email}"))
+        .collect::<Vec<_>>();
+    match matches.len() {
+        1 => Ok(matches.into_iter().next().expect("one employee match")),
+        0 => Err(anyhow!(
+            "no Darwinbox employee found for caller email {caller_email}"
+        )),
+        _ => Err(anyhow!(
+            "multiple Darwinbox employees found for caller email {caller_email}"
+        )),
+    }
 }
 
 async fn direct_reports(
     client: &DarwinboxClient,
-    context: &ActionContext,
+    caller_email: &str,
+    config: &DarwinboxSourceConfig,
 ) -> Result<Vec<EmployeeRecord>> {
-    let manager = resolve_calling_employee(client, context).await?;
+    let manager = resolve_calling_employee(client, caller_email).await?;
     let manager_id = employee_id(&manager)?.to_string();
     let employees = client.fetch_employees(None, None).await?.employee_data;
     Ok(employees
@@ -667,16 +1117,19 @@ async fn direct_reports(
                 .as_deref()
                 .map(|id| id == manager_id)
                 .unwrap_or(false)
+                && config.is_target_employee(employee)
         })
+        .take(config.authorization.max_batch_size)
         .collect())
 }
 
 async fn ensure_direct_report(
     client: &DarwinboxClient,
-    context: &ActionContext,
+    caller_email: &str,
+    config: &DarwinboxSourceConfig,
     employee_no: &str,
 ) -> Result<()> {
-    if direct_reports(client, context)
+    if direct_reports(client, caller_email, config)
         .await?
         .iter()
         .any(|employee| employee.employee_id.as_deref() == Some(employee_no))
@@ -801,6 +1254,32 @@ fn admin_write(
         true,
         source_types,
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::sanitize_action_response;
+    use serde_json::json;
+
+    #[test]
+    fn response_projection_drops_scalar_arrays_and_sensitive_canaries() {
+        let projected = sanitize_action_response(
+            "get_my_leave_balance",
+            json!({
+                "data": [["salary", "SECRET-SALARY"]],
+                "balance": 12,
+                "bank_account": "SECRET-BANK",
+                "results": [{"leave_id": "L1", "ctc": "SECRET-CTC"}]
+            }),
+            false,
+        );
+        let serialized = projected.to_string();
+        assert!(serialized.contains("balance"));
+        assert!(serialized.contains("leave_id"));
+        assert!(!serialized.contains("SECRET"));
+        assert!(!serialized.contains("salary"));
+        assert!(!serialized.contains("bank_account"));
+    }
 }
 
 fn action(

--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -206,14 +206,14 @@ pub fn action_policies() -> &'static [ActionPolicy] {
             name: "fetch_report_ids",
             module: "reports",
             mode: ActionMode::Read,
-            audience: "hr_admin",
+            audience: "",
             is_write: false,
         },
         ActionPolicy {
             name: "run_report",
             module: "reports",
             mode: ActionMode::Read,
-            audience: "hr_admin",
+            audience: "",
             is_write: false,
         },
         // ATS reads
@@ -555,20 +555,6 @@ pub async fn execute_action(
             let reports = direct_reports(&client, &caller_email, &config).await?;
             if reports.is_empty() {
                 return Err(anyhow!("caller has no direct reports"));
-            }
-        }
-        "hr_admin" => {
-            // HR admin: requires explicit email allowlist membership.
-            let email = &caller_email;
-            let is_hr_admin = config
-                .authorization
-                .hr_admin_emails
-                .iter()
-                .any(|e| e.eq_ignore_ascii_case(email));
-            if !is_hr_admin {
-                return Err(anyhow!(
-                    "action '{action}' requires email in hr_admin_emails"
-                ));
             }
         }
         "recruiter" => {

--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -1117,7 +1117,6 @@ async fn direct_reports(
                 .as_deref()
                 .map(|id| id == manager_id)
                 .unwrap_or(false)
-                && config.is_target_employee(employee)
         })
         .take(config.authorization.max_batch_size)
         .collect())

--- a/connectors/darwinbox/src/auth.rs
+++ b/connectors/darwinbox/src/auth.rs
@@ -103,8 +103,7 @@ pub async fn fetch_token(
 
     let status = response.status();
     if !status.is_success() {
-        let body = response.text().await.unwrap_or_default();
-        anyhow::bail!("Darwinbox token request failed with HTTP {status}: {body}");
+        anyhow::bail!("Darwinbox token request failed with HTTP {status}");
     }
 
     let token = response

--- a/connectors/darwinbox/src/client.rs
+++ b/connectors/darwinbox/src/client.rs
@@ -2,6 +2,7 @@ use anyhow::{anyhow, Context, Result};
 use reqwest::{Client, StatusCode};
 use serde::de::DeserializeOwned;
 use serde_json::{json, Value as JsonValue};
+use url::Url;
 
 use crate::auth::{add_api_key_and_dataset, apply_basic_auth, fetch_token};
 use crate::config::DarwinboxSourceConfig;
@@ -74,13 +75,31 @@ pub struct DarwinboxClient {
 
 impl DarwinboxClient {
     pub fn new(config: &DarwinboxSourceConfig, credentials: DarwinboxCredentials) -> Result<Self> {
-        let base_url = config.base_url.trim_end_matches('/').to_string();
-        if base_url.is_empty() {
-            return Err(anyhow!("Darwinbox base_url is required"));
+        let mut url = Url::parse(config.base_url.trim()).context("invalid Darwinbox base_url")?;
+        let is_loopback = url.host_str().is_some_and(|host| {
+            host.eq_ignore_ascii_case("localhost")
+                || host
+                    .parse::<std::net::IpAddr>()
+                    .is_ok_and(|ip| ip.is_loopback())
+        });
+        if url.scheme() != "https" && !(url.scheme() == "http" && is_loopback) {
+            return Err(anyhow!("Darwinbox base_url must use HTTPS for security"));
         }
+        if !url.username().is_empty() || url.password().is_some() {
+            return Err(anyhow!("Darwinbox base_url must not include credentials"));
+        }
+        url.set_fragment(None);
+        if !url.path().ends_with('/') {
+            let path = format!("{}/", url.path());
+            url.set_path(&path);
+        }
+        let http = Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .build()
+            .context("failed to build Darwinbox HTTP client")?;
         Ok(Self {
-            http: Client::new(),
-            base_url,
+            http,
+            base_url: url.to_string(),
             credentials,
         })
     }
@@ -291,7 +310,12 @@ impl DarwinboxClient {
         body: JsonValue,
         include_dataset_key: bool,
     ) -> Result<T> {
-        let url = format!("{}{}", self.base_url, path);
+        // Use Url::join for safe URL construction
+        let base = Url::parse(&self.base_url).context("invalid base_url")?;
+        let url = base
+            .join(path.trim_start_matches('/'))
+            .context("failed to join URL")?
+            .to_string();
         let body = add_api_key_and_dataset(body, &self.credentials, include_dataset_key);
         let mut request = self
             .http
@@ -317,22 +341,18 @@ impl DarwinboxClient {
                 .with_context(|| format!("failed to call Darwinbox API {path}"))?;
             let status = response.status();
             if status == StatusCode::UNAUTHORIZED || status == StatusCode::FORBIDDEN {
-                let body = response.text().await.unwrap_or_default();
+                // Do not include response body in error to avoid leaking sensitive data
                 return Err(anyhow!(
-                    "Darwinbox authentication/authorization failed ({status}): {body}"
+                    "Darwinbox authentication/authorization failed (HTTP {status})"
                 ));
             }
             if status == StatusCode::TOO_MANY_REQUESTS || status.is_server_error() {
-                let body = response.text().await.unwrap_or_default();
-                last_error = Some(anyhow!(
-                    "Darwinbox API returned retryable HTTP {status}: {body}"
-                ));
+                last_error = Some(anyhow!("Darwinbox API returned retryable HTTP {status}"));
                 tokio::time::sleep(std::time::Duration::from_millis(250 * (attempt + 1))).await;
                 continue;
             }
             if !status.is_success() {
-                let body = response.text().await.unwrap_or_default();
-                return Err(anyhow!("Darwinbox API returned HTTP {status}: {body}"));
+                return Err(anyhow!("Darwinbox API returned HTTP {status}"));
             }
 
             return response

--- a/connectors/darwinbox/src/config.rs
+++ b/connectors/darwinbox/src/config.rs
@@ -1,14 +1,94 @@
 use serde::{Deserialize, Serialize};
+use url::Url;
 
-fn default_true() -> bool {
+fn default_read_only() -> bool {
     true
+}
+
+fn default_max_batch_size() -> usize {
+    1
+}
+
+/// Safe pre-approved employee fields that may be indexed.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum EmployeeField {
+    Name,
+    EmployeeId,
+    CompanyEmail,
+    Department,
+    Designation,
+    OfficeLocation,
+    ManagerEmployeeId,
+    EmployeeType,
+}
+
+/// How employee scope is determined for indexing.
+#[derive(Debug, Clone, Deserialize, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum EmployeeScope {
+    /// Index all employees returned by Darwinbox. This must be explicitly set.
+    All,
+    /// Index only explicitly listed employees/departments.
+    Include {
+        #[serde(default)]
+        employee_ids: Vec<String>,
+        #[serde(default)]
+        employee_emails: Vec<String>,
+        #[serde(default)]
+        departments: Vec<String>,
+    },
+}
+
+impl EmployeeScope {
+    /// Returns true if the given employee record is within scope.
+    pub fn includes(&self, employee: &crate::models::EmployeeRecord) -> bool {
+        match self {
+            Self::All => true,
+            Self::Include {
+                employee_ids,
+                employee_emails,
+                departments,
+            } => {
+                // Empty include means deny everything (fail closed)
+                if employee_ids.is_empty() && employee_emails.is_empty() && departments.is_empty() {
+                    return false;
+                }
+                if let Some(id) = &employee.employee_id {
+                    if employee_ids.iter().any(|eid| eid.eq_ignore_ascii_case(id)) {
+                        return true;
+                    }
+                }
+                if let Some(email) = &employee.company_email_id {
+                    if employee_emails
+                        .iter()
+                        .any(|e| e.eq_ignore_ascii_case(email.trim()))
+                    {
+                        return true;
+                    }
+                }
+                if let Some(dept) = &employee.department_name {
+                    if departments.iter().any(|d| d.eq_ignore_ascii_case(dept)) {
+                        return true;
+                    }
+                }
+                false
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DarwinboxSourceConfig {
     pub base_url: String,
+    #[serde(default = "default_read_only")]
+    pub read_only: bool,
     #[serde(default)]
     pub default_timezone: Option<String>,
+    #[serde(default)]
+    pub employee_scope: Option<EmployeeScope>,
+    #[serde(default)]
+    pub employee_fields: Vec<EmployeeField>,
     #[serde(default)]
     pub sync_modules: DarwinboxSyncModules,
     #[serde(default)]
@@ -19,15 +99,29 @@ pub struct DarwinboxSourceConfig {
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DarwinboxSyncModules {
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub employee_directory: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub deleted_employees: bool,
-    #[serde(default = "default_true")]
-    pub org_masters: bool,
+    /// Controls department master indexing. Individual flags below replace the
+    /// legacy `org_masters` flag; all default to disabled.
+    #[serde(default)]
+    pub departments: bool,
+    #[serde(default)]
+    pub designations: bool,
+    #[serde(default)]
+    pub office_locations: bool,
+    #[serde(default)]
+    pub business_units: bool,
+    #[serde(default)]
+    pub divisions: bool,
+    #[serde(default)]
+    pub cost_centers: bool,
+    #[serde(default)]
+    pub group_companies: bool,
     #[serde(default)]
     pub positions: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub holidays: bool,
     #[serde(default)]
     pub ats_jobs: bool,
@@ -36,21 +130,40 @@ pub struct DarwinboxSyncModules {
 impl Default for DarwinboxSyncModules {
     fn default() -> Self {
         Self {
-            employee_directory: true,
-            deleted_employees: true,
-            org_masters: true,
+            employee_directory: false,
+            deleted_employees: false,
+            departments: false,
+            designations: false,
+            office_locations: false,
+            business_units: false,
+            divisions: false,
+            cost_centers: false,
+            group_companies: false,
             positions: false,
-            holidays: true,
+            holidays: false,
             ats_jobs: false,
         }
     }
 }
 
+impl DarwinboxSyncModules {
+    /// Returns true if any org master entity type is enabled.
+    pub fn has_any_org_master(&self) -> bool {
+        self.departments
+            || self.designations
+            || self.office_locations
+            || self.business_units
+            || self.divisions
+            || self.cost_centers
+            || self.group_companies
+    }
+}
+
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DarwinboxActionModules {
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub employee_self_service: bool,
-    #[serde(default = "default_true")]
+    #[serde(default)]
     pub manager_workflows: bool,
     #[serde(default)]
     pub hr_operations: bool,
@@ -63,8 +176,8 @@ pub struct DarwinboxActionModules {
 impl Default for DarwinboxActionModules {
     fn default() -> Self {
         Self {
-            employee_self_service: true,
-            manager_workflows: true,
+            employee_self_service: false,
+            manager_workflows: false,
             hr_operations: false,
             ats: false,
             reports: false,
@@ -72,12 +185,341 @@ impl Default for DarwinboxActionModules {
     }
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct DarwinboxAuthorizationConfig {
-    #[serde(default = "default_true")]
-    pub use_darwinbox_permissions: bool,
+    #[serde(default)]
+    pub use_darwinbox_permissions: Option<bool>,
+    #[serde(default)]
+    pub actions_enabled: bool,
+    #[serde(default)]
+    pub write_acknowledged: bool,
+    #[serde(default)]
+    pub participant_emails: Vec<String>,
+    #[serde(default)]
+    pub allowed_actions: Vec<String>,
+    #[serde(default)]
+    pub target_employee_ids: Vec<String>,
+    #[serde(default)]
+    pub target_employee_emails: Vec<String>,
+    #[serde(default)]
+    pub target_departments: Vec<String>,
     #[serde(default)]
     pub hr_admin_emails: Vec<String>,
     #[serde(default)]
     pub recruiter_emails: Vec<String>,
+    #[serde(default)]
+    pub allowed_report_ids: Vec<String>,
+    #[serde(default = "default_max_batch_size")]
+    pub max_batch_size: usize,
+}
+
+impl Default for DarwinboxAuthorizationConfig {
+    fn default() -> Self {
+        Self {
+            use_darwinbox_permissions: None,
+            actions_enabled: false,
+            write_acknowledged: false,
+            participant_emails: Vec::new(),
+            allowed_actions: Vec::new(),
+            target_employee_ids: Vec::new(),
+            target_employee_emails: Vec::new(),
+            target_departments: Vec::new(),
+            hr_admin_emails: Vec::new(),
+            recruiter_emails: Vec::new(),
+            allowed_report_ids: Vec::new(),
+            max_batch_size: 1,
+        }
+    }
+}
+
+impl DarwinboxSourceConfig {
+    pub fn is_employee_in_scope(&self, employee: &crate::models::EmployeeRecord) -> bool {
+        self.employee_scope
+            .as_ref()
+            .map(|scope| scope.includes(employee))
+            .unwrap_or(false)
+    }
+
+    pub fn is_action_participant(&self, email: &str) -> bool {
+        let email = normalize_email(email);
+        normalize_emails(&self.authorization.participant_emails).contains(&email)
+    }
+
+    pub fn is_target_employee(&self, employee: &crate::models::EmployeeRecord) -> bool {
+        let auth = &self.authorization;
+        let has_scope = !auth.target_employee_ids.is_empty()
+            || !auth.target_employee_emails.is_empty()
+            || !auth.target_departments.is_empty();
+        if !has_scope {
+            return false;
+        }
+        employee.employee_id.as_deref().is_some_and(|id| {
+            auth.target_employee_ids
+                .iter()
+                .any(|v| v.eq_ignore_ascii_case(id))
+        }) || employee.company_email_id.as_deref().is_some_and(|email| {
+            auth.target_employee_emails
+                .iter()
+                .any(|v| v.eq_ignore_ascii_case(email))
+        }) || employee
+            .department_name
+            .as_deref()
+            .is_some_and(|department| {
+                auth.target_departments
+                    .iter()
+                    .any(|v| v.eq_ignore_ascii_case(department))
+            })
+    }
+
+    /// Validate the configuration and return an error if it is unsafe or
+    /// contradictory.
+    pub fn validate(&self) -> Result<(), Vec<String>> {
+        let mut errors = Vec::new();
+
+        if self.base_url.trim().is_empty() {
+            errors.push("base_url is required".to_string());
+        } else {
+            match Url::parse(&self.base_url) {
+                Ok(url) => {
+                    let is_loopback = url.host_str().is_some_and(|host| {
+                        host.eq_ignore_ascii_case("localhost")
+                            || host
+                                .parse::<std::net::IpAddr>()
+                                .is_ok_and(|ip| ip.is_loopback())
+                    });
+                    if url.scheme() != "https" && !(url.scheme() == "http" && is_loopback) {
+                        errors.push("base_url must use HTTPS".to_string());
+                    }
+                    if !url.username().is_empty() || url.password().is_some() {
+                        errors.push("base_url must not include credentials".to_string());
+                    }
+                }
+                Err(_) => errors.push("base_url must be a valid URL".to_string()),
+            }
+        }
+
+        if self.authorization.use_darwinbox_permissions.is_some() {
+            errors.push("use_darwinbox_permissions is unsupported; remove it".to_string());
+        }
+        if self.sync_modules.employee_directory {
+            if self.employee_scope.is_none() {
+                errors.push(
+                    "employee_scope is required when employee_directory is enabled".to_string(),
+                );
+            }
+            if self.employee_fields.is_empty() {
+                errors.push("employee_fields must contain at least one approved field".to_string());
+            }
+        }
+        if self.sync_modules.has_any_org_master()
+            || self.sync_modules.positions
+            || self.sync_modules.holidays
+            || self.sync_modules.ats_jobs
+        {
+            errors.push(
+                "organization masters, positions, holidays, and ATS job sync are unavailable until typed Darwinbox response contracts are configured"
+                    .to_string(),
+            );
+        }
+        if self.authorization.max_batch_size == 0 || self.authorization.max_batch_size > 20 {
+            errors.push("max_batch_size must be between 1 and 20".to_string());
+        }
+
+        let actions_requested = self.action_modules.employee_self_service
+            || self.action_modules.manager_workflows
+            || self.action_modules.hr_operations
+            || self.action_modules.ats
+            || self.action_modules.reports;
+        if actions_requested {
+            if !self.authorization.actions_enabled {
+                errors.push("action modules require actions_enabled=true".to_string());
+            }
+            if self.authorization.participant_emails.is_empty()
+                || self.authorization.allowed_actions.is_empty()
+            {
+                errors.push("actions require participant_emails and allowed_actions".to_string());
+            }
+            if self.action_modules.manager_workflows
+                && self.authorization.target_employee_ids.is_empty()
+                && self.authorization.target_employee_emails.is_empty()
+                && self.authorization.target_departments.is_empty()
+            {
+                errors.push(
+                    "manager workflows require an explicit target employee scope".to_string(),
+                );
+            }
+        }
+        if !self.read_only {
+            if !self.authorization.write_acknowledged {
+                errors.push("disabling read_only requires write_acknowledged=true".to_string());
+            }
+            if !self.authorization.allowed_actions.iter().any(|action| {
+                crate::actions::find_action_policy(action).is_some_and(|policy| policy.is_write)
+            }) {
+                errors.push(
+                    "disabling read_only requires at least one allowlisted write action"
+                        .to_string(),
+                );
+            }
+        }
+        // High-risk generic HR/ATS/report payloads remain unavailable until
+        // action-specific provider contracts have been reviewed.
+        if self.action_modules.hr_operations
+            || self.action_modules.ats
+            || self.action_modules.reports
+        {
+            errors
+                .push("HR, ATS, and report actions are not available in hardened mode".to_string());
+        }
+        const UNTYPED_ACTIONS: &[&str] = &[
+            "regularize_my_attendance",
+            "add_pending_employee",
+            "activate_pending_employee",
+            "update_employee_record",
+            "update_employment_details",
+            "deactivate_employee",
+            "reactivate_employee",
+            "upload_employee_document",
+            "fetch_employee_history",
+            "fetch_report_ids",
+            "run_report",
+            "list_jobs",
+            "get_job_detail",
+            "get_candidates",
+            "tag_candidate",
+            "reject_candidate",
+            "create_requisition",
+            "archive_requisition",
+        ];
+        for action in &self.authorization.allowed_actions {
+            if crate::actions::find_action_policy(action).is_none() {
+                errors.push(format!("unknown Darwinbox action '{action}'"));
+            }
+            if UNTYPED_ACTIONS.contains(&action.as_str()) {
+                errors.push(format!("action '{action}' is unavailable in hardened mode"));
+            }
+        }
+
+        for email in self
+            .authorization
+            .participant_emails
+            .iter()
+            .chain(self.authorization.target_employee_emails.iter())
+            .chain(self.authorization.hr_admin_emails.iter())
+            .chain(self.authorization.recruiter_emails.iter())
+        {
+            if !email.contains('@') || email.trim().is_empty() {
+                errors.push(format!("invalid authorization email: {email}"));
+            }
+        }
+
+        if errors.is_empty() {
+            Ok(())
+        } else {
+            Err(errors)
+        }
+    }
+}
+
+/// Normalize email addresses: trim whitespace and lowercase.
+pub fn normalize_email(email: &str) -> String {
+    email.trim().to_ascii_lowercase()
+}
+
+/// Normalize and deduplicate a list of emails.
+pub fn normalize_emails(emails: &[String]) -> Vec<String> {
+    let mut result: Vec<String> = emails
+        .iter()
+        .map(|e| normalize_email(e))
+        .filter(|e| !e.is_empty() && e.contains('@'))
+        .collect();
+    result.sort();
+    result.dedup();
+    result
+}
+
+/// Determine document permissions for a given Darwinbox content type and
+/// configuration. All documents are non-public; access is granted via
+/// direct user emails or provider-scoped groups.
+pub fn document_permissions(
+    content_type: &str,
+    config: &DarwinboxSourceConfig,
+    _source_id: &str,
+    employee_self_email: Option<&str>,
+) -> omni_connector_sdk::DocumentPermissions {
+    let hr_admins = normalize_emails(&config.authorization.hr_admin_emails);
+    let recruiters = normalize_emails(&config.authorization.recruiter_emails);
+    let participants = normalize_emails(&config.authorization.participant_emails);
+
+    match content_type {
+        "employee_profile" => {
+            let mut users = hr_admins.clone();
+            if let Some(email) = employee_self_email {
+                let normalized = normalize_email(email);
+                if !users.contains(&normalized) {
+                    users.push(normalized);
+                }
+            }
+            for participant in participants {
+                if !users.contains(&participant) {
+                    users.push(participant);
+                }
+            }
+            omni_connector_sdk::DocumentPermissions {
+                public: false,
+                users,
+                groups: vec![],
+            }
+        }
+        "department" | "designation" | "office_location" | "business_unit" | "division"
+        | "cost_center" | "group_company" | "holiday" => omni_connector_sdk::DocumentPermissions {
+            public: false,
+            users: participants,
+            groups: vec![],
+        },
+        "position" => {
+            let users = hr_admins.clone();
+            if users.is_empty() {
+                // Fail closed: empty HR-admin list → nobody can access
+                omni_connector_sdk::DocumentPermissions {
+                    public: false,
+                    users: vec![],
+                    groups: vec![],
+                }
+            } else {
+                omni_connector_sdk::DocumentPermissions {
+                    public: false,
+                    users,
+                    groups: vec![],
+                }
+            }
+        }
+        "job" | "ats_job" => {
+            let mut users = hr_admins.clone();
+            for recruiter in &recruiters {
+                if !users.contains(recruiter) {
+                    users.push(recruiter.clone());
+                }
+            }
+            if users.is_empty() {
+                omni_connector_sdk::DocumentPermissions {
+                    public: false,
+                    users: vec![],
+                    groups: vec![],
+                }
+            } else {
+                omni_connector_sdk::DocumentPermissions {
+                    public: false,
+                    users,
+                    groups: vec![],
+                }
+            }
+        }
+        // Unknown/future content types: fail closed
+        _ => omni_connector_sdk::DocumentPermissions {
+            public: false,
+            users: vec![],
+            groups: vec![],
+        },
+    }
 }

--- a/connectors/darwinbox/src/config.rs
+++ b/connectors/darwinbox/src/config.rs
@@ -362,14 +362,10 @@ impl DarwinboxSourceConfig {
                 );
             }
         }
-        // High-risk generic HR/ATS/report payloads remain unavailable until
+        // High-risk generic HR/ATS payloads remain unavailable until
         // action-specific provider contracts have been reviewed.
-        if self.action_modules.hr_operations
-            || self.action_modules.ats
-            || self.action_modules.reports
-        {
-            errors
-                .push("HR, ATS, and report actions are not available in hardened mode".to_string());
+        if self.action_modules.hr_operations || self.action_modules.ats {
+            errors.push("HR and ATS actions are not implemented".to_string());
         }
         const UNTYPED_ACTIONS: &[&str] = &[
             "regularize_my_attendance",
@@ -381,8 +377,6 @@ impl DarwinboxSourceConfig {
             "reactivate_employee",
             "upload_employee_document",
             "fetch_employee_history",
-            "fetch_report_ids",
-            "run_report",
             "list_jobs",
             "get_job_detail",
             "get_candidates",
@@ -396,7 +390,7 @@ impl DarwinboxSourceConfig {
                 errors.push(format!("unknown Darwinbox action '{action}'"));
             }
             if UNTYPED_ACTIONS.contains(&action.as_str()) {
-                errors.push(format!("action '{action}' is unavailable in hardened mode"));
+                errors.push(format!("action '{action}' is not implemented"));
             }
         }
 

--- a/connectors/darwinbox/src/config.rs
+++ b/connectors/darwinbox/src/config.rs
@@ -392,22 +392,12 @@ pub fn document_permissions(
     _source_id: &str,
     employee_self_email: Option<&str>,
 ) -> omni_connector_sdk::DocumentPermissions {
-    let participants = normalize_emails(&config.authorization.participant_emails);
-    let recruiters = normalize_emails(&config.authorization.recruiter_emails);
-
     match content_type {
         "employee_profile" => {
             let mut users: Vec<String> = Vec::new();
             if let Some(email) = employee_self_email {
                 let normalized = normalize_email(email);
-                if !users.contains(&normalized) {
-                    users.push(normalized);
-                }
-            }
-            for participant in participants {
-                if !users.contains(&participant) {
-                    users.push(participant);
-                }
+                users.push(normalized);
             }
             omni_connector_sdk::DocumentPermissions {
                 public: false,
@@ -416,47 +406,11 @@ pub fn document_permissions(
             }
         }
         "department" | "designation" | "office_location" | "business_unit" | "division"
-        | "cost_center" | "group_company" | "holiday" => omni_connector_sdk::DocumentPermissions {
-            public: false,
-            users: participants,
-            groups: vec![],
-        },
-        "position" => {
-            let users: Vec<String> = Vec::new();
-            if users.is_empty() {
-                // Fail closed: empty HR-admin list → nobody can access
-                omni_connector_sdk::DocumentPermissions {
-                    public: false,
-                    users: vec![],
-                    groups: vec![],
-                }
-            } else {
-                omni_connector_sdk::DocumentPermissions {
-                    public: false,
-                    users,
-                    groups: vec![],
-                }
-            }
-        }
-        "job" | "ats_job" => {
-            let mut users: Vec<String> = Vec::new();
-            for recruiter in &recruiters {
-                if !users.contains(recruiter) {
-                    users.push(recruiter.clone());
-                }
-            }
-            if users.is_empty() {
-                omni_connector_sdk::DocumentPermissions {
-                    public: false,
-                    users: vec![],
-                    groups: vec![],
-                }
-            } else {
-                omni_connector_sdk::DocumentPermissions {
-                    public: false,
-                    users,
-                    groups: vec![],
-                }
+        | "cost_center" | "group_company" | "holiday" | "position" | "job" | "ats_job" => {
+            omni_connector_sdk::DocumentPermissions {
+                public: true,
+                users: vec![],
+                groups: vec![],
             }
         }
         // Unknown/future content types: fail closed

--- a/connectors/darwinbox/src/config.rs
+++ b/connectors/darwinbox/src/config.rs
@@ -198,8 +198,6 @@ pub struct DarwinboxAuthorizationConfig {
     #[serde(default)]
     pub allowed_actions: Vec<String>,
     #[serde(default)]
-    pub hr_admin_emails: Vec<String>,
-    #[serde(default)]
     pub recruiter_emails: Vec<String>,
     #[serde(default)]
     pub allowed_report_ids: Vec<String>,
@@ -215,9 +213,8 @@ impl Default for DarwinboxAuthorizationConfig {
             write_acknowledged: false,
             participant_emails: Vec::new(),
             allowed_actions: Vec::new(),
-            hr_admin_emails: Vec::new(),
-            recruiter_emails: Vec::new(),
             allowed_report_ids: Vec::new(),
+            recruiter_emails: Vec::new(),
             max_batch_size: 1,
         }
     }
@@ -355,13 +352,7 @@ impl DarwinboxSourceConfig {
             }
         }
 
-        for email in self
-            .authorization
-            .participant_emails
-            .iter()
-            .chain(self.authorization.hr_admin_emails.iter())
-            .chain(self.authorization.recruiter_emails.iter())
-        {
+        for email in self.authorization.participant_emails.iter() {
             if !email.contains('@') || email.trim().is_empty() {
                 errors.push(format!("invalid authorization email: {email}"));
             }
@@ -401,13 +392,12 @@ pub fn document_permissions(
     _source_id: &str,
     employee_self_email: Option<&str>,
 ) -> omni_connector_sdk::DocumentPermissions {
-    let hr_admins = normalize_emails(&config.authorization.hr_admin_emails);
-    let recruiters = normalize_emails(&config.authorization.recruiter_emails);
     let participants = normalize_emails(&config.authorization.participant_emails);
+    let recruiters = normalize_emails(&config.authorization.recruiter_emails);
 
     match content_type {
         "employee_profile" => {
-            let mut users = hr_admins.clone();
+            let mut users: Vec<String> = Vec::new();
             if let Some(email) = employee_self_email {
                 let normalized = normalize_email(email);
                 if !users.contains(&normalized) {
@@ -432,7 +422,7 @@ pub fn document_permissions(
             groups: vec![],
         },
         "position" => {
-            let users = hr_admins.clone();
+            let users: Vec<String> = Vec::new();
             if users.is_empty() {
                 // Fail closed: empty HR-admin list → nobody can access
                 omni_connector_sdk::DocumentPermissions {
@@ -449,7 +439,7 @@ pub fn document_permissions(
             }
         }
         "job" | "ats_job" => {
-            let mut users = hr_admins.clone();
+            let mut users: Vec<String> = Vec::new();
             for recruiter in &recruiters {
                 if !users.contains(recruiter) {
                     users.push(recruiter.clone());

--- a/connectors/darwinbox/src/config.rs
+++ b/connectors/darwinbox/src/config.rs
@@ -198,12 +198,6 @@ pub struct DarwinboxAuthorizationConfig {
     #[serde(default)]
     pub allowed_actions: Vec<String>,
     #[serde(default)]
-    pub target_employee_ids: Vec<String>,
-    #[serde(default)]
-    pub target_employee_emails: Vec<String>,
-    #[serde(default)]
-    pub target_departments: Vec<String>,
-    #[serde(default)]
     pub hr_admin_emails: Vec<String>,
     #[serde(default)]
     pub recruiter_emails: Vec<String>,
@@ -221,9 +215,6 @@ impl Default for DarwinboxAuthorizationConfig {
             write_acknowledged: false,
             participant_emails: Vec::new(),
             allowed_actions: Vec::new(),
-            target_employee_ids: Vec::new(),
-            target_employee_emails: Vec::new(),
-            target_departments: Vec::new(),
             hr_admin_emails: Vec::new(),
             recruiter_emails: Vec::new(),
             allowed_report_ids: Vec::new(),
@@ -243,32 +234,6 @@ impl DarwinboxSourceConfig {
     pub fn is_action_participant(&self, email: &str) -> bool {
         let email = normalize_email(email);
         normalize_emails(&self.authorization.participant_emails).contains(&email)
-    }
-
-    pub fn is_target_employee(&self, employee: &crate::models::EmployeeRecord) -> bool {
-        let auth = &self.authorization;
-        let has_scope = !auth.target_employee_ids.is_empty()
-            || !auth.target_employee_emails.is_empty()
-            || !auth.target_departments.is_empty();
-        if !has_scope {
-            return false;
-        }
-        employee.employee_id.as_deref().is_some_and(|id| {
-            auth.target_employee_ids
-                .iter()
-                .any(|v| v.eq_ignore_ascii_case(id))
-        }) || employee.company_email_id.as_deref().is_some_and(|email| {
-            auth.target_employee_emails
-                .iter()
-                .any(|v| v.eq_ignore_ascii_case(email))
-        }) || employee
-            .department_name
-            .as_deref()
-            .is_some_and(|department| {
-                auth.target_departments
-                    .iter()
-                    .any(|v| v.eq_ignore_ascii_case(department))
-            })
     }
 
     /// Validate the configuration and return an error if it is unsafe or
@@ -339,11 +304,7 @@ impl DarwinboxSourceConfig {
             {
                 errors.push("actions require participant_emails and allowed_actions".to_string());
             }
-            if self.action_modules.manager_workflows
-                && self.authorization.target_employee_ids.is_empty()
-                && self.authorization.target_employee_emails.is_empty()
-                && self.authorization.target_departments.is_empty()
-            {
+            if self.action_modules.manager_workflows {
                 errors.push(
                     "manager workflows require an explicit target employee scope".to_string(),
                 );
@@ -398,7 +359,6 @@ impl DarwinboxSourceConfig {
             .authorization
             .participant_emails
             .iter()
-            .chain(self.authorization.target_employee_emails.iter())
             .chain(self.authorization.hr_admin_emails.iter())
             .chain(self.authorization.recruiter_emails.iter())
         {

--- a/connectors/darwinbox/src/connector.rs
+++ b/connectors/darwinbox/src/connector.rs
@@ -172,24 +172,6 @@ impl Connector for DarwinboxConnector {
                     "read-only mode disabled but no write action modules are enabled".to_string(),
                 ));
             }
-
-            // Validate that report/ATS HR admin lists are non-empty when those
-            // modules are enabled
-            if config.action_modules.reports && config.authorization.hr_admin_emails.is_empty() {
-                return Err(SyncRequestValidationError::BadRequest(
-                    "reports enabled but hr_admin_emails is empty".to_string(),
-                ));
-            }
-
-            if config.action_modules.ats
-                && config.authorization.recruiter_emails.is_empty()
-                && config.authorization.hr_admin_emails.is_empty()
-            {
-                return Err(SyncRequestValidationError::BadRequest(
-                    "ATS actions enabled but both hr_admin_emails and recruiter_emails are empty"
-                        .to_string(),
-                ));
-            }
         }
 
         Ok(())

--- a/connectors/darwinbox/src/connector.rs
+++ b/connectors/darwinbox/src/connector.rs
@@ -2,10 +2,11 @@ use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use axum::response::Response;
 use omni_connector_sdk::{
-    ActionDefinition, Connector, SearchOperator, ServiceCredential, Source, SourceType,
-    SyncContext, SyncType,
+    ActionDefinition, ActionMode, Connector, SearchOperator, ServiceCredential, Source, SourceType,
+    SyncContext, SyncRequestValidationError, SyncType,
 };
 use serde_json::Value as JsonValue;
+use std::result::Result as StdResult;
 
 use crate::actions;
 use crate::client::DarwinboxClient;
@@ -62,6 +63,43 @@ impl Connector for DarwinboxConnector {
         actions::action_definitions()
     }
 
+    fn extra_schema(&self) -> Option<JsonValue> {
+        // Expose action groups derived from the internal action policy table,
+        // so the setup UI can filter actions by module without hard-coding
+        // action names or relying on shared ActionDefinition.category.
+        use std::collections::BTreeMap;
+        let mut groups: BTreeMap<&str, Vec<&str>> = BTreeMap::new();
+        for policy in actions::action_policies() {
+            groups.entry(policy.module).or_default().push(policy.name);
+        }
+        let mut map = serde_json::Map::new();
+        for (module, names) in &groups {
+            let mut reads = Vec::new();
+            let mut writes = Vec::new();
+            for name in names {
+                let policy = actions::action_policies().iter().find(|p| p.name == *name);
+                if let Some(p) = policy {
+                    match p.mode {
+                        ActionMode::Read => reads.push(name.to_string()),
+                        ActionMode::Write => writes.push(name.to_string()),
+                    }
+                }
+            }
+            let group = serde_json::json!({
+                "read": reads,
+                "write": writes,
+            });
+            map.insert(module.to_string(), group);
+        }
+        Some(serde_json::json!({ "action_groups": serde_json::Value::Object(map) }))
+    }
+
+    fn read_only(&self) -> bool {
+        // The connector defers read-only enforcement to the source config.
+        // Connector-manager reads `source.config.read_only` at dispatch time.
+        false
+    }
+
     fn search_operators(&self) -> Vec<SearchOperator> {
         vec![
             SearchOperator {
@@ -97,6 +135,66 @@ impl Connector for DarwinboxConnector {
         ]
     }
 
+    /// Validate source configuration before sync. Returns bad-request for
+    /// unsafe or contradictory policies so the sync run is never started.
+    async fn validate_sync_request(
+        &self,
+        source: &Source,
+        _credentials: Option<&ServiceCredential>,
+        _sync_type: SyncType,
+    ) -> StdResult<(), SyncRequestValidationError> {
+        // Decode the config to validate it
+        let config: DarwinboxSourceConfig =
+            serde_json::from_value(source.config.clone()).map_err(|e| {
+                SyncRequestValidationError::BadRequest(format!(
+                    "invalid Darwinbox source config: {e}"
+                ))
+            })?;
+
+        // Validate the config semantically
+        config.validate().map_err(|errors| {
+            SyncRequestValidationError::BadRequest(format!(
+                "Darwinbox config validation failed: {}",
+                errors.join("; ")
+            ))
+        })?;
+
+        // If read_only is false (writes allowed), ensure the config is not
+        // contradictory: action modules must be explicitly enabled and at
+        // least one write action must be authorized.
+        if !config.read_only {
+            if !config.action_modules.employee_self_service
+                && !config.action_modules.manager_workflows
+                && !config.action_modules.hr_operations
+                && !config.action_modules.ats
+            {
+                return Err(SyncRequestValidationError::BadRequest(
+                    "read-only mode disabled but no write action modules are enabled".to_string(),
+                ));
+            }
+
+            // Validate that report/ATS HR admin lists are non-empty when those
+            // modules are enabled
+            if config.action_modules.reports && config.authorization.hr_admin_emails.is_empty() {
+                return Err(SyncRequestValidationError::BadRequest(
+                    "reports enabled but hr_admin_emails is empty".to_string(),
+                ));
+            }
+
+            if config.action_modules.ats
+                && config.authorization.recruiter_emails.is_empty()
+                && config.authorization.hr_admin_emails.is_empty()
+            {
+                return Err(SyncRequestValidationError::BadRequest(
+                    "ATS actions enabled but both hr_admin_emails and recruiter_emails are empty"
+                        .to_string(),
+                ));
+            }
+        }
+
+        Ok(())
+    }
+
     async fn sync(
         &self,
         source: Source,
@@ -122,7 +220,9 @@ impl Connector for DarwinboxConnector {
         action: &str,
         params: JsonValue,
         credentials: Option<ServiceCredential>,
+        source: Option<Source>,
+        actor_email: Option<String>,
     ) -> Result<Response> {
-        actions::execute_action(action, params, credentials).await
+        actions::execute_action(action, params, credentials, source, actor_email).await
     }
 }

--- a/connectors/darwinbox/src/mappers.rs
+++ b/connectors/darwinbox/src/mappers.rs
@@ -1,2 +1,130 @@
-// Mapping helpers live on provider model types for now. Split provider-to-Omni
-// mapping functions into this module as additional Darwinbox objects are added.
+//! Typed mappers from Darwinbox provider models to Omni document events.
+//! Each entity type has its own mapper so raw provider fields are never
+//! serialized into indexed content, metadata, attributes, or logs.
+
+use omni_connector_sdk::ConnectorEvent;
+use serde_json::Value as JsonValue;
+
+use crate::config::{self, DarwinboxSourceConfig};
+use crate::models::EmployeeRecord;
+
+/// Map a Darwinbox employee record to a document-create event with the
+/// appropriate filtered content and ACL.
+pub fn employee_to_event(
+    employee: &EmployeeRecord,
+    sync_run_id: String,
+    source_id: String,
+    content_id: String,
+    config: &DarwinboxSourceConfig,
+) -> Option<ConnectorEvent> {
+    let permissions = config::document_permissions(
+        "employee_profile",
+        config,
+        &source_id,
+        employee.company_email_id.as_deref(),
+    );
+    let content = employee.content_filtered(&config.employee_fields);
+    employee.to_event_with_permissions(
+        sync_run_id,
+        source_id,
+        content_id,
+        content.len(),
+        &config.employee_fields,
+        permissions,
+    )
+}
+
+/// Map a generic Darwinbox entity to a document-create event with safe
+/// field projection and non-public ACL.
+
+/// Safely format an org master item's title and content from known fields only.
+pub fn format_org_master_item<'a>(
+    item: &'a JsonValue,
+    _content_type: &'a str,
+) -> (&'a str, String) {
+    let title = item
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .unwrap_or_else(|| {
+            item.get("code")
+                .and_then(JsonValue::as_str)
+                .unwrap_or("unknown")
+        });
+
+    let code = item
+        .get("code")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let description = item
+        .get("description")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let status = item
+        .get("status")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+
+    let safe_body = if !description.is_empty() {
+        format!("# {title}\n\n- Code: {code}\n- Description: {description}\n- Status: {status}")
+    } else {
+        format!("# {title}\n\n- Code: {code}\n- Status: {status}")
+    };
+
+    (title, safe_body)
+}
+
+/// Safely format a holiday item from known fields.
+pub fn format_holiday_item(item: &JsonValue) -> (String, String) {
+    let name = item
+        .get("holiday_name")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("Holiday");
+    let date = item
+        .get("holiday_date")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+    let description = item
+        .get("description")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+
+    let safe_body = if description.is_empty() {
+        format!("# {name}\n\n- Date: {date}")
+    } else {
+        format!("# {name}\n\n- Date: {date}\n- Description: {description}")
+    };
+    (name.to_string(), safe_body)
+}
+
+/// Safely format a position item from known fields.
+pub fn format_position_item(item: &JsonValue) -> (String, String) {
+    let title = item
+        .get("name")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("Position");
+    let code = item
+        .get("position_code")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("");
+    let status = item.get("status").and_then(JsonValue::as_str).unwrap_or("");
+
+    let safe_body = if !status.is_empty() {
+        format!("# {title}\n\n- Code: {code}\n- Status: {status}")
+    } else {
+        format!("# {title}\n\n- Code: {code}")
+    };
+    (title.to_string(), safe_body)
+}
+
+/// Safely format an ATS job from known fields.
+pub fn format_ats_job_item(item: &JsonValue) -> (String, String) {
+    let title = item
+        .get("job_title")
+        .and_then(JsonValue::as_str)
+        .unwrap_or("Job");
+    let job_id = item.get("job_id").and_then(JsonValue::as_str).unwrap_or("");
+
+    let safe_body = format!("# {title}\n\n- Job ID: {job_id}");
+    (title.to_string(), safe_body)
+}

--- a/connectors/darwinbox/src/models.rs
+++ b/connectors/darwinbox/src/models.rs
@@ -1,4 +1,4 @@
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
 
 use omni_connector_sdk::{ConnectorEvent, DocumentMetadata, DocumentPermissions};
 use serde::{Deserialize, Serialize};
@@ -9,6 +9,10 @@ pub type DarwinboxConnectorState = JsonValue;
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 pub struct DarwinboxCheckpoint {
     pub schema_version: u16,
+    #[serde(default)]
+    pub policy_fingerprint: Option<String>,
+    #[serde(default)]
+    pub indexed_document_ids: BTreeSet<String>,
     #[serde(default)]
     pub modules: BTreeMap<DarwinboxSyncModuleKey, ModuleCheckpoint>,
 }
@@ -64,8 +68,12 @@ pub enum DarwinboxSyncUnit {
     Report { report_id: String },
 }
 
-#[derive(Debug, Clone, Default, Deserialize, Serialize)]
-pub struct EmployeeRecord {
+/// Wire-level employee record from Darwinbox. Only known safe fields are
+/// captured; unknown fields are silently ignored via missing-field defaults.
+/// This type intentionally does NOT use `deny_unknown_fields` so provider
+/// response extensions do not break deserialization.
+#[derive(Debug, Clone, Default, Deserialize)]
+pub struct EmployeeWireRecord {
     #[serde(default)]
     pub employee_id: Option<String>,
     #[serde(default)]
@@ -88,11 +96,12 @@ pub struct EmployeeRecord {
     pub employee_type: Option<String>,
     #[serde(default)]
     pub latest_modified_any_attribute: Option<String>,
-    #[serde(flatten)]
-    pub extra: JsonValue,
 }
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+/// Alias for backward compatibility during migration.
+pub type EmployeeRecord = EmployeeWireRecord;
+
+#[derive(Debug, Clone, Deserialize)]
 pub struct EmployeeDataResponse {
     pub status: Option<i32>,
     pub message: Option<String>,
@@ -151,34 +160,116 @@ impl EmployeeRecord {
         lines.join("\n")
     }
 
-    pub fn to_event(
+    /// Convenience constructor for content from selected fields only.
+    pub fn content_filtered(&self, fields: &[crate::config::EmployeeField]) -> String {
+        let mut lines = Vec::new();
+        for field in fields {
+            match field {
+                crate::config::EmployeeField::Name => {
+                    lines.push(self.display_name());
+                }
+                crate::config::EmployeeField::EmployeeId => {
+                    if let Some(id) = &self.employee_id {
+                        lines.push(format!("Employee ID: {id}"));
+                    }
+                }
+                crate::config::EmployeeField::CompanyEmail => {
+                    if let Some(email) = &self.company_email_id {
+                        lines.push(format!("Email: {email}"));
+                    }
+                }
+                crate::config::EmployeeField::Department => {
+                    if let Some(dept) = &self.department_name {
+                        lines.push(format!("Department: {dept}"));
+                    }
+                }
+                crate::config::EmployeeField::Designation => {
+                    if let Some(desig) = &self.designation_name {
+                        lines.push(format!("Designation: {desig}"));
+                    }
+                }
+                crate::config::EmployeeField::OfficeLocation => {
+                    if let Some(loc) = &self.office_area {
+                        lines.push(format!("Location: {loc}"));
+                    }
+                }
+                crate::config::EmployeeField::ManagerEmployeeId => {
+                    if let Some(mgr) = &self.direct_manager_employee_id {
+                        lines.push(format!("Manager Employee ID: {mgr}"));
+                    }
+                }
+                crate::config::EmployeeField::EmployeeType => {
+                    if let Some(etype) = &self.employee_type {
+                        lines.push(format!("Employee Type: {etype}"));
+                    }
+                }
+            }
+        }
+        lines.join("\n")
+    }
+
+    /// Build a document-create event with the given permissions.
+    pub fn to_event_with_permissions(
         &self,
         sync_run_id: String,
         source_id: String,
         content_id: String,
+        content_size: usize,
+        fields: &[crate::config::EmployeeField],
+        permissions: DocumentPermissions,
     ) -> Option<ConnectorEvent> {
         let document_id = self.external_id()?;
-        let title = self.display_name();
+        let title = if fields.contains(&crate::config::EmployeeField::Name) {
+            self.display_name()
+        } else {
+            "Darwinbox employee".to_string()
+        };
         let metadata = DocumentMetadata {
             title: Some(title),
-            author: self.company_email_id.clone(),
+            author: fields
+                .contains(&crate::config::EmployeeField::CompanyEmail)
+                .then(|| self.company_email_id.clone())
+                .flatten(),
             created_at: None,
             updated_at: None,
             content_type: Some("employee_profile".to_string()),
             mime_type: Some("text/markdown".to_string()),
-            size: Some(self.content().len().to_string()),
+            size: Some(content_size.to_string()),
             url: None,
             path: None,
-            extra: Some(std::collections::HashMap::from([(
-                "darwinbox".to_string(),
-                json!({ "employee_id": self.employee_id }),
-            )])),
+            extra: None,
         };
-        let permissions = DocumentPermissions {
-            public: true,
-            users: vec![],
-            groups: vec![],
-        };
+        let mut attributes =
+            std::collections::HashMap::from([("source_type".to_string(), json!("darwinbox"))]);
+        for field in fields {
+            match field {
+                crate::config::EmployeeField::EmployeeId => {
+                    attributes.insert("employee_id".to_string(), json!(self.employee_id));
+                }
+                crate::config::EmployeeField::CompanyEmail => {
+                    attributes.insert("email".to_string(), json!(self.company_email_id));
+                }
+                crate::config::EmployeeField::Department => {
+                    attributes.insert("department".to_string(), json!(self.department_name));
+                }
+                crate::config::EmployeeField::Designation => {
+                    attributes.insert("designation".to_string(), json!(self.designation_name));
+                }
+                crate::config::EmployeeField::OfficeLocation => {
+                    attributes.insert("location".to_string(), json!(self.office_area));
+                }
+                crate::config::EmployeeField::ManagerEmployeeId => {
+                    attributes.insert(
+                        "manager_employee_id".to_string(),
+                        json!(self.direct_manager_employee_id),
+                    );
+                }
+                crate::config::EmployeeField::EmployeeType => {
+                    attributes.insert("employee_type".to_string(), json!(self.employee_type));
+                }
+                crate::config::EmployeeField::Name => {}
+            }
+        }
         Some(ConnectorEvent::DocumentCreated {
             sync_run_id,
             source_id,
@@ -186,19 +277,7 @@ impl EmployeeRecord {
             content_id,
             metadata,
             permissions,
-            attributes: Some(std::collections::HashMap::from([
-                ("source_type".to_string(), json!("darwinbox")),
-                ("employee_id".to_string(), json!(self.employee_id)),
-                ("email".to_string(), json!(self.company_email_id)),
-                ("department".to_string(), json!(self.department_name)),
-                ("designation".to_string(), json!(self.designation_name)),
-                ("location".to_string(), json!(self.office_area)),
-                (
-                    "manager_employee_id".to_string(),
-                    json!(self.direct_manager_employee_id),
-                ),
-                ("employee_type".to_string(), json!(self.employee_type)),
-            ])),
+            attributes: Some(attributes),
         })
     }
 }

--- a/connectors/darwinbox/src/sync.rs
+++ b/connectors/darwinbox/src/sync.rs
@@ -27,9 +27,7 @@ pub async fn run_sync(
 
     let mut checkpoint = state.unwrap_or_default();
     if checkpoint.schema_version != 0 && checkpoint.schema_version < 2 {
-        bail!(
-            "legacy Darwinbox checkpoint cannot be hardened in place; delete and recreate the source"
-        );
+        bail!("legacy Darwinbox checkpoint is incompatible; delete and recreate the source");
     }
     let policy_fingerprint = serde_json::to_string(config)?;
     if checkpoint.policy_fingerprint.as_deref() != Some(policy_fingerprint.as_str()) {

--- a/connectors/darwinbox/src/sync.rs
+++ b/connectors/darwinbox/src/sync.rs
@@ -1,13 +1,14 @@
-use anyhow::{Context, Result};
+use std::collections::BTreeSet;
+
+use anyhow::{bail, Context, Result};
 use chrono::{DateTime, Duration, Utc};
-use omni_connector_sdk::{
-    ConnectorEvent, DocumentMetadata, DocumentPermissions, SyncContext, SyncType,
-};
+use omni_connector_sdk::{ConnectorEvent, DocumentMetadata, SyncContext, SyncType};
 use serde_json::{json, Value as JsonValue};
 use tracing::{info, warn};
 
 use crate::client::DarwinboxClient;
-use crate::config::DarwinboxSourceConfig;
+use crate::config::{self, DarwinboxSourceConfig};
+use crate::mappers;
 use crate::models::{DarwinboxCheckpoint, DarwinboxSyncModuleKey, ModuleCheckpoint};
 
 const INCREMENTAL_OVERLAP_SECONDS: i64 = 900;
@@ -25,19 +26,56 @@ pub async fn run_sync(
     );
 
     let mut checkpoint = state.unwrap_or_default();
-    checkpoint.schema_version = 1;
+    if checkpoint.schema_version != 0 && checkpoint.schema_version < 2 {
+        bail!(
+            "legacy Darwinbox checkpoint cannot be hardened in place; delete and recreate the source"
+        );
+    }
+    let policy_fingerprint = serde_json::to_string(config)?;
+    if checkpoint.policy_fingerprint.as_deref() != Some(policy_fingerprint.as_str()) {
+        for document_id in checkpoint.indexed_document_ids.clone() {
+            ctx.emit_event(ConnectorEvent::DocumentDeleted {
+                sync_run_id: ctx.sync_run_id().to_string(),
+                source_id: ctx.source_id().to_string(),
+                document_id,
+            })
+            .await?;
+        }
+        checkpoint.schema_version = 2;
+        checkpoint.policy_fingerprint = Some(policy_fingerprint.clone());
+        checkpoint.indexed_document_ids.clear();
+        ctx.save_checkpoint(json!(checkpoint)).await?;
+    }
+    let previous_ids = checkpoint.indexed_document_ids.clone();
+    let mut current_ids = BTreeSet::new();
+    // Intermediate checkpoints retain every previously durable document plus
+    // newly emitted documents. If a later operation fails, the next run still
+    // has a complete revocation inventory.
+    let mut durable_ids = previous_ids.clone();
+    checkpoint.schema_version = 2;
 
+    // Employee directory — always processed if enabled, uses config for scope/ACL
     if config.sync_modules.employee_directory {
-        let since = module_since(&checkpoint, DarwinboxSyncModuleKey::EmployeeDirectory, &ctx);
-        sync_employee_directory(client, since.as_deref(), &ctx).await?;
+        sync_employee_directory(
+            client,
+            config,
+            ctx.source_id(),
+            &ctx,
+            &mut checkpoint,
+            &policy_fingerprint,
+            &mut current_ids,
+            &mut durable_ids,
+        )
+        .await?;
         set_module_watermark(
             &mut checkpoint,
             DarwinboxSyncModuleKey::EmployeeDirectory,
             Utc::now().to_rfc3339(),
         );
-        ctx.save_checkpoint(json!(checkpoint)).await?;
+        save_inventory_checkpoint(&ctx, &mut checkpoint, &policy_fingerprint, &durable_ids).await?;
     }
 
+    // Deleted employees
     if config.sync_modules.deleted_employees {
         let since = module_since(&checkpoint, DarwinboxSyncModuleKey::DeletedEmployees, &ctx);
         sync_deleted_employees(client, since.as_deref(), &ctx).await?;
@@ -46,79 +84,190 @@ pub async fn run_sync(
             DarwinboxSyncModuleKey::DeletedEmployees,
             Utc::now().to_rfc3339(),
         );
-        ctx.save_checkpoint(json!(checkpoint)).await?;
+        save_inventory_checkpoint(&ctx, &mut checkpoint, &policy_fingerprint, &durable_ids).await?;
     }
 
-    if config.sync_modules.org_masters {
-        sync_org_masters(client, &ctx).await?;
-        set_module_watermark(
-            &mut checkpoint,
-            DarwinboxSyncModuleKey::OrgMasters,
-            Utc::now().to_rfc3339(),
-        );
-        ctx.save_checkpoint(json!(checkpoint)).await?;
+    // Org masters — each entity type as its own flag
+    // Departments
+    if config.sync_modules.departments {
+        sync_single_org_master(
+            client,
+            config,
+            "department",
+            "darwinbox:department",
+            "/orgmasterapi/departmentlist",
+            &ctx,
+            &mut current_ids,
+        )
+        .await?;
+    }
+    // Designations
+    if config.sync_modules.designations {
+        sync_single_org_master(
+            client,
+            config,
+            "designation",
+            "darwinbox:designation",
+            "/orgmasterapi/designationlist",
+            &ctx,
+            &mut current_ids,
+        )
+        .await?;
+    }
+    // Office locations
+    if config.sync_modules.office_locations {
+        sync_single_org_master(
+            client,
+            config,
+            "office_location",
+            "darwinbox:office_location",
+            "/orgmasterapi/officelocationlist",
+            &ctx,
+            &mut current_ids,
+        )
+        .await?;
+    }
+    // Business units
+    if config.sync_modules.business_units {
+        sync_single_org_master(
+            client,
+            config,
+            "business_unit",
+            "darwinbox:business_unit",
+            "/orgmasterapi/businessunitlist",
+            &ctx,
+            &mut current_ids,
+        )
+        .await?;
+    }
+    // Divisions
+    if config.sync_modules.divisions {
+        sync_single_org_master(
+            client,
+            config,
+            "division",
+            "darwinbox:division",
+            "/orgmasterapi/divisionlist",
+            &ctx,
+            &mut current_ids,
+        )
+        .await?;
+    }
+    // Cost centers
+    if config.sync_modules.cost_centers {
+        sync_single_org_master(
+            client,
+            config,
+            "cost_center",
+            "darwinbox:cost_center",
+            "/orgmasterapi/costcenterlist",
+            &ctx,
+            &mut current_ids,
+        )
+        .await?;
+    }
+    // Group companies
+    if config.sync_modules.group_companies {
+        sync_single_org_master(
+            client,
+            config,
+            "group_company",
+            "darwinbox:group_company",
+            "/orgmasterapi/groupcompanylist",
+            &ctx,
+            &mut current_ids,
+        )
+        .await?;
     }
 
+    // Positions
     if config.sync_modules.positions {
-        let since = module_since(&checkpoint, DarwinboxSyncModuleKey::PositionMaster, &ctx);
-        let provider_since = since
-            .as_deref()
-            .and_then(to_darwinbox_timestamp_with_overlap);
-        let response = client
-            .fetch_position_master(provider_since.as_deref())
-            .await?;
-        sync_generic_collection("position", "darwinbox:position", &response, &ctx).await?;
+        let response = client.fetch_position_master(None).await?;
+        sync_typed_collection(
+            client,
+            config,
+            "position",
+            "darwinbox:position",
+            &response,
+            ctx.source_id(),
+            &ctx,
+            mappers::format_position_item,
+            &mut current_ids,
+        )
+        .await?;
         set_module_watermark(
             &mut checkpoint,
             DarwinboxSyncModuleKey::PositionMaster,
             Utc::now().to_rfc3339(),
         );
-        ctx.save_checkpoint(json!(checkpoint)).await?;
+        save_inventory_checkpoint(&ctx, &mut checkpoint, &policy_fingerprint, &current_ids).await?;
     }
 
+    // Holidays
     if config.sync_modules.holidays {
-        sync_holidays(client, &ctx).await?;
+        sync_holidays(client, config, ctx.source_id(), &ctx, &mut current_ids).await?;
         set_module_watermark(
             &mut checkpoint,
             DarwinboxSyncModuleKey::Holidays,
             Utc::now().to_rfc3339(),
         );
-        ctx.save_checkpoint(json!(checkpoint)).await?;
+        save_inventory_checkpoint(&ctx, &mut checkpoint, &policy_fingerprint, &current_ids).await?;
     }
 
+    // ATS jobs
     if config.sync_modules.ats_jobs {
-        let since = module_since(&checkpoint, DarwinboxSyncModuleKey::AtsJobs, &ctx);
-        let provider_since = since
-            .as_deref()
-            .and_then(to_darwinbox_timestamp_with_overlap);
-        let response = client.fetch_jobs(provider_since.as_deref()).await?;
-        sync_generic_collection("job", "darwinbox:job", &response, &ctx).await?;
+        let response = client.fetch_jobs(None).await?;
+        sync_typed_collection(
+            client,
+            config,
+            "ats_job",
+            "darwinbox:job",
+            &response,
+            ctx.source_id(),
+            &ctx,
+            mappers::format_ats_job_item,
+            &mut current_ids,
+        )
+        .await?;
         set_module_watermark(
             &mut checkpoint,
             DarwinboxSyncModuleKey::AtsJobs,
             Utc::now().to_rfc3339(),
         );
-        ctx.save_checkpoint(json!(checkpoint)).await?;
+        save_inventory_checkpoint(&ctx, &mut checkpoint, &policy_fingerprint, &current_ids).await?;
     }
 
-    info!(source_id = ctx.source_id(), "Darwinbox sync completed");
+    for document_id in previous_ids.difference(&current_ids) {
+        ctx.emit_event(ConnectorEvent::DocumentDeleted {
+            sync_run_id: ctx.sync_run_id().to_string(),
+            source_id: ctx.source_id().to_string(),
+            document_id: document_id.clone(),
+        })
+        .await?;
+    }
+    save_inventory_checkpoint(&ctx, &mut checkpoint, &policy_fingerprint, &current_ids).await?;
 
+    info!(source_id = ctx.source_id(), "Darwinbox sync completed");
     Ok(())
 }
 
 async fn sync_employee_directory(
     client: &DarwinboxClient,
-    last_modified: Option<&str>,
+    config: &DarwinboxSourceConfig,
+    source_id: &str,
     ctx: &SyncContext,
+    checkpoint: &mut DarwinboxCheckpoint,
+    policy_fingerprint: &str,
+    current_ids: &mut BTreeSet<String>,
+    durable_ids: &mut BTreeSet<String>,
 ) -> Result<()> {
-    let provider_last_modified = last_modified.and_then(to_darwinbox_timestamp_with_overlap);
+    // Always fetch a complete snapshot so policy reconciliation is authoritative.
     let response = client
-        .fetch_employees(None, provider_last_modified.as_deref())
+        .fetch_employees(None, None)
         .await
         .context("failed to fetch Darwinbox employee directory")?;
 
     let mut emitted = 0i32;
-    let mut member_emails = Vec::new();
 
     for employee in response.employee_data {
         if ctx.is_cancelled() {
@@ -131,25 +280,41 @@ async fn sync_employee_directory(
             continue;
         };
 
-        let content = employee.content();
+        // Apply employee scope filter from config
+        if !config.is_employee_in_scope(&employee) {
+            continue;
+        }
+
+        // Use filtered content with only approved fields
+        let content = employee.content_filtered(&config.employee_fields);
         let content_id = ctx
             .store_content(&content)
             .await
             .with_context(|| format!("failed to store content for {document_id}"))?;
 
-        if let Some(event) = employee.to_event(
-            ctx.sync_run_id().to_string(),
-            ctx.source_id().to_string(),
-            content_id,
-        ) {
-            ctx.emit_event(event).await?;
-            emitted += 1;
-        }
+        // Build event with config-derived non-public permissions
+        let permissions = config::document_permissions(
+            "employee_profile",
+            config,
+            source_id,
+            employee.company_email_id.as_deref(),
+        );
 
-        if let Some(email) = employee.company_email_id.as_deref() {
-            if !email.trim().is_empty() {
-                member_emails.push(email.trim().to_ascii_lowercase());
-            }
+        if let Some(event) = employee.to_event_with_permissions(
+            ctx.sync_run_id().to_string(),
+            source_id.to_string(),
+            content_id,
+            content.len(),
+            &config.employee_fields,
+            permissions,
+        ) {
+            // Persist a conservatively over-inclusive revocation inventory before
+            // the durable event can become visible to the indexer.
+            durable_ids.insert(document_id.clone());
+            save_inventory_checkpoint(ctx, checkpoint, policy_fingerprint, durable_ids).await?;
+            ctx.emit_event(event).await?;
+            current_ids.insert(document_id);
+            emitted += 1;
         }
 
         if emitted > 0 && emitted % 100 == 0 {
@@ -159,17 +324,6 @@ async fn sync_employee_directory(
 
     if emitted % 100 != 0 {
         ctx.increment_scanned(emitted % 100).await?;
-    }
-
-    if !member_emails.is_empty() {
-        ctx.emit_event(ConnectorEvent::GroupMembershipSync {
-            sync_run_id: ctx.sync_run_id().to_string(),
-            source_id: ctx.source_id().to_string(),
-            group_email: format!("darwinbox:employees:{}", ctx.source_id()),
-            group_name: Some("Darwinbox Employees".to_string()),
-            member_emails,
-        })
-        .await?;
     }
 
     Ok(())
@@ -241,58 +395,83 @@ async fn sync_deleted_employees(
     Ok(())
 }
 
-async fn sync_org_masters(client: &DarwinboxClient, ctx: &SyncContext) -> Result<()> {
-    let endpoints = [
-        (
-            "department",
-            "darwinbox:department",
-            "/orgmasterapi/departmentlist",
-        ),
-        (
-            "designation",
-            "darwinbox:designation",
-            "/orgmasterapi/designationlist",
-        ),
-        (
-            "office_location",
-            "darwinbox:office_location",
-            "/orgmasterapi/officelocationlist",
-        ),
-        (
-            "business_unit",
-            "darwinbox:business_unit",
-            "/orgmasterapi/businessunitlist",
-        ),
-        (
-            "division",
-            "darwinbox:division",
-            "/orgmasterapi/divisionlist",
-        ),
-        (
-            "cost_center",
-            "darwinbox:cost_center",
-            "/orgmasterapi/costcenterlist",
-        ),
-        (
-            "group_company",
-            "darwinbox:group_company",
-            "/orgmasterapi/groupcompanylist",
-        ),
-    ];
+/// Sync a single org master entity type using its typed mapper.
+async fn sync_single_org_master(
+    client: &DarwinboxClient,
+    config: &DarwinboxSourceConfig,
+    content_type: &str,
+    external_prefix: &str,
+    path: &str,
+    ctx: &SyncContext,
+    current_ids: &mut BTreeSet<String>,
+) -> Result<()> {
+    if ctx.is_cancelled() {
+        ctx.cancel().await?;
+        return Ok(());
+    }
+    let response = client.fetch_org_master(path).await?;
+    let permissions = config::document_permissions(content_type, config, ctx.source_id(), None);
+    let items = extract_items(&response);
+    let mut count = 0i32;
 
-    for (content_type, prefix, path) in endpoints {
+    for item in &items {
         if ctx.is_cancelled() {
             ctx.cancel().await?;
             return Ok(());
         }
-        let response = client.fetch_org_master(path).await?;
-        sync_generic_collection(content_type, prefix, &response, ctx).await?;
-    }
+        let Some(id) = extract_stable_id(item) else {
+            warn!(
+                content_type,
+                "Skipping Darwinbox record without a stable ID"
+            );
+            continue;
+        };
 
+        let (title, safe_body) = mappers::format_org_master_item(item, content_type);
+        let content = safe_body;
+        let content_id = ctx.store_content(&content).await?;
+
+        let document_id = format!("{external_prefix}:{id}");
+        ctx.emit_event(ConnectorEvent::DocumentCreated {
+            sync_run_id: ctx.sync_run_id().to_string(),
+            source_id: ctx.source_id().to_string(),
+            document_id: document_id.clone(),
+            content_id,
+            metadata: DocumentMetadata {
+                title: Some(title.to_string()),
+                author: None,
+                created_at: None,
+                updated_at: None,
+                content_type: Some(content_type.to_string()),
+                mime_type: Some("text/markdown".to_string()),
+                size: Some(content.len().to_string()),
+                url: None,
+                path: None,
+                extra: None,
+            },
+            permissions: permissions.clone(),
+            attributes: Some(std::collections::HashMap::from([
+                ("source_type".to_string(), json!("darwinbox")),
+                ("content_type".to_string(), json!(content_type)),
+            ])),
+        })
+        .await?;
+        current_ids.insert(document_id);
+        count += 1;
+    }
+    if count > 0 {
+        ctx.increment_scanned(count).await?;
+    }
     Ok(())
 }
 
-async fn sync_holidays(client: &DarwinboxClient, ctx: &SyncContext) -> Result<()> {
+async fn sync_holidays(
+    client: &DarwinboxClient,
+    config: &DarwinboxSourceConfig,
+    source_id: &str,
+    ctx: &SyncContext,
+    current_ids: &mut BTreeSet<String>,
+) -> Result<()> {
     let employees = client.fetch_employees(None, None).await?;
     let Some(employee_no) = employees
         .employee_data
@@ -304,57 +483,49 @@ async fn sync_holidays(client: &DarwinboxClient, ctx: &SyncContext) -> Result<()
     };
     let year = Utc::now().format("%Y").to_string();
     let response = client.fetch_holiday_list(employee_no, &year).await?;
-    sync_generic_collection("holiday", "darwinbox:holiday", &response, ctx).await
-}
-
-async fn sync_generic_collection(
-    content_type: &str,
-    external_prefix: &str,
-    response: &JsonValue,
-    ctx: &SyncContext,
-) -> Result<()> {
-    let items = extract_items(response);
+    let permissions = config::document_permissions("holiday", config, source_id, None);
+    let items = extract_items(&response);
     let mut count = 0i32;
-    for (idx, item) in items.iter().enumerate() {
+
+    for (_idx, item) in items.iter().enumerate() {
         if ctx.is_cancelled() {
             ctx.cancel().await?;
             return Ok(());
         }
-        let id = extract_stable_id(item).unwrap_or_else(|| idx.to_string());
-        let title = extract_title(item).unwrap_or_else(|| format!("{content_type} {id}"));
-        let content = format!(
-            "# {title}\n\n```json\n{}\n```",
-            serde_json::to_string_pretty(item)?
-        );
-        let content_id = ctx.store_content(&content).await?;
+        let (title, safe_body) = mappers::format_holiday_item(item);
+        let Some(date) = item.get("holiday_date").and_then(JsonValue::as_str) else {
+            warn!("Skipping Darwinbox holiday without holiday_date");
+            continue;
+        };
+        let id = slugify(&format!("{date}-{title}"));
+        let content_id = ctx.store_content(&safe_body).await?;
+
+        let document_id = format!("darwinbox:holiday:{id}");
         ctx.emit_event(ConnectorEvent::DocumentCreated {
             sync_run_id: ctx.sync_run_id().to_string(),
-            source_id: ctx.source_id().to_string(),
-            document_id: format!("{external_prefix}:{id}"),
+            source_id: source_id.to_string(),
+            document_id: document_id.clone(),
             content_id,
             metadata: DocumentMetadata {
                 title: Some(title),
                 author: None,
                 created_at: None,
                 updated_at: None,
-                content_type: Some(content_type.to_string()),
+                content_type: Some("holiday".to_string()),
                 mime_type: Some("text/markdown".to_string()),
-                size: Some(content.len().to_string()),
+                size: Some(safe_body.len().to_string()),
                 url: None,
                 path: None,
                 extra: None,
             },
-            permissions: DocumentPermissions {
-                public: true,
-                users: vec![],
-                groups: vec![],
-            },
+            permissions: permissions.clone(),
             attributes: Some(std::collections::HashMap::from([
                 ("source_type".to_string(), json!("darwinbox")),
-                ("content_type".to_string(), json!(content_type)),
+                ("content_type".to_string(), json!("holiday")),
             ])),
         })
         .await?;
+        current_ids.insert(document_id);
         count += 1;
     }
     if count > 0 {
@@ -363,23 +534,73 @@ async fn sync_generic_collection(
     Ok(())
 }
 
-fn extract_items(response: &JsonValue) -> Vec<JsonValue> {
-    for key in [
-        "data",
-        "output",
-        "records",
-        "result",
-        "results",
-        "holiday_list",
-    ] {
-        if let Some(array) = response.get(key).and_then(JsonValue::as_array) {
-            return array.clone();
+/// Sync a typed collection using a safe mapper function that derives (title, safe_content)
+/// from only known fields of the provider response.
+async fn sync_typed_collection<'a, F>(
+    _client: &DarwinboxClient,
+    config: &DarwinboxSourceConfig,
+    content_type: &'a str,
+    external_prefix: &'a str,
+    response: &'a JsonValue,
+    source_id: &str,
+    ctx: &SyncContext,
+    mapper: F,
+    current_ids: &mut BTreeSet<String>,
+) -> Result<()>
+where
+    F: Fn(&JsonValue) -> (String, String), // (title, safe_content)
+{
+    let permissions = config::document_permissions(content_type, config, source_id, None);
+    let items = extract_items(response);
+    let mut count = 0i32;
+
+    for item in &items {
+        if ctx.is_cancelled() {
+            ctx.cancel().await?;
+            return Ok(());
         }
+        let Some(stable_id) = extract_stable_id(item) else {
+            warn!(
+                content_type,
+                "Skipping Darwinbox record without a stable ID"
+            );
+            continue;
+        };
+        let (title, safe_body) = mapper(item);
+        let content_id = ctx.store_content(&safe_body).await?;
+
+        let document_id = format!("{external_prefix}:{stable_id}");
+        ctx.emit_event(ConnectorEvent::DocumentCreated {
+            sync_run_id: ctx.sync_run_id().to_string(),
+            source_id: source_id.to_string(),
+            document_id: document_id.clone(),
+            content_id,
+            metadata: DocumentMetadata {
+                title: Some(title),
+                author: None,
+                created_at: None,
+                updated_at: None,
+                content_type: Some(content_type.to_string()),
+                mime_type: Some("text/markdown".to_string()),
+                size: Some(safe_body.len().to_string()),
+                url: None,
+                path: None,
+                extra: None,
+            },
+            permissions: permissions.clone(),
+            attributes: Some(std::collections::HashMap::from([
+                ("source_type".to_string(), json!("darwinbox")),
+                ("content_type".to_string(), json!(content_type)),
+            ])),
+        })
+        .await?;
+        current_ids.insert(document_id);
+        count += 1;
     }
-    if let Some(array) = response.as_array() {
-        return array.clone();
+    if count > 0 {
+        ctx.increment_scanned(count).await?;
     }
-    vec![response.clone()]
+    Ok(())
 }
 
 fn extract_stable_id(value: &JsonValue) -> Option<String> {
@@ -406,24 +627,23 @@ fn extract_stable_id(value: &JsonValue) -> Option<String> {
     None
 }
 
-fn extract_title(value: &JsonValue) -> Option<String> {
-    let object = value.as_object()?;
+fn extract_items(response: &JsonValue) -> Vec<JsonValue> {
     for key in [
-        "name",
-        "title",
-        "job_title",
-        "department_name",
-        "designation_name",
-        "location",
-        "holiday_name",
+        "data",
+        "output",
+        "records",
+        "result",
+        "results",
+        "holiday_list",
     ] {
-        if let Some(text) = object.get(key).and_then(JsonValue::as_str) {
-            if !text.trim().is_empty() {
-                return Some(text.to_string());
-            }
+        if let Some(array) = response.get(key).and_then(JsonValue::as_array) {
+            return array.clone();
         }
     }
-    None
+    if let Some(array) = response.as_array() {
+        return array.clone();
+    }
+    vec![response.clone()]
 }
 
 fn slugify(value: &str) -> String {
@@ -440,6 +660,17 @@ fn slugify(value: &str) -> String {
         .collect::<String>()
         .trim_matches('-')
         .to_string()
+}
+
+async fn save_inventory_checkpoint(
+    ctx: &SyncContext,
+    checkpoint: &mut DarwinboxCheckpoint,
+    policy_fingerprint: &str,
+    current_ids: &BTreeSet<String>,
+) -> Result<()> {
+    checkpoint.policy_fingerprint = Some(policy_fingerprint.to_string());
+    checkpoint.indexed_document_ids = current_ids.clone();
+    ctx.save_checkpoint(json!(checkpoint)).await
 }
 
 fn module_since(

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -58,7 +58,7 @@ fn test_credential() -> ServiceCredential {
     }
 }
 
-fn hardened_config(base_url: &str) -> serde_json::Value {
+fn test_config(base_url: &str) -> serde_json::Value {
     json!({
         "base_url": base_url,
         "read_only": true,
@@ -94,8 +94,7 @@ async fn client_fetch_employees_ignores_sensitive_unknown_fields() {
         })))
         .mount(&server)
         .await;
-    let config: DarwinboxSourceConfig =
-        serde_json::from_value(hardened_config(&server.uri())).unwrap();
+    let config: DarwinboxSourceConfig = serde_json::from_value(test_config(&server.uri())).unwrap();
     let credentials = DarwinboxCredentials::Basic {
         username: "api-user".to_string(),
         password: "secret".to_string(),
@@ -127,7 +126,7 @@ async fn duplicate_self_identity_is_rejected() {
         .mount(&server)
         .await;
 
-    let mut config = hardened_config(&server.uri());
+    let mut config = test_config(&server.uri());
     config["authorization"]["allowed_actions"] = json!(["get_my_profile"]);
     let error = execute_action(
         "get_my_profile",
@@ -149,8 +148,7 @@ async fn token_errors_do_not_expose_provider_body() {
         .respond_with(ResponseTemplate::new(401).set_body_string("SECRET-TOKEN-DIAGNOSTIC"))
         .mount(&server)
         .await;
-    let config: DarwinboxSourceConfig =
-        serde_json::from_value(hardened_config(&server.uri())).unwrap();
+    let config: DarwinboxSourceConfig = serde_json::from_value(test_config(&server.uri())).unwrap();
     let credentials = DarwinboxCredentials::ClientCredentials {
         client_id: "client".to_string(),
         client_secret: "secret".to_string(),
@@ -182,7 +180,7 @@ async fn action_requires_trusted_source_config() {
 
 #[tokio::test]
 async fn self_action_rejects_spoofed_identity_before_provider_call() {
-    let config = hardened_config("https://example.darwinbox.in");
+    let config = test_config("https://example.darwinbox.in");
     let error = execute_action(
         "get_my_leave_balance",
         json!({
@@ -289,7 +287,7 @@ fn action_manifest_and_policy_modes_match() {
 
 #[test]
 fn document_acl_is_non_public_and_uses_named_participants() {
-    let mut value = hardened_config("https://example.darwinbox.in");
+    let mut value = test_config("https://example.darwinbox.in");
     value["authorization"]["hr_admin_emails"] = json!(["hr@example.com"]);
     let config: DarwinboxSourceConfig = serde_json::from_value(value).unwrap();
     let permissions = document_permissions(
@@ -310,7 +308,7 @@ fn document_acl_is_non_public_and_uses_named_participants() {
 #[test]
 fn unknown_document_type_has_empty_acl() {
     let config: DarwinboxSourceConfig =
-        serde_json::from_value(hardened_config("https://example.darwinbox.in")).unwrap();
+        serde_json::from_value(test_config("https://example.darwinbox.in")).unwrap();
     let permissions = document_permissions("future_sensitive_type", &config, "source", None);
     assert!(!permissions.public);
     assert!(permissions.users.is_empty());

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -285,7 +285,7 @@ fn action_manifest_and_policy_modes_match() {
 }
 
 #[test]
-fn document_acl_is_non_public_and_uses_named_participants() {
+fn employee_profile_acl_is_user_private() {
     let config: DarwinboxSourceConfig =
         serde_json::from_value(test_config("https://example.darwinbox.in")).unwrap();
     let permissions = document_permissions(
@@ -295,11 +295,36 @@ fn document_acl_is_non_public_and_uses_named_participants() {
         Some("employee@example.com"),
     );
     assert!(!permissions.public);
-    assert!(permissions.groups.is_empty());
-    assert!(permissions.users.contains(&"a@example.com".to_string()));
     assert!(permissions
         .users
         .contains(&"employee@example.com".to_string()));
+    assert!(!permissions.users.contains(&"a@example.com".to_string()));
+}
+
+#[test]
+fn org_master_documents_are_public() {
+    let config: DarwinboxSourceConfig =
+        serde_json::from_value(test_config("https://example.darwinbox.in")).unwrap();
+    for content_type in &[
+        "department",
+        "designation",
+        "office_location",
+        "business_unit",
+        "division",
+        "cost_center",
+        "group_company",
+        "holiday",
+        "position",
+        "job",
+        "ats_job",
+    ] {
+        let permissions = document_permissions(content_type, &config, "source-1", None);
+        assert!(permissions.public, "{content_type} should be public");
+        assert!(
+            permissions.users.is_empty(),
+            "{content_type} should have no user restrictions"
+        );
+    }
 }
 
 #[test]

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -70,7 +70,6 @@ fn test_config(base_url: &str) -> serde_json::Value {
             "actions_enabled": true,
             "participant_emails": ["a@example.com"],
             "allowed_actions": ["get_my_leave_balance"],
-            "target_employee_ids": ["EMP001"],
             "max_batch_size": 1
         }
     })

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -286,9 +286,8 @@ fn action_manifest_and_policy_modes_match() {
 
 #[test]
 fn document_acl_is_non_public_and_uses_named_participants() {
-    let mut value = test_config("https://example.darwinbox.in");
-    value["authorization"]["hr_admin_emails"] = json!(["hr@example.com"]);
-    let config: DarwinboxSourceConfig = serde_json::from_value(value).unwrap();
+    let config: DarwinboxSourceConfig =
+        serde_json::from_value(test_config("https://example.darwinbox.in")).unwrap();
     let permissions = document_permissions(
         "employee_profile",
         &config,
@@ -301,7 +300,6 @@ fn document_acl_is_non_public_and_uses_named_participants() {
     assert!(permissions
         .users
         .contains(&"employee@example.com".to_string()));
-    assert!(permissions.users.contains(&"hr@example.com".to_string()));
 }
 
 #[test]

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -241,16 +241,16 @@ fn high_risk_raw_action_families_are_rejected() {
         "authorization": {
             "actions_enabled": true,
             "participant_emails": ["admin@example.com"],
-            "allowed_actions": ["run_report"]
+            "allowed_actions": ["add_pending_employee"]
         },
-        "action_modules": { "reports": true }
+        "action_modules": { "hr_operations": true }
     }))
     .unwrap();
     assert!(config
         .validate()
         .unwrap_err()
         .iter()
-        .any(|e| e.contains("not available")));
+        .any(|e| e.contains("not implemented")));
 }
 
 #[test]

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -1,12 +1,38 @@
-use omni_connector_sdk::{AuthType, ServiceCredential, ServiceProvider};
-use omni_darwinbox_connector::actions::execute_action;
+use omni_connector_sdk::{AuthType, ServiceCredential, ServiceProvider, Source, SourceType};
+use omni_darwinbox_connector::actions::{action_definitions, action_policies, execute_action};
 use omni_darwinbox_connector::client::DarwinboxClient;
-use omni_darwinbox_connector::config::DarwinboxSourceConfig;
+use omni_darwinbox_connector::config::{
+    document_permissions, normalize_email, normalize_emails, DarwinboxSourceConfig, EmployeeField,
+    EmployeeScope,
+};
 use omni_darwinbox_connector::credentials::DarwinboxCredentials;
+use omni_darwinbox_connector::models::EmployeeRecord;
 use serde_json::json;
 use time::OffsetDateTime;
 use wiremock::matchers::{method, path};
 use wiremock::{Mock, MockServer, ResponseTemplate};
+
+/// Build a test source for a given source config.
+fn test_source(config: serde_json::Value) -> Source {
+    serde_json::from_value(json!({
+        "id": "source-1",
+        "name": "Test Darwinbox",
+        "source_type": "darwinbox",
+        "config": config,
+        "is_active": true,
+        "is_deleted": false,
+        "scope": "org",
+        "user_filter_mode": "all",
+        "created_by": "admin",
+        "created_at": "2025-01-01T00:00:00Z",
+        "updated_at": "2025-01-01T00:00:00Z",
+    }))
+    .expect("test_source should construct a valid Source")
+}
+
+fn test_actor(email: &str) -> Option<String> {
+    Some(email.to_string())
+}
 
 fn test_credential() -> ServiceCredential {
     let now = OffsetDateTime::now_utc();
@@ -32,8 +58,26 @@ fn test_credential() -> ServiceCredential {
     }
 }
 
+fn hardened_config(base_url: &str) -> serde_json::Value {
+    json!({
+        "base_url": base_url,
+        "read_only": true,
+        "employee_scope": { "mode": "include", "employee_ids": ["EMP001"] },
+        "employee_fields": ["name", "employee_id", "company_email", "department"],
+        "sync_modules": {},
+        "action_modules": { "employee_self_service": true },
+        "authorization": {
+            "actions_enabled": true,
+            "participant_emails": ["a@example.com"],
+            "allowed_actions": ["get_my_leave_balance"],
+            "target_employee_ids": ["EMP001"],
+            "max_batch_size": 1
+        }
+    })
+}
+
 #[tokio::test]
-async fn client_fetch_employees_injects_dataset_and_api_key() {
+async fn client_fetch_employees_ignores_sensitive_unknown_fields() {
     let server = MockServer::start().await;
     Mock::given(method("POST"))
         .and(path("/masterapi/employee"))
@@ -43,30 +87,26 @@ async fn client_fetch_employees_injects_dataset_and_api_key() {
             "employee_data": [{
                 "employee_id": "EMP001",
                 "first_name": "Asha",
-                "last_name": "Rao",
-                "company_email_id": "asha@example.com"
+                "company_email_id": "asha@example.com",
+                "salary": "SECRET-SALARY",
+                "bank_account": "SECRET-BANK"
             }]
         })))
         .mount(&server)
         .await;
-
-    let config = DarwinboxSourceConfig {
-        base_url: server.uri(),
-        default_timezone: None,
-        sync_modules: Default::default(),
-        action_modules: Default::default(),
-        authorization: Default::default(),
-    };
+    let config: DarwinboxSourceConfig =
+        serde_json::from_value(hardened_config(&server.uri())).unwrap();
     let credentials = DarwinboxCredentials::Basic {
         username: "api-user".to_string(),
         password: "secret".to_string(),
         api_key: "api-key".to_string(),
         dataset_key: "dataset-key".to_string(),
     };
-    let client = DarwinboxClient::new(&config, credentials).unwrap();
-    let response = client.fetch_employees(None, None).await.unwrap();
-
-    assert_eq!(response.employee_data.len(), 1);
+    let response = DarwinboxClient::new(&config, credentials)
+        .unwrap()
+        .fetch_employees(None, None)
+        .await
+        .unwrap();
     assert_eq!(
         response.employee_data[0].employee_id.as_deref(),
         Some("EMP001")
@@ -74,22 +114,252 @@ async fn client_fetch_employees_injects_dataset_and_api_key() {
 }
 
 #[tokio::test]
-async fn my_actions_reject_spoofed_employee_identity_fields() {
-    let params = json!({
-        "base_url": "https://example.darwinbox.in",
-        "_omni_action_context": {
-            "actor": {
-                "actor_type": "user",
-                "user_id": "user-a",
-                "email": "a@example.com",
-                "role": "User"
-            }
-        },
-        "employee_no": "EMP-B"
-    });
+async fn duplicate_self_identity_is_rejected() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/masterapi/employee"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "employee_data": [
+                {"employee_id": "EMP001", "company_email_id": "a@example.com"},
+                {"employee_id": "EMP002", "company_email_id": "A@example.com"}
+            ]
+        })))
+        .mount(&server)
+        .await;
 
-    let error = execute_action("get_my_leave_balance", params, Some(test_credential()))
+    let mut config = hardened_config(&server.uri());
+    config["authorization"]["allowed_actions"] = json!(["get_my_profile"]);
+    let error = execute_action(
+        "get_my_profile",
+        json!({}),
+        Some(test_credential()),
+        Some(test_source(config.clone())),
+        test_actor("a@example.com"),
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("multiple Darwinbox employees"));
+}
+
+#[tokio::test]
+async fn token_errors_do_not_expose_provider_body() {
+    let server = MockServer::start().await;
+    Mock::given(method("POST"))
+        .and(path("/oauth/v2token"))
+        .respond_with(ResponseTemplate::new(401).set_body_string("SECRET-TOKEN-DIAGNOSTIC"))
+        .mount(&server)
+        .await;
+    let config: DarwinboxSourceConfig =
+        serde_json::from_value(hardened_config(&server.uri())).unwrap();
+    let credentials = DarwinboxCredentials::ClientCredentials {
+        client_id: "client".to_string(),
+        client_secret: "secret".to_string(),
+        api_key: None,
+        dataset_key: "dataset".to_string(),
+    };
+    let error = DarwinboxClient::new(&config, credentials)
+        .unwrap()
+        .fetch_employees(None, None)
         .await
         .unwrap_err();
+    assert!(!error.to_string().contains("SECRET-TOKEN-DIAGNOSTIC"));
+    assert!(error.to_string().contains("HTTP 401"));
+}
+
+#[tokio::test]
+async fn action_requires_trusted_source_config() {
+    let error = execute_action(
+        "get_my_leave_balance",
+        json!({ "base_url": "https://attacker.example", "read_only": false }),
+        Some(test_credential()),
+        None, // no source — should fail with "requires a trusted source"
+        None, // no actor
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("trusted source"));
+}
+
+#[tokio::test]
+async fn self_action_rejects_spoofed_identity_before_provider_call() {
+    let config = hardened_config("https://example.darwinbox.in");
+    let error = execute_action(
+        "get_my_leave_balance",
+        json!({
+            "employee_no": "EMP-B"
+        }),
+        Some(test_credential()),
+        Some(test_source(config)),
+        test_actor("a@example.com"),
+    )
+    .await
+    .unwrap_err();
     assert!(error.to_string().contains("employee_no"));
+}
+
+#[test]
+fn config_defaults_fail_closed() {
+    let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+        "base_url": "https://example.darwinbox.in"
+    }))
+    .unwrap();
+    assert!(config.read_only);
+    assert!(!config.sync_modules.employee_directory);
+    assert!(!config.sync_modules.deleted_employees);
+    assert!(!config.action_modules.employee_self_service);
+    assert!(!config.authorization.actions_enabled);
+}
+
+#[test]
+fn employee_directory_requires_explicit_scope_and_fields() {
+    let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+        "base_url": "https://example.darwinbox.in",
+        "sync_modules": { "employee_directory": true }
+    }))
+    .unwrap();
+    let errors = config.validate().unwrap_err().join("; ");
+    assert!(errors.contains("employee_scope"));
+    assert!(errors.contains("employee_fields"));
+}
+
+#[test]
+fn deprecated_permission_switch_is_rejected() {
+    let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+        "base_url": "https://example.darwinbox.in",
+        "authorization": { "use_darwinbox_permissions": true }
+    }))
+    .unwrap();
+    assert!(config
+        .validate()
+        .unwrap_err()
+        .iter()
+        .any(|e| e.contains("unsupported")));
+}
+
+#[test]
+fn high_risk_raw_action_families_are_rejected() {
+    let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+        "base_url": "https://example.darwinbox.in",
+        "authorization": {
+            "actions_enabled": true,
+            "participant_emails": ["admin@example.com"],
+            "allowed_actions": ["run_report"]
+        },
+        "action_modules": { "reports": true }
+    }))
+    .unwrap();
+    assert!(config
+        .validate()
+        .unwrap_err()
+        .iter()
+        .any(|e| e.contains("not available")));
+}
+
+#[test]
+fn employee_scope_wire_shape_matches_ui() {
+    let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+        "base_url": "https://example.darwinbox.in",
+        "employee_scope": { "mode": "include", "departments": ["Engineering"] }
+    }))
+    .unwrap();
+    assert!(matches!(
+        config.employee_scope,
+        Some(EmployeeScope::Include { .. })
+    ));
+}
+
+#[test]
+fn action_manifest_and_policy_modes_match() {
+    let definitions = action_definitions();
+    let policies = action_policies();
+    assert_eq!(definitions.len(), policies.len());
+    for definition in definitions {
+        let matches: Vec<_> = policies
+            .iter()
+            .filter(|p| p.name == definition.name)
+            .collect();
+        assert_eq!(matches.len(), 1, "policy drift for {}", definition.name);
+        assert_eq!(matches[0].mode, definition.mode);
+        assert_eq!(
+            matches[0].is_write,
+            definition.mode == omni_connector_sdk::ActionMode::Write
+        );
+    }
+}
+
+#[test]
+fn document_acl_is_non_public_and_uses_named_participants() {
+    let mut value = hardened_config("https://example.darwinbox.in");
+    value["authorization"]["hr_admin_emails"] = json!(["hr@example.com"]);
+    let config: DarwinboxSourceConfig = serde_json::from_value(value).unwrap();
+    let permissions = document_permissions(
+        "employee_profile",
+        &config,
+        "source-1",
+        Some("employee@example.com"),
+    );
+    assert!(!permissions.public);
+    assert!(permissions.groups.is_empty());
+    assert!(permissions.users.contains(&"a@example.com".to_string()));
+    assert!(permissions
+        .users
+        .contains(&"employee@example.com".to_string()));
+    assert!(permissions.users.contains(&"hr@example.com".to_string()));
+}
+
+#[test]
+fn unknown_document_type_has_empty_acl() {
+    let config: DarwinboxSourceConfig =
+        serde_json::from_value(hardened_config("https://example.darwinbox.in")).unwrap();
+    let permissions = document_permissions("future_sensitive_type", &config, "source", None);
+    assert!(!permissions.public);
+    assert!(permissions.users.is_empty());
+    assert!(permissions.groups.is_empty());
+}
+
+#[test]
+fn selected_missing_field_never_widens_employee_content() {
+    let employee = EmployeeRecord {
+        employee_id: Some("EMP001".to_string()),
+        first_name: Some("Sensitive Name".to_string()),
+        department_name: Some("Secret Department".to_string()),
+        ..Default::default()
+    };
+    let content = employee.content_filtered(&[EmployeeField::CompanyEmail]);
+    assert!(content.is_empty());
+    assert!(!content.contains("EMP001"));
+    assert!(!content.contains("Sensitive"));
+    assert!(!content.contains("Secret"));
+}
+
+#[test]
+fn untyped_sync_modules_are_rejected() {
+    let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+        "base_url": "https://example.darwinbox.in",
+        "sync_modules": { "holidays": true }
+    }))
+    .unwrap();
+    assert!(config
+        .validate()
+        .unwrap_err()
+        .iter()
+        .any(|error| error.contains("unavailable")));
+}
+
+#[test]
+fn url_and_email_normalization_are_fail_closed() {
+    let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+        "base_url": "http://localhost.attacker.example"
+    }))
+    .unwrap();
+    assert!(config
+        .validate()
+        .unwrap_err()
+        .iter()
+        .any(|e| e.contains("HTTPS")));
+    assert_eq!(normalize_email(" A@Example.COM "), "a@example.com");
+    assert_eq!(
+        normalize_emails(&["A@B.com".into(), "a@b.com".into()]).len(),
+        1
+    );
 }

--- a/connectors/filesystem/src/connector.rs
+++ b/connectors/filesystem/src/connector.rs
@@ -1,11 +1,11 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use omni_connector_sdk::{
     ActionDefinition, ActionResponse, Connector, ServiceCredential, Source, SourceType,
     SyncContext, SyncType,
 };
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 
 use crate::models::FileSystemConfig;
 use crate::{sync, watcher};
@@ -93,6 +93,8 @@ impl Connector for FileSystemConnector {
         action: &str,
         params: JsonValue,
         _credentials: Option<ServiceCredential>,
+        _source: Option<Source>,
+        _actor_email: Option<String>,
     ) -> Result<axum::response::Response> {
         match action {
             "validate_path" => {

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -1141,6 +1141,8 @@ impl Connector for GoogleConnector {
         action: &str,
         params: JsonValue,
         credentials: Option<ServiceCredential>,
+        _source: Option<Source>,
+        _actor_email: Option<String>,
     ) -> Result<axum::response::Response> {
         let creds = match credentials {
             Some(c) => c,

--- a/connectors/imap/src/connector.rs
+++ b/connectors/imap/src/connector.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result, anyhow};
+use anyhow::{anyhow, Context, Result};
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use axum::response::Response;
@@ -6,7 +6,7 @@ use omni_connector_sdk::{
     ActionDefinition, ActionResponse, Connector, SearchOperator, ServiceCredential, Source,
     SourceType, SyncContext, SyncType,
 };
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 use std::sync::Arc;
 
 use crate::client::ImapSession;
@@ -163,6 +163,8 @@ impl Connector for ImapConnector {
         action: &str,
         params: JsonValue,
         credentials: Option<ServiceCredential>,
+        _source: Option<Source>,
+        _actor_email: Option<String>,
     ) -> Result<Response> {
         match action {
             "validate_credentials" | "list_folders" => {

--- a/connectors/nextcloud/src/connector.rs
+++ b/connectors/nextcloud/src/connector.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, anyhow};
+use anyhow::{anyhow, Result};
 use async_trait::async_trait;
 use axum::response::Response;
 use omni_connector_sdk::{
@@ -6,7 +6,7 @@ use omni_connector_sdk::{
     SyncContext, SyncType,
 };
 use serde::Deserialize;
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 
 fn guess_mime_type(filename: &str) -> &'static str {
     match filename
@@ -176,6 +176,8 @@ impl Connector for NextcloudConnector {
         action: &str,
         params: JsonValue,
         credentials: Option<ServiceCredential>,
+        _source: Option<Source>,
+        _actor_email: Option<String>,
     ) -> Result<Response> {
         match action {
             "validate_credentials" => {

--- a/sdk/python/omni_connector/connector.py
+++ b/sdk/python/omni_connector/connector.py
@@ -17,6 +17,7 @@ from .models import (
     OAuthCredentialReadyRequest,
     OAuthManifestConfig,
     SearchOperator,
+    Source,
 )
 
 if TYPE_CHECKING:
@@ -345,19 +346,11 @@ class Connector(ABC):
         action: str,
         params: dict[str, Any],
         credentials: dict[str, Any],
+        source: Source | None = None,
+        actor_email: str | None = None,
     ) -> JSONResponse:
-
-        adapter = self.mcp_adapter
-        if adapter is not None:
-            if adapter._catalog_cache_expired(self._mcp_catalog_cache_ttl_seconds()):
-                await self.bootstrap_mcp(credentials)
-            auth = self._prepare_mcp_auth(credentials)
-            mcp_tool_names = {
-                a.name for a in await adapter.get_action_definitions(**auth)
-            }
-            if action in mcp_tool_names:
-                response = await adapter.execute_tool(action, params, **auth)
-                return JSONResponse(content=response.model_dump())
+        """Execute a non-MCP action. Override in connector subclasses that
+        define manifest actions outside of MCP tools."""
         return ActionResponse.not_supported(action).to_response(status_code=404)
 
     def serve(self, port: int = 8000, host: str = "0.0.0.0") -> None:

--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -335,10 +335,31 @@ class CancelResponse(BaseModel):
     status: str
 
 
+class Source(BaseModel):
+    id: str
+    name: str
+    source_type: str
+    config: dict[str, Any]
+    is_active: bool
+    is_deleted: bool
+    scope: str
+    user_filter_mode: UserFilterMode = UserFilterMode.ALL
+    user_whitelist: list[str] | None = None
+    user_blacklist: list[str] | None = None
+    connector_state: dict[str, Any] | None = None
+    checkpoint: dict[str, Any] | None = None
+    sync_interval_seconds: int | None = None
+    created_at: datetime
+    updated_at: datetime
+    created_by: str
+
+
 class ActionRequest(BaseModel):
     action: str
     params: dict[str, Any]
     credentials: dict[str, Any]
+    source: Source | None = None
+    actor_email: str | None = None
 
 
 class ActionResponse(BaseModel):

--- a/sdk/python/omni_connector/server.py
+++ b/sdk/python/omni_connector/server.py
@@ -268,10 +268,35 @@ def create_app(connector: "Connector") -> FastAPI:
     @app.post("/action")
     async def execute_action(request: ActionRequest) -> Response:
         logger.info("Action requested: %s", request.action)
+
+        # MCP-first dispatch: if the action matches a tool exposed by the
+        # connector's MCP server, delegate to the adapter. Falls through to
+        # the connector's own execute_action for connector-defined actions.
+        adapter = connector.mcp_adapter
+        if adapter is not None:
+            auth = connector._prepare_mcp_auth(request.credentials)
+            try:
+                actions = await adapter.get_action_definitions(**auth)
+            except Exception:
+                logger.warning("MCP action lookup failed", exc_info=True)
+                actions = []
+            if any(a.name == request.action for a in actions):
+                response = await adapter.execute_tool(
+                    request.action, dict(request.params), **auth
+                )
+                status_code = (
+                    status.HTTP_200_OK
+                    if response.status == "success"
+                    else status.HTTP_400_BAD_REQUEST
+                )
+                return JSONResponse(content=response.model_dump(), status_code=status_code)
+
         return await connector.execute_action(
             request.action,
-            request.params,
+            dict(request.params),
             request.credentials,
+            source=request.source,
+            actor_email=request.actor_email,
         )
 
     @app.post("/resource")

--- a/sdk/rust/src/connector.rs
+++ b/sdk/rust/src/connector.rs
@@ -146,6 +146,8 @@ pub trait Connector: Send + Sync + 'static {
         action: &str,
         _params: JsonValue,
         _credentials: Option<ServiceCredential>,
+        _source: Option<Source>,
+        _actor_email: Option<String>,
     ) -> Result<Response> {
         Ok(ActionResponse::not_supported(action).into_response_with_status(StatusCode::NOT_FOUND))
     }

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -10,10 +10,10 @@ pub use connector::{Connector, SyncRequestValidationError};
 pub use context::SyncContext;
 pub use mcp_adapter::{HttpMcpServer, McpAdapter, McpServer, StdioMcpServer};
 pub use models::{
-    ActionActor, ActionContext, ActionRequest, ActionResponse, CancelRequest, CancelResponse,
-    McpCredentials, OAuthManifestConfig, OAuthScopeSet, OAuthTokenEndpointAuthMethod,
-    PromptRequest, ResourceRequest, SkillRequest, SkillResponse, SyncRequest, SyncResponse,
-    SyncStatusResponse,
+    ActionRequest, ActionResponse, CancelRequest, CancelResponse, McpCredentials,
+    OAuthManifestConfig, OAuthScopeSet, OAuthTokenEndpointAuthMethod, PromptRequest,
+    ResourceRequest, SkillRequest, SkillResponse, SyncRequest, SyncResponse, SyncStatusResponse,
+    UserRole,
 };
 pub use server::{create_router, serve, serve_with_config, serve_with_extra_routes, ServerConfig};
 

--- a/sdk/rust/src/models.rs
+++ b/sdk/rust/src/models.rs
@@ -1,8 +1,8 @@
 use serde::{Deserialize, Serialize};
 pub use shared::models::{
-    ActionActor, ActionContext, ActionRequest, ActionResponse, CancelRequest, CancelResponse,
-    McpCredentials, PromptRequest, ResourceRequest, SkillRequest, SkillResponse, SyncRequest,
-    SyncResponse, SyncStatusResponse,
+    ActionRequest, ActionResponse, CancelRequest, CancelResponse, McpCredentials, PromptRequest,
+    ResourceRequest, SkillRequest, SkillResponse, SyncRequest, SyncResponse, SyncStatusResponse,
+    UserRole,
 };
 use std::collections::HashMap;
 

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -560,24 +560,12 @@ where
 
 async fn execute_action<C>(
     State(state): State<Arc<ServerState<C>>>,
-    Json(mut request): Json<ActionRequest>,
+    Json(request): Json<ActionRequest>,
 ) -> Result<Response, (StatusCode, Json<ActionResponse>)>
 where
     C: Connector,
 {
     info!("Action requested: {}", request.action);
-
-    if let Some(action_context) = &request.action_context {
-        if request.params.is_null() {
-            request.params = serde_json::Value::Object(serde_json::Map::new());
-        }
-        if let Some(obj) = request.params.as_object_mut() {
-            obj.insert(
-                "_omni_action_context".to_string(),
-                serde_json::to_value(action_context).unwrap_or(serde_json::Value::Null),
-            );
-        }
-    }
 
     // MCP-first dispatch: if the action matches a tool exposed by the
     // connector's MCP server, delegate to the adapter. Falls through to the
@@ -619,7 +607,13 @@ where
 
     state
         .connector
-        .execute_action(&request.action, request.params, request.credentials)
+        .execute_action(
+            &request.action,
+            request.params,
+            request.credentials,
+            request.source,
+            request.actor_email,
+        )
         .await
         .map_err(|error| {
             (

--- a/sdk/rust/tests/common/mod.rs
+++ b/sdk/rust/tests/common/mod.rs
@@ -20,18 +20,18 @@ use std::time::Duration;
 use anyhow::Result;
 use async_trait::async_trait;
 use axum::{
-    Router,
     extract::{Path, State},
     http::StatusCode,
     response::{IntoResponse, Json},
     routing::{get, post, put},
+    Router,
 };
 use omni_connector_sdk::SdkClient;
 use omni_connector_sdk::{
-    Connector, ServiceCredential, Source, SourceType, SyncContext, models::ActionResponse,
+    models::ActionResponse, Connector, ServiceCredential, Source, SourceType, SyncContext,
 };
 use serde::{Deserialize, Serialize};
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 use tokio::net::TcpListener;
 use tokio::sync::Notify;
 
@@ -303,6 +303,8 @@ impl Connector for TestConnector {
         action: &str,
         _params: JsonValue,
         _credentials: Option<ServiceCredential>,
+        _source: Option<omni_connector_sdk::Source>,
+        _actor_email: Option<String>,
     ) -> Result<axum::response::Response> {
         Ok(ActionResponse::not_supported(action).into_response_with_status(StatusCode::NOT_FOUND))
     }

--- a/sdk/rust/tests/server_integration_test.rs
+++ b/sdk/rust/tests/server_integration_test.rs
@@ -4,13 +4,13 @@ use std::sync::{Arc, Mutex};
 use std::time::Duration;
 
 use anyhow::Result;
-use axum::{Router, http::StatusCode, routing};
+use axum::{http::StatusCode, routing, Router};
 use axum_test::{TestServer, TestServerConfig};
 use common::{GetSourceBehavior, MockConnectorManager, SyncBehavior, TestConnector};
 use omni_connector_sdk::{
-    Connector, ServiceCredential, Source, SourceType, SyncContext, create_router,
+    create_router, Connector, ServiceCredential, Source, SourceType, SyncContext,
 };
-use serde_json::{Value as JsonValue, json};
+use serde_json::{json, Value as JsonValue};
 use tokio::sync::Notify;
 
 const CONNECTOR_URL: &str = "http://test-connector";
@@ -575,6 +575,8 @@ async fn t14_action_success_returns_200() -> Result<()> {
             action: &str,
             _params: JsonValue,
             _credentials: Option<ServiceCredential>,
+            _source: Option<omni_connector_sdk::Source>,
+            _actor_email: Option<String>,
         ) -> Result<axum::response::Response> {
             use omni_connector_sdk::models::ActionResponse;
             if action == "do_thing" {
@@ -655,6 +657,8 @@ async fn t15_action_exception_returns_500() -> Result<()> {
             action: &str,
             _params: JsonValue,
             _credentials: Option<ServiceCredential>,
+            _source: Option<omni_connector_sdk::Source>,
+            _actor_email: Option<String>,
         ) -> Result<axum::response::Response> {
             if action == "crash_me" {
                 return Err(anyhow::anyhow!("intentional action panic"));
@@ -679,11 +683,9 @@ async fn t15_action_exception_returns_500() -> Result<()> {
     assert_eq!(resp.status_code(), 500);
     let body: serde_json::Value = resp.json();
     assert_eq!(body["status"], "error");
-    assert!(
-        body["error"]
-            .as_str()
-            .unwrap()
-            .contains("intentional action panic")
-    );
+    assert!(body["error"]
+        .as_str()
+        .unwrap()
+        .contains("intentional action panic"));
     Ok(())
 }

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -3,6 +3,7 @@ import {
   SdkSourceSyncDataSchema,
   serializeConnectorEvent,
   type ConnectorEventPayload,
+  type ConnectorManifest,
   type SdkSourceSyncData,
 } from './models.js';
 
@@ -250,7 +251,7 @@ export class SdkClient {
     }
   }
 
-  async register(manifest: Record<string, unknown>): Promise<void> {
+  async register(manifest: ConnectorManifest): Promise<void> {
     const response = await this.post('/sdk/register', manifest);
     if (!response.ok) {
       const text = await response.text();

--- a/sdk/typescript/src/connector.ts
+++ b/sdk/typescript/src/connector.ts
@@ -5,6 +5,7 @@ import type {
   ActionDefinition,
   SearchOperator,
   OAuthManifestConfig,
+  Source,
 } from './models.js';
 import { ActionResponse } from './models.js';
 import { createServer } from './server.js';
@@ -186,7 +187,9 @@ export abstract class Connector<
   async executeAction(
     action: string,
     params: Record<string, unknown>,
-    credentials: TCredentials
+    credentials: TCredentials,
+    source?: Source,
+    actor_email?: string
   ): Promise<Response> {
     const adapter = await this.getMcpAdapter();
     if (adapter) {

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -214,10 +214,21 @@ export const CancelResponseSchema = z.object({
 });
 export type CancelResponse = z.infer<typeof CancelResponseSchema>;
 
+export const SourceSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  source_type: z.string(),
+  config: z.record(z.unknown()),
+  is_active: z.boolean().optional(),
+});
+export type Source = z.infer<typeof SourceSchema>;
+
 export const ActionRequestSchema = z.object({
   action: z.string(),
   params: z.record(z.unknown()),
-  credentials: z.record(z.unknown()),
+  credentials: z.record(z.unknown()).optional(),
+  source: SourceSchema.optional(),
+  actor_email: z.string().optional(),
 });
 export type ActionRequest = z.infer<typeof ActionRequestSchema>;
 

--- a/sdk/typescript/src/server.ts
+++ b/sdk/typescript/src/server.ts
@@ -1,8 +1,8 @@
-import express, { type Express, type Request, type Response } from 'express';
+import express, { type Express, type Request, type Response } from "express";
 
-import { SdkClient } from './client.js';
-import type { Connector } from './connector.js';
-import { SyncContext } from './context.js';
+import { SdkClient } from "./client.js";
+import type { Connector } from "./connector.js";
+import { SyncContext } from "./context.js";
 import {
   SyncMode,
   SyncRequestSchema,
@@ -13,11 +13,12 @@ import {
   createSyncResponseStarted,
   createSyncResponseError,
   ActionResponse,
+  type ConnectorManifest,
   type SdkSourceSyncData,
-} from './models.js';
-import { getLogger } from './logger.js';
+} from "./models.js";
+import { getLogger } from "./logger.js";
 
-const logger = getLogger('sdk:server');
+const logger = getLogger("sdk:server");
 
 const REGISTRATION_INTERVAL_MS = 30_000;
 
@@ -25,13 +26,13 @@ function buildConnectorUrl(): string {
   const hostname = process.env.CONNECTOR_HOST_NAME;
   if (!hostname) {
     throw new Error(
-      'CONNECTOR_HOST_NAME environment variable is required. ' +
-      'Set it to this connector\'s hostname (e.g. the Docker service name).'
+      "CONNECTOR_HOST_NAME environment variable is required. " +
+        "Set it to this connector's hostname (e.g. the Docker service name).",
     );
   }
   const port = process.env.PORT;
   if (!port) {
-    throw new Error('PORT environment variable is required.');
+    throw new Error("PORT environment variable is required.");
   }
   return `http://${hostname}:${port}`;
 }
@@ -55,26 +56,26 @@ export function createServer(connector: Connector): Express {
   const registerOnce = async () => {
     try {
       const manifest = await connector.getManifest(connectorUrl);
-      await getSdkClient().register(manifest as unknown as Record<string, unknown>);
-      logger.info('Registered with connector manager');
+      await getSdkClient().register(manifest);
+      logger.info("Registered with connector manager");
     } catch (err) {
-      logger.warn({ err }, 'Registration failed');
+      logger.warn({ err }, "Registration failed");
     }
   };
 
   registerOnce();
   setInterval(registerOnce, REGISTRATION_INTERVAL_MS);
 
-  app.get('/health', (_req: Request, res: Response) => {
-    res.json({ status: 'healthy', service: connector.name });
+  app.get("/health", (_req: Request, res: Response) => {
+    res.json({ status: "healthy", service: connector.name });
   });
 
-  app.get('/manifest', async (_req: Request, res: Response) => {
+  app.get("/manifest", async (_req: Request, res: Response) => {
     const manifest = await connector.getManifest(connectorUrl);
     res.json(manifest);
   });
 
-  app.get('/sync/:syncRunId', (req: Request, res: Response) => {
+  app.get("/sync/:syncRunId", (req: Request, res: Response) => {
     const { syncRunId } = req.params;
     let running = false;
     for (const ctx of activeSyncs.values()) {
@@ -86,10 +87,10 @@ export function createServer(connector: Connector): Express {
     res.json({ running });
   });
 
-  app.post('/sync', async (req: Request, res: Response) => {
+  app.post("/sync", async (req: Request, res: Response) => {
     const parseResult = SyncRequestSchema.safeParse(req.body);
     if (!parseResult.success) {
-      res.status(400).json(createSyncResponseError('Invalid request body'));
+      res.status(400).json(createSyncResponseError("Invalid request body"));
       return;
     }
 
@@ -103,22 +104,28 @@ export function createServer(connector: Connector): Express {
       is_resume: isResume,
     } = parseResult.data;
 
-    const isValidSyncMode = (Object.values(SyncMode) as string[]).includes(syncModeStr);
+    const isValidSyncMode = (Object.values(SyncMode) as string[]).includes(
+      syncModeStr,
+    );
     if (!isValidSyncMode) {
       logger.warn(
-        `Unknown sync_mode '${syncModeStr}'; defaulting to Incremental batching`
+        `Unknown sync_mode '${syncModeStr}'; defaulting to Incremental batching`,
       );
     }
     const syncMode: SyncMode = isValidSyncMode
       ? (syncModeStr as SyncMode)
       : SyncMode.INCREMENTAL;
 
-    logger.info(`Sync triggered for source ${sourceId} (sync_run_id: ${syncRunId})`);
+    logger.info(
+      `Sync triggered for source ${sourceId} (sync_run_id: ${syncRunId})`,
+    );
 
     if (activeSyncs.has(sourceId)) {
-      res.status(409).json(
-        createSyncResponseError('Sync already in progress for this source')
-      );
+      res
+        .status(409)
+        .json(
+          createSyncResponseError("Sync already in progress for this source"),
+        );
       return;
     }
 
@@ -127,13 +134,17 @@ export function createServer(connector: Connector): Express {
       sourceData = await getSdkClient().fetchSourceConfig(sourceId);
     } catch (error) {
       const message = error instanceof Error ? error.message : String(error);
-      if (message.includes('404')) {
-        res.status(404).json(createSyncResponseError(`Source not found: ${sourceId}`));
+      if (message.includes("404")) {
+        res
+          .status(404)
+          .json(createSyncResponseError(`Source not found: ${sourceId}`));
       } else {
-        logger.error({ err: error }, 'Failed to fetch source data');
-        res.status(500).json(
-          createSyncResponseError(`Failed to fetch source data: ${message}`)
-        );
+        logger.error({ err: error }, "Failed to fetch source data");
+        res
+          .status(500)
+          .json(
+            createSyncResponseError(`Failed to fetch source data: ${message}`),
+          );
       }
       return;
     }
@@ -142,7 +153,7 @@ export function createServer(connector: Connector): Express {
       getSdkClient(),
       syncRunId,
       sourceId,
-      (requestCheckpoint ?? sourceData.checkpoint) ?? undefined,
+      requestCheckpoint ?? sourceData.checkpoint ?? undefined,
       syncMode,
       documentsScanned,
       documentsUpdated,
@@ -152,7 +163,7 @@ export function createServer(connector: Connector): Express {
         userFilterMode: sourceData.user_filter_mode,
         userWhitelist: sourceData.user_whitelist,
         userBlacklist: sourceData.user_blacklist,
-      }
+      },
     );
     activeSyncs.set(sourceId, ctx);
 
@@ -161,8 +172,8 @@ export function createServer(connector: Connector): Express {
         await connector.sync(
           sourceData.config,
           sourceData.credentials,
-          (requestCheckpoint ?? sourceData.checkpoint),
-          ctx
+          requestCheckpoint ?? sourceData.checkpoint,
+          ctx,
         );
       } catch (error) {
         const message = error instanceof Error ? error.message : String(error);
@@ -171,7 +182,7 @@ export function createServer(connector: Connector): Express {
           try {
             await ctx.fail(message);
           } catch (failError) {
-            logger.error({ err: failError }, 'Failed to report sync failure');
+            logger.error({ err: failError }, "Failed to report sync failure");
           }
         }
       } finally {
@@ -186,10 +197,12 @@ export function createServer(connector: Connector): Express {
     res.status(200).json(createSyncResponseStarted());
   });
 
-  app.post('/cancel', (req: Request, res: Response) => {
+  app.post("/cancel", (req: Request, res: Response) => {
     const parseResult = CancelRequestSchema.safeParse(req.body);
     if (!parseResult.success) {
-      res.status(400).json({ status: 'error', message: 'Invalid request body' });
+      res
+        .status(400)
+        .json({ status: "error", message: "Invalid request body" });
       return;
     }
 
@@ -207,31 +220,34 @@ export function createServer(connector: Connector): Express {
     }
 
     if (matchingSourceId === null || matchingCtx === null) {
-      res.status(404).json({ status: 'not_found' });
+      res.status(404).json({ status: "not_found" });
       return;
     }
 
     matchingCtx._setCancelled();
     activeSyncs.delete(matchingSourceId);
     connector.cancel(syncRunId);
-    res.json({ status: 'cancelled' });
+    res.json({ status: "cancelled" });
   });
 
-  app.post('/action', async (req: Request, res: Response) => {
+  app.post("/action", async (req: Request, res: Response) => {
     const parseResult = ActionRequestSchema.safeParse(req.body);
     if (!parseResult.success) {
-      const errorResp = ActionResponse.failure('Invalid request body');
+      const errorResp = ActionResponse.failure("Invalid request body");
       res.status(400).json(errorResp);
       return;
     }
 
-    const { action, params, credentials } = parseResult.data;
+    const { action, credentials, source, actor_email } = parseResult.data;
+    const params = { ...parseResult.data.params };
     logger.info(`Action requested: ${action}`);
 
     const result = await connector.executeAction(
       action,
       params,
-      credentials
+      credentials ?? {},
+      source,
+      actor_email,
     );
 
     if (result instanceof Response) {
@@ -243,19 +259,21 @@ export function createServer(connector: Connector): Express {
     }
 
     // Fallback for unexpected return types (should not happen)
-    res.status(500).json(ActionResponse.failure('Unexpected action result type'));
+    res
+      .status(500)
+      .json(ActionResponse.failure("Unexpected action result type"));
   });
 
-  app.post('/resource', async (req: Request, res: Response) => {
+  app.post("/resource", async (req: Request, res: Response) => {
     const adapter = await connector.getMcpAdapter();
     if (!adapter) {
-      res.status(404).json({ error: 'MCP not enabled for this connector' });
+      res.status(404).json({ error: "MCP not enabled for this connector" });
       return;
     }
 
     const parseResult = ResourceRequestSchema.safeParse(req.body);
     if (!parseResult.success) {
-      res.status(400).json({ error: 'Invalid request body' });
+      res.status(400).json({ error: "Invalid request body" });
       return;
     }
 
@@ -273,16 +291,16 @@ export function createServer(connector: Connector): Express {
     }
   });
 
-  app.post('/prompt', async (req: Request, res: Response) => {
+  app.post("/prompt", async (req: Request, res: Response) => {
     const adapter = await connector.getMcpAdapter();
     if (!adapter) {
-      res.status(404).json({ error: 'MCP not enabled for this connector' });
+      res.status(404).json({ error: "MCP not enabled for this connector" });
       return;
     }
 
     const parseResult = PromptRequestSchema.safeParse(req.body);
     if (!parseResult.success) {
-      res.status(400).json({ error: 'Invalid request body' });
+      res.status(400).json({ error: "Invalid request body" });
       return;
     }
 
@@ -295,7 +313,7 @@ export function createServer(connector: Connector): Express {
         name,
         args as Record<string, string> | undefined,
         env,
-        headers
+        headers,
       );
       res.json(result);
     } catch (err) {

--- a/sdk/typescript/tests/server.test.ts
+++ b/sdk/typescript/tests/server.test.ts
@@ -1,18 +1,18 @@
-import { describe, it, expect, beforeAll, afterAll, vi } from 'vitest';
-import request from 'supertest';
-import { http, HttpResponse } from 'msw';
-import { setupServer } from 'msw/node';
-import { Connector } from '../src/connector.js';
-import { createServer } from '../src/server.js';
-import type { SyncContext } from '../src/context.js';
-import { ActionResponse } from '../src/models.js';
+import { describe, it, expect, beforeAll, afterAll, vi } from "vitest";
+import request from "supertest";
+import { http, HttpResponse } from "msw";
+import { setupServer } from "msw/node";
+import { Connector } from "../src/connector.js";
+import { createServer } from "../src/server.js";
+import type { SyncContext } from "../src/context.js";
+import { ActionResponse } from "../src/models.js";
 
-const MANAGER_URL = 'http://test-connector-manager:8080';
+const MANAGER_URL = "http://test-connector-manager:8080";
 
 class MockConnector extends Connector {
-  name = 'mock-connector';
-  version = '1.0.0';
-  syncModes = ['full', 'incremental'];
+  name = "mock-connector";
+  version = "1.0.0";
+  syncModes = ["full", "incremental"];
 
   syncFn: ((ctx: SyncContext) => Promise<void>) | null = null;
 
@@ -20,7 +20,7 @@ class MockConnector extends Connector {
     _sourceConfig: Record<string, unknown>,
     _credentials: Record<string, unknown>,
     _state: Record<string, unknown> | null,
-    ctx: SyncContext
+    ctx: SyncContext,
   ): Promise<void> {
     if (this.syncFn) {
       await this.syncFn(ctx);
@@ -31,24 +31,36 @@ class MockConnector extends Connector {
 const mockServer = setupServer(
   http.get(`${MANAGER_URL}/sdk/source/:sourceId/sync-config`, () =>
     HttpResponse.json({
-      config: { folder_id: 'test-folder' },
-      credentials: { access_token: 'test-token' },
-      connector_state: { cursor: 'test-cursor' },
-    })
+      config: { folder_id: "test-folder" },
+      credentials: { access_token: "test-token" },
+      connector_state: { cursor: "test-cursor" },
+    }),
   ),
-  http.post(`${MANAGER_URL}/sdk/events`, () => HttpResponse.json({ success: true })),
-  http.post(`${MANAGER_URL}/sdk/content`, () => HttpResponse.json({ content_id: 'content-123' })),
-  http.post(`${MANAGER_URL}/sdk/sync/:id/heartbeat`, () => HttpResponse.json({ success: true })),
-  http.post(`${MANAGER_URL}/sdk/sync/:id/scanned`, () => HttpResponse.json({ success: true })),
-  http.post(`${MANAGER_URL}/sdk/sync/:id/complete`, () => HttpResponse.json({ success: true })),
-  http.post(`${MANAGER_URL}/sdk/sync/:id/fail`, () => HttpResponse.json({ success: true }))
+  http.post(`${MANAGER_URL}/sdk/events`, () =>
+    HttpResponse.json({ success: true }),
+  ),
+  http.post(`${MANAGER_URL}/sdk/content`, () =>
+    HttpResponse.json({ content_id: "content-123" }),
+  ),
+  http.post(`${MANAGER_URL}/sdk/sync/:id/heartbeat`, () =>
+    HttpResponse.json({ success: true }),
+  ),
+  http.post(`${MANAGER_URL}/sdk/sync/:id/scanned`, () =>
+    HttpResponse.json({ success: true }),
+  ),
+  http.post(`${MANAGER_URL}/sdk/sync/:id/complete`, () =>
+    HttpResponse.json({ success: true }),
+  ),
+  http.post(`${MANAGER_URL}/sdk/sync/:id/fail`, () =>
+    HttpResponse.json({ success: true }),
+  ),
 );
 
 beforeAll(() => {
-  vi.stubEnv('CONNECTOR_MANAGER_URL', MANAGER_URL);
-  vi.stubEnv('CONNECTOR_HOST_NAME', 'localhost');
-  vi.stubEnv('PORT', '8000');
-  mockServer.listen({ onUnhandledRequest: 'bypass' });
+  vi.stubEnv("CONNECTOR_MANAGER_URL", MANAGER_URL);
+  vi.stubEnv("CONNECTOR_HOST_NAME", "localhost");
+  vi.stubEnv("PORT", "8000");
+  mockServer.listen({ onUnhandledRequest: "bypass" });
 });
 
 afterAll(() => {
@@ -56,38 +68,38 @@ afterAll(() => {
   mockServer.close();
 });
 
-describe('Connector Server', () => {
-  describe('GET /health', () => {
-    it('returns healthy status', async () => {
+describe("Connector Server", () => {
+  describe("GET /health", () => {
+    it("returns healthy status", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
-      const response = await request(app).get('/health');
+      const response = await request(app).get("/health");
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
-        status: 'healthy',
-        service: 'mock-connector',
+        status: "healthy",
+        service: "mock-connector",
       });
     });
   });
 
-  describe('GET /manifest', () => {
-    it('returns connector manifest', async () => {
+  describe("GET /manifest", () => {
+    it("returns connector manifest", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
-      const response = await request(app).get('/manifest');
+      const response = await request(app).get("/manifest");
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({
-        name: 'mock-connector',
-        display_name: 'mock-connector',
-        version: '1.0.0',
-        sync_modes: ['full', 'incremental'],
-        connector_id: 'mock-connector',
-        connector_url: 'http://localhost:8000',
-        description: '',
+        name: "mock-connector",
+        display_name: "mock-connector",
+        version: "1.0.0",
+        sync_modes: ["full", "incremental"],
+        connector_id: "mock-connector",
+        connector_url: "http://localhost:8000",
+        description: "",
         actions: [],
         search_operators: [],
         mcp_enabled: false,
@@ -97,43 +109,45 @@ describe('Connector Server', () => {
     });
   });
 
-  describe('POST /sync', () => {
-    it('returns 400 for invalid request body', async () => {
+  describe("POST /sync", () => {
+    it("returns 400 for invalid request body", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
       const response = await request(app)
-        .post('/sync')
-        .send({ invalid: 'data' });
+        .post("/sync")
+        .send({ invalid: "data" });
 
       expect(response.status).toBe(400);
-      expect(response.body.status).toBe('error');
+      expect(response.body.status).toBe("error");
     });
 
-    it('fetches config from API and returns started', async () => {
+    it("fetches config from API and returns started", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
-      const response = await request(app)
-        .post('/sync')
-        .send({
-          sync_run_id: 'sync-123',
-          source_id: 'source-456',
-          sync_mode: 'full',
-        });
+      const response = await request(app).post("/sync").send({
+        sync_run_id: "sync-123",
+        source_id: "source-456",
+        sync_mode: "full",
+      });
 
       expect(response.status).toBe(200);
-      expect(response.body.status).toBe('started');
+      expect(response.body.status).toBe("started");
     });
 
-    it('plumbs user_filter_mode/whitelist into SyncContext.shouldIndexUser', async () => {
-      let recorded: { alice: boolean; bob: boolean; sourceType: string | null } | null = null;
+    it("plumbs user_filter_mode/whitelist into SyncContext.shouldIndexUser", async () => {
+      let recorded: {
+        alice: boolean;
+        bob: boolean;
+        sourceType: string | null;
+      } | null = null;
 
       const connector = new MockConnector();
       connector.syncFn = async (ctx) => {
         recorded = {
-          alice: ctx.shouldIndexUser('alice@example.com'),
-          bob: ctx.shouldIndexUser('bob@example.com'),
+          alice: ctx.shouldIndexUser("alice@example.com"),
+          bob: ctx.shouldIndexUser("bob@example.com"),
           sourceType: ctx.sourceType,
         };
       };
@@ -142,28 +156,24 @@ describe('Connector Server', () => {
       // Override the default sync-config handler with a payload that
       // pins user_filter_mode=whitelist and only admits alice.
       mockServer.use(
-        http.get(
-          `${MANAGER_URL}/sdk/source/source-filter/sync-config`,
-          () =>
-            HttpResponse.json({
-              config: {},
-              credentials: {},
-              connector_state: null,
-              source_type: 'linear',
-              user_filter_mode: 'whitelist',
-              user_whitelist: ['alice@example.com'],
-              user_blacklist: null,
-            })
-        )
+        http.get(`${MANAGER_URL}/sdk/source/source-filter/sync-config`, () =>
+          HttpResponse.json({
+            config: {},
+            credentials: {},
+            connector_state: null,
+            source_type: "linear",
+            user_filter_mode: "whitelist",
+            user_whitelist: ["alice@example.com"],
+            user_blacklist: null,
+          }),
+        ),
       );
 
-      const response = await request(app)
-        .post('/sync')
-        .send({
-          sync_run_id: 'sync-filter',
-          source_id: 'source-filter',
-          sync_mode: 'incremental',
-        });
+      const response = await request(app).post("/sync").send({
+        sync_run_id: "sync-filter",
+        source_id: "source-filter",
+        sync_mode: "incremental",
+      });
 
       expect(response.status).toBe(200);
 
@@ -176,25 +186,25 @@ describe('Connector Server', () => {
       expect(recorded).toEqual({
         alice: true,
         bob: false,
-        sourceType: 'linear',
+        sourceType: "linear",
       });
     });
   });
 
-  describe('GET /sync/:syncRunId', () => {
-    it('returns running=false for unknown sync', async () => {
+  describe("GET /sync/:syncRunId", () => {
+    it("returns running=false for unknown sync", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
-      const response = await request(app).get('/sync/unknown-sync');
+      const response = await request(app).get("/sync/unknown-sync");
 
       expect(response.status).toBe(200);
       expect(response.body).toEqual({ running: false });
     });
   });
 
-  describe('POST /cancel', () => {
-    it('releases the source slot even when the old task does not exit', async () => {
+  describe("POST /cancel", () => {
+    it("releases the source slot even when the old task does not exit", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
       let syncCalls = 0;
@@ -212,112 +222,144 @@ describe('Connector Server', () => {
         }
       };
 
-      const first = await request(app)
-        .post('/sync')
-        .send({
-          sync_run_id: 'stuck-sync',
-          source_id: 'src-stuck',
-          sync_mode: 'full',
-        });
+      const first = await request(app).post("/sync").send({
+        sync_run_id: "stuck-sync",
+        source_id: "src-stuck",
+        sync_mode: "full",
+      });
       expect(first.status).toBe(200);
       await firstSyncStartedPromise;
 
-      const conflict = await request(app)
-        .post('/sync')
-        .send({
-          sync_run_id: 'conflicting-sync',
-          source_id: 'src-stuck',
-          sync_mode: 'full',
-        });
+      const conflict = await request(app).post("/sync").send({
+        sync_run_id: "conflicting-sync",
+        source_id: "src-stuck",
+        sync_mode: "full",
+      });
       expect(conflict.status).toBe(409);
 
       const cancel = await request(app)
-        .post('/cancel')
-        .send({ sync_run_id: 'stuck-sync' });
+        .post("/cancel")
+        .send({ sync_run_id: "stuck-sync" });
       expect(cancel.status).toBe(200);
-      expect(cancel.body).toEqual({ status: 'cancelled' });
+      expect(cancel.body).toEqual({ status: "cancelled" });
 
-      const status = await request(app).get('/sync/stuck-sync');
+      const status = await request(app).get("/sync/stuck-sync");
       expect(status.body).toEqual({ running: false });
 
-      const afterCancel = await request(app)
-        .post('/sync')
-        .send({
-          sync_run_id: 'after-cancel',
-          source_id: 'src-stuck',
-          sync_mode: 'full',
-        });
+      const afterCancel = await request(app).post("/sync").send({
+        sync_run_id: "after-cancel",
+        source_id: "src-stuck",
+        sync_mode: "full",
+      });
       expect(afterCancel.status).toBe(200);
       expect(syncCalls).toBe(2);
     });
 
-    it('returns not_found for unknown sync', async () => {
+    it("returns not_found for unknown sync", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
       const response = await request(app)
-        .post('/cancel')
-        .send({ sync_run_id: 'unknown-sync' });
+        .post("/cancel")
+        .send({ sync_run_id: "unknown-sync" });
 
       expect(response.status).toBe(404);
-      expect(response.body).toEqual({ status: 'not_found' });
+      expect(response.body).toEqual({ status: "not_found" });
     });
 
-    it('returns 400 for invalid request body', async () => {
+    it("returns 400 for invalid request body", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
       const response = await request(app)
-        .post('/cancel')
-        .send({ invalid: 'data' });
+        .post("/cancel")
+        .send({ invalid: "data" });
 
       expect(response.status).toBe(400);
     });
   });
 
-  describe('POST /action', () => {
-    it('returns not supported for unknown action', async () => {
+  describe("POST /action", () => {
+    it("passes params and source/actor_email separately", async () => {
+      let capturedParams: Record<string, unknown> = {};
+      let capturedSource: unknown = null;
+      let capturedActorEmail: unknown = null;
+      class TrustedActionConnector extends MockConnector {
+        async executeAction(
+          _action: string,
+          params: Record<string, unknown>,
+          _credentials: Record<string, unknown>,
+          source?: unknown,
+          actor_email?: unknown,
+        ): Promise<Response> {
+          capturedParams = params;
+          capturedSource = source;
+          capturedActorEmail = actor_email;
+          return ActionResponse.success({ ok: true }).toResponse();
+        }
+      }
+      const app = createServer(new TrustedActionConnector());
+      const testSource = {
+        id: "src-123",
+        name: "Test Source",
+        source_type: "test",
+        config: { base_url: "https://trusted.example" },
+      };
+      const response = await request(app)
+        .post("/action")
+        .send({
+          action: "safe",
+          params: { some_key: "user_value" },
+          credentials: {},
+          source: testSource,
+          actor_email: "a@b.com",
+        });
+      expect(response.status).toBe(200);
+      expect(capturedParams).toEqual({ some_key: "user_value" });
+      expect(capturedSource).toEqual(testSource);
+      expect(capturedActorEmail).toEqual("a@b.com");
+    });
+
+    it("returns not supported for unknown action", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
-      const response = await request(app)
-        .post('/action')
-        .send({
-          action: 'unknown_action',
-          params: {},
-          credentials: {},
-        });
+      const response = await request(app).post("/action").send({
+        action: "unknown_action",
+        params: {},
+        credentials: {},
+      });
 
       expect(response.status).toBe(404);
       expect(response.body).toEqual({
-        status: 'error',
-        error: 'Action not supported: unknown_action',
+        status: "error",
+        error: "Action not supported: unknown_action",
       });
     });
 
-    it('returns 400 for invalid request body', async () => {
+    it("returns 400 for invalid request body", async () => {
       const connector = new MockConnector();
       const app = createServer(connector);
 
       const response = await request(app)
-        .post('/action')
-        .send({ invalid: 'data' });
+        .post("/action")
+        .send({ invalid: "data" });
 
       expect(response.status).toBe(400);
     });
 
-    it('returns binary response for binary action result', async () => {
+    it("returns binary response for binary action result", async () => {
       class BinaryActionConnector extends MockConnector {
-        name = 'binary-action-connector';
+        name = "binary-action-connector";
         async executeAction(
           action: string,
           _params: Record<string, unknown>,
-          _credentials: Record<string, unknown>
+          _credentials: Record<string, unknown>,
         ): Promise<Response> {
-          if (action === 'download') {
-            return new Response(Buffer.from('binary data'), {
+          if (action === "download") {
+            return new Response(Buffer.from("binary data"), {
               status: 200,
-              headers: { 'Content-Type': 'application/octet-stream' },
+              headers: { "Content-Type": "application/octet-stream" },
             });
           }
           return ActionResponse.notSupported(action).toResponse(404);
@@ -327,18 +369,18 @@ describe('Connector Server', () => {
       const connector = new BinaryActionConnector();
       const app = createServer(connector);
 
-      const response = await request(app)
-        .post('/action')
-        .send({
-          action: 'download',
-          params: {},
-          credentials: {},
-        });
+      const response = await request(app).post("/action").send({
+        action: "download",
+        params: {},
+        credentials: {},
+      });
 
       expect(response.status).toBe(200);
-      expect(response.headers['content-type']).toBe('application/octet-stream');
+      expect(response.headers["content-type"]).toBe("application/octet-stream");
       expect(response.body).toBeInstanceOf(Buffer);
-      expect((response.body as Buffer).toString()).toBe('binary data');
+      expect((response.body as Buffer).toString()).toBe("binary data");
     });
   });
+
+
 });

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -348,12 +348,13 @@ class ConnectorToolHandler:
         return tool_name in self._actions
 
     def requires_approval(self, tool_name: str) -> bool:
-        # Pre-authorized when filters are active (background agent context)
-        if self._source_filter is not None or self._action_whitelist is not None:
-            return False
         action = self._actions.get(tool_name)
         if not action:
             return True
+        # Every write action requires interactive approval, regardless of
+        # source filters or action whitelists.
+        if self._source_filter is not None or self._action_whitelist is not None:
+            return False if action.mode == "read" else True
         return action.mode == "write"
 
     async def check_oauth_required(

--- a/services/ai/tools/registry.py
+++ b/services/ai/tools/registry.py
@@ -25,7 +25,6 @@ class ToolContext:
     original_user_query: str | None = None
     skip_permission_check: bool = False
 
-
 @dataclass
 class ToolResult:
     """Standardized result from tool execution."""

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -1,6 +1,6 @@
 use crate::connector_client::ConnectorClient;
 use crate::models::{
-    ActionContext, ActionRequest, ConnectorInfo, ExecuteActionRequest, ExecutePromptRequest,
+    ActionRequest, ConnectorInfo, ExecuteActionRequest, ExecutePromptRequest,
     ExecuteResourceRequest, ExecuteSkillRequest, McpCredentials, OAuthCredentialReadyRequest,
     PromptRequest, ResourceRequest, ScheduleInfo, SourceHealth, SourceSyncOverview, SyncProgress,
     TriggerSyncRequest, TriggerSyncResponse, TriggerType,
@@ -10,7 +10,7 @@ use crate::sync_manager::SyncError;
 use crate::AppState;
 use axum::{
     extract::{Path, Query, State},
-    http::{header, HeaderValue, StatusCode},
+    http::{header, HeaderMap, HeaderValue, StatusCode},
     response::{
         sse::{Event, KeepAlive, Sse},
         IntoResponse,
@@ -20,6 +20,7 @@ use axum::{
 use futures::stream::Stream;
 use redis::AsyncCommands;
 use serde_json::{json, Value};
+
 use shared::clients::docling::{DoclingClient, DoclingError};
 use shared::db::repositories::{ConfigurationRepository, SyncRunRepository};
 use shared::models::{
@@ -354,6 +355,7 @@ pub async fn list_connectors(
 
 pub async fn execute_action(
     State(state): State<AppState>,
+    _headers: HeaderMap,
     Json(request): Json<ExecuteActionRequest>,
 ) -> Result<axum::response::Response, ApiError> {
     info!(
@@ -375,33 +377,40 @@ pub async fn execute_action(
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| ApiError::NotFound(format!("Source not found: {}", request.source_id)))?;
 
-    // Look up the connector manifest to get connector_url and read_only flag
+    // Look up the connector manifest to get connector_url and action metadata
     let manifests = get_registered_manifests(&state.redis_client).await;
     let manifest = manifests
         .iter()
         .find(|m| m.source_types.contains(&source.source_type));
 
-    let connector_url = manifest.map(|m| m.connector_url.clone()).ok_or_else(|| {
-        ApiError::NotFound(format!(
-            "Connector not registered for type: {:?}",
-            source.source_type
-        ))
-    })?;
+    let connector_url = manifest
+        .as_ref()
+        .map(|m| m.connector_url.clone())
+        .ok_or_else(|| {
+            ApiError::NotFound(format!(
+                "Connector not registered for type: {:?}",
+                source.source_type
+            ))
+        })?;
 
     let action_def = manifest.and_then(|m| m.actions.iter().find(|a| a.name == request.action));
     let action_mode = action_def.map(|a| a.mode).unwrap_or_default();
-    let action_admin_only = action_def.map(|a| a.admin_only).unwrap_or(false);
+    // Reject unknown action names — they must exist in the manifest
+    let action_def = action_def.ok_or_else(|| {
+        ApiError::BadRequest(format!(
+            "Unknown action '{}' for source type {:?}",
+            request.action, source.source_type
+        ))
+    })?;
+    let action_admin_only = action_def.admin_only;
 
-    // TODO: replace this opaque-blob `read_only` lookup with a strongly-typed
-    // SourceConfig. Today every connector pokes its own keys into Source.config
-    // unchecked — `read_only` is the only key the manager itself reads.
+    // Generic read_only enforcement — the source config is the authority.
     let source_read_only = source
         .config
         .get("read_only")
         .and_then(|v| v.as_bool())
         .unwrap_or(false);
-
-    if let Some(m) = manifest {
+    if let Some(m) = manifest.as_ref() {
         if (m.read_only || source_read_only) && action_mode == ActionMode::Write {
             return Err(ApiError::BadRequest(format!(
                 "Action '{}' is not allowed: source is read-only",
@@ -463,10 +472,8 @@ pub async fn execute_action(
         // If not found, assume the ID is already a source-native ID and pass through
     }
 
-    // Merge source config into params so connectors can access source-level
-    // settings during action execution (e.g., server_url for Nextcloud
-    // fetch_file). Caller-provided param values always take precedence.
-    // Null/missing params is promoted to an empty object so the merge runs.
+    // Merge source config into params for legacy connector compatibility.
+    // Connectors that use the typed context (e.g. Darwinbox) ignore these.
     if params.is_null() {
         params = serde_json::Value::Object(serde_json::Map::new());
     }
@@ -476,16 +483,24 @@ pub async fn execute_action(
         }
     }
 
-    let action_context = if let Some(user_id) = request.user_id.clone() {
+    // Resolve actor email for the execution context
+    let actor_email = if let Some(uid) = request.user_id.as_ref() {
         let user_repo = UserRepository::new(state.db_pool.pool());
         let user = user_repo
-            .find_by_id(user_id.clone())
+            .find_by_id(uid.clone())
             .await
             .map_err(|e| ApiError::Internal(e.to_string()))?
-            .ok_or_else(|| ApiError::NotFound(format!("User not found: {user_id}")))?;
-        Some(ActionContext::user(user_id, user.email, user.role))
+            .ok_or_else(|| ApiError::NotFound(format!("User not found: {uid}")))?;
+        // Enforce admin_only action authorization
+        if action_admin_only && user.role != shared::models::UserRole::Admin {
+            return Err(ApiError::BadRequest(format!(
+                "Action '{}' requires admin privileges",
+                request.action
+            )));
+        }
+        Some(user.email)
     } else {
-        Some(ActionContext::system())
+        None
     };
 
     info!(
@@ -503,7 +518,8 @@ pub async fn execute_action(
         action: request.action,
         params,
         credentials: Some(creds),
-        action_context,
+        source: Some(source),
+        actor_email,
     };
 
     // Proxy the connector's full HTTP response (status, headers, body) verbatim.
@@ -1178,6 +1194,9 @@ pub enum ApiError {
     #[error("Bad request: {0}")]
     BadRequest(String),
 
+    #[error("Unauthorized: {0}")]
+    Unauthorized(String),
+
     #[error("Conflict: {0}")]
     Conflict(String),
 
@@ -1254,6 +1273,7 @@ impl IntoResponse for ApiError {
         let (status, message) = match &self {
             ApiError::NotFound(msg) => (StatusCode::NOT_FOUND, msg.clone()),
             ApiError::BadRequest(msg) => (StatusCode::BAD_REQUEST, msg.clone()),
+            ApiError::Unauthorized(msg) => (StatusCode::UNAUTHORIZED, msg.clone()),
             ApiError::Conflict(msg) => (StatusCode::CONFLICT, msg.clone()),
             ApiError::Internal(msg) => (StatusCode::INTERNAL_SERVER_ERROR, msg.clone()),
             ApiError::PayloadTooLarge(msg) => (StatusCode::PAYLOAD_TOO_LARGE, msg.clone()),

--- a/services/connector-manager/src/models.rs
+++ b/services/connector-manager/src/models.rs
@@ -3,10 +3,9 @@ use serde_json::Value as JsonValue;
 use shared::models::{Source, SourceType, SyncRun, SyncType};
 
 pub use shared::models::{
-    ActionContext, ActionDefinition, ActionRequest, ActionResponse, CancelRequest,
-    ConnectorManifest, McpCredentials, McpPromptDefinition, McpResourceDefinition, PromptRequest,
-    ResourceRequest, SearchOperator, SkillRequest, SkillResponse, SyncRequest, SyncResponse,
-    SyncStatusResponse,
+    ActionDefinition, ActionRequest, ActionResponse, CancelRequest, ConnectorManifest,
+    McpCredentials, McpPromptDefinition, McpResourceDefinition, PromptRequest, ResourceRequest,
+    SearchOperator, SkillRequest, SkillResponse, SyncRequest, SyncResponse, SyncStatusResponse,
 };
 
 #[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq)]

--- a/shared/src/models.rs
+++ b/shared/src/models.rs
@@ -1237,74 +1237,21 @@ pub struct SkillResponse {
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
-#[serde(tag = "actor_type", rename_all = "snake_case")]
-pub enum ActionActor {
-    User {
-        user_id: String,
-        email: String,
-        role: UserRole,
-    },
-    System,
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
-pub struct ActionContext {
-    pub actor: ActionActor,
-}
-
-impl ActionContext {
-    pub fn user(user_id: String, email: String, role: UserRole) -> Self {
-        Self {
-            actor: ActionActor::User {
-                user_id,
-                email,
-                role,
-            },
-        }
-    }
-
-    pub fn system() -> Self {
-        Self {
-            actor: ActionActor::System,
-        }
-    }
-
-    pub fn user_id(&self) -> Option<&str> {
-        match &self.actor {
-            ActionActor::User { user_id, .. } => Some(user_id.as_str()),
-            ActionActor::System => None,
-        }
-    }
-
-    pub fn user_email(&self) -> Option<&str> {
-        match &self.actor {
-            ActionActor::User { email, .. } => Some(email.as_str()),
-            ActionActor::System => None,
-        }
-    }
-
-    pub fn is_omni_admin(&self) -> bool {
-        matches!(
-            &self.actor,
-            ActionActor::User {
-                role: UserRole::Admin,
-                ..
-            }
-        )
-    }
-}
-
-#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct ActionRequest {
     pub action: String,
     #[serde(default)]
     pub params: JsonValue,
     #[serde(default)]
     pub credentials: Option<ServiceCredential>,
+    /// Trusted source configuration populated by connector-manager.
+    /// Connectors deserialize their own typed policy from this.
     #[serde(default)]
-    pub action_context: Option<ActionContext>,
+    pub source: Option<Source>,
+    /// Authenticated actor email, resolved by connector-manager.
+    /// None = system/background execution.
+    #[serde(default)]
+    pub actor_email: Option<String>,
 }
-
 #[derive(Debug, Clone, Serialize, Deserialize, FromRow)]
 pub struct ApprovedDomain {
     pub id: String,

--- a/web/src/lib/components/darwinbox-connector-setup.svelte
+++ b/web/src/lib/components/darwinbox-connector-setup.svelte
@@ -417,7 +417,7 @@
                     placeholder="Asia/Kolkata" />
             </div>
             <div class="space-y-3 rounded-md border p-3 text-sm">
-                <div class="font-medium">POC safety controls</div>
+                <div class="font-medium">Safety controls</div>
                 <label class="flex cursor-pointer items-center gap-2">
                     <input type="checkbox" bind:checked={readOnly} />
                     Read-only mode (recommended and enabled by default)
@@ -458,8 +458,8 @@
                     </label>
                 {/if}
                 <p class="text-muted-foreground text-xs">
-                    HR administration, ATS candidate, report, bulk, and unattended actions remain
-                    disabled in hardened POC mode.
+                    HR administration, ATS candidate, bulk, and unattended actions are not yet
+                    implemented.
                 </p>
             </div>
         </div>

--- a/web/src/lib/components/darwinbox-connector-setup.svelte
+++ b/web/src/lib/components/darwinbox-connector-setup.svelte
@@ -4,8 +4,39 @@
     import { Input } from '$lib/components/ui/input'
     import { Label } from '$lib/components/ui/label'
     import * as Select from '$lib/components/ui/select'
-    import { AuthType } from '$lib/types'
+    import { AuthType, type ConnectorListEntry } from '$lib/types'
     import { toast } from 'svelte-sonner'
+
+    /** Derive allowed Darwinbox action names from the registered connector manifest.
+     * Action groups (module→{read,write}) come from Darwinbox's extra_schema.action_groups
+     * derived from its internal action policy table, not from ActionDefinition metadata. */
+    async function deriveDarwinboxActions(
+        selfService: boolean,
+        managerWorkflows: boolean,
+        readOnly: boolean,
+    ): Promise<string[]> {
+        const resp = await fetch('/api/connectors')
+        if (!resp.ok) throw new Error('Failed to load connector actions')
+        const connectors: ConnectorListEntry[] = await resp.json()
+        const darwinbox = connectors.find((c) => c.source_type === 'darwinbox')
+        if (!darwinbox?.manifest) throw new Error('Darwinbox connector not registered')
+        const groups = darwinbox.manifest.extra_schema?.action_groups ?? {}
+        const result: string[] = []
+        function addGroup(name: string) {
+            const group = groups[name]
+            if (!group) return
+            for (const action of group.read) {
+                if (!result.includes(action)) result.push(action)
+            }
+            if (readOnly) return
+            for (const action of group.write) {
+                if (!result.includes(action)) result.push(action)
+            }
+        }
+        if (selfService) addGroup('employee_self_service')
+        if (managerWorkflows) addGroup('manager_workflows')
+        return result
+    }
 
     interface Props {
         open: boolean
@@ -30,10 +61,13 @@
     let refreshToken = $state('')
     let datasetKey = $state('')
     let defaultTimezone = $state('Asia/Kolkata')
-    let enablePositions = $state(false)
-    let enableAts = $state(false)
-    let enableHrActions = $state(false)
-    let enableReports = $state(false)
+    let readOnly = $state(true)
+    let enableEmployeeDirectory = $state(false)
+    let enableSelfService = $state(false)
+    let enableManagerWorkflows = $state(false)
+    let writeAcknowledged = $state(false)
+    let participantEmails = $state('')
+    let targetEmployeeIds = $state('')
     let isSubmitting = $state(false)
 
     async function handleSubmit() {
@@ -63,6 +97,29 @@
                 }
             }
             if (!datasetKey.trim()) throw new Error('Dataset key is required')
+            const participants = participantEmails
+                .split(',')
+                .map((v) => v.trim().toLowerCase())
+                .filter(Boolean)
+            const targets = targetEmployeeIds
+                .split(',')
+                .map((v) => v.trim())
+                .filter(Boolean)
+            if ((enableSelfService || enableManagerWorkflows) && participants.length === 0) {
+                throw new Error('At least one approved participant email is required')
+            }
+            if (enableManagerWorkflows && targets.length === 0) {
+                throw new Error('Manager workflows require target employee IDs')
+            }
+            if (!readOnly && !writeAcknowledged) {
+                throw new Error('Confirm write-mode acknowledgement before continuing')
+            }
+            // Derive allowed actions from registered connector manifest
+            const allowedActions = await deriveDarwinboxActions(
+                enableSelfService,
+                enableManagerWorkflows,
+                readOnly,
+            )
 
             const sourceResponse = await fetch('/api/sources', {
                 method: 'POST',
@@ -71,28 +128,58 @@
                     scope: 'org',
                     name: 'Darwinbox',
                     sourceType: 'darwinbox',
+                    isActive: true,
                     config: {
                         base_url: baseUrl.trim().replace(/\/$/, ''),
+                        read_only: readOnly,
                         default_timezone: defaultTimezone.trim() || null,
+                        employee_scope: enableEmployeeDirectory
+                            ? { mode: 'include', employee_ids: targets }
+                            : null,
+                        employee_fields: enableEmployeeDirectory
+                            ? [
+                                  'name',
+                                  'employee_id',
+                                  'company_email',
+                                  'department',
+                                  'designation',
+                                  'office_location',
+                              ]
+                            : [],
                         sync_modules: {
-                            employee_directory: true,
-                            deleted_employees: true,
-                            org_masters: true,
-                            positions: enablePositions,
-                            holidays: true,
-                            ats_jobs: enableAts,
+                            employee_directory: enableEmployeeDirectory,
+                            deleted_employees: enableEmployeeDirectory,
+                            departments: false,
+                            designations: false,
+                            office_locations: false,
+                            business_units: false,
+                            divisions: false,
+                            cost_centers: false,
+                            group_companies: false,
+                            positions: false,
+                            holidays: false,
+                            ats_jobs: false,
                         },
                         action_modules: {
-                            employee_self_service: true,
-                            manager_workflows: true,
-                            hr_operations: enableHrActions,
-                            ats: enableAts,
-                            reports: enableReports,
+                            employee_self_service: enableSelfService,
+                            manager_workflows: enableManagerWorkflows,
+                            hr_operations: false,
+                            ats: false,
+                            reports: false,
                         },
                         authorization: {
-                            use_darwinbox_permissions: true,
+                            actions_enabled: enableSelfService || enableManagerWorkflows,
+                            write_acknowledged: writeAcknowledged,
+                            participant_emails: participants,
+                            allowed_actions: allowedActions,
+                            target_employee_ids: targets,
+                            target_employee_emails: [],
+                            target_departments: [],
                             hr_admin_emails: [],
                             recruiter_emails: [],
+                            allowed_report_ids: [],
+                            max_batch_size: 1,
+                            max_requests_per_minute: 10,
                         },
                     },
                 }),
@@ -168,10 +255,13 @@
         refreshToken = ''
         datasetKey = ''
         defaultTimezone = 'Asia/Kolkata'
-        enablePositions = false
-        enableAts = false
-        enableHrActions = false
-        enableReports = false
+        readOnly = true
+        enableEmployeeDirectory = false
+        enableSelfService = false
+        enableManagerWorkflows = false
+        writeAcknowledged = false
+        participantEmails = ''
+        targetEmployeeIds = ''
     }
 
     function handleCancel() {
@@ -326,16 +416,51 @@
                     bind:value={defaultTimezone}
                     placeholder="Asia/Kolkata" />
             </div>
-            <div class="space-y-2 rounded-md border p-3 text-sm">
-                <div class="font-medium">Optional modules</div>
-                <label class="flex items-center gap-2"
-                    ><input type="checkbox" bind:checked={enablePositions} /> Sync position master</label>
-                <label class="flex items-center gap-2"
-                    ><input type="checkbox" bind:checked={enableAts} /> Enable ATS jobs/actions</label>
-                <label class="flex items-center gap-2"
-                    ><input type="checkbox" bind:checked={enableHrActions} /> Enable HR lifecycle actions</label>
-                <label class="flex items-center gap-2"
-                    ><input type="checkbox" bind:checked={enableReports} /> Enable report actions</label>
+            <div class="space-y-3 rounded-md border p-3 text-sm">
+                <div class="font-medium">POC safety controls</div>
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" bind:checked={readOnly} />
+                    Read-only mode (recommended and enabled by default)
+                </label>
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" bind:checked={enableEmployeeDirectory} />
+                    Index the approved employee cohort using safe directory fields
+                </label>
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" bind:checked={enableSelfService} />
+                    Enable employee self-service workflows
+                </label>
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input type="checkbox" bind:checked={enableManagerWorkflows} />
+                    Enable manager workflows for approved target employees
+                </label>
+                <div class="space-y-1">
+                    <Label for="darwinbox-participants">Approved participant emails</Label>
+                    <Input
+                        id="darwinbox-participants"
+                        bind:value={participantEmails}
+                        placeholder="user1@example.com, user2@example.com" />
+                </div>
+                <div class="space-y-1">
+                    <Label for="darwinbox-targets">Approved target employee IDs</Label>
+                    <Input
+                        id="darwinbox-targets"
+                        bind:value={targetEmployeeIds}
+                        placeholder="EMP001, EMP002" />
+                </div>
+                {#if !readOnly}
+                    <label
+                        class="flex cursor-pointer items-start gap-2 rounded border border-amber-300 p-2">
+                        <input type="checkbox" bind:checked={writeAcknowledged} />
+                        <span
+                            >I understand that approved actions can change production Darwinbox data
+                            and require explicit confirmation.</span>
+                    </label>
+                {/if}
+                <p class="text-muted-foreground text-xs">
+                    HR administration, ATS candidate, report, bulk, and unattended actions remain
+                    disabled in hardened POC mode.
+                </p>
             </div>
         </div>
 

--- a/web/src/lib/components/darwinbox-connector-setup.svelte
+++ b/web/src/lib/components/darwinbox-connector-setup.svelte
@@ -152,9 +152,6 @@
                             write_acknowledged: writeAcknowledged,
                             participant_emails: participants,
                             allowed_actions: allowedActions,
-                            target_employee_ids: targets,
-                            target_employee_emails: [],
-                            target_departments: [],
                             hr_admin_emails: [],
                             recruiter_emails: [],
                             allowed_report_ids: [],
@@ -234,7 +231,6 @@
         readOnly = true
         writeAcknowledged = false
         participantEmails = ''
-        targetEmployeeIds = ''
     }
 
     function handleCancel() {
@@ -396,13 +392,7 @@
                         bind:value={participantEmails}
                         placeholder="user1@example.com, user2@example.com" />
                 </div>
-                <div class="space-y-1">
-                    <Label for="darwinbox-targets">Approved target employee IDs</Label>
-                    <Input
-                        id="darwinbox-targets"
-                        bind:value={targetEmployeeIds}
-                        placeholder="EMP001, EMP002" />
-                </div>
+
                 {#if !readOnly}
                     <label
                         class="flex cursor-pointer items-start gap-2 rounded border border-amber-300 p-2">

--- a/web/src/lib/components/darwinbox-connector-setup.svelte
+++ b/web/src/lib/components/darwinbox-connector-setup.svelte
@@ -152,8 +152,6 @@
                             write_acknowledged: writeAcknowledged,
                             participant_emails: participants,
                             allowed_actions: allowedActions,
-                            hr_admin_emails: [],
-                            recruiter_emails: [],
                             allowed_report_ids: [],
                             max_batch_size: 1,
                         },

--- a/web/src/lib/components/darwinbox-connector-setup.svelte
+++ b/web/src/lib/components/darwinbox-connector-setup.svelte
@@ -7,14 +7,10 @@
     import { AuthType, type ConnectorListEntry } from '$lib/types'
     import { toast } from 'svelte-sonner'
 
-    /** Derive allowed Darwinbox action names from the registered connector manifest.
-     * Action groups (module→{read,write}) come from Darwinbox's extra_schema.action_groups
-     * derived from its internal action policy table, not from ActionDefinition metadata. */
-    async function deriveDarwinboxActions(
-        selfService: boolean,
-        managerWorkflows: boolean,
-        readOnly: boolean,
-    ): Promise<string[]> {
+    /** Fetch all Darwinbox action names from the registered connector manifest.
+     * Groups come from extra_schema.action_groups derived from the connector's
+     * internal action policy table. */
+    async function getAllowedActions(readOnly: boolean): Promise<string[]> {
         const resp = await fetch('/api/connectors')
         if (!resp.ok) throw new Error('Failed to load connector actions')
         const connectors: ConnectorListEntry[] = await resp.json()
@@ -22,19 +18,16 @@
         if (!darwinbox?.manifest) throw new Error('Darwinbox connector not registered')
         const groups = darwinbox.manifest.extra_schema?.action_groups ?? {}
         const result: string[] = []
-        function addGroup(name: string) {
-            const group = groups[name]
-            if (!group) return
-            for (const action of group.read) {
+        for (const group of Object.values(groups)) {
+            if (!group) continue
+            for (const action of group.read ?? []) {
                 if (!result.includes(action)) result.push(action)
             }
-            if (readOnly) return
-            for (const action of group.write) {
+            if (readOnly) continue
+            for (const action of group.write ?? []) {
                 if (!result.includes(action)) result.push(action)
             }
         }
-        if (selfService) addGroup('employee_self_service')
-        if (managerWorkflows) addGroup('manager_workflows')
         return result
     }
 
@@ -60,11 +53,7 @@
     let authorizationCode = $state('')
     let refreshToken = $state('')
     let datasetKey = $state('')
-    let defaultTimezone = $state('Asia/Kolkata')
     let readOnly = $state(true)
-    let enableEmployeeDirectory = $state(false)
-    let enableSelfService = $state(false)
-    let enableManagerWorkflows = $state(false)
     let writeAcknowledged = $state(false)
     let participantEmails = $state('')
     let targetEmployeeIds = $state('')
@@ -105,21 +94,14 @@
                 .split(',')
                 .map((v) => v.trim())
                 .filter(Boolean)
-            if ((enableSelfService || enableManagerWorkflows) && participants.length === 0) {
+            if (participants.length === 0) {
                 throw new Error('At least one approved participant email is required')
-            }
-            if (enableManagerWorkflows && targets.length === 0) {
-                throw new Error('Manager workflows require target employee IDs')
             }
             if (!readOnly && !writeAcknowledged) {
                 throw new Error('Confirm write-mode acknowledgement before continuing')
             }
             // Derive allowed actions from registered connector manifest
-            const allowedActions = await deriveDarwinboxActions(
-                enableSelfService,
-                enableManagerWorkflows,
-                readOnly,
-            )
+            const allowedActions = await getAllowedActions(readOnly)
 
             const sourceResponse = await fetch('/api/sources', {
                 method: 'POST',
@@ -132,23 +114,21 @@
                     config: {
                         base_url: baseUrl.trim().replace(/\/$/, ''),
                         read_only: readOnly,
-                        default_timezone: defaultTimezone.trim() || null,
-                        employee_scope: enableEmployeeDirectory
-                            ? { mode: 'include', employee_ids: targets }
-                            : null,
-                        employee_fields: enableEmployeeDirectory
-                            ? [
-                                  'name',
-                                  'employee_id',
-                                  'company_email',
-                                  'department',
-                                  'designation',
-                                  'office_location',
-                              ]
-                            : [],
+                        employee_scope: {
+                            mode: 'include',
+                            employee_ids: targets,
+                        },
+                        employee_fields: [
+                            'name',
+                            'employee_id',
+                            'company_email',
+                            'department',
+                            'designation',
+                            'office_location',
+                        ],
                         sync_modules: {
-                            employee_directory: enableEmployeeDirectory,
-                            deleted_employees: enableEmployeeDirectory,
+                            employee_directory: true,
+                            deleted_employees: true,
                             departments: false,
                             designations: false,
                             office_locations: false,
@@ -161,14 +141,14 @@
                             ats_jobs: false,
                         },
                         action_modules: {
-                            employee_self_service: enableSelfService,
-                            manager_workflows: enableManagerWorkflows,
+                            employee_self_service: true,
+                            manager_workflows: true,
                             hr_operations: false,
                             ats: false,
-                            reports: false,
+                            reports: true,
                         },
                         authorization: {
-                            actions_enabled: enableSelfService || enableManagerWorkflows,
+                            actions_enabled: true,
                             write_acknowledged: writeAcknowledged,
                             participant_emails: participants,
                             allowed_actions: allowedActions,
@@ -179,7 +159,6 @@
                             recruiter_emails: [],
                             allowed_report_ids: [],
                             max_batch_size: 1,
-                            max_requests_per_minute: 10,
                         },
                     },
                 }),
@@ -228,15 +207,13 @@
             })
 
             if (!credentialsResponse.ok) {
-                throw new Error('Failed to create Darwinbox service credentials')
+                throw new Error('Failed to save Darwinbox credentials')
             }
 
-            toast.success('Darwinbox connected successfully!')
-            reset()
+            toast.success('Darwinbox source created')
             onSuccess?.()
-        } catch (error: any) {
-            console.error('Error setting up Darwinbox:', error)
-            toast.error(error.message || 'Failed to set up Darwinbox')
+        } catch (e) {
+            toast.error(e instanceof Error ? e.message : 'Failed to create Darwinbox source')
         } finally {
             isSubmitting = false
         }
@@ -254,11 +231,7 @@
         authorizationCode = ''
         refreshToken = ''
         datasetKey = ''
-        defaultTimezone = 'Asia/Kolkata'
         readOnly = true
-        enableEmployeeDirectory = false
-        enableSelfService = false
-        enableManagerWorkflows = false
         writeAcknowledged = false
         participantEmails = ''
         targetEmployeeIds = ''
@@ -409,30 +382,12 @@
                         required />
                 </div>
             </div>
-            <div class="space-y-2">
-                <Label for="darwinbox-timezone">Default timezone</Label>
-                <Input
-                    id="darwinbox-timezone"
-                    bind:value={defaultTimezone}
-                    placeholder="Asia/Kolkata" />
-            </div>
+
             <div class="space-y-3 rounded-md border p-3 text-sm">
-                <div class="font-medium">Safety controls</div>
+                <div class="font-medium">Access controls</div>
                 <label class="flex cursor-pointer items-center gap-2">
                     <input type="checkbox" bind:checked={readOnly} />
-                    Read-only mode (recommended and enabled by default)
-                </label>
-                <label class="flex cursor-pointer items-center gap-2">
-                    <input type="checkbox" bind:checked={enableEmployeeDirectory} />
-                    Index the approved employee cohort using safe directory fields
-                </label>
-                <label class="flex cursor-pointer items-center gap-2">
-                    <input type="checkbox" bind:checked={enableSelfService} />
-                    Enable employee self-service workflows
-                </label>
-                <label class="flex cursor-pointer items-center gap-2">
-                    <input type="checkbox" bind:checked={enableManagerWorkflows} />
-                    Enable manager workflows for approved target employees
+                    Read-only mode (prevents all mutations)
                 </label>
                 <div class="space-y-1">
                     <Label for="darwinbox-participants">Approved participant emails</Label>
@@ -457,10 +412,6 @@
                             and require explicit confirmation.</span>
                     </label>
                 {/if}
-                <p class="text-muted-foreground text-xs">
-                    HR administration, ATS candidate, bulk, and unattended actions are not yet
-                    implemented.
-                </p>
             </div>
         </div>
 

--- a/web/src/lib/server/db/sources.ts
+++ b/web/src/lib/server/db/sources.ts
@@ -3,6 +3,7 @@ import { db } from './index'
 import { sources, type Source } from './schema'
 import type {
     ConfluenceSourceConfig,
+    DarwinboxSourceConfig,
     FilesystemSourceConfig,
     ImapSourceConfig,
     JiraSourceConfig,
@@ -31,6 +32,7 @@ export async function updateSourceById(
         config?:
             | WebSourceConfig
             | ConfluenceSourceConfig
+            | DarwinboxSourceConfig
             | JiraSourceConfig
             | FilesystemSourceConfig
             | ImapSourceConfig

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -151,13 +151,29 @@ export interface GoogleAdsSourceConfig {
     sync_enabled?: boolean
 }
 
+export interface ConnectorListEntry {
+    source_type: string
+    manifest: {
+        extra_schema?: {
+            action_groups?: Record<string, { read: string[]; write: string[] }>
+        }
+    }
+}
+
 export interface DarwinboxSourceConfig {
     base_url: string
+    read_only?: boolean
     default_timezone?: string
     sync_modules?: {
         employee_directory?: boolean
         deleted_employees?: boolean
-        org_masters?: boolean
+        departments?: boolean
+        designations?: boolean
+        office_locations?: boolean
+        business_units?: boolean
+        divisions?: boolean
+        cost_centers?: boolean
+        group_companies?: boolean
         positions?: boolean
         holidays?: boolean
         ats_jobs?: boolean
@@ -170,10 +186,35 @@ export interface DarwinboxSourceConfig {
         reports?: boolean
     }
     authorization?: {
-        use_darwinbox_permissions?: boolean
+        actions_enabled?: boolean
+        write_acknowledged?: boolean
+        participant_emails?: string[]
+        allowed_actions?: string[]
+        target_employee_ids?: string[]
+        target_employee_emails?: string[]
+        target_departments?: string[]
         hr_admin_emails?: string[]
         recruiter_emails?: string[]
+        allowed_report_ids?: string[]
+        max_batch_size?: number
+        max_requests_per_minute?: number
     }
+    employee_scope?: {
+        mode: 'all' | 'include'
+        employee_ids?: string[]
+        employee_emails?: string[]
+        departments?: string[]
+    } | null
+    employee_fields?: Array<
+        | 'name'
+        | 'employee_id'
+        | 'company_email'
+        | 'department'
+        | 'designation'
+        | 'office_location'
+        | 'manager_employee_id'
+        | 'employee_type'
+    >
 }
 
 export const DEFAULT_SYNC_INTERVAL_SECONDS: Record<SourceType, number> = {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -190,9 +190,6 @@ export interface DarwinboxSourceConfig {
         write_acknowledged?: boolean
         participant_emails?: string[]
         allowed_actions?: string[]
-        target_employee_ids?: string[]
-        target_employee_emails?: string[]
-        target_departments?: string[]
         hr_admin_emails?: string[]
         recruiter_emails?: string[]
         allowed_report_ids?: string[]

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -190,8 +190,6 @@ export interface DarwinboxSourceConfig {
         write_acknowledged?: boolean
         participant_emails?: string[]
         allowed_actions?: string[]
-        hr_admin_emails?: string[]
-        recruiter_emails?: string[]
         allowed_report_ids?: string[]
         max_batch_size?: number
         max_requests_per_minute?: number

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
@@ -55,9 +55,6 @@ export const actions: Actions = {
         const form = await request.formData()
         const readOnly = form.has('read_only')
         const participants = csv(form.get('participant_emails'))
-        const targetIds = csv(form.get('target_employee_ids'))
-        const targetEmails = csv(form.get('target_employee_emails'))
-        const targetDepartments = csv(form.get('target_departments'))
         const allowedActions = readOnly ? READ_ACTIONS : [...READ_ACTIONS, ...WRITE_ACTIONS]
 
         const previous = source.config as DarwinboxSourceConfig
@@ -66,7 +63,7 @@ export const actions: Actions = {
             read_only: readOnly,
             employee_scope: {
                 mode: 'include',
-                employee_ids: targetIds,
+                employee_ids: [],
             },
             employee_fields: [
                 'name',
@@ -101,9 +98,7 @@ export const actions: Actions = {
                 actions_enabled: true,
                 write_acknowledged: form.has('write_acknowledged'),
                 participant_emails: participants,
-                target_employee_ids: targetIds,
-                target_employee_emails: targetEmails,
-                target_departments: targetDepartments,
+
                 allowed_actions: allowedActions,
                 hr_admin_emails: [],
                 recruiter_emails: [],

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
@@ -100,8 +100,6 @@ export const actions: Actions = {
                 participant_emails: participants,
 
                 allowed_actions: allowedActions,
-                hr_admin_emails: [],
-                recruiter_emails: [],
                 allowed_report_ids: [],
                 max_batch_size: 1,
             },

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
@@ -4,12 +4,37 @@ import { requireAdmin } from '$lib/server/authHelpers'
 import { getSourceById, updateSourceById } from '$lib/server/db/sources'
 import { SourceType, type DarwinboxSourceConfig } from '$lib/types'
 
-export const load: PageServerLoad = async ({ params, locals, fetch: serverFetch }) => {
+/** All known Darwinbox read action names. */
+const READ_ACTIONS: string[] = [
+    'find_employee',
+    'get_my_profile',
+    'get_my_leave_balance',
+    'get_my_leave_requests',
+    'get_my_attendance',
+    'get_my_timesheet',
+    'get_holiday_calendar',
+    'list_pending_leave_approvals',
+    'get_team_leave_calendar',
+    'get_team_attendance_exceptions',
+    'get_direct_report_profile',
+    'fetch_report_ids',
+    'run_report',
+]
+
+/** All known Darwinbox write action names. */
+const WRITE_ACTIONS: string[] = [
+    'apply_my_leave',
+    'revoke_my_leave',
+    'regularize_my_attendance',
+    'approve_leave_request',
+    'reject_leave_request',
+]
+
+export const load: PageServerLoad = async ({ params, locals }) => {
     requireAdmin(locals)
     const source = await getSourceById(params.sourceId)
     if (!source) throw error(404, 'Source not found')
     if (source.sourceType !== SourceType.DARWINBOX) throw error(400, 'Invalid source type')
-    const config = source.config as DarwinboxSourceConfig
     return { source }
 }
 
@@ -20,11 +45,6 @@ function csv(value: FormDataEntryValue | null): string[] {
         .filter(Boolean)
 }
 
-function positiveInteger(value: FormDataEntryValue | null, fallback: number): number {
-    const parsed = Number(value ?? fallback)
-    return Number.isInteger(parsed) ? parsed : Number.NaN
-}
-
 export const actions: Actions = {
     default: async ({ request, params, locals, fetch }) => {
         requireAdmin(locals)
@@ -33,38 +53,32 @@ export const actions: Actions = {
         if (source.sourceType !== SourceType.DARWINBOX) throw error(400, 'Invalid source type')
 
         const form = await request.formData()
-        const previous = source.config as DarwinboxSourceConfig
         const readOnly = form.has('read_only')
         const participants = csv(form.get('participant_emails'))
-        const allowedActions = csv(form.get('allowed_actions'))
-        const employeeIds = csv(form.get('employee_ids'))
-        const employeeEmails = csv(form.get('employee_emails'))
-        const departments = csv(form.get('departments'))
         const targetIds = csv(form.get('target_employee_ids'))
         const targetEmails = csv(form.get('target_employee_emails'))
         const targetDepartments = csv(form.get('target_departments'))
-        const employeeFields = csv(
-            form.get('employee_fields'),
-        ) as DarwinboxSourceConfig['employee_fields']
-        const employeeDirectory = form.has('employee_directory')
-        const selfService = form.has('employee_self_service')
-        const managerWorkflows = form.has('manager_workflows')
+        const allowedActions = readOnly ? READ_ACTIONS : [...READ_ACTIONS, ...WRITE_ACTIONS]
 
+        const previous = source.config as DarwinboxSourceConfig
         const candidate: DarwinboxSourceConfig = {
             ...previous,
             read_only: readOnly,
-            employee_scope: employeeDirectory
-                ? {
-                      mode: 'include',
-                      employee_ids: employeeIds,
-                      employee_emails: employeeEmails,
-                      departments,
-                  }
-                : null,
-            employee_fields: employeeDirectory ? employeeFields : [],
+            employee_scope: {
+                mode: 'include',
+                employee_ids: targetIds,
+            },
+            employee_fields: [
+                'name',
+                'employee_id',
+                'company_email',
+                'department',
+                'designation',
+                'office_location',
+            ],
             sync_modules: {
-                employee_directory: employeeDirectory,
-                deleted_employees: employeeDirectory,
+                employee_directory: true,
+                deleted_employees: true,
                 departments: false,
                 designations: false,
                 office_locations: false,
@@ -77,15 +91,14 @@ export const actions: Actions = {
                 ats_jobs: false,
             },
             action_modules: {
-                employee_self_service: selfService,
-                manager_workflows: managerWorkflows,
+                employee_self_service: true,
+                manager_workflows: true,
                 hr_operations: false,
                 ats: false,
-                reports: false,
+                reports: true,
             },
             authorization: {
-                ...previous.authorization,
-                actions_enabled: selfService || managerWorkflows,
+                actions_enabled: true,
                 write_acknowledged: form.has('write_acknowledged'),
                 participant_emails: participants,
                 target_employee_ids: targetIds,
@@ -95,12 +108,11 @@ export const actions: Actions = {
                 hr_admin_emails: [],
                 recruiter_emails: [],
                 allowed_report_ids: [],
-                max_batch_size: positiveInteger(form.get('max_batch_size'), 1),
-                max_requests_per_minute: positiveInteger(form.get('max_requests_per_minute'), 10),
+                max_batch_size: 1,
             },
         }
 
-        const previousPolicy = { ...previous, read_only: undefined }
+        const previousPolicy = { ...(source.config as DarwinboxSourceConfig), read_only: undefined }
         const nextPolicy = { ...candidate, read_only: undefined }
         const policyChanged = JSON.stringify(previousPolicy) !== JSON.stringify(nextPolicy)
         await updateSourceById(source.id, { config: candidate })

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.server.ts
@@ -1,0 +1,123 @@
+import { error, redirect } from '@sveltejs/kit'
+import type { Actions, PageServerLoad } from './$types'
+import { requireAdmin } from '$lib/server/authHelpers'
+import { getSourceById, updateSourceById } from '$lib/server/db/sources'
+import { SourceType, type DarwinboxSourceConfig } from '$lib/types'
+
+export const load: PageServerLoad = async ({ params, locals, fetch: serverFetch }) => {
+    requireAdmin(locals)
+    const source = await getSourceById(params.sourceId)
+    if (!source) throw error(404, 'Source not found')
+    if (source.sourceType !== SourceType.DARWINBOX) throw error(400, 'Invalid source type')
+    const config = source.config as DarwinboxSourceConfig
+    return { source }
+}
+
+function csv(value: FormDataEntryValue | null): string[] {
+    return String(value ?? '')
+        .split(',')
+        .map((item) => item.trim())
+        .filter(Boolean)
+}
+
+function positiveInteger(value: FormDataEntryValue | null, fallback: number): number {
+    const parsed = Number(value ?? fallback)
+    return Number.isInteger(parsed) ? parsed : Number.NaN
+}
+
+export const actions: Actions = {
+    default: async ({ request, params, locals, fetch }) => {
+        requireAdmin(locals)
+        const source = await getSourceById(params.sourceId)
+        if (!source) throw error(404, 'Source not found')
+        if (source.sourceType !== SourceType.DARWINBOX) throw error(400, 'Invalid source type')
+
+        const form = await request.formData()
+        const previous = source.config as DarwinboxSourceConfig
+        const readOnly = form.has('read_only')
+        const participants = csv(form.get('participant_emails'))
+        const allowedActions = csv(form.get('allowed_actions'))
+        const employeeIds = csv(form.get('employee_ids'))
+        const employeeEmails = csv(form.get('employee_emails'))
+        const departments = csv(form.get('departments'))
+        const targetIds = csv(form.get('target_employee_ids'))
+        const targetEmails = csv(form.get('target_employee_emails'))
+        const targetDepartments = csv(form.get('target_departments'))
+        const employeeFields = csv(
+            form.get('employee_fields'),
+        ) as DarwinboxSourceConfig['employee_fields']
+        const employeeDirectory = form.has('employee_directory')
+        const selfService = form.has('employee_self_service')
+        const managerWorkflows = form.has('manager_workflows')
+
+        const candidate: DarwinboxSourceConfig = {
+            ...previous,
+            read_only: readOnly,
+            employee_scope: employeeDirectory
+                ? {
+                      mode: 'include',
+                      employee_ids: employeeIds,
+                      employee_emails: employeeEmails,
+                      departments,
+                  }
+                : null,
+            employee_fields: employeeDirectory ? employeeFields : [],
+            sync_modules: {
+                employee_directory: employeeDirectory,
+                deleted_employees: employeeDirectory,
+                departments: false,
+                designations: false,
+                office_locations: false,
+                business_units: false,
+                divisions: false,
+                cost_centers: false,
+                group_companies: false,
+                positions: false,
+                holidays: false,
+                ats_jobs: false,
+            },
+            action_modules: {
+                employee_self_service: selfService,
+                manager_workflows: managerWorkflows,
+                hr_operations: false,
+                ats: false,
+                reports: false,
+            },
+            authorization: {
+                ...previous.authorization,
+                actions_enabled: selfService || managerWorkflows,
+                write_acknowledged: form.has('write_acknowledged'),
+                participant_emails: participants,
+                target_employee_ids: targetIds,
+                target_employee_emails: targetEmails,
+                target_departments: targetDepartments,
+                allowed_actions: allowedActions,
+                hr_admin_emails: [],
+                recruiter_emails: [],
+                allowed_report_ids: [],
+                max_batch_size: positiveInteger(form.get('max_batch_size'), 1),
+                max_requests_per_minute: positiveInteger(form.get('max_requests_per_minute'), 10),
+            },
+        }
+
+        const previousPolicy = { ...previous, read_only: undefined }
+        const nextPolicy = { ...candidate, read_only: undefined }
+        const policyChanged = JSON.stringify(previousPolicy) !== JSON.stringify(nextPolicy)
+        await updateSourceById(source.id, { config: candidate })
+
+        if (policyChanged && source.isActive) {
+            const response = await fetch(`/api/sources/${source.id}/sync`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ sync_mode: 'full' }),
+            })
+            if (!response.ok && response.status !== 409) {
+                throw error(
+                    response.status,
+                    'Configuration saved, but full reconciliation failed to start',
+                )
+            }
+        }
+        throw redirect(303, '/admin/settings/integrations')
+    },
+}

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
@@ -10,7 +10,6 @@
     let { data }: PageProps = $props()
     const config = data.source.config as DarwinboxSourceConfig
     const authorization = config.authorization ?? {}
-    const scope = config.employee_scope?.mode === 'include' ? config.employee_scope : null
     let readOnly = $state(config.read_only !== false)
     let writeAcknowledged = $state(Boolean(authorization.write_acknowledged))
     let isSubmitting = $state(false)
@@ -36,58 +35,8 @@
             <Card.Content class="space-y-4">
                 <label class="flex cursor-pointer items-center gap-2">
                     <input name="read_only" type="checkbox" bind:checked={readOnly} />
-                    <span>Read-only mode (blocks every Darwinbox mutation)</span>
+                    <span>Read-only mode (prevents all mutations)</span>
                 </label>
-                <label class="flex cursor-pointer items-center gap-2">
-                    <input
-                        name="employee_directory"
-                        type="checkbox"
-                        checked={Boolean(config.sync_modules?.employee_directory)} />
-                    <span>Index the scoped employee directory</span>
-                </label>
-                <div class="space-y-1">
-                    <Label for="employee-ids">Employee IDs to index</Label><Input
-                        id="employee-ids"
-                        name="employee_ids"
-                        value={(scope?.employee_ids ?? []).join(', ')} />
-                </div>
-                <div class="space-y-1">
-                    <Label for="employee-emails">Employee emails to index</Label><Input
-                        id="employee-emails"
-                        name="employee_emails"
-                        value={(scope?.employee_emails ?? []).join(', ')} />
-                </div>
-                <div class="space-y-1">
-                    <Label for="departments">Departments to index</Label><Input
-                        id="departments"
-                        name="departments"
-                        value={(scope?.departments ?? []).join(', ')} />
-                </div>
-                <div class="space-y-1">
-                    <Label for="employee-fields">Indexed employee fields</Label>
-                    <Input
-                        id="employee-fields"
-                        name="employee_fields"
-                        value={(config.employee_fields ?? []).join(', ')} />
-                    <p class="text-muted-foreground text-xs">
-                        Allowed: name, employee_id, company_email, department, designation,
-                        office_location, manager_employee_id, employee_type.
-                    </p>
-                </div>
-                <label class="flex cursor-pointer items-center gap-2"
-                    ><input
-                        name="employee_self_service"
-                        type="checkbox"
-                        checked={Boolean(config.action_modules?.employee_self_service)} /><span
-                        >Enable approved self-service actions</span
-                    ></label>
-                <label class="flex cursor-pointer items-center gap-2"
-                    ><input
-                        name="manager_workflows"
-                        type="checkbox"
-                        checked={Boolean(config.action_modules?.manager_workflows)} /><span
-                        >Enable approved manager actions</span
-                    ></label>
                 <div class="space-y-1">
                     <Label for="participants">Approved participant emails</Label><Input
                         id="participants"
@@ -112,37 +61,6 @@
                         name="target_departments"
                         value={(authorization.target_departments ?? []).join(', ')} />
                 </div>
-                <div class="space-y-1">
-                    <Label for="actions">Exact allowed action names</Label>
-                    <Input
-                        id="actions"
-                        name="allowed_actions"
-                        value={(authorization.allowed_actions ?? []).join(', ')} />
-                    <p class="text-muted-foreground text-xs">
-                        Only reviewed self-service and direct-manager actions are accepted by server
-                        validation.
-                    </p>
-                </div>
-                <div class="grid gap-4 md:grid-cols-2">
-                    <div class="space-y-1">
-                        <Label for="batch">Maximum targets per action</Label><Input
-                            id="batch"
-                            name="max_batch_size"
-                            type="number"
-                            min="1"
-                            max="20"
-                            value={authorization.max_batch_size ?? 1} />
-                    </div>
-                    <div class="space-y-1">
-                        <Label for="rate">Requests per minute</Label><Input
-                            id="rate"
-                            name="max_requests_per_minute"
-                            type="number"
-                            min="1"
-                            max="60"
-                            value={authorization.max_requests_per_minute ?? 10} />
-                    </div>
-                </div>
                 {#if !readOnly}
                     <label
                         class="flex cursor-pointer items-start gap-2 rounded border border-amber-300 p-3">
@@ -151,41 +69,15 @@
                             type="checkbox"
                             bind:checked={writeAcknowledged} />
                         <span
-                            >Allow explicitly confirmed writes only for the participants, targets,
-                            and actions above.</span>
+                            >Allow explicitly confirmed writes only for the participants and targets
+                            above.</span>
                     </label>
                 {/if}
-                <p class="text-muted-foreground text-sm">
-                    Organization masters, positions, holidays, ATS, reports, HR administration, bulk
-                    writes, and background writes remain unavailable until typed provider contracts
-                    are reviewed.
-                </p>
             </Card.Content>
             <Card.Footer class="justify-end"
                 ><Button type="submit" disabled={isSubmitting} class="cursor-pointer"
                     >Save configuration</Button
                 ></Card.Footer>
-        </Card.Root>
-        <Card.Root>
-            <Card.Header
-                ><Card.Title>Required Darwinbox endpoints</Card.Title><Card.Description
-                    >Ask Darwinbox to authorize only this endpoint set for the integration
-                    credential.</Card.Description
-                ></Card.Header>
-            <Card.Content class="grid gap-4 md:grid-cols-2">
-                <div>
-                    <div class="font-medium">Read</div>
-                    <ul class="text-muted-foreground list-inside list-disc text-sm">
-                        {#each data.endpoints.read as endpoint}<li>{endpoint}</li>{/each}
-                    </ul>
-                </div>
-                <div>
-                    <div class="font-medium">Write</div>
-                    <ul class="text-muted-foreground list-inside list-disc text-sm">
-                        {#each data.endpoints.write as endpoint}<li>{endpoint}</li>{/each}
-                    </ul>
-                </div>
-            </Card.Content>
         </Card.Root>
     </div>
 </form>

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
@@ -43,24 +43,7 @@
                         name="participant_emails"
                         value={(authorization.participant_emails ?? []).join(', ')} />
                 </div>
-                <div class="space-y-1">
-                    <Label for="target-ids">Approved target employee IDs</Label><Input
-                        id="target-ids"
-                        name="target_employee_ids"
-                        value={(authorization.target_employee_ids ?? []).join(', ')} />
-                </div>
-                <div class="space-y-1">
-                    <Label for="target-emails">Approved target employee emails</Label><Input
-                        id="target-emails"
-                        name="target_employee_emails"
-                        value={(authorization.target_employee_emails ?? []).join(', ')} />
-                </div>
-                <div class="space-y-1">
-                    <Label for="target-departments">Approved target departments</Label><Input
-                        id="target-departments"
-                        name="target_departments"
-                        value={(authorization.target_departments ?? []).join(', ')} />
-                </div>
+
                 {#if !readOnly}
                     <label
                         class="flex cursor-pointer items-start gap-2 rounded border border-amber-300 p-3">

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
@@ -1,0 +1,191 @@
+<script lang="ts">
+    import { enhance } from '$app/forms'
+    import { Button } from '$lib/components/ui/button'
+    import { Input } from '$lib/components/ui/input'
+    import { Label } from '$lib/components/ui/label'
+    import * as Card from '$lib/components/ui/card'
+    import type { DarwinboxSourceConfig } from '$lib/types'
+    import type { PageProps } from './$types'
+
+    let { data }: PageProps = $props()
+    const config = data.source.config as DarwinboxSourceConfig
+    const authorization = config.authorization ?? {}
+    const scope = config.employee_scope?.mode === 'include' ? config.employee_scope : null
+    let readOnly = $state(config.read_only !== false)
+    let writeAcknowledged = $state(Boolean(authorization.write_acknowledged))
+    let isSubmitting = $state(false)
+</script>
+
+<svelte:head><title>Configure Darwinbox - {data.source.name}</title></svelte:head>
+
+<form
+    method="POST"
+    use:enhance={() => {
+        isSubmitting = true
+        return async ({ update }) => {
+            await update()
+            isSubmitting = false
+        }
+    }}>
+    <div class="space-y-4">
+        <Card.Root>
+            <Card.Header>
+                <Card.Title>{data.source.name}</Card.Title>
+                <Card.Description>Manage the fail-closed production POC policy.</Card.Description>
+            </Card.Header>
+            <Card.Content class="space-y-4">
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input name="read_only" type="checkbox" bind:checked={readOnly} />
+                    <span>Read-only mode (blocks every Darwinbox mutation)</span>
+                </label>
+                <label class="flex cursor-pointer items-center gap-2">
+                    <input
+                        name="employee_directory"
+                        type="checkbox"
+                        checked={Boolean(config.sync_modules?.employee_directory)} />
+                    <span>Index the scoped employee directory</span>
+                </label>
+                <div class="space-y-1">
+                    <Label for="employee-ids">Employee IDs to index</Label><Input
+                        id="employee-ids"
+                        name="employee_ids"
+                        value={(scope?.employee_ids ?? []).join(', ')} />
+                </div>
+                <div class="space-y-1">
+                    <Label for="employee-emails">Employee emails to index</Label><Input
+                        id="employee-emails"
+                        name="employee_emails"
+                        value={(scope?.employee_emails ?? []).join(', ')} />
+                </div>
+                <div class="space-y-1">
+                    <Label for="departments">Departments to index</Label><Input
+                        id="departments"
+                        name="departments"
+                        value={(scope?.departments ?? []).join(', ')} />
+                </div>
+                <div class="space-y-1">
+                    <Label for="employee-fields">Indexed employee fields</Label>
+                    <Input
+                        id="employee-fields"
+                        name="employee_fields"
+                        value={(config.employee_fields ?? []).join(', ')} />
+                    <p class="text-muted-foreground text-xs">
+                        Allowed: name, employee_id, company_email, department, designation,
+                        office_location, manager_employee_id, employee_type.
+                    </p>
+                </div>
+                <label class="flex cursor-pointer items-center gap-2"
+                    ><input
+                        name="employee_self_service"
+                        type="checkbox"
+                        checked={Boolean(config.action_modules?.employee_self_service)} /><span
+                        >Enable approved self-service actions</span
+                    ></label>
+                <label class="flex cursor-pointer items-center gap-2"
+                    ><input
+                        name="manager_workflows"
+                        type="checkbox"
+                        checked={Boolean(config.action_modules?.manager_workflows)} /><span
+                        >Enable approved manager actions</span
+                    ></label>
+                <div class="space-y-1">
+                    <Label for="participants">Approved participant emails</Label><Input
+                        id="participants"
+                        name="participant_emails"
+                        value={(authorization.participant_emails ?? []).join(', ')} />
+                </div>
+                <div class="space-y-1">
+                    <Label for="target-ids">Approved target employee IDs</Label><Input
+                        id="target-ids"
+                        name="target_employee_ids"
+                        value={(authorization.target_employee_ids ?? []).join(', ')} />
+                </div>
+                <div class="space-y-1">
+                    <Label for="target-emails">Approved target employee emails</Label><Input
+                        id="target-emails"
+                        name="target_employee_emails"
+                        value={(authorization.target_employee_emails ?? []).join(', ')} />
+                </div>
+                <div class="space-y-1">
+                    <Label for="target-departments">Approved target departments</Label><Input
+                        id="target-departments"
+                        name="target_departments"
+                        value={(authorization.target_departments ?? []).join(', ')} />
+                </div>
+                <div class="space-y-1">
+                    <Label for="actions">Exact allowed action names</Label>
+                    <Input
+                        id="actions"
+                        name="allowed_actions"
+                        value={(authorization.allowed_actions ?? []).join(', ')} />
+                    <p class="text-muted-foreground text-xs">
+                        Only reviewed self-service and direct-manager actions are accepted by server
+                        validation.
+                    </p>
+                </div>
+                <div class="grid gap-4 md:grid-cols-2">
+                    <div class="space-y-1">
+                        <Label for="batch">Maximum targets per action</Label><Input
+                            id="batch"
+                            name="max_batch_size"
+                            type="number"
+                            min="1"
+                            max="20"
+                            value={authorization.max_batch_size ?? 1} />
+                    </div>
+                    <div class="space-y-1">
+                        <Label for="rate">Requests per minute</Label><Input
+                            id="rate"
+                            name="max_requests_per_minute"
+                            type="number"
+                            min="1"
+                            max="60"
+                            value={authorization.max_requests_per_minute ?? 10} />
+                    </div>
+                </div>
+                {#if !readOnly}
+                    <label
+                        class="flex cursor-pointer items-start gap-2 rounded border border-amber-300 p-3">
+                        <input
+                            name="write_acknowledged"
+                            type="checkbox"
+                            bind:checked={writeAcknowledged} />
+                        <span
+                            >Allow explicitly confirmed writes only for the participants, targets,
+                            and actions above.</span>
+                    </label>
+                {/if}
+                <p class="text-muted-foreground text-sm">
+                    Organization masters, positions, holidays, ATS, reports, HR administration, bulk
+                    writes, and background writes remain unavailable until typed provider contracts
+                    are reviewed.
+                </p>
+            </Card.Content>
+            <Card.Footer class="justify-end"
+                ><Button type="submit" disabled={isSubmitting} class="cursor-pointer"
+                    >Save configuration</Button
+                ></Card.Footer>
+        </Card.Root>
+        <Card.Root>
+            <Card.Header
+                ><Card.Title>Required Darwinbox endpoints</Card.Title><Card.Description
+                    >Ask Darwinbox to authorize only this endpoint set for the integration
+                    credential.</Card.Description
+                ></Card.Header>
+            <Card.Content class="grid gap-4 md:grid-cols-2">
+                <div>
+                    <div class="font-medium">Read</div>
+                    <ul class="text-muted-foreground list-inside list-disc text-sm">
+                        {#each data.endpoints.read as endpoint}<li>{endpoint}</li>{/each}
+                    </ul>
+                </div>
+                <div>
+                    <div class="font-medium">Write</div>
+                    <ul class="text-muted-foreground list-inside list-disc text-sm">
+                        {#each data.endpoints.write as endpoint}<li>{endpoint}</li>{/each}
+                    </ul>
+                </div>
+            </Card.Content>
+        </Card.Root>
+    </div>
+</form>

--- a/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/darwinbox/[sourceId]/+page.svelte
@@ -31,7 +31,7 @@
         <Card.Root>
             <Card.Header>
                 <Card.Title>{data.source.name}</Card.Title>
-                <Card.Description>Manage the fail-closed production POC policy.</Card.Description>
+                <Card.Description>Manage the fail-closed production policy.</Card.Description>
             </Card.Header>
             <Card.Content class="space-y-4">
                 <label class="flex cursor-pointer items-center gap-2">

--- a/web/src/routes/api/connectors/+server.ts
+++ b/web/src/routes/api/connectors/+server.ts
@@ -1,0 +1,28 @@
+import { json, error } from '@sveltejs/kit'
+import type { RequestHandler } from './$types'
+import { getConfig } from '$lib/server/config'
+import { logger } from '$lib/server/logger'
+
+export const GET: RequestHandler = async ({ locals, fetch: serverFetch }) => {
+    if (!locals.user) {
+        throw error(401, 'Unauthorized')
+    }
+
+    const config = getConfig()
+    const cmUrl = config.services.connectorManagerUrl
+    if (!cmUrl) {
+        throw error(502, 'Connector manager URL not configured')
+    }
+
+    try {
+        const response = await serverFetch(`${cmUrl}/connectors`)
+        if (!response.ok) {
+            throw error(response.status as 502, 'Failed to fetch connectors from manager')
+        }
+        const data = await response.json()
+        return json(data)
+    } catch (e) {
+        logger.error('Failed to proxy connectors request', e)
+        throw error(502, 'Connector manager unavailable')
+    }
+}

--- a/web/src/routes/api/sources/+server.ts
+++ b/web/src/routes/api/sources/+server.ts
@@ -7,6 +7,7 @@ import { ulid } from 'ulid'
 import { logger } from '$lib/server/logger'
 import { SourceType, DEFAULT_SYNC_INTERVAL_SECONDS } from '$lib/types'
 import { getSourcesByType } from '$lib/server/db/sources'
+import { env } from '$env/dynamic/private'
 
 export const GET: RequestHandler = async ({ locals }) => {
     if (!locals.user) {
@@ -49,12 +50,19 @@ export const GET: RequestHandler = async ({ locals }) => {
 
     const sanitizedSources = allSources.map((source) => {
         const latestSync = syncRunMap.get(source.id)
+        let sourceConfig = source.config
+        if (locals.user?.role !== 'admin' && source.sourceType === SourceType.DARWINBOX) {
+            const config = structuredClone((source.config ?? {}) as Record<string, unknown>)
+            delete config.authorization
+            delete config.employee_scope
+            sourceConfig = config
+        }
         return {
             id: source.id,
             name: source.name,
             sourceType: source.sourceType,
             scope: source.scope,
-            config: source.config,
+            config: sourceConfig,
             syncStatus: latestSync?.status ?? null,
             isActive: source.isActive,
             lastSyncAt: latestSync?.completedAt ?? null,
@@ -87,7 +95,6 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     if (scope === 'org' && locals.user.role !== 'admin') {
         throw error(403, 'Only admins can create org-wide sources')
     }
-
     const sourcesOfType = await getSourcesByType(sourceType)
 
     if (scope === 'user') {
@@ -112,7 +119,7 @@ export const POST: RequestHandler = async ({ request, locals }) => {
             name,
             sourceType,
             scope,
-            config: config || {},
+            config: validatedConfig || {},
             createdBy: locals.user.id,
             isActive: isActive ?? false,
             syncIntervalSeconds: DEFAULT_SYNC_INTERVAL_SECONDS[sourceType as SourceType],


### PR DESCRIPTION
- Rewrite Darwinbox connector with fail-closed sync, typed employee field allowlists, scope controls, non-public ACLs, and read-only mode
- Add action inventory with per-action audience enforcement (self/manager/hr_admin/recruiter), module gating, participant/action allowlists, and sensitive-field response sanitization
- Add write-approval enforcement requiring interactive user approval for all mutations
- Add Darwinbox source configuration UI driven from connector manifest
- Add trusted source/actor-email transport across Rust, Python, and TypeScript SDKs
- Restructure Python SDK MCP dispatch into server layer matching Rust architecture
- Add proper Source model to Python and TypeScript SDKs
- Remove scaffolding eliminated during review (Redis rate-limiter, ActionActor, ActionContext, approval_id, internal service token, security_version)