### PR TITLE
fix(ai): remove sampling params and use DB as source of truth for model resolution

### DIFF
--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -50,6 +50,7 @@ from db.users import UsersRepository
 from memory import MemoryMode, agent_key, resolve_memory_mode
 from prompts import build_agent_system_prompt
 from providers import LLMProvider, ProviderError
+from provider_cache import ResolvedModel
 from services.compaction import ConversationCompactor
 from services.usage import UsageContext, UsagePurpose, UsageTracker, track_usage
 from state import AppState
@@ -110,17 +111,16 @@ AgentContentBlock = (
 )
 
 
-def _resolve_llm_provider(state: AppState, agent: Agent) -> LLMProvider:
-    """Resolve which LLM provider to use for an agent."""
-    models = state.models
-    if not models:
-        raise RuntimeError("No models configured")
-
-    if agent.model_id and agent.model_id in models:
-        return models[agent.model_id]
-    if state.default_model_id and state.default_model_id in models:
-        return models[state.default_model_id]
-    return next(iter(models.values()))
+async def _resolve_llm_provider(state: AppState, agent: Agent) -> ResolvedModel:
+    """Resolve which LLM provider to use for an agent from the database."""
+    if not agent.model_id:
+        raise RuntimeError("Agent has no model configured")
+    resolved = await state.provider_cache.resolve_for_model(agent.model_id)
+    if resolved is None:
+        raise RuntimeError(
+            f"Agent model {agent.model_id} is no longer available"
+        )
+    return resolved
 
 
 async def _fetch_sources() -> list[Source] | None:
