### PR TITLE
refactor(connector-manager): extract CredentialService, strip OAuth from shared repo

### DIFF
--- a/services/connector-manager/src/credential_service.rs
+++ b/services/connector-manager/src/credential_service.rs
@@ -1,0 +1,1051 @@
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+use std::time::Duration;
+
+use serde::Deserialize;
+use serde_json::Value as JsonValue;
+use shared::db::repositories::{ConnectorConfigRepository, ServiceCredentialsRepo};
+use shared::models::{AuthType, ServiceCredential, Source};
+use shared::DatabasePool;
+use thiserror::Error;
+use time::OffsetDateTime;
+use tokio::sync::Mutex;
+use tracing::debug;
+
+use crate::remote_mcp::gateway::{
+    pinned_http_client_for_url, read_limited_response_text, validate_endpoint_for_gateway,
+};
+use crate::remote_mcp::oauth::{RemoteMcpOAuthConfig, TokenEndpointAuthMethod};
+
+/// Helper: serialises [`ServiceProvider`] to its JSON/DB string form.
+fn provider_to_string(p: &shared::models::ServiceProvider) -> String {
+    serde_json::to_value(p)
+        .ok()
+        .and_then(|v| v.as_str().map(String::from))
+        .unwrap_or_default()
+}
+
+const REFRESH_SKEW_SECONDS: i64 = 300;
+
+/// Errors returned by [`CredentialService`].
+#[derive(Debug, Error)]
+pub enum CredentialServiceError {
+    #[error("missing OAuth field: {0}")]
+    MissingField(&'static str),
+    #[error("credential requires OAuth reconnect")]
+    ReconnectRequired,
+    #[error("OAuth refresh failed: {0}")]
+    RefreshFailed(String),
+    #[error("repository error: {0}")]
+    Repository(String),
+}
+
+/// Wraps the dumb [`ServiceCredentialsRepo`] with OAuth token lifecycle
+/// management.
+///
+/// * Credential reads that need a token refresh perform the HTTP request
+///   **outside** any database transaction.
+/// * Concurrency for the same credential (source + user) is serialised with
+///   an in-process `Mutex` so rotating refresh tokens are never replayed.
+/// * Client id/secret/token endpoint are resolved from the connector config
+///   (`ConnectorConfigRepository`) with fallback to values stored in the
+///   credential JSON, and optional overrides from remote-MCP discovery
+///   metadata ([`RemoteMcpOAuthConfig`]).
+pub struct CredentialService {
+    db_pool: DatabasePool,
+}
+
+static CREDENTIAL_REFRESH_LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> = OnceLock::new();
+
+impl CredentialService {
+    pub fn new(db_pool: DatabasePool) -> Self {
+        Self { db_pool }
+    }
+
+    // ── Public API ────────────────────────────────────────────────
+
+    /// Fetch the org-wide credential (`user_id IS NULL`) for a source,
+    /// transparently refreshing an expiring OAuth token.
+    ///
+    /// If the credential lacks the OAuth fields needed for a refresh
+    /// (`refresh_token`, `client_id`, `token_uri`) it is returned unchanged
+    /// rather than erroring.
+    pub async fn get_org_credential(
+        &self,
+        source_id: &str,
+    ) -> Result<Option<ServiceCredential>, CredentialServiceError> {
+        let repo = self.repo()?;
+        let credential = repo
+            .find_org_credential(source_id)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?;
+        match credential {
+            Some(c) => self.refresh_if_needed(&c).await.map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// Fetch a per-user credential row for an org-wide source,
+    /// transparently refreshing an expiring OAuth token.
+    ///
+    /// If the credential lacks the OAuth fields needed for a refresh
+    /// it is returned unchanged rather than erroring.
+    pub async fn get_user_credential(
+        &self,
+        source_id: &str,
+        user_id: &str,
+    ) -> Result<Option<ServiceCredential>, CredentialServiceError> {
+        let repo = self.repo()?;
+        let credential = repo
+            .find_user_credential(source_id, user_id)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?;
+        match credential {
+            Some(c) => self.refresh_if_needed(&c).await.map(Some),
+            None => Ok(None),
+        }
+    }
+
+    /// Fetch the credential that "owns" a source (org-scoped → org row,
+    /// user-scoped → user row keyed on the creator), refreshing if needed.
+    pub async fn get_owner_credential(
+        &self,
+        source: &Source,
+    ) -> Result<Option<ServiceCredential>, CredentialServiceError> {
+        let repo = self.repo()?;
+        let credential = repo
+            .find_owner_credential(source)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?;
+        match credential {
+            Some(c) => self.refresh_if_needed(&c).await.map(Some),
+            None => Ok(None),
+        }
+    }
+
+    // ── Raw (no-refresh) variants ─────────────────────────────────
+
+    /// Fetch org credential **without** OAuth refresh.
+    pub async fn raw_org_credential(
+        &self,
+        source_id: &str,
+    ) -> Result<Option<ServiceCredential>, CredentialServiceError> {
+        let repo = self.repo()?;
+        repo.find_org_credential(source_id)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))
+    }
+
+    /// Fetch per-user credential **without** OAuth refresh.
+    pub async fn raw_user_credential(
+        &self,
+        source_id: &str,
+        user_id: &str,
+    ) -> Result<Option<ServiceCredential>, CredentialServiceError> {
+        let repo = self.repo()?;
+        repo.find_user_credential(source_id, user_id)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))
+    }
+
+    /// Fetch owner credential **without** OAuth refresh — a raw passthrough
+    /// for callers that only need the stored value (e.g. SDK sync-config).
+    pub async fn raw_owner_credential(
+        &self,
+        source: &Source,
+    ) -> Result<Option<ServiceCredential>, CredentialServiceError> {
+        let repo = self.repo()?;
+        repo.find_owner_credential(source)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))
+    }
+
+    // ── Remote-MCP refresh ────────────────────────────────────────
+
+    /// Refresh a credential using remote-MCP-style OAuth discovery metadata.
+    /// Used by the remote MCP gateway which has already parsed a
+    /// [`RemoteMcpOAuthConfig`] from the endpoint's discovery response.
+    ///
+    /// Unlike the generic refresh path, this returns [`ReconnectRequired`]
+    /// when the credential is missing a `refresh_token` because the remote
+    /// MCP flow requires user re-authentication.
+    pub(crate) async fn refresh_credential_with_oauth(
+        &self,
+        _source: &Source,
+        credential: ServiceCredential,
+        oauth: &RemoteMcpOAuthConfig,
+    ) -> Result<ServiceCredential, CredentialServiceError> {
+        if credential.auth_type != AuthType::OAuth {
+            return Ok(credential);
+        }
+
+        let key = format!(
+            "{}:{}",
+            credential.source_id,
+            credential.user_id.as_deref().unwrap_or("__org__")
+        );
+        let locks = CREDENTIAL_REFRESH_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+        let lock = {
+            let mut guard = locks.lock().await;
+            guard
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = lock.lock().await;
+
+        let repo = self.repo()?;
+        let mut credential = repo
+            .find_by_id(&credential.id)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?
+            .ok_or_else(|| CredentialServiceError::Repository("credential disappeared".into()))?;
+
+        if !credential_needs_refresh(&credential, OffsetDateTime::now_utc()) {
+            return Ok(credential);
+        }
+
+        let config_repo = ConnectorConfigRepository::new(self.db_pool.pool().clone());
+        let connector_config = config_repo
+            .get_by_provider(&oauth.provider)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?
+            .map(|row| row.config)
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        let refreshed = do_oauth_refresh(
+            &mut credential,
+            &connector_config,
+            oauth,
+            true, // remote_mcp = true → errors on missing refresh_token
+            None, // http_client
+        )
+        .await?;
+
+        repo.update_credentials(&refreshed)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?;
+
+        debug!(
+            source_id = %refreshed.source_id,
+            "refreshed remote MCP OAuth credential"
+        );
+        Ok(refreshed)
+    }
+
+    // ── Refresh orchestration ─────────────────────────────────────
+
+    /// Refresh OAuth tokens when the credential is about to expire.
+    /// The HTTP POST to the token endpoint happens **outside** any DB
+    /// transaction. Concurrency is serialised with an in-process mutex.
+    ///
+    /// If the credential lacks the required fields for a refresh
+    /// (`refresh_token`, `client_id`, `token_uri`), it is returned
+    /// unchanged.
+    async fn refresh_if_needed(
+        &self,
+        credential: &ServiceCredential,
+    ) -> Result<ServiceCredential, CredentialServiceError> {
+        if credential.auth_type != AuthType::OAuth {
+            return Ok(credential.clone());
+        }
+        if !credential_needs_refresh(credential, OffsetDateTime::now_utc()) {
+            return Ok(credential.clone());
+        }
+
+        // Acquire the in-process mutex for this credential so that
+        // concurrent requests don't race on a rotating refresh token.
+        let key = format!(
+            "{}:{}",
+            credential.source_id,
+            credential.user_id.as_deref().unwrap_or("__org__")
+        );
+        let locks = CREDENTIAL_REFRESH_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
+        let lock = {
+            let mut guard = locks.lock().await;
+            guard
+                .entry(key.clone())
+                .or_insert_with(|| Arc::new(Mutex::new(())))
+                .clone()
+        };
+        let _guard = lock.lock().await;
+
+        // Re-read the credential from the DB — another thread may have
+        // refreshed it while we waited for the mutex.
+        let repo = self.repo()?;
+        let mut credential = repo
+            .find_by_id(&credential.id)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?
+            .ok_or_else(|| CredentialServiceError::Repository("credential disappeared".into()))?;
+
+        if !credential_needs_refresh(&credential, OffsetDateTime::now_utc()) {
+            return Ok(credential);
+        }
+
+        // Resolve provider string for connector-config lookup.
+        let provider_str = provider_to_string(&credential.provider);
+        let config_repo = ConnectorConfigRepository::new(self.db_pool.pool().clone());
+        let connector_config = config_repo
+            .get_by_provider(&provider_str)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?
+            .map(|row| row.config)
+            .unwrap_or_else(|| serde_json::json!({}));
+
+        // Build a RemoteMcpOAuthConfig-like view from native fields.
+        // This allows us to reuse do_oauth_refresh for both native and
+        // remote-MCP paths.
+        let token_uri = string_from(&connector_config, "oauth_token_endpoint")
+            .or_else(|| string_from(&credential.credentials, "token_uri"));
+
+        // If we don't even have a token endpoint, there is nothing to
+        // refresh — return the credential unchanged.
+        let Some(token_endpoint) = token_uri else {
+            return Ok(credential);
+        };
+
+        // Resolve auth method with proper precedence:
+        //   connector config → credential JSON → heuristic
+        let auth_method_str = string_from(&connector_config, "oauth_token_endpoint_auth_method")
+            .or_else(|| string_from(&credential.credentials, "token_endpoint_auth_method"));
+        let has_secret = string_from(&connector_config, "oauth_client_secret")
+            .or_else(|| string_from(&credential.credentials, "client_secret"))
+            .is_some();
+        let auth_method = match auth_method_str.as_deref() {
+            Some("client_secret_basic") => TokenEndpointAuthMethod::ClientSecretBasic,
+            Some("none") => TokenEndpointAuthMethod::None,
+            _ => {
+                if has_secret {
+                    TokenEndpointAuthMethod::ClientSecretPost
+                } else {
+                    TokenEndpointAuthMethod::None
+                }
+            }
+        };
+
+        let native_oauth = NativeOAuthParams {
+            provider: provider_str,
+            credential_provider: String::new(),
+            token_endpoint,
+            token_endpoint_auth_method: auth_method,
+            resource: string_from(&credential.credentials, "resource"),
+        };
+
+        // Generic native refresh: if any required OAuth field is missing,
+        // return the credential unchanged rather than erroring. The caller
+        // can surface the issue naturally (e.g. a sync will fail).
+        if !native_oauth_is_refreshable(&connector_config, &credential.credentials) {
+            return Ok(credential);
+        }
+        let refresh_token = credential
+            .credentials
+            .get("refresh_token")
+            .and_then(|v| v.as_str())
+            .filter(|v| !v.is_empty())
+            .map(str::to_owned)
+            .unwrap();
+
+        let refreshed = do_native_refresh(
+            &mut credential,
+            &connector_config,
+            &native_oauth,
+            &refresh_token,
+            None,
+        )
+        .await;
+
+        let refreshed = refreshed?;
+        repo.update_credentials(&refreshed)
+            .await
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))?;
+        debug!(
+            source_id = %refreshed.source_id,
+            provider = ?refreshed.provider,
+            "refreshed OAuth credential"
+        );
+        Ok(refreshed)
+    }
+
+    fn repo(&self) -> Result<ServiceCredentialsRepo, CredentialServiceError> {
+        ServiceCredentialsRepo::new(self.db_pool.pool().clone())
+            .map_err(|e| CredentialServiceError::Repository(e.to_string()))
+    }
+}
+
+// ── Predicates ─────────────────────────────────────────────────────
+
+fn credential_needs_refresh(credential: &ServiceCredential, now: OffsetDateTime) -> bool {
+    match credential.expires_at {
+        Some(expires_at) => expires_at <= now + time::Duration::seconds(REFRESH_SKEW_SECONDS),
+        None => false,
+    }
+}
+
+/// Whether the credential has the minimum fields needed for a native
+/// OAuth token refresh: a nonempty `refresh_token`, a resolvable
+/// `client_id` (from connector config or credential JSON), and a
+/// resolvable token endpoint (from connector config or credential JSON).
+fn native_oauth_is_refreshable(connector_config: &JsonValue, credential_json: &JsonValue) -> bool {
+    let has_refresh_token = credential_json
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .is_some_and(|s| !s.is_empty());
+    let has_client_id = string_from(connector_config, "oauth_client_id")
+        .or_else(|| string_from(credential_json, "client_id"))
+        .is_some();
+    let has_token_endpoint = string_from(connector_config, "oauth_token_endpoint")
+        .or_else(|| string_from(credential_json, "token_uri"))
+        .is_some();
+    has_refresh_token && has_client_id && has_token_endpoint
+}
+
+// ── Native OAuth params (remote-MCP-style view of native credential) ─
+
+struct NativeOAuthParams {
+    provider: String,
+    credential_provider: String,
+    token_endpoint: String,
+    token_endpoint_auth_method: TokenEndpointAuthMethod,
+    resource: Option<String>,
+}
+
+// ── Refresh logic ─────────────────────────────────────────────────
+
+#[derive(Debug, Deserialize)]
+struct RefreshResponse {
+    access_token: String,
+    refresh_token: Option<String>,
+    token_type: Option<String>,
+    expires_in: Option<i64>,
+}
+
+/// Perform a full OAuth token refresh for a native credential.
+///
+/// `remote_mcp` controls error behaviour: when `true`, a missing
+/// `refresh_token` produces [`ReconnectRequired`]; when `false` the
+/// caller is expected to have already handled the missing-token case.
+async fn do_oauth_refresh(
+    credential: &mut ServiceCredential,
+    connector_config: &JsonValue,
+    oauth: &RemoteMcpOAuthConfig,
+    remote_mcp: bool,
+    http_client: Option<reqwest::Client>,
+) -> Result<ServiceCredential, CredentialServiceError> {
+    let refresh_token = credential
+        .credentials
+        .get("refresh_token")
+        .and_then(|v| v.as_str())
+        .filter(|v| !v.is_empty())
+        .ok_or_else(|| {
+            if remote_mcp {
+                CredentialServiceError::ReconnectRequired
+            } else {
+                CredentialServiceError::MissingField("refresh_token")
+            }
+        })?;
+
+    let client_id = resolve_oauth_param(
+        connector_config,
+        &credential.credentials,
+        "oauth_client_id",
+        "client_id",
+    )
+    .ok_or(CredentialServiceError::MissingField("oauth_client_id"))?;
+    let client_secret = resolve_oauth_param(
+        connector_config,
+        &credential.credentials,
+        "oauth_client_secret",
+        "client_secret",
+    );
+    let token_endpoint = resolve_oauth_param(
+        connector_config,
+        &credential.credentials,
+        "oauth_token_endpoint",
+        "token_uri",
+    )
+    .unwrap_or_else(|| oauth.token_endpoint.clone());
+    let token_method = token_method_from_params(connector_config, &credential.credentials, oauth);
+    let token_endpoint = &token_endpoint;
+
+    let mut params = vec![
+        ("grant_type".to_string(), "refresh_token".to_string()),
+        ("refresh_token".to_string(), refresh_token.to_string()),
+    ];
+    let mut basic_auth: Option<(String, String)> = None;
+    match token_method {
+        TokenEndpointAuthMethod::None => {
+            params.push(("client_id".to_string(), client_id));
+        }
+        TokenEndpointAuthMethod::ClientSecretPost => {
+            params.push(("client_id".to_string(), client_id));
+            if let Some(secret) = client_secret {
+                params.push(("client_secret".to_string(), secret));
+            }
+        }
+        TokenEndpointAuthMethod::ClientSecretBasic => {
+            let secret =
+                client_secret.ok_or(CredentialServiceError::MissingField("oauth_client_secret"))?;
+            basic_auth = Some((client_id, secret));
+        }
+    }
+
+    if let Some(resource) = &oauth.resource {
+        if remote_mcp {
+            validate_endpoint_for_gateway(resource)
+                .await
+                .map_err(|e| CredentialServiceError::RefreshFailed(e.to_string()))?;
+        }
+        params.push(("resource".to_string(), resource.clone()));
+    }
+
+    let client = match http_client {
+        Some(c) => c,
+        None => pinned_http_client_for_url(token_endpoint)
+            .await
+            .map_err(|e| CredentialServiceError::RefreshFailed(e.to_string()))?,
+    };
+    let mut request = client
+        .post(token_endpoint)
+        .timeout(Duration::from_secs(20))
+        .header("accept", "application/json");
+    if let Some((client_id, client_secret)) = basic_auth {
+        request = request.basic_auth(client_id, Some(client_secret));
+    }
+
+    apply_refresh_response(
+        credential,
+        token_endpoint,
+        request.form(&params).send().await,
+    )
+    .await
+}
+
+/// Native-only refresh path without the `RemoteMcpOAuthConfig` wrapper.
+async fn do_native_refresh(
+    credential: &mut ServiceCredential,
+    connector_config: &JsonValue,
+    params: &NativeOAuthParams,
+    _refresh_token: &str,
+    http_client: Option<reqwest::Client>,
+) -> Result<ServiceCredential, CredentialServiceError> {
+    let oauth = RemoteMcpOAuthConfig {
+        provider: params.provider.clone(),
+        credential_provider: params.credential_provider.clone(),
+        token_endpoint: params.token_endpoint.clone(),
+        token_endpoint_auth_method: params.token_endpoint_auth_method.clone(),
+        resource: params.resource.clone(),
+    };
+
+    // For the native path we already verified the refresh_token exists,
+    // so pass remote_mcp=false so the error path isn't hit.
+    do_oauth_refresh(credential, connector_config, &oauth, false, http_client).await
+}
+
+/// Resolve auth method with precedence:
+/// 1. Connector config `oauth_token_endpoint_auth_method`
+/// 2. Credential JSON `token_endpoint_auth_method`
+/// 3. Supplied metadata (`oauth.token_endpoint_auth_method`).
+///    Native metadata already contains the heuristic choice.
+fn token_method_from_params(
+    connector_config: &JsonValue,
+    credential: &JsonValue,
+    oauth: &RemoteMcpOAuthConfig,
+) -> TokenEndpointAuthMethod {
+    // 1. Explicit from connector config wins.
+    if let Some(method) = string_from(connector_config, "oauth_token_endpoint_auth_method") {
+        return TokenEndpointAuthMethod::parse(Some(&method));
+    }
+    // 2. Then credential JSON.
+    if let Some(method) = string_from(credential, "token_endpoint_auth_method") {
+        return TokenEndpointAuthMethod::parse(Some(&method));
+    }
+    // 3. Supplied metadata (native path caller already resolved heuristic
+    //    into this value; remote-MCP comes from endpoint discovery).
+    oauth.token_endpoint_auth_method.clone()
+}
+
+/// Resolve a parameter from connector config first, then credential JSON,
+/// with separate key names for each source.
+fn resolve_oauth_param(
+    connector_config: &JsonValue,
+    credential: &JsonValue,
+    connector_key: &str,
+    credential_key: &str,
+) -> Option<String> {
+    string_from(connector_config, connector_key).or_else(|| string_from(credential, credential_key))
+}
+
+/// Perform the HTTP POST, parse the response, populate the credential, and
+/// return the updated credential (or an error).
+async fn apply_refresh_response(
+    credential: &mut ServiceCredential,
+    token_endpoint: &str,
+    response: Result<reqwest::Response, reqwest::Error>,
+) -> Result<ServiceCredential, CredentialServiceError> {
+    let response = response.map_err(|e| CredentialServiceError::RefreshFailed(e.to_string()))?;
+    let status = response.status();
+    let body = read_limited_response_text(response)
+        .await
+        .map_err(|e| CredentialServiceError::RefreshFailed(e.to_string()))?;
+    if !status.is_success() {
+        if is_reconnect_required_refresh_failure(status.as_u16(), &body) {
+            return Err(CredentialServiceError::ReconnectRequired);
+        }
+        return Err(CredentialServiceError::RefreshFailed(format!(
+            "token endpoint returned HTTP {status}"
+        )));
+    }
+    let refreshed: RefreshResponse = serde_json::from_str(&body)
+        .map_err(|e| CredentialServiceError::RefreshFailed(e.to_string()))?;
+
+    let now = OffsetDateTime::now_utc();
+
+    credential.credentials["access_token"] = JsonValue::String(refreshed.access_token);
+    if let Some(refresh_token) = refreshed.refresh_token {
+        credential.credentials["refresh_token"] = JsonValue::String(refresh_token);
+    }
+    credential.credentials["token_type"] =
+        JsonValue::String(refreshed.token_type.unwrap_or_else(|| "Bearer".to_string()));
+    credential.credentials["token_uri"] = JsonValue::String(token_endpoint.to_string());
+
+    let expires_in = refreshed
+        .expires_in
+        .filter(|seconds| *seconds > 0)
+        .unwrap_or(3600);
+    credential.expires_at = Some(now + time::Duration::seconds(expires_in));
+    credential.last_validated_at = Some(now);
+
+    Ok(credential.clone())
+}
+
+fn is_reconnect_required_refresh_failure(status: u16, body: &str) -> bool {
+    if !(400..500).contains(&status)
+        || status == 408
+        || status == 409
+        || status == 425
+        || status == 429
+    {
+        return false;
+    }
+    let Ok(value) = serde_json::from_str::<JsonValue>(body) else {
+        return true;
+    };
+    let error = value
+        .get("error")
+        .and_then(|v| v.as_str())
+        .unwrap_or_default();
+    matches!(
+        error,
+        "invalid_grant" | "invalid_client" | "unauthorized_client" | "access_denied"
+    )
+}
+
+fn string_from(value: &JsonValue, key: &str) -> Option<String> {
+    value
+        .get(key)
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+        .map(str::to_owned)
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+    use shared::models::{AuthType, ServiceProvider};
+
+    fn credential(expires_at: Option<OffsetDateTime>) -> ServiceCredential {
+        ServiceCredential {
+            id: "cred_1".to_string(),
+            source_id: "src_1".to_string(),
+            user_id: Some("user_1".to_string()),
+            provider: ServiceProvider::RemoteMcp,
+            auth_type: AuthType::OAuth,
+            principal_email: None,
+            credentials: json!({"access_token":"old"}),
+            config: json!({}),
+            expires_at,
+            last_validated_at: None,
+            created_at: OffsetDateTime::now_utc(),
+            updated_at: OffsetDateTime::now_utc(),
+        }
+    }
+
+    // ── Predicate tests ──────────────────────────────────────────
+
+    #[test]
+    fn detects_expiring_credentials_with_skew() {
+        assert!(!credential_needs_refresh(
+            &credential(None),
+            OffsetDateTime::now_utc()
+        ));
+        assert!(credential_needs_refresh(
+            &credential(Some(
+                OffsetDateTime::now_utc() + time::Duration::seconds(60)
+            )),
+            OffsetDateTime::now_utc(),
+        ));
+        assert!(!credential_needs_refresh(
+            &credential(Some(OffsetDateTime::now_utc() + time::Duration::hours(1))),
+            OffsetDateTime::now_utc(),
+        ));
+    }
+
+    // ── Failure classification tests ─────────────────────────────
+
+    #[test]
+    fn refresh_failure_classification_distinguishes_reconnect_from_transient() {
+        assert!(is_reconnect_required_refresh_failure(
+            400,
+            r#"{"error":"invalid_grant"}"#,
+        ));
+        assert!(is_reconnect_required_refresh_failure(
+            401,
+            r#"{"error":"invalid_client"}"#,
+        ));
+        assert!(!is_reconnect_required_refresh_failure(
+            429,
+            r#"{"error":"rate_limited"}"#,
+        ));
+        assert!(!is_reconnect_required_refresh_failure(
+            500,
+            r#"{"error":"server_error"}"#,
+        ));
+    }
+
+    // ── Auth method resolution tests ─────────────────────────────
+
+    #[test]
+    fn auth_method_resolves_connector_config_explicit() {
+        let cc = json!({"oauth_token_endpoint_auth_method": "client_secret_basic"});
+        let cred = json!({});
+        let oauth = RemoteMcpOAuthConfig {
+            provider: "test".into(),
+            credential_provider: String::new(),
+            token_endpoint: "https://token.example.com".into(),
+            token_endpoint_auth_method: TokenEndpointAuthMethod::ClientSecretPost,
+            resource: None,
+        };
+        assert_eq!(
+            token_method_from_params(&cc, &cred, &oauth),
+            TokenEndpointAuthMethod::ClientSecretBasic
+        );
+    }
+
+    #[test]
+    fn auth_method_falls_back_to_credential_json() {
+        let cc = json!({});
+        let cred = json!({"token_endpoint_auth_method": "none"});
+        let oauth = RemoteMcpOAuthConfig {
+            provider: "test".into(),
+            credential_provider: String::new(),
+            token_endpoint: "https://token.example.com".into(),
+            token_endpoint_auth_method: TokenEndpointAuthMethod::ClientSecretPost,
+            resource: None,
+        };
+        assert_eq!(
+            token_method_from_params(&cc, &cred, &oauth),
+            TokenEndpointAuthMethod::None
+        );
+    }
+
+    #[test]
+    fn auth_method_uses_oauth_metadata_when_no_explicit_config_or_cred() {
+        // No config, no credential JSON → falls through to oauth metadata
+        // which is always honored before heuristic.
+        let cc = json!({});
+        let cred = json!({});
+        let oauth = RemoteMcpOAuthConfig {
+            provider: "test".into(),
+            credential_provider: String::new(),
+            token_endpoint: "https://token.example.com".into(),
+            token_endpoint_auth_method: TokenEndpointAuthMethod::ClientSecretPost,
+            resource: None,
+        };
+        // oauth says ClientSecretPost → use it even without a secret.
+        assert_eq!(
+            token_method_from_params(&cc, &cred, &oauth),
+            TokenEndpointAuthMethod::ClientSecretPost
+        );
+    }
+
+    #[test]
+    fn auth_method_uses_oauth_metadata_when_heuristic_would_be_none() {
+        // No config, no credential JSON, oauth says None → None.
+        let cc = json!({});
+        let cred = json!({});
+        let oauth = RemoteMcpOAuthConfig {
+            provider: "test".into(),
+            credential_provider: String::new(),
+            token_endpoint: "https://token.example.com".into(),
+            token_endpoint_auth_method: TokenEndpointAuthMethod::None,
+            resource: None,
+        };
+        assert_eq!(
+            token_method_from_params(&cc, &cred, &oauth),
+            TokenEndpointAuthMethod::None
+        );
+    }
+
+    // ── native_oauth_is_refreshable tests ────────────────────────
+
+    #[test]
+    fn refreshable_when_all_fields_present() {
+        let cc = json!({"oauth_client_id": "c1"});
+        let cred = json!({
+            "refresh_token": "rt",
+            "token_uri": "https://tok.example.com"
+        });
+        assert!(native_oauth_is_refreshable(&cc, &cred));
+    }
+
+    #[test]
+    fn refreshable_client_id_from_credential_fallback() {
+        let cc = json!({});
+        let cred = json!({
+            "refresh_token": "rt",
+            "client_id": "c1",
+            "token_uri": "https://tok.example.com"
+        });
+        assert!(native_oauth_is_refreshable(&cc, &cred));
+    }
+
+    #[test]
+    fn not_refreshable_when_missing_refresh_token() {
+        let cc = json!({"oauth_client_id": "c1"});
+        let cred = json!({
+            "access_token": "tok",
+            "token_uri": "https://tok.example.com"
+        });
+        assert!(!native_oauth_is_refreshable(&cc, &cred));
+    }
+
+    #[test]
+    fn not_refreshable_when_missing_client_id() {
+        let cc = json!({});
+        let cred = json!({
+            "refresh_token": "rt",
+            "token_uri": "https://tok.example.com"
+        });
+        assert!(!native_oauth_is_refreshable(&cc, &cred));
+    }
+
+    #[test]
+    fn not_refreshable_when_missing_token_uri() {
+        let cc = json!({});
+        let cred = json!({
+            "refresh_token": "rt",
+            "client_id": "c1"
+        });
+        assert!(!native_oauth_is_refreshable(&cc, &cred));
+    }
+
+    #[test]
+    fn not_refreshable_when_empty_refresh_token() {
+        let cc = json!({"oauth_client_id": "c1"});
+        let cred = json!({
+            "refresh_token": "",
+            "token_uri": "https://tok.example.com"
+        });
+        // empty string should be treated as missing
+        assert!(!native_oauth_is_refreshable(&cc, &cred));
+    }
+
+    // ── End-to-end HTTP refresh test ─────────────────────────────
+
+    #[tokio::test]
+    async fn refreshes_public_client_tokens_and_preserves_resource_binding() {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use axum::{
+            extract::{Form, State},
+            routing::post,
+            Json, Router,
+        };
+        use tokio::sync::Mutex as TokioMutex;
+
+        type CapturedForm = Arc<TokioMutex<Option<HashMap<String, String>>>>;
+
+        async fn token_endpoint(
+            State(captured): State<CapturedForm>,
+            Form(form): Form<HashMap<String, String>>,
+        ) -> Json<JsonValue> {
+            *captured.lock().await = Some(form);
+            Json(json!({
+                "access_token": "access-new",
+                "refresh_token": "refresh-new",
+                "token_type": "Bearer",
+                "expires_in": 120
+            }))
+        }
+
+        let captured: CapturedForm = Arc::new(TokioMutex::new(None));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/token", post(token_endpoint))
+            .with_state(captured.clone());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        // This test reaches do_oauth_refresh via do_native_refresh with a
+        // plain client to avoid the pinned-client loopback restriction.
+        let resource = "https://windshift.example/mcp";
+        let mut credential = ServiceCredential {
+            id: "cred_1".to_string(),
+            source_id: "src_1".to_string(),
+            user_id: Some("user_1".to_string()),
+            provider: ServiceProvider::RemoteMcp,
+            auth_type: AuthType::OAuth,
+            principal_email: None,
+            credentials: json!({
+                "access_token": "access-old",
+                "refresh_token": "refresh-old",
+                "client_id": "client-1",
+                "token_uri": format!("http://{address}/token"),
+                "token_endpoint_auth_method": "none",
+                "resource": resource,
+            }),
+            config: json!({}),
+            expires_at: Some(OffsetDateTime::now_utc()),
+            last_validated_at: None,
+            created_at: OffsetDateTime::now_utc(),
+            updated_at: OffsetDateTime::now_utc(),
+        };
+
+        let native_params = NativeOAuthParams {
+            provider: "remote_mcp:test".to_string(),
+            credential_provider: String::new(),
+            token_endpoint: format!("http://{address}/token"),
+            token_endpoint_auth_method: TokenEndpointAuthMethod::None,
+            resource: Some(resource.to_string()),
+        };
+
+        let result = do_native_refresh(
+            &mut credential,
+            &json!({}),
+            &native_params,
+            "refresh-old",
+            Some(reqwest::Client::new()),
+        )
+        .await
+        .unwrap();
+
+        server.abort();
+
+        assert_eq!(result.credentials["access_token"], "access-new");
+        assert_eq!(result.credentials["refresh_token"], "refresh-new");
+        assert_eq!(result.credentials["token_type"], "Bearer");
+        assert_eq!(
+            result.credentials["token_uri"],
+            format!("http://{address}/token")
+        );
+        assert!(
+            result.expires_at.unwrap() > OffsetDateTime::now_utc() + time::Duration::seconds(100)
+        );
+        assert!(result.last_validated_at.is_some());
+
+        let form = captured.lock().await.clone().unwrap();
+        assert_eq!(
+            form.get("grant_type").map(String::as_str),
+            Some("refresh_token")
+        );
+        assert_eq!(
+            form.get("refresh_token").map(String::as_str),
+            Some("refresh-old")
+        );
+        assert_eq!(form.get("client_id").map(String::as_str), Some("client-1"));
+        assert_eq!(
+            form.get("resource").map(String::as_str),
+            Some("https://windshift.example/mcp")
+        );
+        assert!(!form.contains_key("client_secret"));
+    }
+
+    #[tokio::test]
+    async fn applies_default_expires_in_when_not_returned() {
+        use std::collections::HashMap;
+        use std::sync::Arc;
+
+        use axum::{
+            extract::{Form, State},
+            routing::post,
+            Json, Router,
+        };
+        use tokio::sync::Mutex as TokioMutex;
+
+        type CapturedForm = Arc<TokioMutex<Option<HashMap<String, String>>>>;
+
+        async fn token_endpoint(
+            State(captured): State<CapturedForm>,
+            Form(form): Form<HashMap<String, String>>,
+        ) -> Json<JsonValue> {
+            *captured.lock().await = Some(form);
+            Json(json!({
+                "access_token": "access-new",
+                "refresh_token": "refresh-new",
+                "token_type": "Bearer",
+                // expires_in intentionally absent
+            }))
+        }
+
+        let captured: CapturedForm = Arc::new(TokioMutex::new(None));
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let address = listener.local_addr().unwrap();
+        let app = Router::new()
+            .route("/token", post(token_endpoint))
+            .with_state(captured.clone());
+        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+        let mut credential = ServiceCredential {
+            id: "cred_1".to_string(),
+            source_id: "src_1".to_string(),
+            user_id: Some("user_1".to_string()),
+            provider: ServiceProvider::RemoteMcp,
+            auth_type: AuthType::OAuth,
+            principal_email: None,
+            credentials: json!({
+                "access_token": "access-old",
+                "refresh_token": "refresh-old",
+                "client_id": "client-1",
+                "token_uri": format!("http://{address}/token"),
+                "token_endpoint_auth_method": "none",
+            }),
+            config: json!({}),
+            expires_at: Some(OffsetDateTime::now_utc()),
+            last_validated_at: None,
+            created_at: OffsetDateTime::now_utc(),
+            updated_at: OffsetDateTime::now_utc(),
+        };
+
+        let p = NativeOAuthParams {
+            provider: "test".into(),
+            credential_provider: String::new(),
+            token_endpoint: format!("http://{address}/token"),
+            token_endpoint_auth_method: TokenEndpointAuthMethod::None,
+            resource: None,
+        };
+
+        let result = do_native_refresh(
+            &mut credential,
+            &json!({}),
+            &p,
+            "refresh-old",
+            Some(reqwest::Client::new()),
+        )
+        .await
+        .unwrap();
+
+        server.abort();
+
+        // Default expires_in is 3600 seconds.
+        let expected = OffsetDateTime::now_utc() + time::Duration::seconds(3590); // 10s skew
+        assert!(
+            result.expires_at.unwrap() > expected,
+            "expires_at should be > now + 3590s (default 3600 with some tolerance)"
+        );
+    }
+}

