### PR TITLE
feat(web): optional Spider Cloud crawling via SPIDER_CLOUD_API_KEY

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -170,6 +170,21 @@ GOOGLE_MAX_AGE_DAYS=712 # Documents older than this will not be indexed
 # Web Connector Configuration
 WEB_SYNC_INTERVAL_SECONDS=86400  # Daily recrawl (24 hours)
 
+# Optional: Spider Cloud (https://spider.cloud) for higher crawl success rates.
+# Sites behind Cloudflare, a WAF, or IP/geo blocking return 403/429/503 to a
+# direct fetch and are dropped from the index. Spider Cloud routes crawls
+# through rotating proxies and anti-bot bypass instead.
+# Leave SPIDER_CLOUD_API_KEY unset to keep the current direct-fetch behavior.
+# SPIDER_CLOUD_API_KEY=sk-...
+# Mode: smart (default) | proxy | unblocker | api | fallback
+#   smart     - proxy everything, auto-escalate to the unblocker on bot walls
+#   proxy     - proxy transport only, cheapest
+#   unblocker - always use the unblocker API
+#   api       - fetch each page through the crawl API
+#   fallback  - direct fetch first, cloud only after a failure
+# SPIDER_CLOUD_MODE=smart
+# SPIDER_CLOUD_API_URL=https://api.spider.cloud
+
 # Log level for all rust services
 RUST_LOG=info
 RUST_BACKTRACE=

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1416,7 +1416,7 @@ dependencies = [
  "rust-ini",
  "serde",
  "serde_json",
- "toml 0.8.23",
+ "toml",
  "yaml-rust2",
 ]
 
@@ -2267,7 +2267,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2812,6 +2812,8 @@ dependencies = [
  "allocator-api2",
  "equivalent",
  "foldhash 0.2.0",
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -3214,7 +3216,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "system-configuration 0.7.0",
  "tokio",
  "tower-service",
@@ -4238,7 +4240,7 @@ version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -4432,7 +4434,7 @@ dependencies = [
  "tar",
  "tempfile",
  "tokio",
- "toml 0.8.23",
+ "toml",
  "tracing",
  "tracing-subscriber",
 ]
@@ -5629,8 +5631,6 @@ checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "encoding_rs",
  "memchr",
- "serde",
- "tokio",
 ]
 
 [[package]]
@@ -5641,6 +5641,17 @@ checksum = "2474bd2e5029e7ccb6abb2ba48cf2383a333851dedf495901544281590c7da7f"
 dependencies = [
  "memchr",
  "serde",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
+ "serde",
+ "tokio",
 ]
 
 [[package]]
