### PR TITLE
fix(darwinbox): typed holiday-list response fails loudly on shape mismatch

### DIFF
--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -547,7 +547,15 @@ pub async fn execute_action(
                 .and_then(JsonValue::as_str)
                 .map(str::to_string)
                 .unwrap_or_else(|| current_year(&config));
-            client.fetch_holiday_list(employee_no, &year).await?
+            // The action relays the raw envelope to the response sanitizer
+            // (the typed `fetch_holiday_list` is for the sync module).
+            client
+                .post_json::<JsonValue>(
+                    "/leavesactionapi/holidaylist",
+                    json!({ "employee_no": employee_no, "year": year }),
+                    false,
+                )
+                .await?
         }
         "apply_my_leave" => {
             let employee = calling_employee.as_ref().expect("self action resolved caller");

--- a/connectors/darwinbox/src/client.rs
+++ b/connectors/darwinbox/src/client.rs
@@ -7,7 +7,7 @@ use url::Url;
 use crate::auth::{add_api_key_and_dataset, apply_basic_auth, fetch_token};
 use crate::config::DarwinboxSourceConfig;
 use crate::credentials::DarwinboxCredentials;
-use crate::models::EmployeeDataResponse;
+use crate::models::{EmployeeDataResponse, HolidayListResponse};
 
 /// Darwinbox API call outcome, split so sync/action callers can tolerate
 /// provider-side denials without treating them as transient failures.
@@ -194,7 +194,7 @@ impl DarwinboxClient {
         &self,
         employee_no: &str,
         year: &str,
-    ) -> std::result::Result<JsonValue, DarwinboxApiError> {
+    ) -> std::result::Result<HolidayListResponse, DarwinboxApiError> {
         self.post_json(
             "/leavesactionapi/holidaylist",
             json!({ "employee_no": employee_no, "year": year }),

--- a/connectors/darwinbox/src/mappers.rs
+++ b/connectors/darwinbox/src/mappers.rs
@@ -4,6 +4,8 @@
 
 use serde_json::Value as JsonValue;
 
+use crate::models;
+
 /// A safe, index-ready document derived from a provider record: only known
 /// fields are projected into the title, body, and search attributes.
 pub struct SafeDocument {
@@ -69,29 +71,25 @@ pub fn field_with_alias<'a>(item: &'a JsonValue, key: &'a str, alias: &'a str) -
         .or_else(|| item.get(alias).and_then(JsonValue::as_str))
 }
 
-/// Safely format a holiday item from known fields.
-pub fn format_holiday_item(item: &JsonValue) -> SafeDocument {
-    let name = field_with_alias(item, "name", "holiday_name").unwrap_or("Holiday");
-    let date = field_with_alias(item, "date", "holiday_date").unwrap_or_default();
-    let description = item
-        .get("description")
-        .and_then(JsonValue::as_str)
-        .unwrap_or_default();
-
-    let safe_body = if description.is_empty() {
-        format!("# {name}\n\n- Date: {date}")
-    } else {
-        format!("# {name}\n\n- Date: {date}\n- Description: {description}")
-    };
-
-    let mut attributes = vec![("holiday_name".to_string(), name.to_string())];
-    if !date.is_empty() {
-        attributes.push(("holiday_date".to_string(), date.to_string()));
+/// Format a holiday document from the typed holiday-list item.
+pub fn format_holiday_item(item: &models::HolidayItem) -> SafeDocument {
+    let mut lines = vec![format!("# {}", item.name), format!("- Date: {}", item.date)];
+    for (label, value) in [
+        ("Repeats", item.holiday_repeats.as_deref()),
+        ("Optional", item.is_optional.as_deref()),
+        ("National", item.is_national.as_deref()),
+    ] {
+        if let Some(value) = value {
+            lines.push(format!("- {label}: {value}"));
+        }
     }
 
+    let mut attributes = vec![("holiday_name".to_string(), item.name.clone())];
+    attributes.push(("holiday_date".to_string(), item.date.clone()));
+
     SafeDocument {
-        title: name.to_string(),
-        body: safe_body,
+        title: item.name.clone(),
+        body: lines.join("\n"),
         attributes,
     }
 }
@@ -151,17 +149,20 @@ mod tests {
     use super::*;
 
     #[test]
-    fn holiday_mapper_accepts_real_api_field_names() {
-        let item = serde_json::json!({
-            "id": 1,
-            "name": "Independence Day",
-            "date": "2026-08-15",
-            "year": 2026,
-            "holiday_repeats": false
-        });
+    fn holiday_mapper_formats_typed_item() {
+        let item = models::HolidayItem {
+            id: Some("a68f996eb7bec5".into()),
+            name: "Independence Day".into(),
+            date: "2026-08-15".into(),
+            year: Some("2026".into()),
+            holiday_repeats: Some("No".into()),
+            is_optional: Some("No".into()),
+            is_national: Some("Yes".into()),
+        };
         let document = format_holiday_item(&item);
         assert_eq!(document.title, "Independence Day");
         assert!(document.body.contains("2026-08-15"));
+        assert!(document.body.contains("- National: Yes"));
         assert!(
             document
                 .attributes
@@ -175,16 +176,19 @@ mod tests {
     }
 
     #[test]
-    fn holiday_mapper_falls_back_to_legacy_field_names() {
-        let item = serde_json::json!({
-            "id": 2,
-            "holiday_name": "Republic Day",
-            "holiday_date": "2026-01-26",
-            "year": 2026,
-            "holiday_repeats": true
-        });
+    fn holiday_mapper_tolerates_absent_optional_fields() {
+        let item = models::HolidayItem {
+            id: None,
+            name: "Republic Day".into(),
+            date: "2026-01-26".into(),
+            year: None,
+            holiday_repeats: None,
+            is_optional: None,
+            is_national: None,
+        };
         let document = format_holiday_item(&item);
         assert_eq!(document.title, "Republic Day");
+        assert_eq!(document.body, "# Republic Day\n- Date: 2026-01-26");
         assert!(
             document
                 .attributes

--- a/connectors/darwinbox/src/models.rs
+++ b/connectors/darwinbox/src/models.rs
@@ -172,6 +172,42 @@ impl EmployeeDataResponse {
     }
 }
 
+/// Response envelope for `POST /leavesactionapi/holidaylist`.
+///
+/// Shape verified live against a production tenant: holidays are returned
+/// under the top-level `holidays` key. `holidays` and each item's `name`/
+/// `date` are required — a response without them is a shape mismatch and
+/// fails the module loudly.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HolidayListResponse {
+    #[serde(default)]
+    pub status: Option<i32>,
+    pub holidays: Vec<HolidayItem>,
+    #[serde(default)]
+    pub errors: Vec<serde_json::Value>,
+    #[serde(default)]
+    pub message: Option<String>,
+}
+
+/// One holiday entry as returned by the Darwinbox holiday-list API.
+/// All fields are strings on the verified tenant; optional fields tolerate
+/// absence with `#[serde(default)]`.
+#[derive(Debug, Clone, Deserialize)]
+pub struct HolidayItem {
+    #[serde(default)]
+    pub id: Option<String>,
+    pub name: String,
+    pub date: String,
+    #[serde(default)]
+    pub year: Option<String>,
+    #[serde(default)]
+    pub holiday_repeats: Option<String>,
+    #[serde(default)]
+    pub is_optional: Option<String>,
+    #[serde(default)]
+    pub is_national: Option<String>,
+}
+
 fn normalize_darwinbox_date(value: Option<&str>) -> Option<String> {
     let value = value?.trim();
     if value.is_empty() {
@@ -733,5 +769,87 @@ mod tests {
                 .to_person_sync_records(&[EmployeeField::EmploymentDates], |_| true)
                 .is_err()
         );
+    }
+
+    #[test]
+    fn holiday_response_deserializes_the_verified_live_shape() {
+        let response: HolidayListResponse = serde_json::from_value(serde_json::json!({
+            "status": 1,
+            "holidays": [{
+                "id": "a68f996eb7bec5",
+                "name": "New Year's Holiday",
+                "date": "2026-01-01",
+                "year": "2026",
+                "holiday_repeats": "No",
+                "is_optional": "No",
+                "is_national": "No"
+            }],
+            "errors": [],
+            "message": "Successfully Loaded All Holidays"
+        }))
+        .unwrap();
+        assert_eq!(response.status, Some(1));
+        assert_eq!(response.holidays.len(), 1);
+        let holiday = &response.holidays[0];
+        assert_eq!(holiday.id.as_deref(), Some("a68f996eb7bec5"));
+        assert_eq!(holiday.name, "New Year's Holiday");
+        assert_eq!(holiday.date, "2026-01-01");
+        assert_eq!(holiday.year.as_deref(), Some("2026"));
+        assert_eq!(holiday.holiday_repeats.as_deref(), Some("No"));
+        assert_eq!(holiday.is_optional.as_deref(), Some("No"));
+        assert_eq!(holiday.is_national.as_deref(), Some("No"));
+    }
+
+    #[test]
+    fn holiday_response_requires_name_and_date_on_every_item() {
+        // A missing `holidays` key is a shape mismatch and must fail loudly.
+        assert!(
+            serde_json::from_value::<HolidayListResponse>(serde_json::json!({
+                "status": 1,
+                "result": []
+            }))
+            .is_err()
+        );
+        // A non-array `holidays` value is likewise a shape mismatch.
+        assert!(
+            serde_json::from_value::<HolidayListResponse>(serde_json::json!({
+                "holidays": "oops"
+            }))
+            .is_err()
+        );
+        // An item without `date` is a shape mismatch and must fail loudly.
+        assert!(
+            serde_json::from_value::<HolidayListResponse>(serde_json::json!({
+                "status": 1,
+                "holidays": [{"id": "a68f996eb7bec5", "name": "Independence Day"}]
+            }))
+            .is_err()
+        );
+        // An item without `name` is likewise a shape mismatch.
+        assert!(
+            serde_json::from_value::<HolidayListResponse>(serde_json::json!({
+                "status": 1,
+                "holidays": [{"id": "a68f996eb7bec5", "date": "2026-08-15"}]
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn holiday_response_tolerates_absent_envelope_and_optional_fields() {
+        // `errors`/`message`/optional item fields may be absent; defaults apply.
+        let response: HolidayListResponse = serde_json::from_value(serde_json::json!({
+            "status": 1,
+            "holidays": [{"name": "Independence Day", "date": "2026-08-15"}]
+        }))
+        .unwrap();
+        assert!(response.errors.is_empty());
+        assert_eq!(response.message, None);
+        let holiday = &response.holidays[0];
+        assert_eq!(holiday.id, None);
+        assert_eq!(holiday.year, None);
+        assert_eq!(holiday.holiday_repeats, None);
+        assert_eq!(holiday.is_optional, None);
+        assert_eq!(holiday.is_national, None);
     }
 }

--- a/connectors/darwinbox/src/sync.rs
+++ b/connectors/darwinbox/src/sync.rs
@@ -369,20 +369,15 @@ async fn sync_holidays(
     let year = Utc::now().format("%Y").to_string();
     let response = client.fetch_holiday_list(employee_id, &year).await?;
     let permissions = config::document_permissions("holiday", config, source_id, None);
-    let items = extract_items(&response);
     let mut count = 0i32;
 
-    for item in &items {
+    for item in &response.holidays {
         if ctx.is_cancelled() {
             ctx.cancel().await?;
             return Ok(());
         }
         let document = mappers::format_holiday_item(item);
-        let Some(date) = mappers::field_with_alias(item, "date", "holiday_date") else {
-            warn!("Skipping Darwinbox holiday without date");
-            continue;
-        };
-        let id = slugify(&format!("{date}-{}", document.title));
+        let id = slugify(&format!("{}-{}", item.date, document.title));
         let content_id = ctx.store_content(&document.body).await?;
 
         let document_id = format!("darwinbox:holiday:{id}");
@@ -588,13 +583,17 @@ mod tests {
             .and(path("/leavesactionapi/holidaylist"))
             .respond_with(ResponseTemplate::new(200).set_body_json(json!({
                 "status": 1,
-                "data": [{
-                    "id": 1,
+                "holidays": [{
+                    "id": "a68f996eb7bec5",
                     "name": "Independence Day",
                     "date": "2026-08-15",
-                    "year": 2026,
-                    "holiday_repeats": false
-                }]
+                    "year": "2026",
+                    "holiday_repeats": "No",
+                    "is_optional": "No",
+                    "is_national": "Yes"
+                }],
+                "errors": [],
+                "message": "Successfully Loaded All Holidays"
             })))
             .mount(&server)
             .await;
@@ -660,6 +659,53 @@ mod tests {
         );
         assert_eq!(event["metadata"]["title"], "Independence Day");
         assert_eq!(event["metadata"]["content_type"], "holiday");
+    }
+
+    #[tokio::test]
+    async fn holiday_sync_fails_loudly_on_mismatched_envelope() {
+        // A shape without the `holidays` key (the pre-fix fallback path) must
+        // fail the module, not silently produce zero documents.
+        for body in [
+            json!({ "status": 1, "result": [] }),
+            json!({ "holidays": "oops" }),
+            json!({ "status": 1, "holidays": [{ "name": "No Date" }] }),
+        ] {
+            let server = MockServer::start().await;
+            Mock::given(method("POST"))
+                .and(path("/leavesactionapi/holidaylist"))
+                .respond_with(ResponseTemplate::new(200).set_body_json(body))
+                .mount(&server)
+                .await;
+
+            let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+                "base_url": server.uri(),
+                "authorization": { "participant_mode": "all" }
+            }))
+            .unwrap();
+            let credentials = crate::credentials::DarwinboxCredentials::Basic {
+                username: "api-user".to_string(),
+                password: "secret".to_string(),
+                api_key: "api-key".to_string(),
+                dataset_key: "dataset-key".to_string(),
+            };
+            let client = DarwinboxClient::new(&config, credentials).unwrap();
+            let ctx = SyncContext::new(
+                SdkClient::new(&server.uri()),
+                "run-1".to_string(),
+                "source-1".to_string(),
+                SourceType::Darwinbox,
+                SyncType::Full,
+                Arc::new(AtomicBool::new(false)),
+            );
+
+            let error = sync_holidays(&client, &config, "source-1", &ctx, "EMP001")
+                .await
+                .expect_err("mismatched holiday envelope must fail the module");
+            assert!(
+                format!("{error}").contains("Darwinbox API request failed"),
+                "unexpected error: {error}"
+            );
+        }
     }
 }
 

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -518,11 +518,16 @@ fn org_master_mappers_emit_searchable_attributes() {
             .contains(&("division_code".to_string(), "CORP".to_string()))
     );
 
-    let holiday = mappers::format_holiday_item(&serde_json::json!({
-        "holiday_name": "Republic Day",
-        "holiday_date": "2025-01-26",
-        "description": "National holiday"
-    }));
+    let holiday = mappers::format_holiday_item(&omni_darwinbox_connector::models::HolidayItem {
+        id: Some("a68f996eb7bec5".into()),
+        name: "Republic Day".into(),
+        date: "2025-01-26".into(),
+        year: Some("2025".into()),
+        holiday_repeats: Some("No".into()),
+        is_optional: Some("No".into()),
+        is_national: Some("Yes".into()),
+    });
+    assert_eq!(holiday.title, "Republic Day");
     assert!(
         holiday
             .attributes


### PR DESCRIPTION
- Parse holiday-list sync responses into a typed `HolidayListResponse` envelope; a missing `holidays` key or items without `name`/`date` now fail the sync instead of silently indexing zero documents
- Holidays are returned under the top-level `holidays` key, which the previous `extract_items` guessing never looked at — the actual reason holidays were skipped
- Make `format_holiday_item` consume the typed `HolidayItem` and enrich the document body with repeats/optional/national
- Keep the `get_holiday_calendar` action on the raw provider envelope so its response sanitizer behavior is unchanged
- Update the sync test fixture to the verified live response shape and add loud-failure and deserialization tests