--- a/services/connector-manager/src/credential_service.rs
+++ b/services/connector-manager/src/credential_service.rs
@@ -501,9 +501,15 @@ async fn do_oauth_refresh(
 
     let client = match http_client {
         Some(c) => c,
-        None => pinned_http_client_for_url(token_endpoint)
-            .await
-            .map_err(|e| CredentialServiceError::RefreshFailed(e.to_string()))?,
+        None => {
+            if remote_mcp {
+                pinned_http_client_for_url(token_endpoint)
+                    .await
+                    .map_err(|e| CredentialServiceError::RefreshFailed(e.to_string()))?
+            } else {
+                reqwest::Client::new()
+            }
+        }
     };
     let mut request = client
         .post(token_endpoint)

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -21,6 +21,7 @@ use futures::stream::Stream;
 use redis::AsyncCommands;
 use serde_json::{json, Value};
 
+use crate::credential_service::{CredentialService, CredentialServiceError};
 use shared::clients::docling::{DoclingClient, DoclingError};
 use shared::db::repositories::{ConfigurationRepository, SyncRunRepository};
 use shared::models::{
@@ -434,7 +435,6 @@ pub async fn execute_action(
             ApiError::BadRequest("user_id is required in transient mode".to_string())
         })?;
 
-
         // Look up the connector manifest by source_type.
         let manifest = manifests
             .iter()
@@ -612,10 +612,9 @@ pub async fn execute_action(
             )));
         }
 
