### PR TITLE
fix(providers): strip empty text blocks from API requests

### DIFF
--- a/services/ai/providers/anthropic_message_adapter.py
+++ b/services/ai/providers/anthropic_message_adapter.py
@@ -33,16 +33,14 @@ type OmniToolResultContentBlockParam = (
 type AnthropicMessageContent = str | Iterable[OmniContentBlockParam]
 
 
-def _is_empty_text_block(block: object) -> bool:
+def _is_empty_text_block(block: ContentBlockParam) -> bool:
     """Return True if *block* is a text content block with empty/whitespace-only text."""
     return bool(
-        isinstance(block, dict)
-        and block.get("type") == "text"
-        and not (block.get("text") or "").strip()
+        block.get("type") == "text" and not (block.get("text") or "").strip()
     )
 
 
-def _drain_empty_text_blocks(blocks: list) -> bool:
+def _drain_empty_text_blocks(blocks: list[ContentBlockParam]) -> bool:
     """Remove empty text blocks in-place; return True if any were removed."""
     before = len(blocks)
     blocks[:] = [b for b in blocks if not _is_empty_text_block(b)]

--- a/services/ai/providers/anthropic_message_adapter.py
+++ b/services/ai/providers/anthropic_message_adapter.py
@@ -33,6 +33,22 @@ type OmniToolResultContentBlockParam = (
 type AnthropicMessageContent = str | Iterable[OmniContentBlockParam]
 
 
+def _is_empty_text_block(block: object) -> bool:
+    """Return True if *block* is a text content block with empty/whitespace-only text."""
+    return bool(
+        isinstance(block, dict)
+        and block.get("type") == "text"
+        and not (block.get("text") or "").strip()
+    )
+
+
+def _drain_empty_text_blocks(blocks: list) -> bool:
+    """Remove empty text blocks in-place; return True if any were removed."""
+    before = len(blocks)
+    blocks[:] = [b for b in blocks if not _is_empty_text_block(b)]
+    return len(blocks) < before
+
+
 def extract_text_document(block: DocumentBlockParam) -> str | None:
     """Convert a text-backed document block into provider-neutral text."""
     if block.get("type") != "document":
@@ -70,7 +86,9 @@ def _build_content_for_api(
 ) -> str | list[ContentBlockParam]:
     if isinstance(content, str):
         return content
-    return [_build_block_for_api(block) for block in content]
+    blocks = [_build_block_for_api(block) for block in content]
+    _drain_empty_text_blocks(blocks)
+    return blocks
 
 
 def _build_block_for_api(block: OmniContentBlockParam) -> ContentBlockParam:
@@ -104,7 +122,9 @@ def _build_tool_result_content_for_api(
 ) -> str | list[ToolResultContentBlockParam]:
     if isinstance(content, str):
         return content
-    return [_build_tool_result_content_block_for_api(block) for block in content]
+    blocks = [_build_tool_result_content_block_for_api(block) for block in content]
+    _drain_empty_text_blocks(blocks)
+    return blocks
 
 
 def _build_tool_result_content_block_for_api(

--- a/services/ai/providers/openai.py
+++ b/services/ai/providers/openai.py
@@ -338,7 +338,9 @@ class OpenAIProvider(LLMProvider):
                 block_type = block.get("type")
 
                 if block_type == "text":
-                    text_parts.append(block.get("text", ""))
+                    text = block.get("text", "")
+                    if text:
+                        text_parts.append(text)
                 elif block_type == "document" and role == "user":
                     document_text = extract_text_document(block)
                     if document_text is not None:
@@ -363,7 +365,9 @@ class OpenAIProvider(LLMProvider):
                         for rb in result_content:
                             if isinstance(rb, dict):
                                 if rb.get("type") == "text":
-                                    parts.append(rb.get("text", ""))
+                                    t = rb.get("text", "")
+                                    if t:
+                                        parts.append(t)
                                 elif rb.get("type") == "search_result":
                                     title = rb.get("title", "")
                                     source = rb.get("source", "")

--- a/services/ai/providers/openai_compatible.py
+++ b/services/ai/providers/openai_compatible.py
@@ -208,7 +208,8 @@ def _convert_messages_to_openai(
                             continue
                         if rb.get("type") == "text":
                             rb = cast(TextBlockParam, rb)
-                            parts.append(rb["text"])
+                            if rb["text"]:
+                                parts.append(rb["text"])
                         elif rb.get("type") == "search_result":
                             title = rb.get("title", "")
                             source = rb.get("source", "")


### PR DESCRIPTION
- Anthropic and Bedrock providers now strip empty/whitespace-only text blocks from message content and tool results via the shared message adapter
- OpenAI provider skips empty text blocks when building response input items
- OpenAI-compatible provider skips empty text blocks inside tool result content (top-level was already guarded)
- Gemini, Vertex AI, and Azure Foundry were already handling this correctly or delegate to the fixed providers
- The fix prevents the Anthropic API's "text blocks must be non-empty" validation error that could occur when persisted conversation history accumulates empty text blocks through interrupted streams or empty tool results