### PR TITLE
fix(oauth): store missing refresh token as SQL NULL

### DIFF
--- a/web/src/lib/server/oauth/userCredentials.ts
+++ b/web/src/lib/server/oauth/userCredentials.ts
@@ -68,7 +68,9 @@ export class UserOAuthCredentialsService {
 
         const scopes = tokens.scope ? tokens.scope.split(' ') : []
         const accessTokenJson = JSON.stringify(encryptToken(tokens.access_token))
-        const refreshTokenJson = JSON.stringify(encryptToken(tokens.refresh_token))
+        const refreshTokenJson = tokens.refresh_token
+            ? JSON.stringify(encryptToken(tokens.refresh_token))
+            : null
 
         const insertQuery = sql`
             INSERT INTO user_oauth_credentials (


### PR DESCRIPTION
saveCredentials serialized an absent refresh token as JSONB `'null'`, violating the `user_oauth_credentials_refresh_token_encrypted` check constraint and breaking Okta SSO logins. Now stores SQL NULL instead, mirroring the existing handling in updateTokens.