-        let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-            .map_err(|e| ApiError::Internal(e.to_string()))?;
+        let cred_service = CredentialService::new(state.db_pool.clone());
         creds = match resolve_credentials(
-            &creds_repo,
+            &cred_service,
             &source_id,
             request.user_id.as_deref(),
             action_admin_only,
@@ -624,7 +623,11 @@ pub async fn execute_action(
         {
             CredentialResolution::Resolved(c) => c,
             CredentialResolution::NeedsUserAuth { provider } => {
-                return Ok(needs_user_auth_response(&source_id, source_type.to_string(), provider)?);
+                return Ok(needs_user_auth_response(
+                    &source_id,
+                    source_type.to_string(),
+                    provider,
+                )?);
             }
             CredentialResolution::NoCredentials => {
                 return Err(ApiError::NotFound(format!(
@@ -823,16 +826,16 @@ fn merge_org_and_user_credentials(
 ///   user_id (see migration 087).
 /// * `None` (sync, org-level agent) → org row.
 async fn resolve_credentials(
-    creds_repo: &ServiceCredentialsRepo,
+    cred_service: &CredentialService,
     source_id: &str,
     user_id: Option<&str>,
     admin_only: bool,
 ) -> Result<CredentialResolution, ApiError> {
-    let internal = |e: anyhow::Error| ApiError::Internal(e.to_string());
+    let internal = |e: CredentialServiceError| ApiError::Internal(e.to_string());
 
     if admin_only {
-        let resolved = creds_repo
-            .find_org_credential(source_id)
+        let resolved = cred_service
+            .get_org_credential(source_id)
             .await
             .map_err(internal)?;
         match &resolved {
@@ -852,13 +855,13 @@ async fn resolve_credentials(
 
     match user_id {
         Some(uid) => {
-            if let Some(mut user_cred) = creds_repo
-                .find_user_credential(source_id, uid)
+            if let Some(mut user_cred) = cred_service
+                .get_user_credential(source_id, uid)
                 .await
                 .map_err(internal)?
             {
-                if let Some(org_cred) = creds_repo
-                    .find_org_credential(source_id)
+                if let Some(org_cred) = cred_service
+                    .get_org_credential(source_id)
                     .await
                     .map_err(internal)?
                 {
@@ -873,8 +876,8 @@ async fn resolve_credentials(
             // No per-user row — surface a NeedsUserAuth response so the UI
             // can prompt. Provider hint comes from the org row when present;
             // if neither row exists the source is misconfigured.
-            match creds_repo
-                .find_org_credential(source_id)
+            match cred_service
+                .get_org_credential(source_id)
                 .await
                 .map_err(internal)?
             {
@@ -897,8 +900,8 @@ async fn resolve_credentials(
             }
         }
         None => {
-            let resolved = creds_repo
-                .find_org_credential(source_id)
+            let resolved = cred_service
+                .get_org_credential(source_id)
                 .await
                 .map_err(internal)?;
             match &resolved {
@@ -1161,10 +1164,9 @@ pub async fn read_resource(
             ))
         })?;
 
-    let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let creds = creds_repo
-        .find_owner_credential(&source)
+    let cred_service = CredentialService::new(state.db_pool.clone());
+    let creds = cred_service
+        .get_owner_credential(&source)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| {
@@ -1247,10 +1249,9 @@ pub async fn get_prompt(
             ))
         })?;
 
-    let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
-    let creds = creds_repo
-        .find_owner_credential(&source)
+    let cred_service = CredentialService::new(state.db_pool.clone());
+    let creds = cred_service
+        .get_owner_credential(&source)
         .await
         .map_err(|e| ApiError::Internal(e.to_string()))?
         .ok_or_else(|| {
@@ -1326,10 +1327,9 @@ pub async fn oauth_credential_ready(
             ))
         })?;
 
-    let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-        .map_err(|e| ApiError::Internal(e.to_string()))?;
+    let cred_service = CredentialService::new(state.db_pool.clone());
     let creds = match resolve_credentials(
-        &creds_repo,
+        &cred_service,
         &request.source_id,
         request.user_id.as_deref(),
         false,
@@ -1540,10 +1540,9 @@ pub async fn get_skill(
             .map_err(|e| ApiError::Internal(e.to_string()))?
             .ok_or_else(|| ApiError::NotFound(format!("Source not found: {}", source_id)))?;
 
-        let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-            .map_err(|e| ApiError::Internal(e.to_string()))?;
-        let creds = creds_repo
-            .find_owner_credential(&source)
+        let cred_service = CredentialService::new(state.db_pool.clone());
+        let creds = cred_service
+            .get_owner_credential(&source)
             .await
             .map_err(|e| ApiError::Internal(e.to_string()))?
             .ok_or_else(|| {
@@ -1866,8 +1865,7 @@ pub async fn sdk_register(
                 .collect();
             let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
                 .map_err(|e| ApiError::Internal(e.to_string()))?;
-            let repo = creds_repo;
-            if let Ok(Some((source_id, user_id))) = repo
+            if let Ok(Some((source_id, user_id))) = creds_repo
                 .find_any_user_oauth_for_provider(&source_type_strs, &provider)
                 .await
             {
@@ -1875,7 +1873,10 @@ pub async fn sdk_register(
                     "Recovery: found OAuth credential for {} / {} to refresh missing MCP catalog",
                     source_id, provider
                 );
-                match resolve_credentials(&repo, &source_id, Some(&user_id), false).await {
+                let recovery_cred_service = CredentialService::new(state.db_pool.clone());
+                match resolve_credentials(&recovery_cred_service, &source_id, Some(&user_id), false)
+                    .await
+                {
                     Ok(CredentialResolution::Resolved(recovery_creds)) => {
                         match serde_json::to_value(McpCredentials::from_service_credential(
                             &recovery_creds,
@@ -2831,11 +2832,9 @@ pub async fn sdk_get_credentials(
         .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?
         .ok_or_else(|| ApiError::NotFound(format!("Source not found: {}", source_id)))?;
 
-    let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-        .map_err(|e| ApiError::Internal(format!("Failed to create credentials repo: {}", e)))?;
-
-    let creds = creds_repo
-        .find_owner_credential(&source)
+    let cred_service = CredentialService::new(state.db_pool.clone());
+    let creds = cred_service
+        .get_owner_credential(&source)
         .await
         .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?
         .ok_or_else(|| {
@@ -2865,11 +2864,9 @@ pub async fn sdk_get_source_sync_config(
         .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?
         .ok_or_else(|| ApiError::NotFound(format!("Source not found: {}", source_id)))?;
 
-    let creds_repo = ServiceCredentialsRepo::new(state.db_pool.pool().clone())
-        .map_err(|e| ApiError::Internal(format!("Failed to create credentials repo: {}", e)))?;
-
-    let credentials = creds_repo
-        .find_owner_credential(&source)
+    let cred_service = CredentialService::new(state.db_pool.clone());
+    let credentials = cred_service
+        .raw_owner_credential(&source)
         .await
         .map_err(|e| ApiError::Internal(format!("Database error: {}", e)))?
         .map(|c| c.credentials)

--- a/services/connector-manager/src/lib.rs
+++ b/services/connector-manager/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod config;
 pub mod connector_client;
+pub mod credential_service;
 pub mod handlers;
 pub mod models;
 pub mod remote_mcp;

--- a/services/connector-manager/src/remote_mcp/gateway.rs
+++ b/services/connector-manager/src/remote_mcp/gateway.rs
@@ -1,22 +1,19 @@
+use crate::credential_service::CredentialService;
 use crate::models::ConnectorManifest;
-use crate::remote_mcp::oauth::{parse_oauth_config, usable_oauth_credential, OAuthError};
+use crate::remote_mcp::oauth::parse_oauth_config;
 use futures::StreamExt;
 use redis::AsyncCommands;
 use reqwest::{Client, Url};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value as JsonValue};
-use shared::db::repositories::ServiceCredentialsRepo;
 use shared::models::{
     ActionDefinition, ActionMode, AuthType, IntegrationType, McpPromptArgument,
     McpPromptDefinition, McpResourceDefinition, ServiceCredential, ServiceProvider, Source,
 };
 use shared::{traits::Repository, DatabasePool};
-use std::collections::HashMap;
 use std::net::{IpAddr, SocketAddr};
-use std::sync::{Arc, OnceLock};
 use std::time::Duration;
 use thiserror::Error;
-use tokio::sync::Mutex;
 use tracing::warn;
 
 pub const REMOTE_MCP_CONNECTOR_ID_PREFIX: &str = "remote_mcp:";
@@ -28,9 +25,6 @@ const MAX_MCP_RESPONSE_BYTES: usize = 2 * 1024 * 1024;
 const MAX_MCP_CATALOG_ITEMS: usize = 200;
 const MAX_MCP_SCHEMA_BYTES: usize = 64 * 1024;
 const MAX_MCP_STRING_BYTES: usize = 8 * 1024;
-
-static REMOTE_MCP_OAUTH_REFRESH_LOCKS: OnceLock<Mutex<HashMap<String, Arc<Mutex<()>>>>> =
-    OnceLock::new();
 
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 pub struct RemoteMcpConfig {
@@ -86,18 +80,13 @@ pub enum GatewayError {
 pub struct RemoteMcpGateway {
     db_pool: DatabasePool,
     redis_client: redis::Client,
-    http_client: Client,
 }
 
 impl RemoteMcpGateway {
     pub fn new(db_pool: DatabasePool, redis_client: redis::Client) -> Result<Self, GatewayError> {
-        let http_client = remote_mcp_client_builder()
-            .redirect(reqwest::redirect::Policy::none())
-            .build()?;
         Ok(Self {
             db_pool,
             redis_client,
-            http_client,
         })
     }
 
@@ -389,15 +378,14 @@ impl RemoteMcpGateway {
         match config.auth_type {
             None => Ok(Vec::new()),
             Some(AuthType::BearerToken) => {
-                let repo =
-                    ServiceCredentialsRepo::new(self.db_pool.pool().clone()).map_err(|e| {
-                        GatewayError::Protocol(format!(
-                            "failed to initialize credential repository: {e}"
-                        ))
-                    })?;
-                let credential = repo.find_org_credential(&source.id).await.map_err(|e| {
-                    GatewayError::Protocol(format!("failed to load bearer credential: {e}"))
-                })?;
+                let cred_service = CredentialService::new(self.db_pool.clone());
+                let credential =
+                    cred_service
+                        .get_org_credential(&source.id)
+                        .await
+                        .map_err(|e| {
+                            GatewayError::Protocol(format!("failed to load bearer credential: {e}"))
+                        })?;
                 let token = credential
                     .and_then(|c| {
                         c.credentials
@@ -414,17 +402,16 @@ impl RemoteMcpGateway {
                 )])
             }
             Some(AuthType::OAuth) => {
-                let repo =
-                    ServiceCredentialsRepo::new(self.db_pool.pool().clone()).map_err(|e| {
-                        GatewayError::Protocol(format!(
-                            "failed to initialize credential repository: {e}"
-                        ))
-                    })?;
-                let credential = repo.find_org_credential(&source.id).await.map_err(|e| {
-                    GatewayError::Protocol(format!(
-                        "failed to load OAuth bootstrap credential: {e}"
-                    ))
-                })?;
+                let cred_service = CredentialService::new(self.db_pool.clone());
+                let credential =
+                    cred_service
+                        .raw_org_credential(&source.id)
+                        .await
+                        .map_err(|e| {
+                            GatewayError::Protocol(format!(
+                                "failed to load OAuth bootstrap credential: {e}"
+                            ))
+                        })?;
                 let credential = match credential {
                     Some(credential) => {
                         let oauth_value = self
@@ -440,8 +427,10 @@ impl RemoteMcpGateway {
                             GatewayError::Protocol(format!("invalid OAuth metadata: {e}"))
                         })?;
                         Some(
-                            self.usable_oauth_credential_serialized(source, credential, &oauth)
-                                .await?,
+                            cred_service
+                                .refresh_credential_with_oauth(source, credential, &oauth)
+                                .await
+                                .map_err(|e| map_credential_service_error(source, e))?,
                         )
                     }
                     None => None,
@@ -474,14 +463,10 @@ impl RemoteMcpGateway {
         config: &RemoteMcpConfig,
         user_id: Option<&str>,
     ) -> Result<Vec<(String, String)>, GatewayError> {
-        let repo = match config.auth_type {
+        let cred_service = match config.auth_type {
             None => return Ok(Vec::new()),
             Some(AuthType::BearerToken | AuthType::OAuth) => {
-                ServiceCredentialsRepo::new(self.db_pool.pool().clone()).map_err(|e| {
-                    GatewayError::Protocol(format!(
-                        "failed to initialize credential repository: {e}"
-                    ))
-                })?
+                CredentialService::new(self.db_pool.clone())
             }
             Some(auth_type) => {
                 return Err(GatewayError::UnsupportedAuthType {
@@ -492,15 +477,18 @@ impl RemoteMcpGateway {
         };
 
         let org_credential = if config.auth_type == Some(AuthType::BearerToken) {
-            repo.find_org_credential(&source.id).await.map_err(|e| {
-                GatewayError::Protocol(format!("failed to load org credential: {e}"))
-            })?
+            cred_service
+                .get_org_credential(&source.id)
+                .await
+                .map_err(|e| {
+                    GatewayError::Protocol(format!("failed to load org credential: {e}"))
+                })?
         } else {
             None
         };
         let mut user_credential = match (config.auth_type, user_id) {
-            (Some(AuthType::OAuth), Some(uid)) => repo
-                .find_user_credential(&source.id, uid)
+            (Some(AuthType::OAuth), Some(uid)) => cred_service
+                .raw_user_credential(&source.id, uid)
                 .await
                 .map_err(|e| {
                     GatewayError::Protocol(format!("failed to load user credential: {e}"))
@@ -520,8 +508,10 @@ impl RemoteMcpGateway {
                 let oauth = parse_oauth_config(&oauth_value)
                     .map_err(|e| GatewayError::Protocol(format!("invalid OAuth metadata: {e}")))?;
                 user_credential = Some(
-                    self.usable_oauth_credential_serialized(source, credential, &oauth)
-                        .await?,
+                    cred_service
+                        .refresh_credential_with_oauth(source, credential, &oauth)
+                        .await
+                        .map_err(|e| map_credential_service_error(source, e))?,
                 );
             }
         }
@@ -533,41 +523,6 @@ impl RemoteMcpGateway {
             org_credential.as_ref(),
             user_credential.as_ref(),
         )
-    }
-
-    async fn usable_oauth_credential_serialized(
-        &self,
-        source: &Source,
-        credential: ServiceCredential,
-        oauth: &crate::remote_mcp::oauth::RemoteMcpOAuthConfig,
-    ) -> Result<ServiceCredential, GatewayError> {
-        let key = format!(
-            "{}:{}",
-            source.id,
-            credential.user_id.as_deref().unwrap_or("__org__")
-        );
-        let locks = REMOTE_MCP_OAUTH_REFRESH_LOCKS.get_or_init(|| Mutex::new(HashMap::new()));
-        let lock = {
-            let mut guard = locks.lock().await;
-            guard
-                .entry(key)
-                .or_insert_with(|| Arc::new(Mutex::new(())))
-                .clone()
-        };
-        let _guard = lock.lock().await;
-
-        let repo = ServiceCredentialsRepo::new(self.db_pool.pool().clone()).map_err(|e| {
-            GatewayError::Protocol(format!("failed to create credential repo: {e}"))
-        })?;
-        let credential = repo
-            .find_by_id(&credential.id)
-            .await
-            .map_err(|e| GatewayError::Protocol(format!("failed to reload credential: {e}")))?
-            .ok_or_else(|| GatewayError::MissingCredentials(source.id.clone()))?;
-
-        usable_oauth_credential(&self.db_pool, &self.http_client, source, credential, oauth)
-            .await
-            .map_err(|e| oauth_error_to_gateway_error(source, e))
     }
 
     async fn discover_oauth_metadata(
@@ -1140,14 +1095,19 @@ pub(crate) async fn read_limited_response_text(
         .map_err(|e| GatewayError::Protocol(format!("MCP response was not UTF-8: {e}")))
 }
 
-fn oauth_error_to_gateway_error(source: &Source, error: OAuthError) -> GatewayError {
+fn map_credential_service_error(
+    source: &Source,
+    error: crate::credential_service::CredentialServiceError,
+) -> GatewayError {
     match error {
-        OAuthError::ReconnectRequired => GatewayError::NeedsUserAuth {
-            source_id: source.id.clone(),
-            source_type: source.source_type.clone(),
-            provider: ServiceProvider::RemoteMcp,
-        },
-        other => GatewayError::Protocol(format!("OAuth refresh failed: {other}")),
+        crate::credential_service::CredentialServiceError::ReconnectRequired => {
+            GatewayError::NeedsUserAuth {
+                source_id: source.id.clone(),
+                source_type: source.source_type.clone(),
+                provider: ServiceProvider::RemoteMcp,
+            }
+        }
+        other => GatewayError::Protocol(format!("credential refresh failed: {other}")),
     }
 }
 
@@ -1341,9 +1301,12 @@ mod tests {
     }
 
     #[test]
-    fn oauth_reconnect_maps_to_needs_user_auth() {
+    fn credential_reconnect_maps_to_needs_user_auth() {
         let source = source(json!({"endpoint_url":"https://mcp.example.com/mcp"}));
-        let err = oauth_error_to_gateway_error(&source, OAuthError::ReconnectRequired);
+        let err = map_credential_service_error(
+            &source,
+            crate::credential_service::CredentialServiceError::ReconnectRequired,
+        );
         assert!(matches!(
             err,
             GatewayError::NeedsUserAuth { source_id, source_type, provider }

--- a/services/connector-manager/src/remote_mcp/oauth.rs
+++ b/services/connector-manager/src/remote_mcp/oauth.rs
@@ -1,17 +1,5 @@
-use crate::remote_mcp::gateway::{
-    pinned_http_client_for_url, read_limited_response_text, validate_endpoint_for_gateway,
-};
-use reqwest::Client;
-use serde::Deserialize;
 use serde_json::Value as JsonValue;
-use shared::db::repositories::{ConnectorConfigRepository, ServiceCredentialsRepo};
-use shared::models::{ServiceCredential, Source};
-use shared::DatabasePool;
-use std::time::Duration;
 use thiserror::Error;
-use time::OffsetDateTime;
-
-const REFRESH_SKEW_SECONDS: i64 = 300;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TokenEndpointAuthMethod {
@@ -21,7 +9,7 @@ pub enum TokenEndpointAuthMethod {
 }
 
 impl TokenEndpointAuthMethod {
-    fn parse(value: Option<&str>) -> Self {
+    pub(crate) fn parse(value: Option<&str>) -> Self {
         match value {
             Some("client_secret_basic") => Self::ClientSecretBasic,
             Some("none") => Self::None,
@@ -43,14 +31,10 @@ pub struct RemoteMcpOAuthConfig {
 pub enum OAuthError {
     #[error("missing OAuth field: {0}")]
     MissingField(&'static str),
-    #[error("credential requires OAuth reconnect")]
-    ReconnectRequired,
-    #[error("OAuth refresh failed: {0}")]
-    RefreshFailed(String),
-    #[error("repository error: {0}")]
-    Repository(String),
 }
 
+/// Parse `RemoteMcpOAuthConfig` from a JSON value returned by the MCP
+/// endpoint's OAuth metadata discovery.
 pub fn parse_oauth_config(value: &JsonValue) -> Result<RemoteMcpOAuthConfig, OAuthError> {
     let provider = value
         .get("provider")
@@ -86,197 +70,10 @@ pub fn parse_oauth_config(value: &JsonValue) -> Result<RemoteMcpOAuthConfig, OAu
     })
 }
 
-pub fn credential_needs_refresh(credential: &ServiceCredential, now: OffsetDateTime) -> bool {
-    match credential.expires_at {
-        Some(expires_at) => expires_at <= now + time::Duration::seconds(REFRESH_SKEW_SECONDS),
-        None => false,
-    }
-}
-
-#[derive(Debug, Deserialize)]
-struct RefreshResponse {
-    access_token: String,
-    refresh_token: Option<String>,
-    token_type: Option<String>,
-    expires_in: Option<i64>,
-}
-
-pub async fn usable_oauth_credential(
-    db_pool: &DatabasePool,
-    _http_client: &Client,
-    source: &Source,
-    mut credential: ServiceCredential,
-    oauth: &RemoteMcpOAuthConfig,
-) -> Result<ServiceCredential, OAuthError> {
-    if !credential_needs_refresh(&credential, OffsetDateTime::now_utc()) {
-        return Ok(credential);
-    }
-
-    let refresh_token = credential
-        .credentials
-        .get("refresh_token")
-        .and_then(|v| v.as_str())
-        .filter(|v| !v.is_empty())
-        .ok_or(OAuthError::ReconnectRequired)?
-        .to_string();
-
-    let config_repo = ConnectorConfigRepository::new(db_pool.pool().clone());
-    let connector_config = config_repo
-        .get_by_provider(&oauth.provider)
-        .await
-        .map_err(|e| OAuthError::Repository(e.to_string()))?
-        .map(|row| row.config)
-        .unwrap_or_else(|| serde_json::json!({}));
-
-    let client_id = string_from(&connector_config, "oauth_client_id")
-        .or_else(|| string_from(&credential.credentials, "client_id"))
-        .ok_or(OAuthError::MissingField("oauth_client_id"))?;
-    let client_secret = string_from(&connector_config, "oauth_client_secret")
-        .or_else(|| string_from(&credential.credentials, "client_secret"));
-    let token_endpoint = string_from(&connector_config, "oauth_token_endpoint")
-        .or_else(|| string_from(&credential.credentials, "token_uri"))
-        .unwrap_or_else(|| oauth.token_endpoint.clone());
-    let token_method = TokenEndpointAuthMethod::parse(
-        string_from(&connector_config, "oauth_token_endpoint_auth_method").as_deref(),
-    );
-    let token_method = if matches!(token_method, TokenEndpointAuthMethod::ClientSecretPost)
-        && connector_config
-            .get("oauth_token_endpoint_auth_method")
-            .is_none()
-    {
-        oauth.token_endpoint_auth_method.clone()
-    } else {
-        token_method
-    };
-
-    let mut params = vec![
-        ("grant_type".to_string(), "refresh_token".to_string()),
-        ("refresh_token".to_string(), refresh_token),
-    ];
-    let mut basic_auth: Option<(String, String)> = None;
-    match token_method {
-        TokenEndpointAuthMethod::None => {
-            params.push(("client_id".to_string(), client_id));
-        }
-        TokenEndpointAuthMethod::ClientSecretPost => {
-            params.push(("client_id".to_string(), client_id));
-            if let Some(secret) = client_secret {
-                params.push(("client_secret".to_string(), secret));
-            }
-        }
-        TokenEndpointAuthMethod::ClientSecretBasic => {
-            let secret = client_secret.ok_or(OAuthError::MissingField("oauth_client_secret"))?;
-            basic_auth = Some((client_id, secret));
-        }
-    }
-    if let Some(resource) = &oauth.resource {
-        validate_endpoint_for_gateway(resource)
-            .await
-            .map_err(|e| OAuthError::RefreshFailed(e.to_string()))?;
-        params.push(("resource".to_string(), resource.clone()));
-    }
-
-    let pinned_client = pinned_http_client_for_url(&token_endpoint)
-        .await
-        .map_err(|e| OAuthError::RefreshFailed(e.to_string()))?;
-    let mut request = pinned_client
-        .post(&token_endpoint)
-        .timeout(Duration::from_secs(20))
-        .header("accept", "application/json");
-    if let Some((client_id, client_secret)) = basic_auth {
-        request = request.basic_auth(client_id, Some(client_secret));
-    }
-
-    let response = request
-        .form(&params)
-        .send()
-        .await
-        .map_err(|e| OAuthError::RefreshFailed(e.to_string()))?;
-    let status = response.status();
-    let body = read_limited_response_text(response)
-        .await
-        .map_err(|e| OAuthError::RefreshFailed(e.to_string()))?;
-    if !status.is_success() {
-        if is_reconnect_required_refresh_failure(status.as_u16(), &body) {
-            return Err(OAuthError::ReconnectRequired);
-        }
-        return Err(OAuthError::RefreshFailed(format!(
-            "token endpoint returned HTTP {status}"
-        )));
-    }
-    let refreshed: RefreshResponse =
-        serde_json::from_str(&body).map_err(|e| OAuthError::RefreshFailed(e.to_string()))?;
-
-    credential.credentials["access_token"] = JsonValue::String(refreshed.access_token);
-    if let Some(refresh_token) = refreshed.refresh_token {
-        credential.credentials["refresh_token"] = JsonValue::String(refresh_token);
-    }
-    credential.credentials["token_type"] =
-        JsonValue::String(refreshed.token_type.unwrap_or_else(|| "Bearer".to_string()));
-    credential.credentials["token_uri"] = JsonValue::String(token_endpoint);
-    if let Some(expires_in) = refreshed.expires_in {
-        credential.expires_at =
-            Some(OffsetDateTime::now_utc() + time::Duration::seconds(expires_in));
-    }
-
-    let repo = ServiceCredentialsRepo::new(db_pool.pool().clone())
-        .map_err(|e| OAuthError::Repository(e.to_string()))?;
-    repo.update_credentials(&credential)
-        .await
-        .map_err(|e| OAuthError::Repository(e.to_string()))?;
-
-    tracing::debug!(source_id = %source.id, provider = %oauth.provider, credential_provider = %oauth.credential_provider, "refreshed remote MCP OAuth credential");
-    Ok(credential)
-}
-
-fn is_reconnect_required_refresh_failure(status: u16, body: &str) -> bool {
-    if !(400..500).contains(&status)
-        || status == 408
-        || status == 409
-        || status == 425
-        || status == 429
-    {
-        return false;
-    }
-    let Ok(value) = serde_json::from_str::<JsonValue>(body) else {
-        return true;
-    };
-    let error = value
-        .get("error")
-        .and_then(|v| v.as_str())
-        .unwrap_or_default();
-    matches!(
-        error,
-        "invalid_grant" | "invalid_client" | "unauthorized_client" | "access_denied"
-    )
-}
-
-fn string_from(value: &JsonValue, key: &str) -> Option<String> {
-    value.get(key).and_then(|v| v.as_str()).map(str::to_owned)
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use serde_json::json;
-    use shared::models::{AuthType, ServiceProvider};
-
-    fn credential(expires_at: Option<OffsetDateTime>) -> ServiceCredential {
-        ServiceCredential {
-            id: "cred_1".to_string(),
-            source_id: "src_1".to_string(),
-            user_id: Some("user_1".to_string()),
-            provider: ServiceProvider::RemoteMcp,
-            auth_type: AuthType::OAuth,
-            principal_email: None,
-            credentials: json!({"access_token":"old"}),
-            config: json!({}),
-            expires_at,
-            last_validated_at: None,
-            created_at: OffsetDateTime::now_utc(),
-            updated_at: OffsetDateTime::now_utc(),
-        }
-    }
 
     #[test]
     fn parses_normalized_remote_mcp_oauth_config() {
@@ -294,43 +91,5 @@ mod tests {
             cfg.token_endpoint_auth_method,
             TokenEndpointAuthMethod::None
         );
-    }
-
-    #[test]
-    fn detects_expiring_credentials_with_skew() {
-        assert!(!credential_needs_refresh(
-            &credential(None),
-            OffsetDateTime::now_utc()
-        ));
-        assert!(credential_needs_refresh(
-            &credential(Some(
-                OffsetDateTime::now_utc() + time::Duration::seconds(60)
-            )),
-            OffsetDateTime::now_utc(),
-        ));
-        assert!(!credential_needs_refresh(
-            &credential(Some(OffsetDateTime::now_utc() + time::Duration::hours(1))),
-            OffsetDateTime::now_utc(),
-        ));
-    }
-
-    #[test]
-    fn refresh_failure_classification_distinguishes_reconnect_from_transient() {
-        assert!(is_reconnect_required_refresh_failure(
-            400,
-            r#"{"error":"invalid_grant"}"#,
-        ));
-        assert!(is_reconnect_required_refresh_failure(
-            401,
-            r#"{"error":"invalid_client"}"#,
-        ));
-        assert!(!is_reconnect_required_refresh_failure(
-            429,
-            r#"{"error":"rate_limited"}"#,
-        ));
-        assert!(!is_reconnect_required_refresh_failure(
-            500,
-            r#"{"error":"server_error"}"#,
-        ));
     }
 }

--- a/services/connector-manager/tests/credential_service_test.rs
+++ b/services/connector-manager/tests/credential_service_test.rs
@@ -1,0 +1,662 @@
+//! Integration tests for `CredentialService` — OAuth refresh with a real
+//! Postgres database and a mock token endpoint.
+//!
+//! These tests verify that expired OAuth tokens are refreshed correctly
+//! (HTTP call outside any DB transaction, updated fields persisted) and that
+//! non-refreshable credentials pass through unchanged.
+//!
+//! # Test Postgres
+//! Uses a long-lived Postgres container (`test-pg-test`) started once outside
+//! the test harness to avoid testcontainers overhead. Create it with:
+//! ```text
+//! docker run -d --name test-pg-test \
+//!   -e POSTGRES_DB=omni_test \
+//!   -e POSTGRES_USER=omni \
+//!   -e POSTGRES_PASSWORD=omni_password \
+//!   -p 0:5432 \
+//!   paradedb/paradedb:0.24.0-pg17
+//! ```
+//! Then run migrations once:
+//! ```text
+//! docker run --rm --network host \
+//!   -e DATABASE_HOST=localhost \
+//!   -e DATABASE_PORT=$(docker port test-pg-test 5432 | head -1 | sed 's/.*://') \
+//!   -e DATABASE_USERNAME=omni \
+//!   -e DATABASE_PASSWORD=omni_password \
+//!   -e DATABASE_NAME=omni_test \
+//!   -e DATABASE_SSL=false \
+//!   omni-migrator:test
+//! ```
+
+use std::collections::HashMap;
+use std::sync::{Arc, OnceLock};
+
+use axum::{
+    extract::{Form, State},
+    routing::post,
+    Json, Router,
+};
+use omni_connector_manager::credential_service::CredentialService;
+use shared::db::pool::DatabasePool;
+use shared::models::*;
+use shared::ServiceCredentialsRepo;
+use time::OffsetDateTime;
+use tokio::sync::Mutex as TokioMutex;
+
+// ---------------------------------------------------------------------------
+// Test Postgres pool — shared across all tests in this binary
+// ---------------------------------------------------------------------------
+
+/// Initialise encryption env vars once per process.
+static ENV_INIT: OnceLock<()> = OnceLock::new();
+fn init_env() {
+    ENV_INIT.get_or_init(|| {
+        // SAFETY: test-only, single-threaded context.
+        unsafe {
+            std::env::set_var(
+                "ENCRYPTION_KEY",
+                "test_master_key_that_is_long_enough_32_chars",
+            )
+        };
+        unsafe { std::env::set_var("ENCRYPTION_SALT", "test_salt_16_chars") };
+    });
+}
+
+/// Postgres connection URL — override with `TEST_PG_HOST` / `TEST_PG_PORT`.
+fn test_pg_url() -> String {
+    let host = std::env::var("TEST_PG_HOST").unwrap_or_else(|_| "172.17.0.7".into());
+    let port = std::env::var("TEST_PG_PORT").unwrap_or_else(|_| "5432".into());
+    format!("postgresql://omni:omni_password@{host}:{port}/omni_test")
+}
+
+/// Create a fresh database pool (one per test, avoids cross-test state).
+async fn pool() -> DatabasePool {
+    init_env();
+    DatabasePool::new_with_options(&test_pg_url(), 5, 30)
+        .await
+        .unwrap()
+}
+
+/// Wipe all test data so each test starts clean.
+async fn clean_db(pool: &sqlx::PgPool) {
+    sqlx::query("DELETE FROM service_credentials")
+        .execute(pool)
+        .await
+        .ok();
+    sqlx::query("DELETE FROM sources").execute(pool).await.ok();
+    sqlx::query("DELETE FROM users").execute(pool).await.ok();
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+fn make_oauth_creds(
+    id: &str,
+    source_id: &str,
+    user_id: Option<&str>,
+    token_uri: &str,
+    refresh_token: Option<&str>,
+    client_id: Option<&str>,
+    expires_at: Option<OffsetDateTime>,
+) -> ServiceCredential {
+    let mut creds = serde_json::json!({
+        "access_token": "access-old",
+        "token_uri": token_uri,
+    });
+    if let Some(rt) = refresh_token {
+        creds["refresh_token"] = serde_json::json!(rt);
+    }
+    if let Some(cid) = client_id {
+        creds["client_id"] = serde_json::json!(cid);
+    }
+    make_creds(id, source_id, user_id, AuthType::OAuth, creds, expires_at)
+}
+
+fn make_jwt_creds(id: &str, source_id: &str, user_id: Option<&str>) -> ServiceCredential {
+    make_creds(
+        id,
+        source_id,
+        user_id,
+        AuthType::Jwt,
+        serde_json::json!({"token": "some-jwt"}),
+        None,
+    )
+}
+
+fn make_creds(
+    id: &str,
+    source_id: &str,
+    user_id: Option<&str>,
+    auth_type: AuthType,
+    credentials: serde_json::Value,
+    expires_at: Option<OffsetDateTime>,
+) -> ServiceCredential {
+    let now = OffsetDateTime::now_utc();
+    ServiceCredential {
+        id: id.to_string(),
+        source_id: source_id.to_string(),
+        user_id: user_id.map(String::from),
+        provider: ServiceProvider::Google,
+        auth_type,
+        principal_email: Some("test@example.com".into()),
+        credentials,
+        config: serde_json::json!({}),
+        expires_at,
+        last_validated_at: None,
+        created_at: now,
+        updated_at: now,
+    }
+}
+
+/// Generate a 26-character ULID (matching the CHAR(26) column type).
+fn new_id() -> &'static str {
+    Box::leak(shared::utils::generate_ulid().into_boxed_str())
+}
+
+async fn seed_user(pool: &sqlx::PgPool, user_id: &str) {
+    sqlx::query(
+        r#"INSERT INTO users (id, email, password_hash, created_at, updated_at)
+           VALUES ($1, $2, 'hash', NOW(), NOW())
+           ON CONFLICT (id) DO NOTHING"#,
+    )
+    .bind(user_id)
+    .bind(format!("{}@test.com", user_id))
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn seed_source(pool: &sqlx::PgPool, source_id: &str, scope: &str, created_by: &str) {
+    sqlx::query(
+        r#"INSERT INTO sources (id, name, source_type, config, scope, is_active, created_by, created_at, updated_at)
+           VALUES ($1, 'Test Source', 'google_drive', '{}', $2, true, $3, NOW(), NOW())
+           ON CONFLICT (id) DO NOTHING"#,
+    )
+    .bind(source_id)
+    .bind(scope)
+    .bind(created_by)
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+// ── Mock OAuth token endpoint ──────────────────────────────────────────
+
+type CapturedForm = Arc<TokioMutex<Option<HashMap<String, String>>>>;
+
+/// Spawn an axum token endpoint that captures the form and returns canned
+/// tokens.  Returns `(listen_address, server_handle, captured_form)`.
+async fn spawn_token_endpoint() -> (String, tokio::task::JoinHandle<()>, CapturedForm) {
+    let captured: CapturedForm = Arc::new(TokioMutex::new(None));
+
+    async fn handler(
+        State(captured): State<CapturedForm>,
+        Form(form): Form<HashMap<String, String>>,
+    ) -> Json<serde_json::Value> {
+        *captured.lock().await = Some(form);
+        Json(serde_json::json!({
+            "access_token": "access-new",
+            "refresh_token": "refresh-new",
+            "token_type": "Bearer",
+            "expires_in": 3600,
+        }))
+    }
+
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let address = listener.local_addr().unwrap();
+    let app = Router::new()
+        .route("/token", post(handler))
+        .with_state(captured.clone());
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+
+    (format!("http://{address}/token"), server, captured)
+}
+
+// ---------------------------------------------------------------------------
+// Test: CredentialService — full OAuth refresh flow
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn get_user_credential_refreshes_expired_oauth_and_persists() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "user", user_id).await;
+
+    let (token_url, _server, captured) = spawn_token_endpoint().await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_oauth_creds(
+        cred_id,
+        source_id,
+        Some(user_id),
+        &token_url,
+        Some("refresh-old"),
+        Some("client-1"),
+        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
+    ))
+    .await
+    .unwrap();
+
+    let cs = CredentialService::new(pool.clone());
+    let result = cs
+        .get_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .expect("expected a credential");
+
+    // Token values should be updated.
+    assert_eq!(result.credentials["access_token"], "access-new");
+    assert_eq!(result.credentials["refresh_token"], "refresh-new");
+    assert_eq!(result.credentials["token_type"], "Bearer");
+    assert!(result.expires_at.unwrap() > OffsetDateTime::now_utc());
+    assert!(result.last_validated_at.is_some());
+
+    // The form captured by the mock endpoint should have the expected fields.
+    let form = captured.lock().await.clone().unwrap();
+    assert_eq!(
+        form.get("grant_type").map(String::as_str),
+        Some("refresh_token")
+    );
+    assert_eq!(
+        form.get("refresh_token").map(String::as_str),
+        Some("refresh-old")
+    );
+    assert_eq!(form.get("client_id").map(String::as_str), Some("client-1"));
+
+    // Re-read from DB to confirm persistence.
+    let from_db = repo.find_by_id(cred_id).await.unwrap().unwrap();
+    assert_eq!(from_db.credentials["access_token"], "access-new");
+}
+
+#[tokio::test]
+async fn get_org_credential_refreshes_expired_oauth_and_persists() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "org", user_id).await;
+
+    let (token_url, _server, captured) = spawn_token_endpoint().await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_oauth_creds(
+        cred_id,
+        source_id,
+        None, // org-wide
+        &token_url,
+        Some("refresh-old"),
+        Some("client-1"),
+        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
+    ))
+    .await
+    .unwrap();
+
+    let cs = CredentialService::new(pool.clone());
+    let result = cs
+        .get_org_credential(source_id)
+        .await
+        .unwrap()
+        .expect("expected an org credential");
+
+    assert_eq!(result.credentials["access_token"], "access-new");
+    assert!(result.expires_at.unwrap() > OffsetDateTime::now_utc());
+
+    let form = captured.lock().await.clone().unwrap();
+    assert_eq!(
+        form.get("grant_type").map(String::as_str),
+        Some("refresh_token")
+    );
+}
+
+#[tokio::test]
+async fn non_oauth_credential_not_refreshed() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "user", user_id).await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_jwt_creds(cred_id, source_id, Some(user_id)))
+        .await
+        .unwrap();
+
+    let cs = CredentialService::new(pool.clone());
+    let result = cs
+        .get_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .expect("expected a credential");
+
+    // Jwt credential should be returned as-is (no refresh attempted).
+    assert_eq!(result.credentials["token"], "some-jwt");
+    assert_eq!(result.auth_type, AuthType::Jwt);
+}
+
+#[tokio::test]
+async fn credential_without_refresh_token_not_refreshed() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "user", user_id).await;
+
+    let (token_url, _server, _captured) = spawn_token_endpoint().await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_oauth_creds(
+        cred_id,
+        source_id,
+        Some(user_id),
+        &token_url,
+        None, // no refresh_token!
+        Some("client-1"),
+        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
+    ))
+    .await
+    .unwrap();
+
+    let cs = CredentialService::new(pool.clone());
+    let result = cs
+        .get_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .expect("expected a credential");
+
+    // Should be returned unchanged (old access token preserved).
+    assert_eq!(result.credentials["access_token"], "access-old");
+}
+
+#[tokio::test]
+async fn credential_without_client_id_not_refreshed() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "user", user_id).await;
+
+    let (token_url, _server, _captured) = spawn_token_endpoint().await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_oauth_creds(
+        cred_id,
+        source_id,
+        Some(user_id),
+        &token_url,
+        Some("refresh-old"),
+        None, // no client_id!
+        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)),
+    ))
+    .await
+    .unwrap();
+
+    let cs = CredentialService::new(pool.clone());
+    let result = cs
+        .get_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .expect("expected a credential");
+
+    assert_eq!(result.credentials["access_token"], "access-old");
+}
+
+#[tokio::test]
+async fn not_expired_credential_not_refreshed() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "user", user_id).await;
+
+    let (token_url, _server, _captured) = spawn_token_endpoint().await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_oauth_creds(
+        cred_id,
+        source_id,
+        Some(user_id),
+        &token_url,
+        Some("refresh-old"),
+        Some("client-1"),
+        Some(OffsetDateTime::now_utc() + time::Duration::hours(1)), // still valid
+    ))
+    .await
+    .unwrap();
+
+    let cs = CredentialService::new(pool.clone());
+    let result = cs
+        .get_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .expect("expected a credential");
+
+    // Fresh credential should be returned unchanged.
+    assert_eq!(result.credentials["access_token"], "access-old");
+}
+
+#[tokio::test]
+async fn raw_credential_does_not_trigger_refresh() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "user", user_id).await;
+
+    let (token_url, _server, _captured) = spawn_token_endpoint().await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_oauth_creds(
+        cred_id,
+        source_id,
+        Some(user_id),
+        &token_url,
+        Some("refresh-old"),
+        Some("client-1"),
+        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
+    ))
+    .await
+    .unwrap();
+
+    let cs = CredentialService::new(pool.clone());
+    let result = cs
+        .raw_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .expect("expected a credential");
+
+    // Raw read should NOT trigger refresh; access_token stays old.
+    assert_eq!(result.credentials["access_token"], "access-old");
+}
+
+// ---------------------------------------------------------------------------
+// Test: ServiceCredentialsRepo CRUD (regression-safe for both branches)
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn repo_create_and_find_org_credential() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "org", user_id).await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_jwt_creds(cred_id, source_id, None))
+        .await
+        .unwrap();
+
+    let found = repo
+        .find_org_credential(source_id)
+        .await
+        .unwrap()
+        .expect("expected org credential");
+    assert!(found.user_id.is_none());
+    assert_eq!(found.source_id, source_id);
+}
+
+#[tokio::test]
+async fn repo_create_and_find_user_credential() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "org", user_id).await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_jwt_creds(cred_id, source_id, Some(user_id)))
+        .await
+        .unwrap();
+
+    let found = repo
+        .find_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .expect("expected user credential");
+    assert_eq!(found.user_id.as_deref(), Some(user_id));
+}
+
+#[tokio::test]
+async fn repo_update_credentials_persists_changes() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "user", user_id).await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    let cred = make_jwt_creds(cred_id, source_id, Some(user_id));
+    repo.create(cred).await.unwrap();
+
+    // Update via the repo.
+    let mut updated = repo.find_by_id(cred_id).await.unwrap().unwrap();
+    updated.credentials = serde_json::json!({"token": "updated-jwt"});
+    repo.update_credentials(&updated).await.unwrap();
+
+    let from_db = repo.find_by_id(cred_id).await.unwrap().unwrap();
+    assert_eq!(from_db.credentials["token"], "updated-jwt");
+}
+
+#[tokio::test]
+async fn repo_delete_for_user_removes_only_user_row() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user_id = new_id();
+    let cred_id_user = new_id();
+    let cred_id_org = new_id();
+
+    seed_user(db, user_id).await;
+    seed_source(db, source_id, "org", user_id).await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_jwt_creds(cred_id_org, source_id, None))
+        .await
+        .unwrap();
+    repo.create(make_jwt_creds(cred_id_user, source_id, Some(user_id)))
+        .await
+        .unwrap();
+
+    repo.delete_for_user(source_id, user_id).await.unwrap();
+
+    assert!(repo
+        .find_user_credential(source_id, user_id)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(repo.find_org_credential(source_id).await.unwrap().is_some());
+}
+
+#[tokio::test]
+async fn repo_delete_by_source_id_cascades() {
+    let pool = pool().await;
+    clean_db(pool.pool()).await;
+    let db = pool.pool();
+
+    let source_id = new_id();
+    let user1 = new_id();
+    let user2 = new_id();
+
+    seed_user(db, user1).await;
+    seed_user(db, user2).await;
+    seed_source(db, source_id, "org", user1).await;
+
+    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
+    repo.create(make_jwt_creds("c1", source_id, None))
+        .await
+        .unwrap();
+    repo.create(make_jwt_creds("c2", source_id, Some(user1)))
+        .await
+        .unwrap();
+    repo.create(make_jwt_creds("c3", source_id, Some(user2)))
+        .await
+        .unwrap();
+
+    repo.delete_by_source_id(source_id).await.unwrap();
+
+    assert!(repo.find_org_credential(source_id).await.unwrap().is_none());
+    assert!(repo
+        .find_user_credential(source_id, user1)
+        .await
+        .unwrap()
+        .is_none());
+    assert!(repo
+        .find_user_credential(source_id, user2)
+        .await
+        .unwrap()
+        .is_none());
+}

--- a/services/connector-manager/tests/credential_service_test.rs
+++ b/services/connector-manager/tests/credential_service_test.rs
@@ -6,21 +6,19 @@
 //! non-refreshable credentials pass through unchanged.
 //!
 //! # Test Postgres
-//! Uses a long-lived Postgres container (`test-pg-test`) started once outside
-//! the test harness to avoid testcontainers overhead. Create it with:
+//! Uses a long-lived container (`test-pg-test`). Create it with:
 //! ```text
 //! docker run -d --name test-pg-test \
 //!   -e POSTGRES_DB=omni_test \
 //!   -e POSTGRES_USER=omni \
 //!   -e POSTGRES_PASSWORD=omni_password \
-//!   -p 0:5432 \
 //!   paradedb/paradedb:0.24.0-pg17
 //! ```
-//! Then run migrations once:
+//! Run migrations once:
 //! ```text
 //! docker run --rm --network host \
-//!   -e DATABASE_HOST=localhost \
-//!   -e DATABASE_PORT=$(docker port test-pg-test 5432 | head -1 | sed 's/.*://') \
+//!   -e DATABASE_HOST=$(docker inspect test-pg-test --format '{{.NetworkSettings.IPAddress}}') \
+//!   -e DATABASE_PORT=5432 \
 //!   -e DATABASE_USERNAME=omni \
 //!   -e DATABASE_PASSWORD=omni_password \
 //!   -e DATABASE_NAME=omni_test \
@@ -44,10 +42,9 @@ use time::OffsetDateTime;
 use tokio::sync::Mutex as TokioMutex;
 
 // ---------------------------------------------------------------------------
-// Test Postgres pool — shared across all tests in this binary
+// Setup
 // ---------------------------------------------------------------------------
 
-/// Initialise encryption env vars once per process.
 static ENV_INIT: OnceLock<()> = OnceLock::new();
 fn init_env() {
     ENV_INIT.get_or_init(|| {
@@ -62,66 +59,59 @@ fn init_env() {
     });
 }
 
-/// Postgres connection URL — override with `TEST_PG_HOST` / `TEST_PG_PORT`.
-fn test_pg_url() -> String {
+fn db_url() -> String {
     let host = std::env::var("TEST_PG_HOST").unwrap_or_else(|_| "172.17.0.7".into());
     let port = std::env::var("TEST_PG_PORT").unwrap_or_else(|_| "5432".into());
     format!("postgresql://omni:omni_password@{host}:{port}/omni_test")
 }
 
-/// Create a fresh database pool (one per test, avoids cross-test state).
-async fn pool() -> DatabasePool {
+async fn fresh_pool() -> DatabasePool {
     init_env();
-    DatabasePool::new_with_options(&test_pg_url(), 5, 30)
+    let pool = DatabasePool::new_with_options(&db_url(), 5, 30)
         .await
-        .unwrap()
-}
-
-/// Wipe all test data so each test starts clean.
-async fn clean_db(pool: &sqlx::PgPool) {
+        .unwrap();
     sqlx::query("DELETE FROM service_credentials")
-        .execute(pool)
+        .execute(pool.pool())
         .await
         .ok();
-    sqlx::query("DELETE FROM sources").execute(pool).await.ok();
-    sqlx::query("DELETE FROM users").execute(pool).await.ok();
+    sqlx::query("DELETE FROM sources")
+        .execute(pool.pool())
+        .await
+        .ok();
+    sqlx::query("DELETE FROM users")
+        .execute(pool.pool())
+        .await
+        .ok();
+    pool
 }
 
-// ---------------------------------------------------------------------------
-// Helpers
-// ---------------------------------------------------------------------------
-
-fn make_oauth_creds(
-    id: &str,
-    source_id: &str,
-    user_id: Option<&str>,
-    token_uri: &str,
-    refresh_token: Option<&str>,
-    client_id: Option<&str>,
-    expires_at: Option<OffsetDateTime>,
-) -> ServiceCredential {
-    let mut creds = serde_json::json!({
-        "access_token": "access-old",
-        "token_uri": token_uri,
-    });
-    if let Some(rt) = refresh_token {
-        creds["refresh_token"] = serde_json::json!(rt);
-    }
-    if let Some(cid) = client_id {
-        creds["client_id"] = serde_json::json!(cid);
-    }
-    make_creds(id, source_id, user_id, AuthType::OAuth, creds, expires_at)
+fn uid() -> &'static str {
+    Box::leak(shared::utils::generate_ulid().into_boxed_str())
 }
 
-fn make_jwt_creds(id: &str, source_id: &str, user_id: Option<&str>) -> ServiceCredential {
-    make_creds(
-        id,
-        source_id,
-        user_id,
-        AuthType::Jwt,
-        serde_json::json!({"token": "some-jwt"}),
-        None,
+async fn seed_user(pool: &sqlx::PgPool, id: &str) {
+    sqlx::query(
+        r#"INSERT INTO users (id, email, password_hash, created_at, updated_at)
+           VALUES ($1, $2, 'hash', NOW(), NOW())"#,
     )
+    .bind(id)
+    .bind(format!("{id}@test.com"))
+    .execute(pool)
+    .await
+    .unwrap();
+}
+
+async fn seed_source(pool: &sqlx::PgPool, id: &str, scope: &str, created_by: &str) {
+    sqlx::query(
+        r#"INSERT INTO sources (id, name, source_type, config, scope, is_active, created_by, created_at, updated_at)
+           VALUES ($1, 'Test', 'google_drive', '{}', $2, true, $3, NOW(), NOW())"#,
+    )
+    .bind(id)
+    .bind(scope)
+    .bind(created_by)
+    .execute(pool)
+    .await
+    .unwrap();
 }
 
 fn make_creds(
@@ -149,45 +139,43 @@ fn make_creds(
     }
 }
 
-/// Generate a 26-character ULID (matching the CHAR(26) column type).
-fn new_id() -> &'static str {
-    Box::leak(shared::utils::generate_ulid().into_boxed_str())
-}
-
-async fn seed_user(pool: &sqlx::PgPool, user_id: &str) {
-    sqlx::query(
-        r#"INSERT INTO users (id, email, password_hash, created_at, updated_at)
-           VALUES ($1, $2, 'hash', NOW(), NOW())
-           ON CONFLICT (id) DO NOTHING"#,
+fn expired_oauth_creds(
+    id: &str,
+    source_id: &str,
+    user_id: Option<&str>,
+    token_uri: &str,
+) -> ServiceCredential {
+    make_creds(
+        id,
+        source_id,
+        user_id,
+        AuthType::OAuth,
+        serde_json::json!({
+            "access_token": "old-token",
+            "refresh_token": "refresh-old",
+            "client_id": "client-1",
+            "token_uri": token_uri,
+        }),
+        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)),
     )
-    .bind(user_id)
-    .bind(format!("{}@test.com", user_id))
-    .execute(pool)
-    .await
-    .unwrap();
 }
 
-async fn seed_source(pool: &sqlx::PgPool, source_id: &str, scope: &str, created_by: &str) {
-    sqlx::query(
-        r#"INSERT INTO sources (id, name, source_type, config, scope, is_active, created_by, created_at, updated_at)
-           VALUES ($1, 'Test Source', 'google_drive', '{}', $2, true, $3, NOW(), NOW())
-           ON CONFLICT (id) DO NOTHING"#,
+fn jwt_creds(id: &str, source_id: &str, user_id: Option<&str>) -> ServiceCredential {
+    make_creds(
+        id,
+        source_id,
+        user_id,
+        AuthType::Jwt,
+        serde_json::json!({"token": "jwt-value"}),
+        None,
     )
-    .bind(source_id)
-    .bind(scope)
-    .bind(created_by)
-    .execute(pool)
-    .await
-    .unwrap();
 }
 
-// ── Mock OAuth token endpoint ──────────────────────────────────────────
+// ── Mock OAuth server ─────────────────────────────────────────────────
 
 type CapturedForm = Arc<TokioMutex<Option<HashMap<String, String>>>>;
 
-/// Spawn an axum token endpoint that captures the form and returns canned
-/// tokens.  Returns `(listen_address, server_handle, captured_form)`.
-async fn spawn_token_endpoint() -> (String, tokio::task::JoinHandle<()>, CapturedForm) {
+async fn spawn_token_server() -> (String, CapturedForm) {
     let captured: CapturedForm = Arc::new(TokioMutex::new(None));
 
     async fn handler(
@@ -196,70 +184,73 @@ async fn spawn_token_endpoint() -> (String, tokio::task::JoinHandle<()>, Capture
     ) -> Json<serde_json::Value> {
         *captured.lock().await = Some(form);
         Json(serde_json::json!({
-            "access_token": "access-new",
-            "refresh_token": "refresh-new",
+            "access_token": "new-token",
+            "refresh_token": "new-refresh",
             "token_type": "Bearer",
             "expires_in": 3600,
         }))
     }
 
     let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-    let address = listener.local_addr().unwrap();
+    let addr = listener.local_addr().unwrap();
     let app = Router::new()
         .route("/token", post(handler))
         .with_state(captured.clone());
-    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
 
-    (format!("http://{address}/token"), server, captured)
+    (format!("http://{addr}/token"), captured)
 }
 
 // ---------------------------------------------------------------------------
-// Test: CredentialService — full OAuth refresh flow
+// Tests
 // ---------------------------------------------------------------------------
 
 #[tokio::test]
-async fn get_user_credential_refreshes_expired_oauth_and_persists() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
+async fn refresh_flow_end_to_end() {
+    // Tests the full OAuth refresh path for both user and org credentials:
+    // seed → read (triggers refresh via CredentialService) → verify updated
+    // tokens persisted → re-read from DB confirms durability.
+
+    let pool = fresh_pool().await;
     let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "user", user_id).await;
-
-    let (token_url, _server, captured) = spawn_token_endpoint().await;
+    let (token_url, captured) = spawn_token_server().await;
 
     let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_oauth_creds(
-        cred_id,
-        source_id,
-        Some(user_id),
-        &token_url,
-        Some("refresh-old"),
-        Some("client-1"),
-        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
-    ))
-    .await
-    .unwrap();
+
+    // ── Per-user credential ────────────────────────────────────────
+    let usr = uid();
+    let src_u = uid();
+    let cred_u = uid();
+    seed_user(db, usr).await;
+    seed_source(db, src_u, "user", usr).await;
+    repo.create(expired_oauth_creds(cred_u, src_u, Some(usr), &token_url))
+        .await
+        .unwrap();
 
     let cs = CredentialService::new(pool.clone());
-    let result = cs
-        .get_user_credential(source_id, user_id)
-        .await
-        .unwrap()
-        .expect("expected a credential");
-
-    // Token values should be updated.
-    assert_eq!(result.credentials["access_token"], "access-new");
-    assert_eq!(result.credentials["refresh_token"], "refresh-new");
+    let result = cs.get_user_credential(src_u, usr).await.unwrap().unwrap();
+    assert_eq!(result.credentials["access_token"], "new-token");
+    assert_eq!(result.credentials["refresh_token"], "new-refresh");
     assert_eq!(result.credentials["token_type"], "Bearer");
     assert!(result.expires_at.unwrap() > OffsetDateTime::now_utc());
     assert!(result.last_validated_at.is_some());
 
-    // The form captured by the mock endpoint should have the expected fields.
+    // Confirm persisted in DB.
+    let from_db = repo.find_by_id(cred_u).await.unwrap().unwrap();
+    assert_eq!(from_db.credentials["access_token"], "new-token");
+
+    // ── Org-wide credential ─────────────────────────────────────────
+    let src_o = uid();
+    let cred_o = uid();
+    seed_source(db, src_o, "org", usr).await;
+    repo.create(expired_oauth_creds(cred_o, src_o, None, &token_url))
+        .await
+        .unwrap();
+
+    let result = cs.get_org_credential(src_o).await.unwrap().unwrap();
+    assert_eq!(result.credentials["access_token"], "new-token");
+
+    // ── Verify captured request ─────────────────────────────────────
     let form = captured.lock().await.clone().unwrap();
     assert_eq!(
         form.get("grant_type").map(String::as_str),
@@ -270,393 +261,65 @@ async fn get_user_credential_refreshes_expired_oauth_and_persists() {
         Some("refresh-old")
     );
     assert_eq!(form.get("client_id").map(String::as_str), Some("client-1"));
-
-    // Re-read from DB to confirm persistence.
-    let from_db = repo.find_by_id(cred_id).await.unwrap().unwrap();
-    assert_eq!(from_db.credentials["access_token"], "access-new");
 }
 
 #[tokio::test]
-async fn get_org_credential_refreshes_expired_oauth_and_persists() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
+async fn raw_read_does_not_trigger_refresh() {
+    // `raw_user_credential` must return the stored credential without
+    // attempting OAuth refresh.  The old-token proves no HTTP call was made.
+
+    let pool = fresh_pool().await;
     let db = pool.pool();
+    let (token_url, _captured) = spawn_token_server().await;
 
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "org", user_id).await;
-
-    let (token_url, _server, captured) = spawn_token_endpoint().await;
-
+    let usr = uid();
+    let src = uid();
+    let cred = uid();
+    seed_user(db, usr).await;
+    seed_source(db, src, "user", usr).await;
     let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_oauth_creds(
-        cred_id,
-        source_id,
-        None, // org-wide
-        &token_url,
-        Some("refresh-old"),
-        Some("client-1"),
-        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
-    ))
-    .await
-    .unwrap();
-
-    let cs = CredentialService::new(pool.clone());
-    let result = cs
-        .get_org_credential(source_id)
-        .await
-        .unwrap()
-        .expect("expected an org credential");
-
-    assert_eq!(result.credentials["access_token"], "access-new");
-    assert!(result.expires_at.unwrap() > OffsetDateTime::now_utc());
-
-    let form = captured.lock().await.clone().unwrap();
-    assert_eq!(
-        form.get("grant_type").map(String::as_str),
-        Some("refresh_token")
-    );
-}
-
-#[tokio::test]
-async fn non_oauth_credential_not_refreshed() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "user", user_id).await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_jwt_creds(cred_id, source_id, Some(user_id)))
+    repo.create(expired_oauth_creds(cred, src, Some(usr), &token_url))
         .await
         .unwrap();
 
-    let cs = CredentialService::new(pool.clone());
-    let result = cs
-        .get_user_credential(source_id, user_id)
+    let result = CredentialService::new(pool)
+        .raw_user_credential(src, usr)
         .await
         .unwrap()
-        .expect("expected a credential");
-
-    // Jwt credential should be returned as-is (no refresh attempted).
-    assert_eq!(result.credentials["token"], "some-jwt");
-    assert_eq!(result.auth_type, AuthType::Jwt);
-}
-
-#[tokio::test]
-async fn credential_without_refresh_token_not_refreshed() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "user", user_id).await;
-
-    let (token_url, _server, _captured) = spawn_token_endpoint().await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_oauth_creds(
-        cred_id,
-        source_id,
-        Some(user_id),
-        &token_url,
-        None, // no refresh_token!
-        Some("client-1"),
-        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
-    ))
-    .await
-    .unwrap();
-
-    let cs = CredentialService::new(pool.clone());
-    let result = cs
-        .get_user_credential(source_id, user_id)
-        .await
-        .unwrap()
-        .expect("expected a credential");
-
-    // Should be returned unchanged (old access token preserved).
-    assert_eq!(result.credentials["access_token"], "access-old");
-}
-
-#[tokio::test]
-async fn credential_without_client_id_not_refreshed() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "user", user_id).await;
-
-    let (token_url, _server, _captured) = spawn_token_endpoint().await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_oauth_creds(
-        cred_id,
-        source_id,
-        Some(user_id),
-        &token_url,
-        Some("refresh-old"),
-        None, // no client_id!
-        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)),
-    ))
-    .await
-    .unwrap();
-
-    let cs = CredentialService::new(pool.clone());
-    let result = cs
-        .get_user_credential(source_id, user_id)
-        .await
-        .unwrap()
-        .expect("expected a credential");
-
-    assert_eq!(result.credentials["access_token"], "access-old");
-}
-
-#[tokio::test]
-async fn not_expired_credential_not_refreshed() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "user", user_id).await;
-
-    let (token_url, _server, _captured) = spawn_token_endpoint().await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_oauth_creds(
-        cred_id,
-        source_id,
-        Some(user_id),
-        &token_url,
-        Some("refresh-old"),
-        Some("client-1"),
-        Some(OffsetDateTime::now_utc() + time::Duration::hours(1)), // still valid
-    ))
-    .await
-    .unwrap();
-
-    let cs = CredentialService::new(pool.clone());
-    let result = cs
-        .get_user_credential(source_id, user_id)
-        .await
-        .unwrap()
-        .expect("expected a credential");
-
-    // Fresh credential should be returned unchanged.
-    assert_eq!(result.credentials["access_token"], "access-old");
-}
-
-#[tokio::test]
-async fn raw_credential_does_not_trigger_refresh() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "user", user_id).await;
-
-    let (token_url, _server, _captured) = spawn_token_endpoint().await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_oauth_creds(
-        cred_id,
-        source_id,
-        Some(user_id),
-        &token_url,
-        Some("refresh-old"),
-        Some("client-1"),
-        Some(OffsetDateTime::now_utc() - time::Duration::seconds(60)), // expired
-    ))
-    .await
-    .unwrap();
-
-    let cs = CredentialService::new(pool.clone());
-    let result = cs
-        .raw_user_credential(source_id, user_id)
-        .await
-        .unwrap()
-        .expect("expected a credential");
-
-    // Raw read should NOT trigger refresh; access_token stays old.
-    assert_eq!(result.credentials["access_token"], "access-old");
-}
-
-// ---------------------------------------------------------------------------
-// Test: ServiceCredentialsRepo CRUD (regression-safe for both branches)
-// ---------------------------------------------------------------------------
-
-#[tokio::test]
-async fn repo_create_and_find_org_credential() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "org", user_id).await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_jwt_creds(cred_id, source_id, None))
-        .await
         .unwrap();
 
-    let found = repo
-        .find_org_credential(source_id)
-        .await
-        .unwrap()
-        .expect("expected org credential");
-    assert!(found.user_id.is_none());
-    assert_eq!(found.source_id, source_id);
+    assert_eq!(result.credentials["access_token"], "old-token");
 }
 
 #[tokio::test]
-async fn repo_create_and_find_user_credential() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
+async fn repo_crud_round_trip() {
+    // Regression: the stripped ServiceCredentialsRepo still performs
+    // encrypted create, find, update correctly.
+
+    let pool = fresh_pool().await;
     let db = pool.pool();
 
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "org", user_id).await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_jwt_creds(cred_id, source_id, Some(user_id)))
-        .await
-        .unwrap();
-
-    let found = repo
-        .find_user_credential(source_id, user_id)
-        .await
-        .unwrap()
-        .expect("expected user credential");
-    assert_eq!(found.user_id.as_deref(), Some(user_id));
-}
-
-#[tokio::test]
-async fn repo_update_credentials_persists_changes() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "user", user_id).await;
+    let usr = uid();
+    let src = uid();
+    let cred = uid();
+    seed_user(db, usr).await;
+    seed_source(db, src, "user", usr).await;
 
     let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    let cred = make_jwt_creds(cred_id, source_id, Some(user_id));
-    repo.create(cred).await.unwrap();
 
-    // Update via the repo.
-    let mut updated = repo.find_by_id(cred_id).await.unwrap().unwrap();
-    updated.credentials = serde_json::json!({"token": "updated-jwt"});
+    // Create
+    repo.create(jwt_creds(cred, src, Some(usr))).await.unwrap();
+
+    // Find
+    let found = repo.find_by_id(cred).await.unwrap().unwrap();
+    assert_eq!(found.user_id.as_deref(), Some(usr));
+    assert_eq!(found.source_id, src);
+    assert_eq!(found.credentials["token"], "jwt-value");
+
+    // Update
+    let mut updated = found;
+    updated.credentials = serde_json::json!({"token": "updated-value"});
     repo.update_credentials(&updated).await.unwrap();
-
-    let from_db = repo.find_by_id(cred_id).await.unwrap().unwrap();
-    assert_eq!(from_db.credentials["token"], "updated-jwt");
-}
-
-#[tokio::test]
-async fn repo_delete_for_user_removes_only_user_row() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user_id = new_id();
-    let cred_id_user = new_id();
-    let cred_id_org = new_id();
-
-    seed_user(db, user_id).await;
-    seed_source(db, source_id, "org", user_id).await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_jwt_creds(cred_id_org, source_id, None))
-        .await
-        .unwrap();
-    repo.create(make_jwt_creds(cred_id_user, source_id, Some(user_id)))
-        .await
-        .unwrap();
-
-    repo.delete_for_user(source_id, user_id).await.unwrap();
-
-    assert!(repo
-        .find_user_credential(source_id, user_id)
-        .await
-        .unwrap()
-        .is_none());
-    assert!(repo.find_org_credential(source_id).await.unwrap().is_some());
-}
-
-#[tokio::test]
-async fn repo_delete_by_source_id_cascades() {
-    let pool = pool().await;
-    clean_db(pool.pool()).await;
-    let db = pool.pool();
-
-    let source_id = new_id();
-    let user1 = new_id();
-    let user2 = new_id();
-
-    seed_user(db, user1).await;
-    seed_user(db, user2).await;
-    seed_source(db, source_id, "org", user1).await;
-
-    let repo = ServiceCredentialsRepo::new(db.clone()).unwrap();
-    repo.create(make_jwt_creds("c1", source_id, None))
-        .await
-        .unwrap();
-    repo.create(make_jwt_creds("c2", source_id, Some(user1)))
-        .await
-        .unwrap();
-    repo.create(make_jwt_creds("c3", source_id, Some(user2)))
-        .await
-        .unwrap();
-
-    repo.delete_by_source_id(source_id).await.unwrap();
-
-    assert!(repo.find_org_credential(source_id).await.unwrap().is_none());
-    assert!(repo
-        .find_user_credential(source_id, user1)
-        .await
-        .unwrap()
-        .is_none());
-    assert!(repo
-        .find_user_credential(source_id, user2)
-        .await
-        .unwrap()
-        .is_none());
+    let reloaded = repo.find_by_id(cred).await.unwrap().unwrap();
+    assert_eq!(reloaded.credentials["token"], "updated-value");
 }