@@ -5656,7 +5667,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -5694,9 +5705,9 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.4",
+ "socket2 0.5.10",
  "tracing",
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6265,7 +6276,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6355,7 +6366,7 @@ dependencies = [
  "security-framework 3.7.0",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6656,6 +6667,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_regex"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bafc8d0c5330cecff10f16b459b479fd9acaa5b4acd7167301414e21b0057012"
+dependencies = [
+ "regex",
+ "serde",
+]
+
+[[package]]
 name = "serde_repr"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6673,15 +6694,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "serde_spanned"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -7022,9 +7034,9 @@ dependencies = [
 
 [[package]]
 name = "spider"
-version = "2.52.0"
+version = "2.52.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2608d8bc4c1e26786a3c57ff6ba632a757c3e8dde4f96ca5765ec1b1a8aa8697"
+checksum = "9c79c3f26013e3dbe4d05c2397d23aacae2f334c10894c2973f3bf7442fdedc2"
 dependencies = [
  "ahash",
  "aho-corasick",
@@ -7049,10 +7061,13 @@ dependencies = [
  "percent-encoding",
  "phf 0.13.1",
  "pin-project-lite",
- "quick-xml 0.39.4",
+ "quick-xml 0.41.0",
  "rand 0.9.4",
  "regex",
  "reqwest 0.13.4",
+ "serde",
+ "serde_json",
+ "serde_regex",
  "simdutf8",
  "sitemap",
  "smallvec",
@@ -7074,9 +7089,9 @@ dependencies = [
 
 [[package]]
 name = "spider_agent_types"
-version = "2.51.208"
+version = "2.52.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1497a0bc8589093df58051adf0c2642c3eef02f87495de686c7a3d75829d4290"
+checksum = "2c6f221fd48d09bf7a586ef467c547daad64cbbc002fc82d3b5f8692c05279c4"
 dependencies = [
  "aho-corasick",
  "llm_models_spider",
@@ -7667,7 +7682,7 @@ dependencies = [
  "getrandom 0.4.2",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -7954,24 +7969,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_edit",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.14.0",
- "serde_core",
- "serde_spanned 1.1.1",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.15",
 ]
 
 [[package]]
@@ -7984,15 +7984,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8000,19 +7991,10 @@ checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
 dependencies = [
  "indexmap 2.14.0",
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
+ "serde_spanned",
+ "toml_datetime",
  "toml_write",
- "winnow 0.7.15",
-]
-
-[[package]]
-name = "toml_parser"
-version = "1.1.2+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
-dependencies = [
- "winnow 1.0.3",
+ "winnow",
 ]
 
 [[package]]
@@ -8020,12 +8002,6 @@ name = "toml_write"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.1.1+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
 
 [[package]]
 name = "tower"
@@ -8260,7 +8236,7 @@ dependencies = [
  "fastrand",
  "serde",
  "serde_json",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
  "ureq",
 ]
 
@@ -8726,7 +8702,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -8876,15 +8852,6 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
-]
-
-[[package]]
-name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -8916,28 +8883,11 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
+ "windows_i686_gnullvm",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -8962,12 +8912,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8978,12 +8922,6 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -8998,22 +8936,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -9028,12 +8954,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9044,12 +8964,6 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -9064,12 +8978,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9082,12 +8990,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9095,12 +8997,6 @@ checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
-
-[[package]]
-name = "winnow"
-version = "1.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "winreg"

--- a/connectors/web/Cargo.toml
+++ b/connectors/web/Cargo.toml
@@ -24,7 +24,7 @@ tokio = { workspace = true, features = ["full"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true, features = ["env-filter"] }
 uuid = { workspace = true, features = ["v4", "serde"] }
-spider = { version = "2", default-features = false, features = ["basic", "sitemap", "headers"] }
+spider = { version = "2", default-features = false, features = ["basic", "sitemap", "headers", "spider_cloud"] }
 scraper = "0.21"
 sha2 = "0.10"
 url = "2.5"

--- a/connectors/web/README.md
+++ b/connectors/web/README.md
@@ -1,0 +1,62 @@
+# Web Connector
+
+Crawls a website into Omni using [spider](https://github.com/spider-rs/spider).
+
+Enabled with the `web` Docker Compose profile. Configuration is managed through the Omni admin UI at `/admin/settings/integrations`.
+
+## Features
+
+- Depth-limited crawl with subdomain and robots.txt controls
+- Blacklist patterns to skip sections of a site
+- Content-hash change detection and automatic deletion detection
+- Optional [Spider Cloud](https://spider.cloud) crawling for sites behind bot protection
+
+## Source Configuration
+
+| Field | Default | Description |
+|---|---|---|
+| `root_url` | *required* | URL to start crawling from |
+| `max_depth` | `10` | Max link depth |
+| `max_pages` | `10000` | Max pages to crawl |
+| `respect_robots_txt` | `true` | Honor robots.txt |
+| `user_agent` | — | Custom user agent |
+| `blacklist_patterns` | `[]` | URL patterns to skip |
+| `include_subdomains` | `false` | Follow links to subdomains |
+
+## Environment Variables
+
+| Variable | Default | Description |
+|---|---|---|
+| `WEB_CONNECTOR_PORT` | `4004` | Port exposed by the connector |
+| `WEB_SYNC_INTERVAL_SECONDS` | `86400` | Recrawl interval |
+| `RUST_LOG` | — | Log level (e.g. `debug`, `info`) |
+
+## Spider Cloud (optional)
+
+Sites behind Cloudflare, a WAF, or IP/geo blocking answer a direct fetch with
+403/429/503. Those pages are dropped and never make it into the index.
+[Spider Cloud](https://spider.cloud) routes the crawl through rotating proxies
+and anti-bot bypass instead, which recovers them.
+
+To enable it, set an API key on the web connector:
+
+```bash
+SPIDER_CLOUD_API_KEY=sk-...
+```
+
+That is the whole setup — every web source then crawls through Spider Cloud.
+**Leave `SPIDER_CLOUD_API_KEY` unset and nothing changes**; the connector uses
+the same direct-fetch path it does today.
+
+| Variable | Default | Description |
+|---|---|---|
+| `SPIDER_CLOUD_API_KEY` | — | API key. Unset disables the integration entirely. |
+| `SPIDER_CLOUD_MODE` | `smart` | `smart` \| `proxy` \| `unblocker` \| `api` \| `fallback` |
+| `SPIDER_CLOUD_API_URL` | `https://api.spider.cloud` | Override the API base URL |
+
+`smart` proxies every request and automatically escalates to the unblocker API
+when it detects bot protection (403/429/503, Cloudflare challenges, CAPTCHA
+pages), which gives the highest success rate. `proxy` is proxy transport only.
+`fallback` fetches directly first and only reaches for the cloud after a
+failure, which is the most cost-conscious option. An unrecognized value falls
+back to `smart`.

--- a/connectors/web/src/config.rs
+++ b/connectors/web/src/config.rs
@@ -1,5 +1,6 @@
 use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
+use spider::configuration::{SpiderCloudConfig, SpiderCloudMode};
 use spider::website::Website;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -31,6 +32,58 @@ fn default_respect_robots() -> bool {
     true
 }
 
+/// Parse a `SPIDER_CLOUD_MODE` value.
+///
+/// Defaults to [`SpiderCloudMode::Smart`] for anything unrecognized so a typo
+/// degrades to the most reliable mode instead of failing a sync. `Smart`
+/// proxies every request and automatically escalates to the unblocker API when
+/// bot protection is detected.
+fn parse_spider_cloud_mode(mode: &str) -> SpiderCloudMode {
+    match mode.trim().to_ascii_lowercase().as_str() {
+        "proxy" => SpiderCloudMode::Proxy,
+        "api" => SpiderCloudMode::Api,
+        "unblocker" => SpiderCloudMode::Unblocker,
+        "fallback" => SpiderCloudMode::Fallback,
+        _ => SpiderCloudMode::Smart,
+    }
+}
+
+/// Process-wide Spider Cloud config, resolved from the environment exactly once.
+///
+/// The environment is fixed at startup (`dotenv` runs in `main`), so this is
+/// read on the first crawl and reused afterwards — no per-crawl `env::var`
+/// lock and allocation.
+static SPIDER_CLOUD: std::sync::OnceLock<Option<SpiderCloudConfig>> = std::sync::OnceLock::new();
+
+/// Resolved Spider Cloud config, or `None` when the integration is not enabled.
+fn spider_cloud() -> Option<&'static SpiderCloudConfig> {
+    SPIDER_CLOUD.get_or_init(spider_cloud_from_env).as_ref()
+}
+
+/// Build a [`SpiderCloudConfig`] from the environment.
+///
+/// Returns `None` unless `SPIDER_CLOUD_API_KEY` is set to a non-empty value,
+/// which keeps crawling on the existing direct-fetch path by default.
+fn spider_cloud_from_env() -> Option<SpiderCloudConfig> {
+    let api_key = std::env::var("SPIDER_CLOUD_API_KEY").ok()?;
+    let api_key = api_key.trim();
+
+    if api_key.is_empty() {
+        return None;
+    }
+
+    let mode = std::env::var("SPIDER_CLOUD_MODE").unwrap_or_default();
+    let mut cloud = SpiderCloudConfig::new(api_key).with_mode(parse_spider_cloud_mode(&mode));
+
+    if let Ok(api_url) = std::env::var("SPIDER_CLOUD_API_URL") {
+        if !api_url.trim().is_empty() {
+            cloud = cloud.with_api_url(api_url.trim());
+        }
+    }
+
+    Some(cloud)
+}
+
 impl WebSourceConfig {
     pub fn from_json(config: &serde_json::Value) -> Result<Self> {
         serde_json::from_value(config.clone()).context("Failed to parse web source configuration")
@@ -53,6 +106,17 @@ impl WebSourceConfig {
             for pattern in &self.blacklist_patterns {
                 website.with_blacklist_url(Some(vec![pattern.as_str().into()]));
             }
+        }
+
+        // Opt-in only: without SPIDER_CLOUD_API_KEY this is a no-op and the
+        // crawl uses the same direct-fetch path as before.
+        if let Some(cloud) = spider_cloud() {
+            tracing::info!(
+                "Spider Cloud enabled ({:?}) for {}",
+                cloud.mode,
+                self.root_url
+            );
+            website.with_spider_cloud_config(cloud.clone());
         }
 
         Ok(website)
@@ -114,5 +178,25 @@ mod tests {
 
         let website = config.build_spider_website();
         assert!(website.is_ok());
+    }
+
+    #[test]
+    fn test_parse_spider_cloud_mode() {
+        assert_eq!(parse_spider_cloud_mode("proxy"), SpiderCloudMode::Proxy);
+        assert_eq!(parse_spider_cloud_mode("api"), SpiderCloudMode::Api);
+        assert_eq!(
+            parse_spider_cloud_mode("unblocker"),
+            SpiderCloudMode::Unblocker
+        );
+        assert_eq!(
+            parse_spider_cloud_mode("fallback"),
+            SpiderCloudMode::Fallback
+        );
+        assert_eq!(parse_spider_cloud_mode("smart"), SpiderCloudMode::Smart);
+        assert_eq!(parse_spider_cloud_mode(" SMART "), SpiderCloudMode::Smart);
+
+        // Unrecognized values degrade to the most reliable mode.
+        assert_eq!(parse_spider_cloud_mode(""), SpiderCloudMode::Smart);
+        assert_eq!(parse_spider_cloud_mode("nonsense"), SpiderCloudMode::Smart);
     }
 }


### PR DESCRIPTION
## Problem

The web connector crawls with a plain direct fetch. Sites behind Cloudflare, a WAF, or IP/geo blocking answer that fetch with 403/429/503, and [`sync.rs`](https://github.com/getomnico/omni/blob/main/connectors/web/src/sync.rs#L45) drops anything that isn't `200 OK` — so those pages silently never reach the index, with no signal that a source is only partially crawled.

## Change

Setting `SPIDER_CLOUD_API_KEY` routes crawls through [Spider Cloud](https://spider.cloud) (proxy rotation + anti-bot bypass) instead. `spider` already ships first-class support for this behind its `spider_cloud` feature, so the wiring is small.

```bash
SPIDER_CLOUD_API_KEY=sk-...      # the entire setup
SPIDER_CLOUD_MODE=smart          # optional: smart (default) | proxy | unblocker | api | fallback
SPIDER_CLOUD_API_URL=...         # optional
```

`smart` is the default: it proxies every request and automatically escalates to the unblocker API when it detects bot protection (403/429/503, Cloudflare challenges, CAPTCHA pages). An unrecognized `SPIDER_CLOUD_MODE` degrades to `smart` rather than failing a sync.

## No behavior change when unset

This is strictly opt-in, and deliberately kept that way:

- With no key, `with_spider_cloud_config` is never called, so `configuration.spider_cloud` stays `None` and every spider-side cloud branch takes the existing direct-fetch arm.
- `spider_cloud = ["serde", "reqwest_json"]` — serialization only. No Chrome, no headless browser, no new system dependencies.
- No config-schema, DB, SDK, API, or admin-UI changes. Existing stored source configs deserialize identically.
- Return format is left at `raw`. This matters: `WebPage::from_html` parses with `scraper` and `sync.rs` stores `raw_html` as `text/html`, so requesting markdown would corrupt title/description extraction and every `content_hash`, forcing a full re-index.
- The env lookup resolves once into a `OnceLock` rather than on every crawl.

## Verification

Crawled `books.toscrape.com` through `build_spider_website` in three configurations:

| Configuration | Result |
|---|---|
| No key set | 2 pages, raw HTML, titles intact — unchanged from today |
| Valid key, `smart` | 2 pages, raw HTML, titles intact |
| Invalid key, `proxy` | 0 pages — confirms the proxy is genuinely in the request path, not silently bypassed |

`cargo test -p omni-web-connector --lib` passes (11 tests, including new mode-parsing coverage) with the cloud env vars explicitly cleared. `cargo clippy` and `cargo fmt --check` are clean.

`Cargo.lock` also picks up `spider` 2.52.0 → 2.52.12, which is a net dependency reduction (drops a `toml` + `windows-sys` chain).

## Unrelated observation

`WebSourceConfig.max_pages` is parsed but never applied — `build_spider_website` never calls `.with_limit(...)`, so the configured limit is currently ignored. Left alone here to keep this diff focused; happy to open a separate issue or PR.