@@ -459,7 +459,10 @@ async def _run_agent_loop(
 
     logger.info("Agent %s run %s: initializing", agent.id, run.id)
 
-    llm_provider = _resolve_llm_provider(app_state, agent)
+    resolved_model = await _resolve_llm_provider(app_state, agent)
+    llm_provider = resolved_model.provider
+    llm_model_record_id = resolved_model.model_record_id
+    llm_model_name = resolved_model.model_name
     sources = await _fetch_sources()
 
     # Each agent run starts with no connector tools loaded — discovery is per-run.
@@ -538,21 +541,26 @@ async def _run_agent_loop(
     )
 
     # Compaction support — use secondary model for summarization when available
-    secondary_provider = llm_provider
-    if (
-        app_state.secondary_model_id
-        and app_state.secondary_model_id in app_state.models
-    ):
-        secondary_provider = app_state.models[app_state.secondary_model_id]
+    secondary_resolved = await app_state.provider_cache.resolve_secondary_or_default()
+    if secondary_resolved is not None:
+        secondary_provider = secondary_resolved.provider
+        secondary_model_record_id = secondary_resolved.model_record_id
+        secondary_model_name = secondary_resolved.model_name
+    else:
+        secondary_provider = llm_provider
+        secondary_model_record_id = llm_model_record_id
+        secondary_model_name = llm_model_name
+
+    secondary_model_provider_type = secondary_provider.provider_type
 
     def _on_compaction_usage(usage):
         track_usage(
             UsageRepository(),
             UsageContext(
                 user_id=agent.user_id if not is_org_agent else None,
-                model_id=secondary_provider.model_record_id,
-                model_name=secondary_provider.model_name,
-                provider_type=secondary_provider.provider_type,
+                model_id=secondary_model_record_id,
+                model_name=secondary_model_name,
+                provider_type=secondary_model_provider_type,
                 purpose=UsagePurpose.COMPACTION,
                 agent_run_id=run.id,
             ),
@@ -564,6 +572,7 @@ async def _run_agent_loop(
 
     compactor = ConversationCompactor(
         llm_provider=secondary_provider,
+        model_name=secondary_model_name,
         on_usage=_on_compaction_usage,
     )
     compactions_repo = CompactionsRepository()
@@ -615,8 +624,8 @@ async def _run_agent_loop(
                 usage_repo,
                 UsageContext(
                     user_id=agent.user_id if not is_org_agent else None,
-                    model_id=llm_provider.model_record_id,
-                    model_name=llm_provider.model_name,
+                    model_id=llm_model_record_id,
+                    model_name=llm_model_name,
                     provider_type=llm_provider.provider_type,
                     purpose=UsagePurpose.AGENT_RUN,
                     agent_run_id=run.id,
@@ -629,6 +638,7 @@ async def _run_agent_loop(
                 tools=turn_tools,
                 max_tokens=DEFAULT_MAX_TOKENS,
                 system_prompt=system_prompt,
+                model=llm_model_name,
             )
 
             try:
@@ -774,8 +784,8 @@ async def _run_agent_loop(
         UsageRepository(),
         UsageContext(
             user_id=agent.user_id if not is_org_agent else None,
-            model_id=llm_provider.model_record_id,
-            model_name=llm_provider.model_name,
+            model_id=llm_model_record_id,
+            model_name=llm_model_name,
             provider_type=llm_provider.provider_type,
             purpose=UsagePurpose.AGENT_SUMMARY,
             agent_run_id=run.id,
@@ -787,6 +797,7 @@ async def _run_agent_loop(
         tools=[],
         max_tokens=500,
         system_prompt=system_prompt,
+        model=llm_model_name,
     )
     async for event in summary_tracker.wrap_stream(raw_summary_stream):
         if event.type == "content_block_start" and event.content_block.type == "text":

--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -39,8 +39,6 @@ from config import (
     AGENT_RUN_MAX_ATTEMPTS,
     CONNECTOR_MANAGER_URL,
     DEFAULT_MAX_TOKENS,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_TOP_P,
     SANDBOX_URL,
 )
 from db import CompactionsRepository, SkillsRepository
@@ -630,8 +628,6 @@ async def _run_agent_loop(
                 messages=conversation_messages,
                 tools=turn_tools,
                 max_tokens=DEFAULT_MAX_TOKENS,
-                temperature=DEFAULT_TEMPERATURE,
-                top_p=DEFAULT_TOP_P,
                 system_prompt=system_prompt,
             )
 
@@ -790,7 +786,6 @@ async def _run_agent_loop(
         messages=conversation_messages,
         tools=[],
         max_tokens=500,
-        temperature=0.3,
         system_prompt=system_prompt,
     )
     async for event in summary_tracker.wrap_stream(raw_summary_stream):

--- a/services/ai/config.py
+++ b/services/ai/config.py
@@ -58,8 +58,6 @@ DATABASE_URL = (
 EMBEDDING_MAX_MODEL_LEN = int(get_optional_env("EMBEDDING_MAX_MODEL_LEN", "8192"))
 
 DEFAULT_MAX_TOKENS = int(get_optional_env("DEFAULT_MAX_TOKENS", "8192"))
-DEFAULT_TEMPERATURE = float(get_optional_env("DEFAULT_TEMPERATURE", "0.0"))
-DEFAULT_TOP_P = float(get_optional_env("DEFAULT_TOP_P", "1.0"))
 
 # AWS configuration (used by online Bedrock embedding/LLM providers)
 AWS_REGION = get_optional_env("AWS_REGION", "")  # Optional, auto-detected in ECS

--- a/services/ai/db/model_providers.py
+++ b/services/ai/db/model_providers.py
@@ -89,7 +89,7 @@ class ModelsRepository:
         query = """
             SELECT m.id, m.model_provider_id, m.model_id, m.display_name,
                    m.is_default, m.is_secondary, m.is_deleted, m.created_at, m.updated_at,
-                   mp.provider_type, mp.config
+                   mp.provider_type, mp.config, mp.updated_at AS provider_updated_at
             FROM models m
             JOIN model_providers mp ON m.model_provider_id = mp.id
             WHERE m.is_deleted = FALSE AND mp.is_deleted = FALSE
@@ -104,7 +104,7 @@ class ModelsRepository:
         query = """
             SELECT m.id, m.model_provider_id, m.model_id, m.display_name,
                    m.is_default, m.is_secondary, m.is_deleted, m.created_at, m.updated_at,
-                   mp.provider_type, mp.config
+                   mp.provider_type, mp.config, mp.updated_at AS provider_updated_at
             FROM models m
             JOIN model_providers mp ON m.model_provider_id = mp.id
             WHERE m.id = $1
@@ -120,10 +120,27 @@ class ModelsRepository:
         query = """
             SELECT m.id, m.model_provider_id, m.model_id, m.display_name,
                    m.is_default, m.is_secondary, m.is_deleted, m.created_at, m.updated_at,
-                   mp.provider_type, mp.config
+                   mp.provider_type, mp.config, mp.updated_at AS provider_updated_at
             FROM models m
             JOIN model_providers mp ON m.model_provider_id = mp.id
             WHERE m.is_default = TRUE AND m.is_deleted = FALSE AND mp.is_deleted = FALSE
+            LIMIT 1
+        """
+        async with pool.acquire() as conn:
+            row = await conn.fetchrow(query)
+        if row:
+            return ModelRecord.from_row(dict(row))
+        return None
+
+    async def get_secondary(self) -> Optional[ModelRecord]:
+        pool = await self._get_pool()
+        query = """
+            SELECT m.id, m.model_provider_id, m.model_id, m.display_name,
+                   m.is_default, m.is_secondary, m.is_deleted, m.created_at, m.updated_at,
+                   mp.provider_type, mp.config, mp.updated_at AS provider_updated_at
+            FROM models m
+            JOIN model_providers mp ON m.model_provider_id = mp.id
+            WHERE m.is_secondary = TRUE AND m.is_deleted = FALSE AND mp.is_deleted = FALSE
             LIMIT 1
         """
         async with pool.acquire() as conn:

--- a/services/ai/db/models.py
+++ b/services/ai/db/models.py
@@ -384,6 +384,7 @@ class ModelRecord:
     config: dict
     created_at: datetime
     updated_at: datetime
+    provider_updated_at: datetime | None = None
 
     @classmethod
     def from_row(cls, row: dict) -> "ModelRecord":
@@ -403,6 +404,7 @@ class ModelRecord:
             config=config,
             created_at=row["created_at"],
             updated_at=row["updated_at"],
+            provider_updated_at=row.get("provider_updated_at"),
         )
 
 

--- a/services/ai/memory/providers/mem0/bootstrap.py
+++ b/services/ai/memory/providers/mem0/bootstrap.py
@@ -156,16 +156,20 @@ async def build_mem0_config(
     history_db_path: str,
 ) -> MemoryConfig:
     """Assemble mem0's `MemoryConfig` from in-process AI-service state."""
-    if not app_state.models:
-        raise MemoryConfigError("No LLM models configured")
+    cache = app_state.provider_cache
 
     config_repo = ConfigurationRepository()
     memory_cfg = await config_repo.get_global("memory_llm_id")
     memory_llm_id = memory_cfg.get("value") if memory_cfg else None
 
-    llm_provider = _pick_memory_llm(
-        app_state.models, memory_llm_id, app_state.default_model_id
-    )
+    resolved = None
+    if memory_llm_id is not None:
+        resolved = await cache.resolve_for_model(memory_llm_id)
+    if resolved is None:
+        resolved = await cache.resolve_default()
+    if resolved is None:
+        raise MemoryConfigError("No LLM models configured")
+    llm_provider = resolved.provider
 
     embed_cfg = await get_embedding_config()
     if embed_cfg is None:

--- a/services/ai/provider_cache.py
+++ b/services/ai/provider_cache.py
@@ -1,0 +1,243 @@
+"""DB-backed provider resolution with cached SDK clients.
+
+Replaces the old in-memory ``app_state.models`` dict that could silently
+drift from the database.  On every request we read the model record (and
+its provider row) from the DB.  The SDK client instance (httpx connection
+pool) is cached by ``model_provider_id`` and reused across requests.
+
+Staleness: the cached entry stores the provider row's ``updated_at``
+timestamp.  If the DB row is newer (admin edited config / rotated key),
+the cached client is discarded and rebuilt automatically.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from providers import LLMProvider, ProviderType
+from providers.types import ProviderError
+from db.model_providers import ModelsRepository, ModelRecord
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ResolvedModel:
+    """Result of resolving a model record to a provider client.
+
+    ``provider`` — the cached SDK client (connection pool), shared across
+    all model records under the same provider config.
+    ``model_record_id`` — the ``models.id`` to use in usage tracking.
+    ``model_name`` — the wire model string (e.g. ``"claude-haiku-4-5"``)
+    to pass into ``stream_response(…, model=…)``.
+    """
+
+    provider: LLMProvider
+    model_record_id: str
+    model_name: str
+
+
+@dataclass
+class _CachedEntry:
+    provider: LLMProvider
+    provider_updated_at: datetime | None
+
+
+class ProviderCache:
+    """Cache of LLMProvider SDK clients, keyed by ``model_provider_id``.
+
+    The database is the source of truth for *which models exist* and *which*
+    model to use.  This cache only prevents re-building the httpx connection
+    pool on every request.
+    """
+
+    def __init__(self) -> None:
+        self._cache: dict[str, _CachedEntry] = {}
+        self._lock = asyncio.Lock()
+
+    def _cache_key(self, record: ModelRecord) -> str:
+        return record.model_provider_id
+
+    async def resolve_for_model(self, model_record_id: str) -> ResolvedModel | None:
+        """Resolve a model record id to a ``ResolvedModel``.
+
+        Returns ``None`` when the model record is missing or its provider
+        has been deleted (caller should fail loud).
+        """
+        repo = ModelsRepository()
+        record = await repo.get(model_record_id)
+        if record is None or record.is_deleted:
+            return None
+        provider = await self._get_or_build(record)
+        if provider is None:
+            return None
+        return ResolvedModel(
+            provider=provider,
+            model_record_id=record.id,
+            model_name=record.model_id,
+        )
+
+    async def resolve_default(self) -> ResolvedModel | None:
+        """Resolve the default (is_default=True) model."""
+        repo = ModelsRepository()
+        record = await repo.get_default()
+        if record is None:
+            return None
+        provider = await self._get_or_build(record)
+        if provider is None:
+            return None
+        return ResolvedModel(
+            provider=provider,
+            model_record_id=record.id,
+            model_name=record.model_id,
+        )
+
+    async def resolve_secondary_or_default(self) -> ResolvedModel | None:
+        """Resolve the secondary model, falling back to default."""
+        repo = ModelsRepository()
+        record = await repo.get_secondary()
+        if record is None:
+            record = await repo.get_default()
+        if record is None:
+            return None
+        provider = await self._get_or_build(record)
+        if provider is None:
+            return None
+        return ResolvedModel(
+            provider=provider,
+            model_record_id=record.id,
+            model_name=record.model_id,
+        )
+
+    async def _get_or_build(self, record: ModelRecord) -> LLMProvider | None:
+        """Return a cached or freshly-built provider for a model record.
+
+        Thread-safe: concurrent callers for the same provider id will
+        serialise on ``_lock`` (intended for burst startup, not steady
+        state — the first call builds the client; subsequent calls find
+        a fresh-enough entry and skip the lock).
+        """
+        key = self._cache_key(record)
+
+        # Fast path — no lock.
+        cached = self._cache.get(key)
+        if cached is not None and _entry_is_fresh(cached, record):
+            return cached.provider
+
+        async with self._lock:
+            # Double-check after acquiring the lock.
+            cached = self._cache.get(key)
+            if cached is not None and _entry_is_fresh(cached, record):
+                return cached.provider
+
+            provider = _build_provider_from_record(record)
+            if provider is None:
+                return None
+
+            self._cache[key] = _CachedEntry(
+                provider=provider,
+                provider_updated_at=record.provider_updated_at,
+            )
+            logger.info(
+                "Cached provider %s (type=%s, model=%s)",
+                key, record.provider_type, record.model_id,
+            )
+            return provider
+
+    def invalidate(self, model_provider_id: str) -> None:
+        """Explicitly drop a cached entry (e.g. after admin config edit)."""
+        self._cache.pop(model_provider_id, None)
+
+    def clear(self) -> None:
+        """Drop all cached providers (e.g. on full reload)."""
+        self._cache.clear()
+
+
+def _entry_is_fresh(entry: _CachedEntry, record: ModelRecord) -> bool:
+    """Return True when the cached entry is still up-to-date with the DB row."""
+    if entry.provider_updated_at is None or record.provider_updated_at is None:
+        # No timestamps available — assume stale and rebuild.
+        return False
+    return entry.provider_updated_at == record.provider_updated_at
+
+
+def _build_provider_from_record(record: ModelRecord) -> LLMProvider | None:
+    """Instantiate an LLMProvider from a model+provider database record.
+
+    Returns ``None`` on init failure (logged).  The caller should fall
+    back to the next candidate instead of failing a chat request.
+    """
+    config = record.config
+    provider_type = record.provider_type
+    model_id = record.model_id
+
+    try:
+        if provider_type == "openai_compatible":
+            base_url = config.get("apiUrl")
+            if not base_url:
+                raise ValueError("apiUrl is required in openai_compatible provider config")
+            from providers.openai_compatible import OpenAICompatibleProvider
+            return OpenAICompatibleProvider(
+                base_url=base_url,
+                api_key=config.get("apiKey"),
+                model=model_id,
+            )
+
+        elif provider_type == "anthropic":
+            from providers.anthropic import AnthropicProvider
+            return AnthropicProvider(
+                api_key=config.get("apiKey"),
+                model=model_id,
+            )
+
+        elif provider_type == "bedrock":
+            from config import AWS_REGION
+            region_name = config.get("regionName") or AWS_REGION or None
+            from providers.bedrock import BedrockProvider
+            return BedrockProvider(
+                model_id=model_id,
+                region_name=region_name,
+            )
+
+        elif provider_type == "openai":
+            from providers.openai import OpenAIProvider
+            return OpenAIProvider(
+                api_key=config.get("apiKey"),
+                model=model_id,
+            )
+
+        elif provider_type == "gemini":
+            from providers.gemini import GeminiProvider
+            return GeminiProvider(
+                api_key=config.get("apiKey"),
+                model=model_id,
+            )
+
+        elif provider_type == "azure_foundry":
+            from providers.azure_foundry import AzureFoundryProvider
+            return AzureFoundryProvider(
+                endpoint_url=config.get("apiUrl", ""),
+                model=model_id,
+            )
+
+        elif provider_type == "vertex_ai":
+            from providers.vertex_ai import VertexAIProvider
+            return VertexAIProvider(
+                region=config.get("regionName", ""),
+                project_id=config.get("projectId", ""),
+                model=model_id,
+            )
+
+        else:
+            raise ValueError(f"Unknown provider type: {provider_type}")
+
+    except Exception as e:
+        logger.error(
+            "Failed to build provider for '%s' (type=%s, id=%s): %s",
+            record.display_name, provider_type, record.id, e,
+        )
+        return None

--- a/services/ai/providers/__init__.py
+++ b/services/ai/providers/__init__.py
@@ -93,8 +93,6 @@ class LLMProvider(ABC):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
@@ -107,8 +105,6 @@ class LLMProvider(ABC):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate a non-streaming response from the LLM provider.
 

--- a/services/ai/providers/__init__.py
+++ b/services/ai/providers/__init__.py
@@ -96,8 +96,14 @@ class LLMProvider(ABC):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
-        """Stream a response from the LLM provider. Returns Anthropic MessageStreamEvent objects."""
+        """Stream a response from the LLM provider. Returns Anthropic MessageStreamEvent objects.
+
+        Args:
+            model: Override the instance's baked-in model for this call.
+        """
         pass
 
     @abstractmethod
@@ -105,16 +111,29 @@ class LLMProvider(ABC):
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate a non-streaming response from the LLM provider.
 
         Returns (response_text, token_usage).
+
+        Args:
+            model: Override the instance's baked-in model for this call.
         """
         pass
 
     @abstractmethod
-    async def health_check(self) -> bool:
-        """Check if the provider is healthy."""
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
+        """Check if the provider is healthy.
+
+        Args:
+            model: Override the instance's baked-in model for this call.
+        """
         pass
 
 

--- a/services/ai/providers/anthropic.py
+++ b/services/ai/providers/anthropic.py
@@ -92,8 +92,6 @@ class AnthropicProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
@@ -111,11 +109,10 @@ class AnthropicProvider(LLMProvider):
             self.add_cache_control(msg_list, cast(list[ToolParam] | None, tools))
 
             # Prepare request parameters
-            request_params = {
+            request_params: dict[str, Any] = {
                 "model": self.model,
                 "messages": msg_list,
                 "max_tokens": max_tokens or 8192,
-                "temperature": temperature or 0.7,
                 "stream": True,
             }
 
@@ -187,18 +184,17 @@ class AnthropicProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from Anthropic Claude API."""
         try:
-            response = await self.client.messages.create(
-                model=self.model,
-                messages=[{"role": "user", "content": prompt}],
-                max_tokens=max_tokens or 4096,
-                temperature=temperature or 0.7,
-                stream=False,
-            )
+            request_params: dict[str, Any] = {
+                "model": self.model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens or 4096,
+                "stream": False,
+            }
+
+            response = await self.client.messages.create(**request_params)
 
             usage = TokenUsage(
                 input_tokens=response.usage.input_tokens,

--- a/services/ai/providers/anthropic.py
+++ b/services/ai/providers/anthropic.py
@@ -95,9 +95,12 @@ class AnthropicProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         """Stream response from Anthropic Claude API."""
         try:
+            active_model = model or self.model
             # Use provided messages or create from prompt
             msg_list = (
                 self.build_messages_for_api(cast(list[MessageParam], messages))
@@ -110,7 +113,7 @@ class AnthropicProvider(LLMProvider):
 
             # Prepare request parameters
             request_params: dict[str, Any] = {
-                "model": self.model,
+                "model": active_model,
                 "messages": msg_list,
                 "max_tokens": max_tokens or 8192,
                 "stream": True,
@@ -174,7 +177,7 @@ class AnthropicProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_anthropic_status_code(e),
                 cause=e,
                 is_context_overflow=_anthropic_context_overflow(e),
@@ -184,11 +187,14 @@ class AnthropicProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from Anthropic Claude API."""
         try:
+            active_model = model or self.model
             request_params: dict[str, Any] = {
-                "model": self.model,
+                "model": active_model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": max_tokens or 4096,
                 "stream": False,
@@ -220,18 +226,22 @@ class AnthropicProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_anthropic_status_code(e),
                 cause=e,
                 is_context_overflow=_anthropic_context_overflow(e),
             ) from e
 
-    async def health_check(self) -> bool:
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
         """Check if Anthropic API is accessible."""
         try:
             # Try a minimal request to check API accessibility
             response = await self.client.messages.create(
-                model=self.model,
+                model=model or self.model,
                 messages=[{"role": "user", "content": "Hello"}],
                 max_tokens=1,
                 stream=False,

--- a/services/ai/providers/azure_foundry.py
+++ b/services/ai/providers/azure_foundry.py
@@ -96,6 +96,8 @@ class AzureFoundryProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         try:
             async for event in self._delegate.stream_response(
@@ -104,13 +106,14 @@ class AzureFoundryProvider(LLMProvider):
                 tools=tools,
                 messages=messages,
                 system_prompt=system_prompt,
+                model=model,
             ):
                 yield event
         except ProviderError as e:
             raise ProviderError(
                 e.message,
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=e.status_code,
                 cause=e,
                 is_context_overflow=e.is_context_overflow,
@@ -120,21 +123,28 @@ class AzureFoundryProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         try:
             return await self._delegate.generate_response(
                 prompt=prompt,
                 max_tokens=max_tokens,
+                model=model,
             )
         except ProviderError as e:
             raise ProviderError(
                 e.message,
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=e.status_code,
                 cause=e,
                 is_context_overflow=e.is_context_overflow,
             ) from e
 
-    async def health_check(self) -> bool:
-        return await self._delegate.health_check()
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
+        return await self._delegate.health_check(model=model)

--- a/services/ai/providers/azure_foundry.py
+++ b/services/ai/providers/azure_foundry.py
@@ -93,8 +93,6 @@ class AzureFoundryProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
@@ -103,8 +101,6 @@ class AzureFoundryProvider(LLMProvider):
             async for event in self._delegate.stream_response(
                 prompt=prompt,
                 max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
                 tools=tools,
                 messages=messages,
                 system_prompt=system_prompt,
@@ -124,15 +120,11 @@ class AzureFoundryProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         try:
             return await self._delegate.generate_response(
                 prompt=prompt,
                 max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
             )
         except ProviderError as e:
             raise ProviderError(

--- a/services/ai/providers/bedrock.py
+++ b/services/ai/providers/bedrock.py
@@ -110,7 +110,7 @@ class BedrockProvider(LLMProvider):
         else:
             self.client = boto3.client("bedrock-runtime", region_name=region_name)
 
-    def _to_provider_error(self, e: Exception) -> ProviderError:
+    def _to_provider_error(self, e: Exception, model: str | None = None) -> ProviderError:
         is_context_overflow = False
         if isinstance(e, ClientError):
             error = e.response.get("Error", {})
@@ -131,7 +131,7 @@ class BedrockProvider(LLMProvider):
         return ProviderError(
             body,
             provider_type=self.provider_type,
-            model=self.model_name,
+            model=model or self.model_name,
             status_code=status,
             cause=e,
             is_context_overflow=is_context_overflow,
@@ -602,7 +602,7 @@ class BedrockProvider(LLMProvider):
                     messages = [{"role": "user", "content": [{"text": prompt}]}]
 
                 request_params = {
-                    "modelId": self.model_id,
+                    "modelId": active_model,
                     "messages": messages,
                     "inferenceConfig": {
                         "maxTokens": max_tokens or 4096,
@@ -643,22 +643,25 @@ class BedrockProvider(LLMProvider):
                 f"[BEDROCK] AWS Bedrock client error ({error_code}): {str(e)}",
                 exc_info=True,
             )
-            raise self._to_provider_error(e) from e
+            raise self._to_provider_error(e, model=model) from e
         except Exception as e:
             logger.error(
                 f"[BEDROCK] Failed to stream from AWS Bedrock: {str(e)}", exc_info=True
             )
-            raise self._to_provider_error(e) from e
+            raise self._to_provider_error(e, model=model) from e
 
     async def generate_response(
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from AWS Bedrock Claude models."""
         try:
+            active_model = model or self.model_id
             logger.info(
-                f"[BEDROCK] Generating non-streaming response using model {self.model_id}"
+                f"[BEDROCK] Generating non-streaming response using model {active_model}"
             )
             if self.model_family == "anthropic":
                 # Prepare the request body for Claude models
@@ -667,7 +670,7 @@ class BedrockProvider(LLMProvider):
                 ]
 
                 request_params: dict[str, Any] = {
-                    "model": self.model_id,
+                    "model": active_model,
                     "messages": conversation,
                     "max_tokens": max_tokens or 4096,
                 }
@@ -699,7 +702,7 @@ class BedrockProvider(LLMProvider):
                 conversation = [{"role": "user", "content": [{"text": prompt}]}]
 
                 response = self.client.converse(
-                    modelId=self.model_id,
+                    modelId=active_model,
                     messages=conversation,
                     inferenceConfig={
                         "maxTokens": max_tokens or 512,
@@ -721,14 +724,19 @@ class BedrockProvider(LLMProvider):
 
         except ClientError as e:
             logger.error(f"AWS Bedrock client error: {str(e)}")
-            raise self._to_provider_error(e) from e
+            raise self._to_provider_error(e, model=model) from e
         except Exception as e:
             logger.error(f"Failed to generate response from AWS Bedrock: {str(e)}")
-            raise self._to_provider_error(e) from e
+            raise self._to_provider_error(e, model=model) from e
 
-    async def health_check(self) -> bool:
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
         """Check if AWS Bedrock service is accessible."""
         try:
+            active_model = model or self.model_id
             # Try a minimal request to check service accessibility
             body = {
                 "anthropic_version": "bedrock-2023-05-31",
@@ -737,7 +745,7 @@ class BedrockProvider(LLMProvider):
             }
 
             response = self.client.invoke_model(
-                modelId=self.model_id,
+                modelId=active_model,
                 body=json.dumps(body),
                 contentType="application/json",
                 accept="application/json",

--- a/services/ai/providers/bedrock.py
+++ b/services/ai/providers/bedrock.py
@@ -492,8 +492,6 @@ class BedrockProvider(LLMProvider):
         messages: list[dict[str, Any]] | None = None,
         tools: list[dict[str, Any]] | None = None,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         system_prompt: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         """Stream response from AWS Bedrock models."""
@@ -506,11 +504,10 @@ class BedrockProvider(LLMProvider):
                 )
 
                 # Prepare the request body for Claude models
-                request_params = {
+                request_params: dict[str, Any] = {
                     "model": self.model_id,
                     "messages": msg_list,
                     "max_tokens": max_tokens or 4096,
-                    "temperature": temperature or 0.7,
                     "stream": True,
                 }
 
@@ -609,8 +606,6 @@ class BedrockProvider(LLMProvider):
                     "messages": messages,
                     "inferenceConfig": {
                         "maxTokens": max_tokens or 4096,
-                        "temperature": temperature or 0.7,
-                        "topP": top_p or 0.9,
                     },
                 }
 
@@ -659,8 +654,6 @@ class BedrockProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from AWS Bedrock Claude models."""
         try:
@@ -673,11 +666,10 @@ class BedrockProvider(LLMProvider):
                     {"role": "user", "content": [{"type": "text", "text": prompt}]}
                 ]
 
-                request_params = {
+                request_params: dict[str, Any] = {
                     "model": self.model_id,
                     "messages": conversation,
                     "max_tokens": max_tokens or 4096,
-                    "temperature": temperature or 0.7,
                 }
 
                 # Invoke the model
@@ -711,8 +703,6 @@ class BedrockProvider(LLMProvider):
                     messages=conversation,
                     inferenceConfig={
                         "maxTokens": max_tokens or 512,
-                        "temperature": temperature or 0.7,
-                        "topP": top_p or 0.9,
                     },
                 )
                 logger.debug(f"generate_response: response from LLM -> {response}")

--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -242,9 +242,12 @@ class GeminiProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         """Stream response from Gemini, yielding Anthropic-compatible MessageStreamEvents."""
         try:
+            active_model = model or self.model
             contents = _convert_messages_to_gemini(
                 messages or [{"role": "user", "content": prompt}]
             )
@@ -263,7 +266,7 @@ class GeminiProvider(LLMProvider):
                 )
 
             logger.info(
-                f"Model: {self.model}, Messages: {len(contents)}, Max tokens: {config.max_output_tokens}"
+                f"Model: {active_model}, Messages: {len(contents)}, Max tokens: {config.max_output_tokens}"
             )
 
             # Emit message_start
@@ -274,7 +277,7 @@ class GeminiProvider(LLMProvider):
                     type="message",
                     role="assistant",
                     content=[],
-                    model=self.model,
+                    model=active_model,
                     usage=Usage(input_tokens=0, output_tokens=0),
                 ),
             )
@@ -285,7 +288,7 @@ class GeminiProvider(LLMProvider):
             last_usage_metadata = None
 
             async for chunk in await self.client.aio.models.generate_content_stream(
-                model=self.model,
+                model=active_model,
                 contents=contents,
                 config=config,
             ):
@@ -396,7 +399,7 @@ class GeminiProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_gemini_status_code(e),
                 cause=e,
                 is_context_overflow=_gemini_context_overflow(e),
@@ -406,15 +409,18 @@ class GeminiProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from Gemini."""
         try:
+            active_model = model or self.model
             config = types.GenerateContentConfig(
                 max_output_tokens=max_tokens or 4096,
             )
 
             response = await self.client.aio.models.generate_content(
-                model=self.model,
+                model=active_model,
                 contents=prompt,
                 config=config,
             )
@@ -438,18 +444,23 @@ class GeminiProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_gemini_status_code(e),
                 cause=e,
                 is_context_overflow=_gemini_context_overflow(e),
             ) from e
 
-    async def health_check(self) -> bool:
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
         """Check if Gemini API is accessible."""
         try:
+            active_model = model or self.model
             config = types.GenerateContentConfig(max_output_tokens=1)
             await self.client.aio.models.generate_content(
-                model=self.model,
+                model=active_model,
                 contents="Hello",
                 config=config,
             )

--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -227,8 +227,6 @@ class GeminiProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
@@ -241,11 +239,7 @@ class GeminiProvider(LLMProvider):
 
             config = types.GenerateContentConfig(
                 max_output_tokens=max_tokens or 4096,
-                temperature=temperature or 0.7,
             )
-
-            if top_p is not None:
-                config.top_p = top_p
 
             if system_prompt:
                 config.system_instruction = system_prompt
@@ -400,17 +394,12 @@ class GeminiProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from Gemini."""
         try:
             config = types.GenerateContentConfig(
                 max_output_tokens=max_tokens or 4096,
-                temperature=temperature or 0.7,
             )
-            if top_p is not None:
-                config.top_p = top_p
 
             response = await self.client.aio.models.generate_content(
                 model=self.model,

--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -202,7 +202,19 @@ class GeminiProvider(LLMProvider):
 
     def __init__(self, api_key: str, model: str):
         self.api_key = api_key
-        self.client = genai.Client(api_key=api_key)
+        self.client = genai.Client(
+            api_key=api_key,
+            http_options=types.HttpOptions(
+                retry_options=types.HttpRetryOptions(
+                    attempts=3,
+                    initial_delay=1.0,
+                    max_delay=30.0,
+                    exp_base=2.0,
+                    jitter=0.5,
+                    http_status_codes=[429, 500, 502, 503],
+                )
+            ),
+        )
         self.model = model
         self.model_name = model
         self._context_window_info: ContextWindowInfo | None = None

--- a/services/ai/providers/openai.py
+++ b/services/ai/providers/openai.py
@@ -102,18 +102,21 @@ class OpenAIProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         """Stream response from OpenAI Responses API, yielding Anthropic-compatible MessageStreamEvents."""
         try:
+            active_model = model or self.model
             input_items = self._convert_messages(
                 messages or [{"role": "user", "content": prompt}]
             )
 
             request_params: dict[str, Any] = {
-                "model": self.model,
+                "model": active_model,
                 "input": input_items,
                 "max_output_tokens": _effective_max_output_tokens(
-                    self.model, max_tokens
+                    active_model, max_tokens
                 ),
                 "stream": True,
             }
@@ -128,7 +131,7 @@ class OpenAIProvider(LLMProvider):
                 )
 
             logger.info(
-                f"Model: {self.model}, Input items: {len(input_items)}, Max tokens: {request_params['max_output_tokens']}"
+                f"Model: {active_model}, Input items: {len(input_items)}, Max tokens: {request_params['max_output_tokens']}"
             )
 
             stream = await self.client.responses.create(**request_params)
@@ -286,7 +289,7 @@ class OpenAIProvider(LLMProvider):
                     raise ProviderError(
                         msg,
                         provider_type=self.provider_type,
-                        model=self.model_name,
+                        model=model or self.model_name,
                         is_context_overflow=code == "context_length_exceeded",
                     )
 
@@ -302,7 +305,7 @@ class OpenAIProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_openai_status_code(e),
                 cause=e,
                 is_context_overflow=_openai_context_overflow(e),
@@ -407,18 +410,21 @@ class OpenAIProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from OpenAI Responses API."""
         try:
+            active_model = model or self.model
             # Reasoning models consume their internal reasoning chain against
             # max_output_tokens before producing any visible text. Enforce a
             # minimum so short utility calls, like title generation, still have
             # room to write an answer.
             effective_max_tokens = _effective_max_output_tokens(
-                self.model, max_tokens
+                active_model, max_tokens
             )
             params: dict[str, Any] = {
-                "model": self.model,
+                "model": active_model,
                 "input": prompt,
                 "max_output_tokens": effective_max_tokens,
                 "stream": False,
@@ -462,19 +468,24 @@ class OpenAIProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_openai_status_code(e),
                 cause=e,
                 is_context_overflow=_openai_context_overflow(e),
             ) from e
 
-    async def health_check(self) -> bool:
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
         """Check if OpenAI API is accessible."""
         try:
+            active_model = model or self.model
             await self.client.responses.create(
-                model=self.model,
+                model=active_model,
                 input="Hello",
-                max_output_tokens=_effective_max_output_tokens(self.model, 16),
+                max_output_tokens=_effective_max_output_tokens(active_model, 16),
                 stream=False,
             )
             return True

--- a/services/ai/providers/openai.py
+++ b/services/ai/providers/openai.py
@@ -64,30 +64,11 @@ def _is_reasoning_model(model: str) -> bool:
     return normalized.startswith(("gpt-5", "o1", "o3", "o4"))
 
 
-def _supports_sampling_params(model: str) -> bool:
-    """Whether the model accepts temperature/top_p on the Responses API."""
-    return not _is_reasoning_model(model)
-
-
 def _effective_max_output_tokens(model: str, max_tokens: int | None) -> int:
     tokens = max_tokens or 4096
     if _is_reasoning_model(model):
         return max(tokens, MIN_REASONING_OUTPUT_TOKENS)
     return tokens
-
-
-def _add_sampling_params(
-    params: dict[str, Any],
-    model: str,
-    temperature: float | None,
-    top_p: float | None,
-) -> None:
-    if not _supports_sampling_params(model):
-        return
-    if temperature is not None:
-        params["temperature"] = temperature
-    if top_p is not None:
-        params["top_p"] = top_p
 
 
 def _convert_tools_to_openai(tools: list[dict[str, Any]]) -> list[dict[str, Any]]:
@@ -118,8 +99,6 @@ class OpenAIProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
@@ -141,8 +120,6 @@ class OpenAIProvider(LLMProvider):
 
             if system_prompt:
                 request_params["instructions"] = system_prompt
-
-            _add_sampling_params(request_params, self.model, temperature, top_p)
 
             if tools:
                 request_params["tools"] = _convert_tools_to_openai(tools)
@@ -430,8 +407,6 @@ class OpenAIProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response from OpenAI Responses API."""
         try:
@@ -448,7 +423,6 @@ class OpenAIProvider(LLMProvider):
                 "max_output_tokens": effective_max_tokens,
                 "stream": False,
             }
-            _add_sampling_params(params, self.model, temperature, top_p)
 
             response = await self.client.responses.create(**params)
 

--- a/services/ai/providers/openai_compatible.py
+++ b/services/ai/providers/openai_compatible.py
@@ -273,9 +273,12 @@ class OpenAICompatibleProvider(LLMProvider):
         tools: list[ToolParam] | None = None,
         messages: list[MessageParam] | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         """Stream response, yielding Anthropic-compatible MessageStreamEvents."""
         try:
+            active_model = model or self.model
             openai_messages = _convert_messages_to_openai(
                 messages or [{"role": "user", "content": prompt}]
             )
@@ -287,7 +290,7 @@ class OpenAICompatibleProvider(LLMProvider):
                 openai_messages = [system_msg] + openai_messages
 
             params: dict[str, Any] = {
-                "model": self.model,
+                "model": active_model,
                 "messages": openai_messages,
                 "max_tokens": max_tokens or 4096,
                 "stream": True,
@@ -310,7 +313,7 @@ class OpenAICompatibleProvider(LLMProvider):
                     type="message",
                     role="assistant",
                     content=[],
-                    model=self.model,
+                    model=active_model,
                     usage=Usage(input_tokens=0, output_tokens=0),
                 ),
             )
@@ -464,7 +467,7 @@ class OpenAICompatibleProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_openai_compat_status_code(e),
                 cause=e,
                 is_context_overflow=_openai_compat_context_overflow(e),
@@ -474,11 +477,14 @@ class OpenAICompatibleProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response."""
         try:
+            active_model = model or self.model
             params: dict[str, Any] = {
-                "model": self.model,
+                "model": active_model,
                 "messages": [{"role": "user", "content": prompt}],
                 "max_tokens": max_tokens or 4096,
                 "stream": False,
@@ -517,13 +523,17 @@ class OpenAICompatibleProvider(LLMProvider):
             raise ProviderError(
                 str(e),
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=_openai_compat_status_code(e),
                 cause=e,
                 is_context_overflow=_openai_compat_context_overflow(e),
             ) from e
 
-    async def health_check(self) -> bool:
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
         """Liveness is determined by inference calls themselves; no separate probe
         since not every OpenAI-compatible server exposes a common health endpoint."""
         return True

--- a/services/ai/providers/openai_compatible.py
+++ b/services/ai/providers/openai_compatible.py
@@ -255,7 +255,7 @@ class OpenAICompatibleProvider(LLMProvider):
     def __init__(
         self, base_url: str, api_key: str | None = None, model: str = "default"
     ):
-        self.base_url = base_url.rstrip("/")
+        self.base_url = base_url.rstrip("/").removesuffix("/v1")
         self.api_key = api_key
         self.model = model
         self.model_name = model
@@ -270,8 +270,6 @@ class OpenAICompatibleProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         tools: list[ToolParam] | None = None,
         messages: list[MessageParam] | None = None,
         system_prompt: str | None = None,
@@ -295,11 +293,6 @@ class OpenAICompatibleProvider(LLMProvider):
                 "stream": True,
                 "stream_options": {"include_usage": True},
             }
-
-            if temperature is not None:
-                params["temperature"] = temperature
-            if top_p is not None:
-                params["top_p"] = top_p
 
             if tools:
                 params["tools"] = _convert_tools_to_openai(tools)
@@ -481,8 +474,6 @@ class OpenAICompatibleProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         """Generate non-streaming response."""
         try:
@@ -492,10 +483,6 @@ class OpenAICompatibleProvider(LLMProvider):
                 "max_tokens": max_tokens or 4096,
                 "stream": False,
             }
-            if temperature is not None:
-                params["temperature"] = temperature
-            if top_p is not None:
-                params["top_p"] = top_p
 
             response = await self.client.chat.completions.create(**params)
 

--- a/services/ai/providers/vertex_ai.py
+++ b/services/ai/providers/vertex_ai.py
@@ -68,8 +68,6 @@ class VertexAIProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
@@ -78,8 +76,6 @@ class VertexAIProvider(LLMProvider):
             async for event in self._delegate.stream_response(
                 prompt=prompt,
                 max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
                 tools=tools,
                 messages=messages,
                 system_prompt=system_prompt,
@@ -99,15 +95,11 @@ class VertexAIProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
-        temperature: float | None = None,
-        top_p: float | None = None,
     ) -> tuple[str, TokenUsage]:
         try:
             return await self._delegate.generate_response(
                 prompt=prompt,
                 max_tokens=max_tokens,
-                temperature=temperature,
-                top_p=top_p,
             )
         except ProviderError as e:
             raise ProviderError(

--- a/services/ai/providers/vertex_ai.py
+++ b/services/ai/providers/vertex_ai.py
@@ -71,6 +71,8 @@ class VertexAIProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         try:
             async for event in self._delegate.stream_response(
@@ -79,13 +81,14 @@ class VertexAIProvider(LLMProvider):
                 tools=tools,
                 messages=messages,
                 system_prompt=system_prompt,
+                model=model,
             ):
                 yield event
         except ProviderError as e:
             raise ProviderError(
                 e.message,
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=e.status_code,
                 cause=e,
                 is_context_overflow=e.is_context_overflow,
@@ -95,21 +98,28 @@ class VertexAIProvider(LLMProvider):
         self,
         prompt: str,
         max_tokens: int | None = None,
+        *,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         try:
             return await self._delegate.generate_response(
                 prompt=prompt,
                 max_tokens=max_tokens,
+                model=model,
             )
         except ProviderError as e:
             raise ProviderError(
                 e.message,
                 provider_type=self.provider_type,
-                model=self.model_name,
+                model=model or self.model_name,
                 status_code=e.status_code,
                 cause=e,
                 is_context_overflow=e.is_context_overflow,
             ) from e
 
-    async def health_check(self) -> bool:
-        return await self._delegate.health_check()
+    async def health_check(
+        self,
+        *,
+        model: str | None = None,
+    ) -> bool:
+        return await self._delegate.health_check(model=model)

--- a/services/ai/pyproject.toml
+++ b/services/ai/pyproject.toml
@@ -55,6 +55,7 @@ markers = [
     "unit: Unit tests (no external dependencies)",
     "integration: Integration tests (require DB/Redis)",
     "slow: Slow tests (skip with -m 'not slow')",
+    "real_llm: Tests against real LLM APIs (require API keys in .env)",
 ]
 
 [tool.coverage.run]

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -56,6 +56,7 @@ from memory import (
 )
 from prompts import build_agent_chat_system_prompt, build_chat_system_prompt
 from providers import LLMProvider
+from provider_cache import ResolvedModel
 from services.compaction import ConversationCompactor
 from services.title_generation import generate_title_for_conversation
 from services.usage import UsageContext, UsagePurpose, UsageTracker, track_usage
@@ -119,24 +120,32 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 
-def _resolve_provider(state: AppState, model_id: str | None) -> LLMProvider:
-    models = state.models
-    if not models:
-        raise HTTPException(status_code=503, detail="No models configured")
+async def _resolve_llm_provider(state: AppState, chat: Chat) -> ResolvedModel:
+    """Resolve the LLM provider for a chat from the database.
 
-    if model_id and model_id in models:
-        return models[model_id]
-    if state.default_model_id and state.default_model_id in models:
-        return models[state.default_model_id]
-    return next(iter(models.values()))
+    FAILS LOUD when the chat's model is no longer available — no silent
+    fallback to a different model.
+    """
+    if not chat.model_id:
+        raise HTTPException(status_code=503, detail="Chat has no model configured")
+
+    resolved = await state.provider_cache.resolve_for_model(chat.model_id)
+    if resolved is None:
+        raise HTTPException(
+            status_code=409,
+            detail="This chat's model is no longer available. Please select a new model.",
+        )
+    return resolved
 
 
-def _resolve_llm_provider(state: AppState, chat: Chat) -> LLMProvider:
-    return _resolve_provider(state, chat.model_id)
-
-
-def _resolve_secondary_provider(state: AppState) -> LLMProvider:
-    return _resolve_provider(state, state.secondary_model_id or state.default_model_id)
+async def _resolve_secondary_provider(state: AppState) -> ResolvedModel:
+    """Resolve the secondary (lightweight) LLM provider from the database."""
+    resolved = await state.provider_cache.resolve_secondary_or_default()
+    if resolved is None:
+        raise HTTPException(
+            status_code=503, detail="No models configured — cannot proceed"
+        )
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -574,7 +583,7 @@ class StreamChatHandler:
         if not chat:
             raise HTTPException(status_code=404, detail="Chat thread not found")
 
-        llm_provider = _resolve_llm_provider(request.app.state, chat)
+        llm_provider = await _resolve_llm_provider(request.app.state, chat)
         redis_client = request.app.state.redis_client
 
         # Reconnect/resume fast path
@@ -910,7 +919,7 @@ class StreamChatHandler:
             )
 
         # Compaction
-        secondary_provider = _resolve_secondary_provider(request.app.state)
+        secondary_provider = await _resolve_secondary_provider(request.app.state)
 
         def _on_compaction_usage(usage):
             track_usage(
@@ -919,7 +928,7 @@ class StreamChatHandler:
                     user_id=chat.user_id,
                     model_id=secondary_provider.model_record_id,
                     model_name=secondary_provider.model_name,
-                    provider_type=secondary_provider.provider_type,
+                    provider_type=secondary_provider.provider.provider_type,
                     purpose=UsagePurpose.COMPACTION,
                     chat_id=chat_id,
                 ),
@@ -930,7 +939,8 @@ class StreamChatHandler:
             )
 
         compactor = ConversationCompactor(
-            llm_provider=secondary_provider,
+            llm_provider=secondary_provider.provider,
+            model_name=secondary_provider.model_name,
             on_usage=_on_compaction_usage,
         )
         initial_tools = build_turn_tools(
@@ -947,9 +957,11 @@ class StreamChatHandler:
             messages=messages,
             compactor=compactor,
             compactions_repo=CompactionsRepository(),
-            target_provider=llm_provider,
+            target_provider=llm_provider.provider,
             initial_tools=initial_tools,
-            llm_provider=llm_provider,
+            llm_provider=llm_provider.provider,
+            model_record_id=llm_provider.model_record_id,
+            model_name=llm_provider.model_name,
             chat_user_id=chat.user_id,
             tool_user_id=tool_user_id,
             user_email=user_email,
@@ -1064,7 +1076,7 @@ async def generate_chat_title(
         if not chat:
             raise HTTPException(status_code=404, detail="Chat thread not found")
 
-        llm_provider = _resolve_secondary_provider(request.app.state)
+        llm_provider = await _resolve_secondary_provider(request.app.state)
 
         if chat.title:
             logger.info(f"Chat already has a title: {chat.title}")
@@ -1098,7 +1110,8 @@ async def generate_chat_title(
         logger.info(f"Extracted conversation text ({len(conversation_text)} chars)")
 
         title_result = await generate_title_for_conversation(
-            llm_provider,
+            llm_provider.provider,
+            llm_provider.model_name,
             conversation_text,
             chat_id,
         )
@@ -1111,7 +1124,7 @@ async def generate_chat_title(
                     user_id=chat.user_id,
                     model_id=llm_provider.model_record_id,
                     model_name=llm_provider.model_name,
-                    provider_type=llm_provider.provider_type,
+                    provider_type=llm_provider.provider.provider_type,
                     purpose=UsagePurpose.TITLE_GENERATION,
                     chat_id=chat_id,
                 ),

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -33,8 +33,6 @@ from config import (
     AGENT_MAX_ITERATIONS,
     CONNECTOR_MANAGER_URL,
     DEFAULT_MAX_TOKENS,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_TOP_P,
     SANDBOX_URL,
 )
 from db import ChatsRepository, CompactionsRepository, MessagesRepository, SkillsRepository

--- a/services/ai/routers/model_providers.py
+++ b/services/ai/routers/model_providers.py
@@ -41,8 +41,13 @@ async def list_models():
 
 @router.post("/admin/reload-providers")
 async def reload_providers(request: Request):
-    """Reload model instances from the database."""
-    await load_models(request.app.state)
+    """Reload model instances from the database.
+
+    With DB-backed resolution the cache is populated on demand, so this
+    just clears the cache to force a fresh fetch next time.
+    """
+    request.app.state.provider_cache.clear()
+    logger.info("Provider cache cleared via admin reload")
     return {"status": "ok"}
 
 

--- a/services/ai/routers/prompts.py
+++ b/services/ai/routers/prompts.py
@@ -55,8 +55,6 @@ async def generate_response(request: Request, body: PromptRequest):
             async for event in llm_provider.stream_response(
                 body.prompt,
                 max_tokens=body.max_tokens,
-                temperature=body.temperature,
-                top_p=body.top_p,
             ):
                 # Extract text content from MessageStreamEvent
                 if event.type == "content_block_delta":
@@ -85,8 +83,6 @@ async def _generate_non_streaming_response(
         generated_text, _ = await llm_provider.generate_response(
             body.prompt,
             max_tokens=body.max_tokens,
-            temperature=body.temperature,
-            top_p=body.top_p,
         )
 
         logger.info(f"Successfully generated response of length: {len(generated_text)}")

--- a/services/ai/routers/prompts.py
+++ b/services/ai/routers/prompts.py
@@ -7,40 +7,35 @@ from fastapi.responses import StreamingResponse
 
 from schemas import PromptRequest, PromptResponse
 from providers import LLMProvider
+from provider_cache import ResolvedModel
 
 logger = logging.getLogger(__name__)
 router = APIRouter(tags=["prompts"])
 
 
-def _get_default_llm_provider(request: Request) -> LLMProvider | None:
-    """Return the default LLM provider from app.state.models."""
-    models = getattr(request.app.state, "models", None)
-    if not models:
+async def _get_default_llm_provider(request: Request) -> ResolvedModel | None:
+    """Return the default LLM provider from the database."""
+    cache = getattr(request.app.state, "provider_cache", None)
+    if cache is None:
         return None
-    default_id = getattr(request.app.state, "default_model_id", None)
-    if default_id and default_id in models:
-        return models[default_id]
-    return next(iter(models.values()), None)
+    return await cache.resolve_default()
 
 
-def _get_secondary_llm_provider(request: Request) -> LLMProvider | None:
+async def _get_secondary_llm_provider(request: Request) -> ResolvedModel | None:
     """Return the secondary (lightweight) LLM provider, falling back to default."""
-    models = getattr(request.app.state, "models", None)
-    if not models:
+    cache = getattr(request.app.state, "provider_cache", None)
+    if cache is None:
         return None
-    secondary_id = getattr(request.app.state, "secondary_model_id", None)
-    if secondary_id and secondary_id in models:
-        return models[secondary_id]
-    return _get_default_llm_provider(request)
+    return await cache.resolve_secondary_or_default()
 
 
 @router.post("/prompt")
 async def generate_response(request: Request, body: PromptRequest):
     """Generate a response from the configured LLM provider with streaming support."""
-    llm_provider = _get_default_llm_provider(request)
-    if not llm_provider:
+    resolved = await _get_default_llm_provider(request)
+    if not resolved:
         raise HTTPException(status_code=500, detail="LLM provider not initialized")
-
+    llm_provider = resolved.provider
     logger.info(
         f"Generating response for prompt: {body.prompt[:50]}... (stream={body.stream})"
     )
@@ -55,6 +50,7 @@ async def generate_response(request: Request, body: PromptRequest):
             async for event in llm_provider.stream_response(
                 body.prompt,
                 max_tokens=body.max_tokens,
+                model=resolved.model_name,
             ):
                 # Extract text content from MessageStreamEvent
                 if event.type == "content_block_delta":
@@ -75,14 +71,15 @@ async def _generate_non_streaming_response(
     request: Request, body: PromptRequest
 ) -> PromptResponse:
     """Generate non-streaming response using the secondary (lightweight) model."""
-    llm_provider = _get_secondary_llm_provider(request)
-    if not llm_provider:
+    resolved = await _get_secondary_llm_provider(request)
+    if not resolved:
         raise HTTPException(status_code=500, detail="LLM provider not initialized")
-
+    llm_provider = resolved.provider
     try:
         generated_text, _ = await llm_provider.generate_response(
             body.prompt,
             max_tokens=body.max_tokens,
+            model=resolved.model_name,
         )
 
         logger.info(f"Successfully generated response of length: {len(generated_text)}")

--- a/services/ai/schemas/api.py
+++ b/services/ai/schemas/api.py
@@ -52,8 +52,6 @@ class PromptRequest(BaseModel):
 
     prompt: str
     max_tokens: int | None = 512
-    temperature: float | None = 0.7
-    top_p: float | None = 0.9
     stream: bool | None = True
 
 

--- a/services/ai/services/compaction.py
+++ b/services/ai/services/compaction.py
@@ -104,10 +104,14 @@ class ConversationCompactor:
     def __init__(
         self,
         llm_provider: LLMProvider,
+        model_name: str | None = None,
         redis_client: Any | None = None,
         on_usage: Callable[[TokenUsage], None] | None = None,
     ):
         self.llm_provider = llm_provider
+        # Wire model name passed per-call so a cached client shared across model
+        # records still targets the correct model.
+        self.model_name = model_name
         # Kept temporarily for constructor compatibility; Redis is no longer used
         # as compaction source of truth.
         self.redis = redis_client
@@ -413,6 +417,7 @@ Summary:"""
             summary, usage = await self.llm_provider.generate_response(
                 prompt=prompt,
                 max_tokens=COMPACTION_SUMMARY_MAX_TOKENS,
+                model=self.model_name,
             )
             if self._on_usage:
                 self._on_usage(usage)
@@ -473,6 +478,7 @@ Summary:"""
             summary, usage = await self.llm_provider.generate_response(
                 prompt=prompt,
                 max_tokens=COMPACTION_SUMMARY_MAX_TOKENS,
+                model=self.model_name,
             )
             if self._on_usage:
                 self._on_usage(usage)

--- a/services/ai/services/compaction.py
+++ b/services/ai/services/compaction.py
@@ -413,7 +413,6 @@ Summary:"""
             summary, usage = await self.llm_provider.generate_response(
                 prompt=prompt,
                 max_tokens=COMPACTION_SUMMARY_MAX_TOKENS,
-                temperature=0.3,
             )
             if self._on_usage:
                 self._on_usage(usage)
@@ -474,7 +473,6 @@ Summary:"""
             summary, usage = await self.llm_provider.generate_response(
                 prompt=prompt,
                 max_tokens=COMPACTION_SUMMARY_MAX_TOKENS,
-                temperature=0.3,
             )
             if self._on_usage:
                 self._on_usage(usage)

--- a/services/ai/services/providers.py
+++ b/services/ai/services/providers.py
@@ -15,13 +15,10 @@ from db_config import (
 )
 from db import (
     EmbeddingProvidersRepository,
-    ModelRecord,
-    ModelsRepository,
     WebFetchProvidersRepository,
     WebSearchProvidersRepository,
 )
 from db.listener import start_db_listener
-from providers import create_llm_provider, LLMProvider
 from embeddings import create_embedding_provider
 from tools import SearcherTool
 from storage import create_content_storage
@@ -33,111 +30,14 @@ from state import AppState
 logger = logging.getLogger(__name__)
 
 
-def _create_provider_from_model_record(record: ModelRecord) -> LLMProvider:
-    """Instantiate an LLMProvider from a model+provider database record."""
-    config = record.config
-    provider_type = record.provider_type
-    model_id = record.model_id
-
-    if provider_type == "openai_compatible":
-        base_url = config.get("apiUrl")
-        if not base_url:
-            raise ValueError("apiUrl is required in openai_compatible provider config")
-        return create_llm_provider(
-            "openai_compatible",
-            base_url=base_url,
-            api_key=config.get("apiKey"),
-            model=model_id,
-        )
-
-    elif provider_type == "anthropic":
-        return create_llm_provider(
-            "anthropic",
-            api_key=config.get("apiKey"),
-            model=model_id,
-        )
-
-    elif provider_type == "bedrock":
-        region_name = config.get("regionName") or AWS_REGION or None
-        return create_llm_provider(
-            "bedrock",
-            model_id=model_id,
-            region_name=region_name,
-        )
-
-    elif provider_type == "openai":
-        return create_llm_provider(
-            "openai",
-            api_key=config.get("apiKey"),
-            model=model_id,
-        )
-
-    elif provider_type == "gemini":
-        return create_llm_provider(
-            "gemini",
-            api_key=config.get("apiKey"),
-            model=model_id,
-        )
-
-    elif provider_type == "azure_foundry":
-        return create_llm_provider(
-            "azure_foundry",
-            endpoint_url=config.get("apiUrl", ""),
-            model=model_id,
-        )
-
-    elif provider_type == "vertex_ai":
-        return create_llm_provider(
-            "vertex_ai",
-            region=config.get("regionName", ""),
-            project_id=config.get("projectId", ""),
-            model=model_id,
-        )
-
-    else:
-        raise ValueError(f"Unknown provider type: {provider_type}")
-
-
 async def load_models(app_state: AppState) -> None:
-    """Load all active models from the database and populate app_state."""
-    repo = ModelsRepository()
-    records = await repo.list_active()
+    """Reload model cache from the database.
 
-    models: dict[str, LLMProvider] = {}
-    default_id: str | None = None
-    secondary_id: str | None = None
-
-    for record in records:
-        try:
-            provider = _create_provider_from_model_record(record)
-            # provider_type is a class attribute on each leaf provider; model_name
-            # is set in the factory. Only model_record_id needs the loader.
-            provider.model_record_id = record.id
-            models[record.id] = provider
-            logger.info(
-                f"Initialized model '{record.display_name}' (type={record.provider_type}, model={record.model_id}, id={record.id})"
-            )
-            if record.is_default:
-                default_id = record.id
-            if record.is_secondary:
-                secondary_id = record.id
-        except Exception as e:
-            logger.error(
-                f"Failed to initialize model '{record.display_name}' (id={record.id}): {e}"
-            )
-
-    app_state.models = models
-    app_state.default_model_id = default_id
-    app_state.secondary_model_id = secondary_id
-
-    if not models:
-        logger.warning(
-            "No models configured — chat will be unavailable until models are added"
-        )
-    else:
-        logger.info(
-            f"Loaded {len(models)} model(s), default={default_id}, secondary={secondary_id}"
-        )
+    With DB-backed resolution the cache is populated on demand, so this
+    just clears the cache to force a fresh fetch next time.
+    """
+    app_state.provider_cache.clear()
+    logger.info("Provider cache cleared (will reload on next request)")
 
 
 async def _init_embedding_provider(app_state: AppState) -> None:
@@ -300,25 +200,7 @@ async def reload_web_fetch_provider(app_state: AppState) -> None:
     await _init_web_fetch_provider(app_state)
 
 
-def _handle_model_provider_notification(app_state: AppState, payload: dict) -> None:
-    """Handle model_provider_changed notification — update default/secondary pointers."""
-    model_id = payload.get("id", "").strip()
-    if not model_id or model_id not in app_state.models:
-        return
 
-    if payload.get("is_default"):
-        app_state.default_model_id = model_id
-        logger.info(f"Default model updated to {model_id} via NOTIFY")
-    elif app_state.default_model_id == model_id:
-        app_state.default_model_id = None
-        logger.info(f"Default model cleared (was {model_id}) via NOTIFY")
-
-    if payload.get("is_secondary"):
-        app_state.secondary_model_id = model_id
-        logger.info(f"Secondary model updated to {model_id} via NOTIFY")
-    elif app_state.secondary_model_id == model_id:
-        app_state.secondary_model_id = None
-        logger.info(f"Secondary model cleared (was {model_id}) via NOTIFY")
 
 
 def _handle_embedding_provider_notification(app_state: AppState, payload: dict) -> None:
@@ -345,43 +227,21 @@ def _handle_web_fetch_provider_notification(app_state: AppState, payload: dict) 
     asyncio.create_task(reload_web_fetch_provider(app_state))
 
 
-async def _refresh_model_flags(app_state: AppState) -> None:
-    """Re-read default/secondary model flags from DB (catch-up after reconnect)."""
-    repo = ModelsRepository()
-    records = await repo.list_active()
-    default_id: str | None = None
-    secondary_id: str | None = None
-    for record in records:
-        if record.is_default:
-            default_id = record.id
-        if record.is_secondary:
-            secondary_id = record.id
-    app_state.default_model_id = default_id
-    app_state.secondary_model_id = secondary_id
-    logger.info(
-        f"Refreshed model flags: default={default_id}, secondary={secondary_id}"
-    )
+
 
 
 async def initialize_providers(app_state: AppState) -> None:
     """Initialize all providers (embedding, LLM, tools, storage)."""
     await _init_embedding_provider(app_state)
 
-    # Initialize models from database
-    await load_models(app_state)
-
     # Start DB listener for real-time config change notifications
     async def _on_reconnect():
-        await _refresh_model_flags(app_state)
         await reload_embedding_provider(app_state)
         await reload_web_search_provider(app_state)
         await reload_web_fetch_provider(app_state)
 
     app_state.listener_task = await start_db_listener(
         channels={
-            "model_provider_changed": lambda payload: _handle_model_provider_notification(
-                app_state, payload
-            ),
             "embedding_provider_changed": lambda payload: _handle_embedding_provider_notification(
                 app_state, payload
             ),

--- a/services/ai/services/title_generation.py
+++ b/services/ai/services/title_generation.py
@@ -51,6 +51,7 @@ def _fallback_chat_title(conversation_text: str) -> str:
 
 async def generate_title_for_conversation(
     llm_provider: LLMProvider,
+    model_name: str | None,
     conversation_text: str,
     chat_id: str,
 ) -> GeneratedChatTitle:
@@ -64,6 +65,7 @@ async def generate_title_for_conversation(
             generated_title, usage = await llm_provider.generate_response(
                 prompt=prompt,
                 max_tokens=512,
+                model=model_name,
             )
             title = _clean_generated_title(generated_title)
             if title:

--- a/services/ai/services/title_generation.py
+++ b/services/ai/services/title_generation.py
@@ -64,8 +64,6 @@ async def generate_title_for_conversation(
             generated_title, usage = await llm_provider.generate_response(
                 prompt=prompt,
                 max_tokens=512,
-                temperature=0.7,
-                top_p=0.9,
             )
             title = _clean_generated_title(generated_title)
             if title:

--- a/services/ai/state.py
+++ b/services/ai/state.py
@@ -7,7 +7,7 @@ from datetime import datetime
 import redis.asyncio as aioredis
 
 from embeddings import EmbeddingProvider
-from providers import LLMProvider
+from provider_cache import ProviderCache
 from tools import SearcherTool
 from storage import ContentStorage
 from memory.provider import MemoryProvider
@@ -26,9 +26,7 @@ class AppState:
     embedding_provider_type: str | None = None
     embedding_provider_id: str | None = None
     embedding_provider_updated_at: datetime | None = None
-    models: dict[str, LLMProvider] = field(default_factory=dict)
-    default_model_id: str | None = None
-    secondary_model_id: str | None = None
+    provider_cache: ProviderCache = field(default_factory=ProviderCache)
     searcher_tool: SearcherTool | None = None
     web_search_provider: WebSearchProvider | None = None
     web_search_provider_type: str | None = None

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -27,8 +27,6 @@ from anthropic.types import (
 from config import (
     AGENT_MAX_ITERATIONS,
     DEFAULT_MAX_TOKENS,
-    DEFAULT_TEMPERATURE,
-    DEFAULT_TOP_P,
 )
 from db.compactions import CompactionsRepository
 from db.models import ChatMessage, UserConfiguration
@@ -127,8 +125,6 @@ async def event_stream_with_context_retry(
             messages=provider_messages,
             tools=turn_tools,
             max_tokens=DEFAULT_MAX_TOKENS,
-            temperature=DEFAULT_TEMPERATURE,
-            top_p=DEFAULT_TOP_P,
             system_prompt=provider_system_prompt,
         )
         processed_stream = tracker.wrap_stream(raw_stream)

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -90,6 +90,8 @@ async def event_stream_with_context_retry(
     compactor: ConversationCompactor,
     latest_compaction_summary: str | None,
     summarizer_context_window_tokens: int,
+    model_record_id: str | None = None,
+    model_name: str | None = None,
 ) -> AsyncIterator[MessageStreamEvent | CompactionStart | CompactionEnd]:
     """Stream events from the LLM provider with one automatic compaction retry
     on context-overflow errors.
@@ -102,8 +104,8 @@ async def event_stream_with_context_retry(
             UsageRepository(),
             UsageContext(
                 user_id=chat_user_id,
-                model_id=llm_provider.model_record_id,
-                model_name=llm_provider.model_name,
+                model_id=model_record_id or llm_provider.model_record_id,
+                model_name=model_name or llm_provider.model_name,
                 provider_type=llm_provider.provider_type,
                 purpose=UsagePurpose.CHAT,
                 chat_id=chat_id,
@@ -126,6 +128,7 @@ async def event_stream_with_context_retry(
             tools=turn_tools,
             max_tokens=DEFAULT_MAX_TOKENS,
             system_prompt=provider_system_prompt,
+            model=model_name or llm_provider.model_name,
         )
         processed_stream = tracker.wrap_stream(raw_stream)
         if citable_index:
@@ -379,6 +382,8 @@ async def prepare_and_stream_chat(
     target_provider: LLMProvider,
     initial_tools: list[ToolParam],
     llm_provider: LLMProvider,
+    model_record_id: str | None = None,
+    model_name: str | None = None,
     chat_user_id: str,
     tool_user_id: str | None = None,
     user_email: str | None = None,
@@ -496,6 +501,8 @@ async def prepare_and_stream_chat(
             approvals_repo=approvals_repo,
             pending_interventions=pending_interventions,
             original_user_query=original_user_query,
+            model_record_id=model_record_id,
+            model_name=model_name,
         ):
             yield event
     except asyncio.CancelledError:
@@ -551,6 +558,8 @@ async def stream_generator(
     approvals_repo=None,
     pending_interventions: list[ToolApproval] | None = None,
     original_user_query: str | None = None,
+    model_record_id: str | None = None,
+    model_name: str | None = None,
 ) -> AsyncIterator[str]:
     """Core agent loop: yields SSE event strings.
 
@@ -710,6 +719,8 @@ async def stream_generator(
                     compactor,
                     latest_compaction_summary,
                     summarizer_context_window_tokens,
+                    model_record_id=model_record_id,
+                    model_name=model_name,
                 )
 
                 event_index = 0

--- a/services/ai/tests/conftest.py
+++ b/services/ai/tests/conftest.py
@@ -317,8 +317,16 @@ def app_state(mock_embedding_provider, mock_llm_provider):
     """Create AppState with mocked providers for unit tests."""
     state = AppState()
     state.embedding_provider = mock_embedding_provider
-    state.models = {"mock-model": mock_llm_provider}
-    state.default_model_id = "mock-model"
+    from provider_cache import ResolvedModel
+    async def _resolve_for_model(model_id: str):
+        return ResolvedModel(provider=mock_llm_provider, model_record_id=model_id, model_name="mock-model")
+    async def _resolve_default():
+        return ResolvedModel(provider=mock_llm_provider, model_record_id="mock-model", model_name="mock-model")
+    async def _resolve_secondary_or_default():
+        return ResolvedModel(provider=mock_llm_provider, model_record_id="mock-model", model_name="mock-model")
+    state.provider_cache.resolve_for_model = _resolve_for_model
+    state.provider_cache.resolve_default = _resolve_default
+    state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
     state.searcher_tool = AsyncMock()
     state.content_storage = AsyncMock()
     return state

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -449,6 +449,7 @@ class GatedRecordingLLM:
     PERSISTED_BLOCK_EXTRAS: tuple[str, ...] = ()
     model_name = "gated-test"
     provider_type = "test"
+    supports_citations = False
 
     def __init__(
         self,

--- a/services/ai/tests/integration/test_agent_run_queue.py
+++ b/services/ai/tests/integration/test_agent_run_queue.py
@@ -57,8 +57,16 @@ def _policy(max_attempts: int = 3) -> AgentRunRetryPolicy:
 
 def _app_state_with_llm(mock_llm) -> AppState:
     app_state = AppState()
-    app_state.models = {"mock-model": mock_llm}
-    app_state.default_model_id = "mock-model"
+    from provider_cache import ResolvedModel
+    async def _resolve_for_model(model_id: str):
+        return ResolvedModel(provider=mock_llm, model_record_id=model_id, model_name="mock-model")
+    async def _resolve_default():
+        return ResolvedModel(provider=mock_llm, model_record_id="mock-model", model_name="mock-model")
+    async def _resolve_secondary_or_default():
+        return ResolvedModel(provider=mock_llm, model_record_id="mock-model", model_name="mock-model")
+    app_state.provider_cache.resolve_for_model = _resolve_for_model
+    app_state.provider_cache.resolve_default = _resolve_default
+    app_state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
     app_state.searcher_tool = AsyncMock()
     app_state.content_storage = AsyncMock()
     app_state.redis_client = None

--- a/services/ai/tests/integration/test_background_agents.py
+++ b/services/ai/tests/integration/test_background_agents.py
@@ -170,8 +170,19 @@ def _patch_env(monkeypatch):
 
 def _build_app_state(mock_llm, searcher_tool) -> AppState:
     app_state = AppState()
-    app_state.models = {"mock-model": mock_llm}
-    app_state.default_model_id = "mock-model"
+    # Stub provider_cache to return the mock LLM
+    async def _resolve_for_model(model_id: str):
+        from provider_cache import ResolvedModel
+        return ResolvedModel(provider=mock_llm, model_record_id=model_id, model_name="mock-model")
+    async def _resolve_default():
+        from provider_cache import ResolvedModel
+        return ResolvedModel(provider=mock_llm, model_record_id="mock-model", model_name="mock-model")
+    async def _resolve_secondary_or_default():
+        from provider_cache import ResolvedModel
+        return ResolvedModel(provider=mock_llm, model_record_id="mock-model", model_name="mock-model")
+    app_state.provider_cache.resolve_for_model = _resolve_for_model
+    app_state.provider_cache.resolve_default = _resolve_default
+    app_state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
     app_state.searcher_tool = searcher_tool
     app_state.content_storage = AsyncMock()
     app_state.redis_client = None

--- a/services/ai/tests/integration/test_chat_attribute_search.py
+++ b/services/ai/tests/integration/test_chat_attribute_search.py
@@ -221,8 +221,16 @@ async def _stream_chat(app: FastAPI, chat_id: str) -> str:
 def _build_app(llm_provider, searcher_tool, model_id: str) -> FastAPI:
     app = FastAPI()
     app.state = AppState()
-    app.state.models = {model_id: llm_provider}
-    app.state.default_model_id = model_id
+    from provider_cache import ResolvedModel
+    async def _resolve_for_model(mid: str):
+        return ResolvedModel(provider=llm_provider, model_record_id=mid, model_name=mid)
+    async def _resolve_default():
+        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+    async def _resolve_secondary_or_default():
+        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+    app.state.provider_cache.resolve_for_model = _resolve_for_model
+    app.state.provider_cache.resolve_default = _resolve_default
+    app.state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
     app.state.searcher_tool = searcher_tool
     app.include_router(chat_router)
     return app

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -85,9 +85,16 @@ def _build_chat_app(
     """Build a minimal test FastAPI app wired to the real Redis client."""
     app = FastAPI()
     app.state = AppState()
-    app.state.models = {model_id: llm_provider}
-    app.state.default_model_id = model_id
-    app.state.secondary_model_id = model_id
+    from provider_cache import ResolvedModel
+    async def _resolve_for_model(mid: str):
+        return ResolvedModel(provider=llm_provider, model_record_id=mid, model_name=mid)
+    async def _resolve_default():
+        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+    async def _resolve_secondary_or_default():
+        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+    app.state.provider_cache.resolve_for_model = _resolve_for_model
+    app.state.provider_cache.resolve_default = _resolve_default
+    app.state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
     app.state.searcher_tool = SearcherTool()
     app.state.content_storage = None
     app.state.redis_client = redis_client

--- a/services/ai/tests/integration/test_compaction_durable.py
+++ b/services/ai/tests/integration/test_compaction_durable.py
@@ -58,6 +58,7 @@ class CannedSummaryProvider(LLMProvider):
         max_tokens: int | None = None,
         temperature: float | None = None,
         top_p: float | None = None,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         if self.fail_on_generate:
             raise AssertionError("summary provider should not have been called")
@@ -76,6 +77,7 @@ class CannedSummaryProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         raise NotImplementedError
         yield  # pragma: no cover
@@ -110,6 +112,7 @@ class RecordingTargetProvider(LLMProvider):
         max_tokens: int | None = None,
         temperature: float | None = None,
         top_p: float | None = None,
+        model: str | None = None,
     ) -> tuple[str, TokenUsage]:
         return "target response", TokenUsage(input_tokens=1, output_tokens=1)
 
@@ -122,6 +125,7 @@ class RecordingTargetProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         messages: list[dict[str, Any]] | None = None,
         system_prompt: str | None = None,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         recorded = list(messages or [])
         self.recorded_messages.append(recorded)
@@ -220,12 +224,20 @@ def _app_state_with_providers(
     summary_provider: CannedSummaryProvider,
 ) -> AppState:
     state = AppState()
-    state.models = {
-        target_model_id: target_provider,
-        summary_model_id: summary_provider,
-    }
-    state.default_model_id = target_model_id
-    state.secondary_model_id = summary_model_id
+    from provider_cache import ResolvedModel
+    async def _resolve_for_model(model_id: str):
+        if model_id == target_model_id:
+            return ResolvedModel(provider=target_provider, model_record_id=model_id, model_name=model_id)
+        if model_id == summary_model_id:
+            return ResolvedModel(provider=summary_provider, model_record_id=model_id, model_name=model_id)
+        return None
+    async def _resolve_default():
+        return ResolvedModel(provider=target_provider, model_record_id=target_model_id, model_name=target_model_id)
+    async def _resolve_secondary_or_default():
+        return ResolvedModel(provider=summary_provider, model_record_id=summary_model_id, model_name=summary_model_id)
+    state.provider_cache.resolve_for_model = _resolve_for_model
+    state.provider_cache.resolve_default = _resolve_default
+    state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
     searcher_tool = AsyncMock()
     searcher_tool.client = _DummySearcherClient()
     state.searcher_tool = searcher_tool

--- a/services/ai/tests/integration/test_model_prompt_and_tools.py
+++ b/services/ai/tests/integration/test_model_prompt_and_tools.py
@@ -208,9 +208,16 @@ async def connector_state(
 def _build_app(llm: _RecordingLLM, model_id: str) -> FastAPI:
     app = FastAPI()
     app.state = AppState()
-    app.state.models = {model_id: llm}
-    app.state.default_model_id = model_id
-    app.state.secondary_model_id = model_id
+    from provider_cache import ResolvedModel
+    async def _resolve_for_model(mid: str):
+        return ResolvedModel(provider=llm, model_record_id=mid, model_name=mid)
+    async def _resolve_default():
+        return ResolvedModel(provider=llm, model_record_id=model_id, model_name=model_id)
+    async def _resolve_secondary_or_default():
+        return ResolvedModel(provider=llm, model_record_id=model_id, model_name=model_id)
+    app.state.provider_cache.resolve_for_model = _resolve_for_model
+    app.state.provider_cache.resolve_default = _resolve_default
+    app.state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
     searcher_tool = SearcherTool()
     recording_client = _RecordingSearcherClient(searcher_tool.client)
     searcher_tool.client = recording_client

--- a/services/ai/tests/integration/test_providers_api/conftest.py
+++ b/services/ai/tests/integration/test_providers_api/conftest.py
@@ -1,0 +1,130 @@
+"""Shared conftest for provider API integration tests.
+
+Loads .env so API keys are available before any test is collected, and prints
+a cumulative token-usage summary at session end.
+"""
+
+import json
+import os
+import tempfile
+from pathlib import Path
+
+import pytest
+from dotenv import load_dotenv
+
+# Load .env before any test is collected
+_repo_root = Path(__file__).resolve().parents[5]
+_service_root = Path(__file__).resolve().parents[3]
+load_dotenv(_repo_root / ".env")
+load_dotenv(_service_root / ".env")
+
+
+# ---------------------------------------------------------------------------
+# Session-level token usage tracker — shared via a temp file to avoid
+# module-identity issues with pytest's conftest loading.
+# ---------------------------------------------------------------------------
+
+_USAGE_FILE = os.path.join(tempfile.gettempdir(), "omni_provider_test_usage.json")
+
+
+def _load_usage() -> list[dict]:
+    try:
+        with open(_USAGE_FILE) as f:
+            return json.load(f)
+    except (FileNotFoundError, json.JSONDecodeError):
+        return []
+
+
+def _save_usage(entries: list[dict]) -> None:
+    with open(_USAGE_FILE, "w") as f:
+        json.dump(entries, f)
+
+
+def report_usage(test_name: str, input_tokens: int, output_tokens: int) -> None:
+    entries = _load_usage()
+    entries.append({"test": test_name, "input": input_tokens, "output": output_tokens})
+    _save_usage(entries)
+
+
+def _format_summary(entries: list[dict]) -> str:
+    if not entries:
+        return ""
+    total_in = sum(e["input"] for e in entries)
+    total_out = sum(e["output"] for e in entries)
+    lines = [
+        "",
+        "=" * 66,
+        "  Token Usage Summary",
+        "=" * 66,
+        f"  {'Test':<36} {'Input':>8} {'Output':>8}",
+        "  " + "-" * 54,
+    ]
+    for e in entries:
+        lines.append(f"  {e['test']:<36} {e['input']:>8} {e['output']:>8}")
+    lines.append("  " + "-" * 54)
+    lines.append(f"  {'TOTAL':<36} {total_in:>8} {total_out:>8}")
+    lines.append(f"  Calls: {len(entries)}")
+    lines.append("=" * 66)
+    return "\n".join(lines)
+
+
+def pytest_sessionfinish(session: pytest.Session, exitstatus: int) -> None:
+    """Print cumulative token usage across all real-LLM tests."""
+    entries = _load_usage()
+    summary = _format_summary(entries)
+    if summary:
+        print(summary)
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers used by test files
+# ---------------------------------------------------------------------------
+
+
+def require_env(key: str) -> str:
+    """Return the env var value or raise a clear ``RuntimeError``."""
+    value = os.environ.get(key)
+    if not value or value.strip() == "":
+        raise RuntimeError(
+            f"Missing required environment variable '{key}'. "
+            f"Set it in .env and re-run the tests."
+        )
+    return value
+
+
+def assert_usage(
+    usage: object,
+    *,
+    max_output_tokens: int | None = None,
+    tag: str = "",
+) -> None:
+    """Assert a TokenUsage-like object has sensible token counts."""
+    input_tokens = getattr(usage, "input_tokens", None)
+    output_tokens = getattr(usage, "output_tokens", None)
+
+    assert input_tokens is not None and input_tokens > 0, (
+        f"{tag}expected positive input_tokens, got {input_tokens}"
+    )
+    assert output_tokens is not None and output_tokens > 0, (
+        f"{tag}expected positive output_tokens, got {output_tokens}"
+    )
+
+    if max_output_tokens is not None:
+        assert output_tokens <= max_output_tokens, (
+            f"{tag}output_tokens={output_tokens} exceeds "
+            f"max_output_tokens={max_output_tokens}"
+        )
+
+
+def stream_usage(events: list[object]) -> tuple[int, int] | None:
+    """Extract ``(input_tokens, output_tokens)`` from a stream's ``message_delta``."""
+    for event in events:
+        typ = getattr(event, "type", None)
+        if typ == "message_delta":
+            u = getattr(event, "usage", None)
+            if u is not None:
+                inp = getattr(u, "input_tokens", 0) or 0
+                out = getattr(u, "output_tokens", 0) or 0
+                if inp > 0 and out > 0:
+                    return (inp, out)
+    return None

--- a/services/ai/tests/integration/test_providers_api/test_anthropic.py
+++ b/services/ai/tests/integration/test_providers_api/test_anthropic.py
@@ -1,0 +1,27 @@
+"""Integration test for the Anthropic provider — one streaming call."""
+
+import os
+import pytest
+
+from tests.integration.test_providers_api.conftest import require_env, stream_usage, report_usage
+from providers.anthropic import AnthropicProvider
+
+pytestmark = pytest.mark.real_llm
+
+API_KEY = require_env("TEST_ANTHROPIC_API_KEY")
+MODEL = os.environ.get("TEST_ANTHROPIC_MODEL", "claude-haiku-4-5")
+
+
+class TestAnthropic:
+    async def test_stream(self) -> None:
+        provider = AnthropicProvider(api_key=API_KEY, model=MODEL)
+        events = [
+            e
+            async for e in provider.stream_response(
+                "Count from one to three", max_tokens=30
+            )
+        ]
+        assert events[-1].type == "message_stop"
+        u = stream_usage(events)
+        if u:
+            report_usage("Anthropic.stream", u[0], u[1])

--- a/services/ai/tests/integration/test_providers_api/test_gemini.py
+++ b/services/ai/tests/integration/test_providers_api/test_gemini.py
@@ -1,0 +1,27 @@
+"""Integration test for the Gemini provider — one streaming call."""
+
+import os
+import pytest
+
+from tests.integration.test_providers_api.conftest import require_env, stream_usage, report_usage
+from providers.gemini import GeminiProvider
+
+pytestmark = pytest.mark.real_llm
+
+API_KEY = require_env("TEST_GEMINI_API_KEY")
+MODEL = os.environ.get("TEST_GEMINI_MODEL", "gemini-2.5-flash")
+
+
+class TestGemini:
+    async def test_stream(self) -> None:
+        provider = GeminiProvider(api_key=API_KEY, model=MODEL)
+        events = [
+            e
+            async for e in provider.stream_response(
+                "Count from one to three", max_tokens=30
+            )
+        ]
+        assert events[-1].type == "message_stop"
+        u = stream_usage(events)
+        if u:
+            report_usage("Gemini.stream", u[0], u[1])

--- a/services/ai/tests/integration/test_providers_api/test_openai.py
+++ b/services/ai/tests/integration/test_providers_api/test_openai.py
@@ -1,0 +1,27 @@
+"""Integration test for the OpenAI provider — one streaming call."""
+
+import os
+import pytest
+
+from tests.integration.test_providers_api.conftest import require_env, stream_usage, report_usage
+from providers.openai import OpenAIProvider
+
+pytestmark = pytest.mark.real_llm
+
+API_KEY = require_env("TEST_OPENAI_API_KEY")
+MODEL = os.environ.get("TEST_OPENAI_MODEL", "gpt-4o")
+
+
+class TestOpenAI:
+    async def test_stream(self) -> None:
+        provider = OpenAIProvider(api_key=API_KEY, model=MODEL)
+        events = [
+            e
+            async for e in provider.stream_response(
+                "Count from one to three", max_tokens=30
+            )
+        ]
+        assert events[-1].type == "message_stop"
+        u = stream_usage(events)
+        if u:
+            report_usage("OpenAI.stream", u[0], u[1])

--- a/services/ai/tests/integration/test_providers_api/test_openai_compatible.py
+++ b/services/ai/tests/integration/test_providers_api/test_openai_compatible.py
@@ -1,0 +1,30 @@
+"""Integration test for the OpenAI-compatible provider — one streaming call."""
+
+import os
+import pytest
+
+from tests.integration.test_providers_api.conftest import require_env, stream_usage, report_usage
+from providers.openai_compatible import OpenAICompatibleProvider
+
+pytestmark = pytest.mark.real_llm
+
+BASE_URL = require_env("TEST_OPENAI_COMPATIBLE_BASE_URL")
+API_KEY = require_env("TEST_OPENAI_COMPATIBLE_API_KEY")
+MODEL = os.environ.get("TEST_OPENAI_COMPATIBLE_MODEL", "gpt-4o-mini")
+
+
+class TestOpenAICompatible:
+    async def test_stream(self) -> None:
+        provider = OpenAICompatibleProvider(
+            base_url=BASE_URL, api_key=API_KEY, model=MODEL
+        )
+        events = [
+            e
+            async for e in provider.stream_response(
+                "Count from one to three", max_tokens=30
+            )
+        ]
+        assert events[-1].type == "message_stop"
+        u = stream_usage(events)
+        if u:
+            report_usage("OpenAICompat.stream", u[0], u[1])

--- a/services/ai/tests/unit/test_memory_bootstrap.py
+++ b/services/ai/tests/unit/test_memory_bootstrap.py
@@ -58,8 +58,23 @@ class TestBuildMem0Config:
     @pytest.fixture
     def state(self):
         s = MagicMock()
-        s.models = {"m1": _stub_provider(), "m2": _stub_provider(model_name="gpt-4o")}
-        s.default_model_id = "m1"
+        from provider_cache import ResolvedModel
+        p1 = _stub_provider()
+        p2 = _stub_provider(model_name="gpt-4o")
+        async def _resolve_for_model(model_id: str):
+            if model_id == "m1":
+                return ResolvedModel(provider=p1, model_record_id="m1", model_name=p1.model_name)
+            if model_id == "m2":
+                return ResolvedModel(provider=p2, model_record_id="m2", model_name=p2.model_name)
+            return None
+        async def _resolve_default():
+            return ResolvedModel(provider=p1, model_record_id="m1", model_name=p1.model_name)
+        async def _resolve_secondary_or_default():
+            return ResolvedModel(provider=p2, model_record_id="m2", model_name=p2.model_name)
+        s.provider_cache = type("cache", (), {})()
+        s.provider_cache.resolve_for_model = _resolve_for_model
+        s.provider_cache.resolve_default = _resolve_default
+        s.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
         s.embedding_provider = MagicMock()
         return s
 


### PR DESCRIPTION
- Remove temperature/top_p/min_p from all providers — Anthropic rejects `temperature=None` and APIs have incompatible defaults; letting providers use their own defaults is the only reliable cross-provider approach
- Replace in-memory `state.models` dict with DB-backed resolution — the dict silently fell back to a different model when a chat's model was absent (e.g., after adding a new model never loaded into the dict), causing undetected semantic errors
- Fail loud with HTTP 409 when a chat's model is unavailable instead of silently swapping to the default model
- Cache SDK clients by provider config, not model — preserves httpx connection pooling across all models sharing a provider, with staleness checks via provider `updated_at`
- Configure Gemini client with retry for rate limits (3 attempts, exponential backoff, jitter on 429/5xx)
- Add real-LLM integration tests — one stream call per provider with token tracking, fails immediately if API keys are missing