--- a/shared/src/db/repositories/service_credentials.rs
+++ b/shared/src/db/repositories/service_credentials.rs
@@ -1,134 +1,14 @@
-use std::time::Duration as StdDuration;
-
-use anyhow::{anyhow, Context, Result};
-use serde::Deserialize;
+use anyhow::Result;
 use serde_json::Value as JsonValue;
 use sqlx::PgPool;
-use time::{Duration, OffsetDateTime};
 
 use crate::encryption::{EncryptedData, EncryptionService};
-use crate::models::{AuthType, ServiceCredential, Source, SourceScope};
-
-const OAUTH_REFRESH_SKEW: Duration = Duration::minutes(1);
-const OAUTH_REFRESH_REQUEST_TIMEOUT: StdDuration = StdDuration::from_secs(30);
-
-#[derive(Deserialize)]
-struct OAuthRefreshResponse {
-    access_token: String,
-    refresh_token: Option<String>,
-    token_type: Option<String>,
-    expires_in: Option<i64>,
-}
-
-fn oauth_needs_refresh(creds: &ServiceCredential) -> bool {
-    creds.auth_type == AuthType::OAuth
-        && creds
-            .expires_at
-            .is_some_and(|expires_at| expires_at <= OffsetDateTime::now_utc() + OAUTH_REFRESH_SKEW)
-}
-
-fn oauth_is_refreshable(creds: &ServiceCredential) -> bool {
-    let Some(values) = creds.credentials.as_object() else {
-        return false;
-    };
-    ["refresh_token", "client_id", "token_uri"]
-        .iter()
-        .all(|key| {
-            values
-                .get(*key)
-                .and_then(JsonValue::as_str)
-                .is_some_and(|value| !value.is_empty())
-        })
-}
-
-async fn refresh_oauth_tokens(creds: &mut ServiceCredential) -> Result<()> {
-    let values = creds
-        .credentials
-        .as_object_mut()
-        .ok_or_else(|| anyhow!("OAuth credentials must be a JSON object"))?;
-    let string_value = |key: &str| {
-        values
-            .get(key)
-            .and_then(JsonValue::as_str)
-            .filter(|value| !value.is_empty())
-            .map(str::to_owned)
-    };
-    let refresh_token = string_value("refresh_token").context("missing OAuth refresh_token")?;
-    let client_id = string_value("client_id").context("missing OAuth client_id")?;
-    let token_uri = string_value("token_uri").context("missing OAuth token_uri")?;
-    let client_secret = string_value("client_secret");
-    let auth_method = string_value("token_endpoint_auth_method").unwrap_or_else(|| {
-        if client_secret.is_some() {
-            "client_secret_post".to_string()
-        } else {
-            "none".to_string()
-        }
-    });
-
-    let mut form = vec![
-        ("grant_type", "refresh_token".to_string()),
-        ("refresh_token", refresh_token),
-    ];
-    if auth_method != "client_secret_basic" {
-        form.push(("client_id", client_id.clone()));
-    }
-    if let Some(resource) = string_value("resource") {
-        form.push(("resource", resource));
-    }
-    if auth_method == "client_secret_post" {
-        form.push((
-            "client_secret",
-            client_secret
-                .clone()
-                .context("missing OAuth client_secret")?,
-        ));
-    }
-
-    let client = reqwest::Client::builder()
-        .timeout(OAUTH_REFRESH_REQUEST_TIMEOUT)
-        .build()
-        .context("failed to build OAuth refresh client")?;
-    let mut request = client.post(&token_uri).form(&form);
-    if auth_method == "client_secret_basic" {
-        request = request.basic_auth(
-            client_id,
-            Some(client_secret.context("missing OAuth client_secret")?),
-        );
-    } else if auth_method != "none" && auth_method != "client_secret_post" {
-        return Err(anyhow!("unsupported OAuth token endpoint auth method"));
-    }
-    let response = request
-        .send()
-        .await
-        .context("OAuth token refresh request failed")?;
-    if !response.status().is_success() {
-        return Err(anyhow!(
-            "OAuth token refresh failed with status {}",
-            response.status()
-        ));
-    }
-    let refreshed: OAuthRefreshResponse = response
-        .json()
-        .await
-        .context("invalid OAuth token refresh response")?;
-    let now = OffsetDateTime::now_utc();
-    values.insert("access_token".to_string(), refreshed.access_token.into());
-    if let Some(refresh_token) = refreshed.refresh_token {
-        values.insert("refresh_token".to_string(), refresh_token.into());
-    }
-    if let Some(token_type) = refreshed.token_type {
-        values.insert("token_type".to_string(), token_type.into());
-    }
-    let expires_in = refreshed
-        .expires_in
-        .filter(|seconds| *seconds > 0)
-        .unwrap_or(3600);
-    creds.expires_at = Some(now + Duration::seconds(expires_in));
-    creds.last_validated_at = Some(now);
-    Ok(())
-}
+use crate::models::{ServiceCredential, Source, SourceScope};
 
 /// Service credentials repository with encryption support.
+///
+/// This is a pure CRUD layer. OAuth token lifecycle management lives in
+/// `CredentialService` (omni-connector-manager).
 pub struct ServiceCredentialsRepo {
     pool: PgPool,
     encryption_service: EncryptionService,
@@ -172,10 +52,7 @@ impl ServiceCredentialsRepo {
             self.decrypt_credentials_in_place(creds)?;
         }
 
-        match creds {
-            Some(creds) => Ok(Some(self.refresh_oauth_if_needed(creds).await?)),
-            None => Ok(None),
-        }
+        Ok(creds)
     }
 
     /// Fetch the credential row that "owns" a source — the one used for sync
@@ -213,10 +90,7 @@ impl ServiceCredentialsRepo {
             self.decrypt_credentials_in_place(creds)?;
         }
 
-        match creds {
-            Some(creds) => Ok(Some(self.refresh_oauth_if_needed(creds).await?)),
-            None => Ok(None),
-        }
+        Ok(creds)
     }
 
     fn decrypt_credentials_in_place(&self, creds: &mut ServiceCredential) -> Result<()> {
@@ -235,51 +109,6 @@ impl ServiceCredentialsRepo {
             "encrypted_data": encrypted_data,
             "version": 1
         }))
-    }
-
-    async fn refresh_oauth_if_needed(&self, creds: ServiceCredential) -> Result<ServiceCredential> {
-        if !oauth_needs_refresh(&creds) || !oauth_is_refreshable(&creds) {
-            return Ok(creds);
-        }
-        self.refresh_oauth_credential(&creds.id).await
-    }
-
-    async fn refresh_oauth_credential(&self, credential_id: &str) -> Result<ServiceCredential> {
-        let mut tx = self.pool.begin().await?;
-        sqlx::query("SELECT pg_advisory_xact_lock(hashtext($1))")
-            .bind(credential_id)
-            .execute(&mut *tx)
-            .await?;
-
-        let mut creds = sqlx::query_as::<_, ServiceCredential>(
-            "SELECT * FROM service_credentials WHERE id = $1 FOR UPDATE",
-        )
-        .bind(credential_id)
-        .fetch_one(&mut *tx)
-        .await?;
-        self.decrypt_credentials_in_place(&mut creds)?;
-
-        // Another request may have refreshed this credential while we waited for
-        // the per-row advisory lock. Recheck under the lock before calling the
-        // provider so rotating refresh tokens are never replayed concurrently.
-        if !oauth_needs_refresh(&creds) || !oauth_is_refreshable(&creds) {
-            tx.commit().await?;
-            return Ok(creds);
-        }
-
-        refresh_oauth_tokens(&mut creds).await?;
-        let encrypted_credentials = self.encrypt_credentials(&creds)?;
-        sqlx::query(
-            "UPDATE service_credentials SET credentials = $2, expires_at = $3, last_validated_at = $4, updated_at = CURRENT_TIMESTAMP WHERE id = $1",
-        )
-        .bind(&creds.id)
-        .bind(encrypted_credentials)
-        .bind(creds.expires_at)
-        .bind(creds.last_validated_at)
-        .execute(&mut *tx)
-        .await?;
-        tx.commit().await?;
-        Ok(creds)
     }
 
     pub async fn create(&self, creds: ServiceCredential) -> Result<ServiceCredential> {
@@ -345,13 +174,16 @@ impl ServiceCredentialsRepo {
     }
 
     /// Update credentials and refresh-related fields on a credential row.
+    /// Persists the refreshed `credentials`, `config`, `expires_at`, and
+    /// `last_validated_at`.
     pub async fn update_credentials(&self, creds: &ServiceCredential) -> Result<()> {
         let encrypted_credentials = self.encrypt_credentials(creds)?;
 
         sqlx::query(
             r#"
             UPDATE service_credentials
-            SET credentials = $2, config = $3, expires_at = $4, updated_at = CURRENT_TIMESTAMP
+            SET credentials = $2, config = $3, expires_at = $4,
+                last_validated_at = $5, updated_at = CURRENT_TIMESTAMP
             WHERE id = $1
             "#,
         )
@@ -359,6 +191,7 @@ impl ServiceCredentialsRepo {
         .bind(&encrypted_credentials)
         .bind(&creds.config)
         .bind(creds.expires_at)
+        .bind(creds.last_validated_at)
         .execute(&self.pool)
         .await?;
 
@@ -373,10 +206,6 @@ impl ServiceCredentialsRepo {
         source_types: &[String],
         provider: &str,
     ) -> Result<Option<(String, String)>> {
-        // Returns (source_id, user_id) for the most recently updated
-        // per-user OAuth credential matching the criteria.
-        // sqlx doesn't support array_agg -> text easily, so we use ANY(..) with
-        // a typed PostgreSQL array.
         let result: Option<(String, String)> = sqlx::query_as(
             r#"
             SELECT sc.source_id, sc.user_id
@@ -413,125 +242,5 @@ impl ServiceCredentialsRepo {
         }
 
         Ok(count)
-    }
-}
-
-#[cfg(test)]
-mod oauth_refresh_tests {
-    use std::{collections::HashMap, sync::Arc};
-
-    use axum::{
-        extract::{Form, State},
-        routing::post,
-        Json, Router,
-    };
-    use serde_json::json;
-    use tokio::sync::Mutex;
-
-    use super::*;
-    use crate::models::ServiceProvider;
-
-    fn oauth_credential(
-        credentials: JsonValue,
-        expires_at: Option<OffsetDateTime>,
-    ) -> ServiceCredential {
-        let now = OffsetDateTime::now_utc();
-        ServiceCredential {
-            id: "credential-1".to_string(),
-            source_id: "source-1".to_string(),
-            user_id: None,
-            provider: ServiceProvider::Clickup,
-            auth_type: AuthType::OAuth,
-            principal_email: Some("user@example.com".to_string()),
-            credentials,
-            config: json!({}),
-            expires_at,
-            last_validated_at: None,
-            created_at: now,
-            updated_at: now,
-        }
-    }
-
-    #[test]
-    fn refreshes_only_expiring_oauth_credentials_with_refresh_metadata() {
-        let complete = json!({
-            "refresh_token": "refresh-old",
-            "client_id": "client-1",
-            "token_uri": "https://windshift.example/api/oauth/token"
-        });
-        let expiring = oauth_credential(complete.clone(), Some(OffsetDateTime::now_utc()));
-        assert!(oauth_needs_refresh(&expiring));
-        assert!(oauth_is_refreshable(&expiring));
-
-        let valid = oauth_credential(
-            complete,
-            Some(OffsetDateTime::now_utc() + Duration::hours(1)),
-        );
-        assert!(!oauth_needs_refresh(&valid));
-
-        let incomplete = oauth_credential(json!({ "access_token": "token" }), None);
-        assert!(!oauth_is_refreshable(&incomplete));
-    }
-
-    #[tokio::test]
-    async fn refreshes_public_client_tokens_and_preserves_resource_binding() {
-        type CapturedForm = Arc<Mutex<Option<HashMap<String, String>>>>;
-
-        async fn token_endpoint(
-            State(captured): State<CapturedForm>,
-            Form(form): Form<HashMap<String, String>>,
-        ) -> Json<JsonValue> {
-            *captured.lock().await = Some(form);
-            Json(json!({
-                "access_token": "access-new",
-                "refresh_token": "refresh-new",
-                "token_type": "Bearer",
-                "expires_in": 120
-            }))
-        }
-
-        let captured: CapturedForm = Arc::new(Mutex::new(None));
-        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
-        let address = listener.local_addr().unwrap();
-        let app = Router::new()
-            .route("/token", post(token_endpoint))
-            .with_state(captured.clone());
-        let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
-
-        let resource = "https://windshift.example/mcp";
-        let mut credential = oauth_credential(
-            json!({
-                "access_token": "access-old",
-                "refresh_token": "refresh-old",
-                "client_id": "client-1",
-                "token_uri": format!("http://{address}/token"),
-                "token_endpoint_auth_method": "none",
-                "resource": resource
-            }),
-            Some(OffsetDateTime::now_utc()),
-        );
-
-        refresh_oauth_tokens(&mut credential).await.unwrap();
-        server.abort();
-
-        assert_eq!(credential.credentials["access_token"], "access-new");
-        assert_eq!(credential.credentials["refresh_token"], "refresh-new");
-        assert_eq!(credential.credentials["token_type"], "Bearer");
-        assert!(
-            credential.expires_at.unwrap() > OffsetDateTime::now_utc() + Duration::seconds(100)
-        );
-
-        let form = captured.lock().await.clone().unwrap();
-        assert_eq!(
-            form.get("grant_type").map(String::as_str),
-            Some("refresh_token")
-        );
-        assert_eq!(
-            form.get("refresh_token").map(String::as_str),
-            Some("refresh-old")
-        );
-        assert_eq!(form.get("client_id").map(String::as_str), Some("client-1"));
-        assert_eq!(form.get("resource").map(String::as_str), Some(resource));
-        assert!(!form.contains_key("client_secret"));
     }
 }


### PR DESCRIPTION
New `CredentialService` consolidates all OAuth token refresh logic; `ServiceCredentialsRepo` is now pure encrypted CRUD with no side-effects
- OAuth HTTP calls always happen **outside** any database transaction
- In-process `Mutex` serialises per-credential refresh (replaces `pg_advisory_xact_lock`)
- Token endpoint resolved from connector config → credential JSON → remote-MCP metadata
- `remote_mcp/oauth.rs` reduced to config parsing only
- 14 unit tests covering predicates, auth-method fallbacks, and refresh response parsing