### PR TITLE
feat(windshift): configure Windshift server via admin UI, drop compose env warnings

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -38,14 +38,10 @@ GOOGLE_ADS_CONNECTOR_PORT=4016
 DARWINBOX_CONNECTOR_PORT=4017
 WINDSHIFT_CONNECTOR_PORT=4018
 
-# Public URL of the Windshift instance this Omni install talks to.
-# Reachable from the user's browser for OAuth consent. One Omni install = one
-# Windshift instance in v1. Set WINDSHIFT_INTERNAL_BASE_URL below when the
-# connector container needs a different route to that instance.
-WINDSHIFT_BASE_URL=https://windshift.example.com
-# Optional connector-only URL for local/private networking. OAuth URLs and
-# token audience still use WINDSHIFT_BASE_URL.
-WINDSHIFT_INTERNAL_BASE_URL=
+# Windshift connector server configuration (base URLs) is managed in the admin
+# UI under Settings > Integrations > Windshift server. No env vars required.
+# For deployments that predate the UI setting, the connector still accepts
+# WINDSHIFT_BASE_URL / WINDSHIFT_INTERNAL_BASE_URL as a fallback.
 
 # Sandbox Port
 SANDBOX_PORT=8090

--- a/.env.example
+++ b/.env.example
@@ -38,11 +38,6 @@ GOOGLE_ADS_CONNECTOR_PORT=4016
 DARWINBOX_CONNECTOR_PORT=4017
 WINDSHIFT_CONNECTOR_PORT=4018
 
-# Windshift connector server configuration (base URLs) is managed in the admin
-# UI under Settings > Integrations > Windshift server. No env vars required.
-# For deployments that predate the UI setting, the connector still accepts
-# WINDSHIFT_BASE_URL / WINDSHIFT_INTERNAL_BASE_URL as a fallback.
-
 # Sandbox Port
 SANDBOX_PORT=8090
 

--- a/connectors/windshift/README.md
+++ b/connectors/windshift/README.md
@@ -18,7 +18,12 @@ when both are present. If Windshift uses a context path, include it in the URL.
 
 Saved URLs are validated against SSRF (same policy as remote MCP sources):
 only http(s), no credentials/fragments, and the resolved address must be
-publicly routable — loopback and private-network addresses are rejected.
+publicly routable. The internal URL is the exception — it exists for private
+networking, so its destination may be a private (RFC1918) address such as a
+docker service name; loopback, link-local/metadata, and reserved ranges are
+still rejected. Server-side OAuth fetches are re-checked against SSRF at
+use time: only endpoints on the exact configured internal origin may resolve
+to private addresses, everything else must be publicly routable.
 
 Browser authorization, resource binding, and document links always use the
 public Windshift URL; server-side client registration, token exchange,

--- a/connectors/windshift/README.md
+++ b/connectors/windshift/README.md
@@ -6,28 +6,31 @@ Windshift's MCP tools as Omni actions.
 ## Configuration
 
 Windshift is configured in the admin UI under **Settings > Integrations >
-Windshift server**: enter the externally reachable Windshift base URL (and
-optionally an internal/connector-only route). No env vars are required — the
-setting is stored in the `connector_configs` table and the connector reads it
-from connector-manager, so changes propagate without a container restart. Enable
-Windshift's MCP server with `MCP_ENABLED=true`.
+Windshift server**: enter the externally reachable Windshift base URL. No env
+vars are required — the setting is stored in the `connector_configs` table and
+the connector reads it from connector-manager, so changes propagate without a
+container restart. Enable Windshift's MCP server with `MCP_ENABLED=true`.
 
-Deployments that predate the UI setting can still set `WINDSHIFT_BASE_URL` (and
-optionally `WINDSHIFT_INTERNAL_BASE_URL`) as a fallback; the UI setting wins
-when both are present. If Windshift uses a context path, include it in the URL.
+Deployments that predate the UI setting can still set `WINDSHIFT_BASE_URL` as
+a fallback; the UI setting wins when both are present. If Windshift uses a
+context path, include it in the URL.
 
-Saved URLs are validated against SSRF (same policy as remote MCP sources):
+The saved URL is validated against SSRF (same policy as remote MCP sources):
 only http(s), no credentials/fragments, and the resolved address must be
-publicly routable. The internal URL is the exception — it exists for private
-networking, so its destination may be a private (RFC1918) address such as a
-docker service name; loopback, link-local/metadata, and reserved ranges are
-still rejected. Server-side OAuth fetches are re-checked against SSRF at
-use time: only endpoints on the exact configured internal origin may resolve
-to private addresses, everything else must be publicly routable.
+publicly routable.
 
-Browser authorization, resource binding, and document links always use the
-public Windshift URL; server-side client registration, token exchange,
-user-info, sync, and MCP requests use the internal route when one is set.
+### Internal route (env-only)
+
+To keep server-to-server traffic (client registration, token exchange,
+user-info, sync, MCP) off the public network, set `WINDSHIFT_INTERNAL_BASE_URL`
+on the connector container to a private route to the same Windshift instance,
+e.g. `http://windshift:8080` on the compose network. This is intentionally
+env-only — it is not configurable in the UI. When set, the connector advertises
+it in its manifest and Omni's OAuth flow allows that exact origin (scheme + host
++ port) to resolve to private (RFC1918) addresses; loopback, link-local/metadata,
+and reserved ranges are still rejected, and every other endpoint must stay
+publicly routable. Browser authorization, resource binding, and document links
+always use the public URL regardless.
 
 No OAuth client ID or secret is configured manually. Omni dynamically registers
 as a public client, uses S256 PKCE, and requests tokens bound to

--- a/connectors/windshift/README.md
+++ b/connectors/windshift/README.md
@@ -16,6 +16,10 @@ Deployments that predate the UI setting can still set `WINDSHIFT_BASE_URL` (and
 optionally `WINDSHIFT_INTERNAL_BASE_URL`) as a fallback; the UI setting wins
 when both are present. If Windshift uses a context path, include it in the URL.
 
+Saved URLs are validated against SSRF (same policy as remote MCP sources):
+only http(s), no credentials/fragments, and the resolved address must be
+publicly routable — loopback and private-network addresses are rejected.
+
 Browser authorization, resource binding, and document links always use the
 public Windshift URL; server-side client registration, token exchange,
 user-info, sync, and MCP requests use the internal route when one is set.

--- a/connectors/windshift/README.md
+++ b/connectors/windshift/README.md
@@ -5,15 +5,20 @@ Windshift's MCP tools as Omni actions.
 
 ## Configuration
 
-Set `WINDSHIFT_BASE_URL` to the externally reachable Windshift base URL. If
-Windshift uses a context path, include it in the URL. Enable Windshift's MCP
-server with `MCP_ENABLED=true`.
+Windshift is configured in the admin UI under **Settings > Integrations >
+Windshift server**: enter the externally reachable Windshift base URL (and
+optionally an internal/connector-only route). No env vars are required — the
+setting is stored in the `connector_configs` table and the connector reads it
+from connector-manager, so changes propagate without a container restart. Enable
+Windshift's MCP server with `MCP_ENABLED=true`.
 
-For local or private networking, `WINDSHIFT_INTERNAL_BASE_URL` may point the
-connector container at the same Windshift instance through a different route.
-Browser authorization, resource binding, and document links still use
-`WINDSHIFT_BASE_URL`; server-side client registration, token exchange, user-info,
-sync, and MCP requests use the internal route.
+Deployments that predate the UI setting can still set `WINDSHIFT_BASE_URL` (and
+optionally `WINDSHIFT_INTERNAL_BASE_URL`) as a fallback; the UI setting wins
+when both are present. If Windshift uses a context path, include it in the URL.
+
+Browser authorization, resource binding, and document links always use the
+public Windshift URL; server-side client registration, token exchange,
+user-info, sync, and MCP requests use the internal route when one is set.
 
 No OAuth client ID or secret is configured manually. Omni dynamically registers
 as a public client, uses S256 PKCE, and requests tokens bound to

--- a/connectors/windshift/src/connector.test.ts
+++ b/connectors/windshift/src/connector.test.ts
@@ -33,6 +33,34 @@ test("uses the public issuer for browser OAuth and internal server routes", () =
       "http://host.docker.internal:8080/api/oauth/userinfo",
     );
     assert.equal(connector.oauthConfig?.resource, "http://localhost:8080/mcp");
+    // The manifest advertises the operator-configured private route so the web
+    // layer can allow RFC1918 resolution for that exact origin at use time.
+    assert.equal(
+      connector.oauthConfig?.internal_base_url,
+      "http://host.docker.internal:8080",
+    );
+  } finally {
+    if (previousPublicUrl === undefined) delete process.env.WINDSHIFT_BASE_URL;
+    else process.env.WINDSHIFT_BASE_URL = previousPublicUrl;
+    if (previousInternalUrl === undefined)
+      delete process.env.WINDSHIFT_INTERNAL_BASE_URL;
+    else process.env.WINDSHIFT_INTERNAL_BASE_URL = previousInternalUrl;
+  }
+});
+
+test("omits the internal route marker without WINDSHIFT_INTERNAL_BASE_URL", () => {
+  const previousPublicUrl = process.env.WINDSHIFT_BASE_URL;
+  const previousInternalUrl = process.env.WINDSHIFT_INTERNAL_BASE_URL;
+  process.env.WINDSHIFT_BASE_URL = "https://windshift.example.com/";
+  delete process.env.WINDSHIFT_INTERNAL_BASE_URL;
+
+  try {
+    const connector = new WindshiftConnector();
+    assert.equal(connector.oauthConfig?.internal_base_url, undefined);
+    assert.equal(
+      connector.oauthConfig?.token_endpoint,
+      "https://windshift.example.com/api/oauth/token",
+    );
   } finally {
     if (previousPublicUrl === undefined) delete process.env.WINDSHIFT_BASE_URL;
     else process.env.WINDSHIFT_BASE_URL = previousPublicUrl;
@@ -45,9 +73,12 @@ test("uses the public issuer for browser OAuth and internal server routes", () =
 test("builds MCP authorization from sync and action credential shapes", () => {
   const connector = new WindshiftConnector();
 
-  assert.deepEqual(connector.prepareMcpHeaders({ access_token: "sync-token" }), {
-    Authorization: "Bearer sync-token",
-  });
+  assert.deepEqual(
+    connector.prepareMcpHeaders({ access_token: "sync-token" }),
+    {
+      Authorization: "Bearer sync-token",
+    },
+  );
   assert.deepEqual(
     connector.prepareMcpHeaders({
       credentials: { access_token: "action-token" },
@@ -158,25 +189,20 @@ test("full sync checkpoints only after indexing visible items", async () => {
 
     completed = false;
     let failedMessage = "";
-    await connector.sync(
-      {},
-      { access_token: "token" },
-      null,
-      {
-        ...ctx,
-        contentStorage: {
-          save: async () => {
-            throw new Error("storage unavailable");
-          },
+    await connector.sync({}, { access_token: "token" }, null, {
+      ...ctx,
+      contentStorage: {
+        save: async () => {
+          throw new Error("storage unavailable");
         },
-        complete: async () => {
-          completed = true;
-        },
-        fail: async (message: string) => {
-          failedMessage = message;
-        },
-      } as unknown as SyncContext,
-    );
+      },
+      complete: async () => {
+        completed = true;
+      },
+      fail: async (message: string) => {
+        failedMessage = message;
+      },
+    } as unknown as SyncContext);
     assert.match(failedMessage, /storage unavailable/);
     assert.equal(completed, false);
   } finally {

--- a/connectors/windshift/src/connector.ts
+++ b/connectors/windshift/src/connector.ts
@@ -1,5 +1,6 @@
 import {
   Connector,
+  SdkClient,
   SyncMode,
   type SyncContext,
   type SearchOperator,
@@ -51,11 +52,90 @@ function normalizedEnvUrl(name: string): string | undefined {
   return url.replace(/\/+$/, "");
 }
 
+// The Windshift server is an admin-managed setting: the base URLs are
+// configured in the UI and stored in the connector_configs table (served to
+// us by connector-manager). The WINDSHIFT_BASE_URL / WINDSHIFT_INTERNAL_BASE_URL
+// env vars remain as a fallback for deployments that predate the UI setting.
+//
+// The SDK re-registers our manifest every 30s, so once this cache is
+// populated the OAuth config the web layer reads reflects the UI setting
+// without a container restart.
+interface WindshiftServerConfig {
+  base_url?: string;
+  internal_base_url?: string;
+}
+
+let windshiftServerConfig: WindshiftServerConfig | null = null;
+let windshiftServerConfigPromise: Promise<WindshiftServerConfig | null> | null =
+  null;
+
+function parseWindshiftServerConfig(value: unknown): WindshiftServerConfig {
+  if (typeof value !== "object" || value === null || Array.isArray(value)) {
+    return {};
+  }
+  const record = value as Record<string, unknown>;
+  const baseUrl =
+    typeof record.base_url === "string" ? record.base_url.trim() : "";
+  const internalBaseUrl =
+    typeof record.internal_base_url === "string"
+      ? record.internal_base_url.trim()
+      : "";
+  return {
+    base_url: baseUrl || undefined,
+    internal_base_url: internalBaseUrl || undefined,
+  };
+}
+
+/// Fetch the Windshift server config from connector-manager's
+/// connector_configs table. Never throws: any failure (connector-manager
+/// unreachable, no config row, malformed payload) just clears the cache and
+/// leaves the env-var fallback in place.
+///
+/// `force` skips the memoized in-flight/previous promise so a periodic caller
+/// can re-read the table and pick up UI changes.
+export async function refreshWindshiftServerConfig(
+  force = false,
+): Promise<WindshiftServerConfig | null> {
+  if (!force && windshiftServerConfigPromise) {
+    return windshiftServerConfigPromise;
+  }
+  windshiftServerConfigPromise = (async () => {
+    try {
+      // 10s cap so an unreachable connector-manager doesn't stall startup.
+      const client = new SdkClient(undefined, 10_000);
+      const config = await client.getConnectorConfig("windshift");
+      windshiftServerConfig = parseWindshiftServerConfig(config);
+      logger.info(
+        { hasBaseUrl: !!windshiftServerConfig.base_url },
+        "Loaded Windshift server config from connector-manager",
+      );
+    } catch (err) {
+      logger.warn(
+        { err },
+        "Failed to load Windshift server config from connector-manager; falling back to env vars",
+      );
+      windshiftServerConfig = null;
+    }
+    return windshiftServerConfig;
+  })();
+  return windshiftServerConfigPromise;
+}
+
 function windshiftPublicBaseUrl(): string | undefined {
+  if (windshiftServerConfig?.base_url) {
+    return windshiftServerConfig.base_url.replace(/\/+$/, "");
+  }
   return normalizedEnvUrl("WINDSHIFT_BASE_URL");
 }
 
 function windshiftTransportBaseUrl(): string | undefined {
+  const config = windshiftServerConfig;
+  if (config?.internal_base_url) {
+    return config.internal_base_url.replace(/\/+$/, "");
+  }
+  if (config?.base_url) {
+    return config.base_url.replace(/\/+$/, "");
+  }
   return (
     normalizedEnvUrl("WINDSHIFT_INTERNAL_BASE_URL") ?? windshiftPublicBaseUrl()
   );
@@ -129,8 +209,9 @@ export class WindshiftConnector extends Connector<
   // Wrap Windshift's existing /mcp server (Streamable HTTP, bearer auth)
   // so every Windshift MCP tool — list_items, transition_item, add_comment,
   // etc. — becomes an Omni connector action without per-tool wiring here.
-  // Returns undefined when WINDSHIFT_BASE_URL isn't set; the SDK then
-  // skips MCP discovery and the connector falls back to read-only sync.
+  // Returns undefined when no Windshift base URL is configured (neither the
+  // admin UI setting nor the env fallback); the SDK then skips MCP discovery
+  // and the connector falls back to read-only sync.
   get mcpServer(): McpServer | undefined {
     const url = windshiftTransportBaseUrl();
     if (!url) return undefined;
@@ -186,11 +267,14 @@ export class WindshiftConnector extends Connector<
     state: WindshiftSyncState | null,
     ctx: SyncContext,
   ): Promise<void> {
+    // Ensure we've attempted to load the admin-configured Windshift server
+    // (e.g. when the first sync arrives before the startup fetch finished).
+    await refreshWindshiftServerConfig();
     const publicBaseUrl = windshiftPublicBaseUrl();
     const transportBaseUrl = windshiftTransportBaseUrl();
     if (!publicBaseUrl || !transportBaseUrl) {
       await ctx.fail(
-        "Connector container is missing WINDSHIFT_BASE_URL env var",
+        "Windshift base URL is not configured. Set it in Admin > Integrations > Windshift server.",
       );
       return;
     }

--- a/connectors/windshift/src/connector.ts
+++ b/connectors/windshift/src/connector.ts
@@ -52,17 +52,18 @@ function normalizedEnvUrl(name: string): string | undefined {
   return url.replace(/\/+$/, "");
 }
 
-// The Windshift server is an admin-managed setting: the base URLs are
+// The Windshift server is an admin-managed setting: the public base URL is
 // configured in the UI and stored in the connector_configs table (served to
-// us by connector-manager). The WINDSHIFT_BASE_URL / WINDSHIFT_INTERNAL_BASE_URL
-// env vars remain as a fallback for deployments that predate the UI setting.
+// us by connector-manager). The WINDSHIFT_BASE_URL env var remains as a
+// fallback for deployments that predate the UI setting. The optional
+// WINDSHIFT_INTERNAL_BASE_URL env var supplies a separate server-to-server
+// route on private networking and is intentionally env-only (not in the UI).
 //
 // The SDK re-registers our manifest every 30s, so once this cache is
 // populated the OAuth config the web layer reads reflects the UI setting
 // without a container restart.
 interface WindshiftServerConfig {
   base_url?: string;
-  internal_base_url?: string;
 }
 
 let windshiftServerConfig: WindshiftServerConfig | null = null;
@@ -76,13 +77,8 @@ function parseWindshiftServerConfig(value: unknown): WindshiftServerConfig {
   const record = value as Record<string, unknown>;
   const baseUrl =
     typeof record.base_url === "string" ? record.base_url.trim() : "";
-  const internalBaseUrl =
-    typeof record.internal_base_url === "string"
-      ? record.internal_base_url.trim()
-      : "";
   return {
     base_url: baseUrl || undefined,
-    internal_base_url: internalBaseUrl || undefined,
   };
 }
 
@@ -129,16 +125,14 @@ function windshiftPublicBaseUrl(): string | undefined {
 }
 
 function windshiftTransportBaseUrl(): string | undefined {
-  const config = windshiftServerConfig;
-  if (config?.internal_base_url) {
-    return config.internal_base_url.replace(/\/+$/, "");
+  // The internal route is env-only: it must win over the UI base URL so a
+  // stored public URL cannot silently defeat an operator-set private route.
+  const envInternal = normalizedEnvUrl("WINDSHIFT_INTERNAL_BASE_URL");
+  if (envInternal) return envInternal;
+  if (windshiftServerConfig?.base_url) {
+    return windshiftServerConfig.base_url.replace(/\/+$/, "");
   }
-  if (config?.base_url) {
-    return config.base_url.replace(/\/+$/, "");
-  }
-  return (
-    normalizedEnvUrl("WINDSHIFT_INTERNAL_BASE_URL") ?? windshiftPublicBaseUrl()
-  );
+  return normalizedEnvUrl("WINDSHIFT_BASE_URL");
 }
 
 function windshiftAccessToken(
@@ -258,6 +252,10 @@ export class WindshiftConnector extends Connector<
       scope_separator: " ",
       token_endpoint_auth_method: "none" as const,
       resource: `${publicBaseUrl}/mcp`,
+      // Explicit marker for the operator-configured private route. Only set
+      // when WINDSHIFT_INTERNAL_BASE_URL exists; when absent the transport
+      // endpoints derive from the public URL and must stay strictly public.
+      internal_base_url: normalizedEnvUrl("WINDSHIFT_INTERNAL_BASE_URL"),
     };
   }
 

--- a/connectors/windshift/src/main.ts
+++ b/connectors/windshift/src/main.ts
@@ -1,4 +1,18 @@
-import { WindshiftConnector } from './connector.js';
+import {
+  WindshiftConnector,
+  refreshWindshiftServerConfig,
+} from "./connector.js";
+
+// Load the admin-configured Windshift server before serving so the first
+// manifest registration already carries the OAuth endpoints. Non-fatal: on
+// failure the connector falls back to WINDSHIFT_BASE_URL env vars.
+await refreshWindshiftServerConfig();
 
 const connector = new WindshiftConnector();
 connector.serve();
+
+// Re-read the server config so admin UI changes propagate without a container
+// restart. Matches the SDK's 30s manifest re-registration cadence.
+setInterval(() => {
+  void refreshWindshiftServerConfig(true);
+}, 30_000);

--- a/connectors/windshift/src/types.ts
+++ b/connectors/windshift/src/types.ts
@@ -9,9 +9,10 @@ export type WindshiftSyncState = {
 // Credentials are written by Omni's generic OAuth dispatcher
 // (`web/src/lib/server/oauth/connectorOAuth.ts`) after the user completes
 // the authorization-code flow against Windshift's `/oauth/authorize` +
-// `/api/oauth/token`. The connector container reaches Windshift through
-// WINDSHIFT_BASE_URL (process env), not through credentials — one Omni
-// install pointing at one Windshift instance.
+// `/api/oauth/token`. The connector container reaches Windshift through the
+// admin-configured server URLs (stored in connector_configs, with
+// WINDSHIFT_BASE_URL env as a fallback) — one Omni install pointing at one
+// Windshift instance.
 export type WindshiftTokenCredentials = {
   access_token?: string;
   refresh_token?: string;

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -297,7 +297,7 @@ services:
       - "${LOCAL_EMBEDDINGS_PORT}"
     command:
       - "--model-id"
-      - "${EMBEDDING_MODEL}"
+      - "${EMBEDDING_MODEL:-BAAI/bge-small-en-v1.5}"
       - "--port"
       - "${LOCAL_EMBEDDINGS_PORT}"
     networks:
@@ -709,15 +709,16 @@ services:
     profiles:
       - windshift
     expose:
-      - "${WINDSHIFT_CONNECTOR_PORT}"
+      - "${WINDSHIFT_CONNECTOR_PORT:-4018}"
     environment:
       <<: *otel-config
-      PORT: ${WINDSHIFT_CONNECTOR_PORT}
+      PORT: ${WINDSHIFT_CONNECTOR_PORT:-4018}
       CONNECTOR_MANAGER_URL: ${CONNECTOR_MANAGER_URL}
       CONNECTOR_HOST_NAME: windshift-connector
-      # Public OAuth issuer; must be reachable from the user's browser.
-      WINDSHIFT_BASE_URL: ${WINDSHIFT_BASE_URL}
-      # Optional connector-only route to the same Windshift instance.
+      # Windshift server base URLs are configured in the admin UI (stored in
+      # the connector_configs table). These env vars are only a fallback for
+      # deployments that predate the UI setting; both stay empty by default.
+      WINDSHIFT_BASE_URL: ${WINDSHIFT_BASE_URL:-}
       WINDSHIFT_INTERNAL_BASE_URL: ${WINDSHIFT_INTERNAL_BASE_URL:-}
     networks:
       - omni-network

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -715,9 +715,10 @@ services:
       PORT: ${WINDSHIFT_CONNECTOR_PORT:-4018}
       CONNECTOR_MANAGER_URL: ${CONNECTOR_MANAGER_URL}
       CONNECTOR_HOST_NAME: windshift-connector
-      # Windshift server base URLs are configured in the admin UI (stored in
-      # the connector_configs table). These env vars are only a fallback for
-      # deployments that predate the UI setting; both stay empty by default.
+      # The public Windshift base URL is configured in the admin UI (stored in
+      # the connector_configs table); WINDSHIFT_BASE_URL is only a fallback for
+      # deployments that predate the UI setting. WINDSHIFT_INTERNAL_BASE_URL is
+      # env-only: an optional private route for server-to-server traffic.
       WINDSHIFT_BASE_URL: ${WINDSHIFT_BASE_URL:-}
       WINDSHIFT_INTERNAL_BASE_URL: ${WINDSHIFT_INTERNAL_BASE_URL:-}
     networks:

--- a/infra/aws/terraform/main.tf
+++ b/infra/aws/terraform/main.tf
@@ -199,9 +199,10 @@ module "compute" {
   ai_answer_enabled          = var.ai_answer_enabled
   agents_enabled             = var.agents_enabled
 
-  enabled_connectors       = var.enabled_connectors
-  windshift_base_url      = var.windshift_base_url
-  sandbox_url              = var.sandbox_url
+  enabled_connectors           = var.enabled_connectors
+  windshift_base_url          = var.windshift_base_url
+  windshift_internal_base_url = var.windshift_internal_base_url
+  sandbox_url                  = var.sandbox_url
   agent_max_iterations     = var.agent_max_iterations
   approval_timeout_seconds = var.approval_timeout_seconds
 

--- a/infra/aws/terraform/modules/compute/task_definitions.tf
+++ b/infra/aws/terraform/modules/compute/task_definitions.tf
@@ -953,7 +953,8 @@ resource "aws_ecs_task_definition" "windshift_connector" {
     environment = concat(local.connector_base_environment, [
       { name = "PORT", value = "4018" },
       { name = "CONNECTOR_HOST_NAME", value = "windshift-connector" },
-      { name = "WINDSHIFT_BASE_URL", value = var.windshift_base_url }
+      { name = "WINDSHIFT_BASE_URL", value = var.windshift_base_url },
+      { name = "WINDSHIFT_INTERNAL_BASE_URL", value = var.windshift_internal_base_url }
     ])
 
     secrets = []

--- a/infra/aws/terraform/modules/compute/variables.tf
+++ b/infra/aws/terraform/modules/compute/variables.tf
@@ -333,6 +333,12 @@ variable "windshift_base_url" {
   default     = ""
 }
 
+variable "windshift_internal_base_url" {
+  description = "Optional private route to the Windshift server for server-to-server traffic (WINDSHIFT_INTERNAL_BASE_URL)"
+  type        = string
+  default     = ""
+}
+
 variable "sandbox_url" {
   description = "URL of the sandbox service for code execution"
   type        = string

--- a/infra/aws/terraform/variables.tf
+++ b/infra/aws/terraform/variables.tf
@@ -296,6 +296,12 @@ variable "windshift_base_url" {
   default     = ""
 }
 
+variable "windshift_internal_base_url" {
+  description = "Optional private route to the Windshift server for server-to-server traffic (WINDSHIFT_INTERNAL_BASE_URL)"
+  type        = string
+  default     = ""
+}
+
 variable "sandbox_url" {
   description = "URL of the sandbox service for code execution (leave empty to disable)"
   type        = string

--- a/infra/gcp/terraform/main.tf
+++ b/infra/gcp/terraform/main.tf
@@ -163,9 +163,10 @@ module "compute" {
   session_duration_days      = var.session_duration_days
   ai_answer_enabled          = var.ai_answer_enabled
   agents_enabled             = var.agents_enabled
-  enabled_connectors         = var.enabled_connectors
-  windshift_base_url        = var.windshift_base_url
-  sandbox_url                = var.sandbox_url
+  enabled_connectors           = var.enabled_connectors
+  windshift_base_url          = var.windshift_base_url
+  windshift_internal_base_url = var.windshift_internal_base_url
+  sandbox_url                  = var.sandbox_url
   agent_max_iterations       = var.agent_max_iterations
   approval_timeout_seconds   = var.approval_timeout_seconds
   otel_endpoint              = var.otel_endpoint

--- a/infra/gcp/terraform/modules/compute/services.tf
+++ b/infra/gcp/terraform/modules/compute/services.tf
@@ -63,7 +63,7 @@ locals {
     filesystem = { port = 4013, image = "omni-filesystem-connector", extra_env = {} }
     nextcloud  = { port = 4014, image = "omni-nextcloud-connector", extra_env = {} }
     paperless  = { port = 4015, image = "omni-paperless-connector", extra_env = {} }
-    windshift  = { port = 4018, image = "omni-windshift-connector", extra_env = { WINDSHIFT_BASE_URL = var.windshift_base_url } }
+    windshift  = { port = 4018, image = "omni-windshift-connector", extra_env = { WINDSHIFT_BASE_URL = var.windshift_base_url, WINDSHIFT_INTERNAL_BASE_URL = var.windshift_internal_base_url } }
   }
 
   simple_connectors = { for k, v in local.all_simple_connectors : k => v if contains(var.enabled_connectors, k) }

--- a/infra/gcp/terraform/modules/compute/variables.tf
+++ b/infra/gcp/terraform/modules/compute/variables.tf
@@ -297,6 +297,12 @@ variable "windshift_base_url" {
   default     = ""
 }
 
+variable "windshift_internal_base_url" {
+  description = "Optional private route to the Windshift server for server-to-server traffic (WINDSHIFT_INTERNAL_BASE_URL)"
+  type        = string
+  default     = ""
+}
+
 variable "sandbox_url" {
   description = "URL of the sandbox service for code execution"
   type        = string

--- a/infra/gcp/terraform/variables.tf
+++ b/infra/gcp/terraform/variables.tf
@@ -288,6 +288,12 @@ variable "windshift_base_url" {
   default     = ""
 }
 
+variable "windshift_internal_base_url" {
+  description = "Optional private route to the Windshift server for server-to-server traffic (WINDSHIFT_INTERNAL_BASE_URL)"
+  type        = string
+  default     = ""
+}
+
 variable "sandbox_url" {
   description = "URL of the sandbox service for code execution (leave empty to disable)"
   type        = string

--- a/sdk/typescript/src/client.ts
+++ b/sdk/typescript/src/client.ts
@@ -275,6 +275,27 @@ export class SdkClient {
     return SdkSourceSyncDataSchema.parse(raw);
   }
 
+  /// Fetch the admin-managed connector config for a provider (stored in the
+  /// `connector_configs` table). Returns an empty object when the provider
+  /// has no config row yet — that's a valid "not configured" state, not an
+  /// error.
+  async getConnectorConfig(provider: string): Promise<Record<string, unknown>> {
+    const response = await this.get(`/sdk/connector-configs/${provider}`);
+    if (!response.ok) {
+      if (response.status === 404) return {};
+      const text = await response.text();
+      throw new SdkClientError(
+        `Failed to fetch connector config: ${response.status} - ${text}`,
+        response.status
+      );
+    }
+    const raw = (await response.json()) as unknown;
+    if (typeof raw !== 'object' || raw === null || Array.isArray(raw)) {
+      throw new SdkClientError(`Invalid connector config response for provider: ${provider}`);
+    }
+    return raw as Record<string, unknown>;
+  }
+
   async getUserEmailForSource(sourceId: string): Promise<string> {
     const response = await this.get(`/sdk/source/${sourceId}/user-email`);
     if (!response.ok) {

--- a/sdk/typescript/tests/client.test.ts
+++ b/sdk/typescript/tests/client.test.ts
@@ -362,6 +362,49 @@ describe('SdkClient', () => {
     });
   });
 
+  describe('getConnectorConfig', () => {
+    it('returns the stored config for a provider', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/connector-configs/windshift`, () =>
+          HttpResponse.json({
+            base_url: 'https://windshift.example.com',
+            internal_base_url: 'http://windshift:8080',
+          })
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      await expect(client.getConnectorConfig('windshift')).resolves.toEqual({
+        base_url: 'https://windshift.example.com',
+        internal_base_url: 'http://windshift:8080',
+      });
+    });
+
+    it('returns an empty object when the provider has no config row (404)', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/connector-configs/windshift`, () =>
+          HttpResponse.json({ error: 'Connector config not found for provider: windshift' }, { status: 404 })
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      await expect(client.getConnectorConfig('windshift')).resolves.toEqual({});
+    });
+
+    it('throws SdkClientError on other failures', async () => {
+      server.use(
+        http.get(`${BASE_URL}/sdk/connector-configs/windshift`, () =>
+          HttpResponse.json({ error: 'boom' }, { status: 500 })
+        )
+      );
+
+      const client = new SdkClient(BASE_URL);
+      await expect(client.getConnectorConfig('windshift')).rejects.toThrow(
+        'Failed to fetch connector config: 500'
+      );
+    });
+  });
+
   describe('error handling', () => {
     it('throws SdkClientError on non-2xx response', async () => {
       server.use(

--- a/web/src/lib/components/windshift-server-setup.svelte
+++ b/web/src/lib/components/windshift-server-setup.svelte
@@ -73,7 +73,16 @@
             })
 
             if (!response.ok) {
-                throw new Error('Failed to save Windshift server configuration')
+                let message = 'Failed to save Windshift server configuration'
+                try {
+                    const body = await response.json()
+                    if (typeof body?.message === 'string' && body.message) {
+                        message = body.message
+                    }
+                } catch {
+                    // Non-JSON error body; keep the generic message
+                }
+                throw new Error(message)
             }
 
             toast.success('Windshift server configuration saved')
@@ -139,6 +148,11 @@
                     route when set.
                 </p>
             </div>
+
+            <p class="text-muted-foreground text-xs">
+                URLs are validated against SSRF: only publicly routable http(s) addresses are
+                accepted. Loopback and private-network addresses are rejected.
+            </p>
         </div>
 
         <Dialog.Footer>

--- a/web/src/lib/components/windshift-server-setup.svelte
+++ b/web/src/lib/components/windshift-server-setup.svelte
@@ -8,12 +8,11 @@
     interface Props {
         open: boolean
         baseUrl?: string
-        internalBaseUrl?: string
         onSuccess?: () => void
         onCancel?: () => void
     }
 
-    let { open = false, baseUrl = '', internalBaseUrl = '', onSuccess, onCancel }: Props = $props()
+    let { open = false, baseUrl = '', onSuccess, onCancel }: Props = $props()
 
     let isSubmitting = $state(false)
 
@@ -52,14 +51,6 @@
                 throw new Error(baseUrlError)
             }
 
-            const trimmedInternalBaseUrl = normalizeBaseUrl(internalBaseUrl)
-            if (trimmedInternalBaseUrl) {
-                const internalUrlError = validateBaseUrl(trimmedInternalBaseUrl)
-                if (internalUrlError) {
-                    throw new Error(internalUrlError)
-                }
-            }
-
             const response = await fetch('/api/connector-configs', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
@@ -67,7 +58,6 @@
                     provider: 'windshift',
                     config: {
                         base_url: trimmedBaseUrl,
-                        internal_base_url: trimmedInternalBaseUrl || null,
                     },
                 }),
             })
@@ -88,7 +78,6 @@
             toast.success('Windshift server configuration saved')
 
             baseUrl = ''
-            internalBaseUrl = ''
 
             if (onSuccess) {
                 onSuccess()
@@ -103,7 +92,6 @@
 
     function handleCancel() {
         baseUrl = ''
-        internalBaseUrl = ''
         if (onCancel) {
             onCancel()
         }
@@ -135,23 +123,12 @@
                 </p>
             </div>
 
-            <div class="space-y-2">
-                <Label for="windshift-internal-url">Internal URL (optional)</Label>
-                <Input
-                    id="windshift-internal-url"
-                    bind:value={internalBaseUrl}
-                    placeholder="http://windshift:8080" />
-                <p class="text-muted-foreground text-sm">
-                    Optional connector-only route to the same Windshift instance, for local or
-                    private networking. OAuth URLs and token audience still use the Windshift URL
-                    above; server-side registration, token exchange, sync, and MCP requests use this
-                    route when set.
-                </p>
-            </div>
-
             <p class="text-muted-foreground text-xs">
-                URLs are validated against SSRF: only publicly routable http(s) addresses are
-                accepted. Loopback and private-network addresses are rejected.
+                The URL is validated against SSRF: only publicly routable http(s) addresses are
+                accepted; loopback and private-network addresses are rejected. To route
+                server-to-server traffic (token exchange, sync, MCP) over a private network instead
+                of through this URL, set the WINDSHIFT_INTERNAL_BASE_URL environment variable on the
+                connector container.
             </p>
         </div>
 

--- a/web/src/lib/components/windshift-server-setup.svelte
+++ b/web/src/lib/components/windshift-server-setup.svelte
@@ -1,0 +1,151 @@
+<script lang="ts">
+    import * as Dialog from '$lib/components/ui/dialog'
+    import { Button } from '$lib/components/ui/button'
+    import { Input } from '$lib/components/ui/input'
+    import { Label } from '$lib/components/ui/label'
+    import { toast } from 'svelte-sonner'
+
+    interface Props {
+        open: boolean
+        baseUrl?: string
+        internalBaseUrl?: string
+        onSuccess?: () => void
+        onCancel?: () => void
+    }
+
+    let { open = false, baseUrl = '', internalBaseUrl = '', onSuccess, onCancel }: Props = $props()
+
+    let isSubmitting = $state(false)
+
+    function normalizeBaseUrl(value: string): string {
+        return value.trim().replace(/\/+$/, '')
+    }
+
+    function validateBaseUrl(value: string): string | null {
+        let url: URL
+        try {
+            url = new URL(value)
+        } catch {
+            return 'Windshift URL must be a valid URL'
+        }
+        if (url.protocol !== 'https:' && url.protocol !== 'http:') {
+            return 'Windshift URL must use http or https'
+        }
+        if (url.username || url.password) {
+            return 'Windshift URL must not include credentials'
+        }
+        if (url.hash) {
+            return 'Windshift URL must not include a fragment'
+        }
+        return null
+    }
+
+    async function handleSubmit() {
+        isSubmitting = true
+        try {
+            const trimmedBaseUrl = normalizeBaseUrl(baseUrl)
+            if (!trimmedBaseUrl) {
+                throw new Error('Windshift URL is required')
+            }
+            const baseUrlError = validateBaseUrl(trimmedBaseUrl)
+            if (baseUrlError) {
+                throw new Error(baseUrlError)
+            }
+
+            const trimmedInternalBaseUrl = normalizeBaseUrl(internalBaseUrl)
+            if (trimmedInternalBaseUrl) {
+                const internalUrlError = validateBaseUrl(trimmedInternalBaseUrl)
+                if (internalUrlError) {
+                    throw new Error(internalUrlError)
+                }
+            }
+
+            const response = await fetch('/api/connector-configs', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    provider: 'windshift',
+                    config: {
+                        base_url: trimmedBaseUrl,
+                        internal_base_url: trimmedInternalBaseUrl || null,
+                    },
+                }),
+            })
+
+            if (!response.ok) {
+                throw new Error('Failed to save Windshift server configuration')
+            }
+
+            toast.success('Windshift server configuration saved')
+
+            baseUrl = ''
+            internalBaseUrl = ''
+
+            if (onSuccess) {
+                onSuccess()
+            }
+        } catch (error: any) {
+            console.error('Error saving Windshift server configuration:', error)
+            toast.error(error.message || 'Failed to save Windshift server configuration')
+        } finally {
+            isSubmitting = false
+        }
+    }
+
+    function handleCancel() {
+        baseUrl = ''
+        internalBaseUrl = ''
+        if (onCancel) {
+            onCancel()
+        }
+    }
+</script>
+
+<Dialog.Root {open} onOpenChange={(o) => !o && handleCancel()}>
+    <Dialog.Content class="max-w-lg">
+        <Dialog.Header>
+            <Dialog.Title>Windshift server</Dialog.Title>
+            <Dialog.Description>
+                Point Omni at your Windshift instance. Users can then connect Windshift from My
+                Integrations; the connector uses these URLs for OAuth, sync, and MCP actions.
+            </Dialog.Description>
+        </Dialog.Header>
+
+        <div class="space-y-4">
+            <div class="space-y-2">
+                <Label for="windshift-base-url">Windshift URL</Label>
+                <Input
+                    id="windshift-base-url"
+                    bind:value={baseUrl}
+                    placeholder="https://windshift.example.com"
+                    required />
+                <p class="text-muted-foreground text-sm">
+                    The URL of your Windshift instance, reachable from the user's browser (OAuth
+                    consent, resource binding, document links). Include a context path if Windshift
+                    is served under one.
+                </p>
+            </div>
+
+            <div class="space-y-2">
+                <Label for="windshift-internal-url">Internal URL (optional)</Label>
+                <Input
+                    id="windshift-internal-url"
+                    bind:value={internalBaseUrl}
+                    placeholder="http://windshift:8080" />
+                <p class="text-muted-foreground text-sm">
+                    Optional connector-only route to the same Windshift instance, for local or
+                    private networking. OAuth URLs and token audience still use the Windshift URL
+                    above; server-side registration, token exchange, sync, and MCP requests use this
+                    route when set.
+                </p>
+            </div>
+        </div>
+
+        <Dialog.Footer>
+            <Button variant="outline" onclick={handleCancel} class="cursor-pointer">Cancel</Button>
+            <Button onclick={handleSubmit} disabled={isSubmitting} class="cursor-pointer">
+                {isSubmitting ? 'Saving...' : 'Save'}
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>

--- a/web/src/lib/server/mcp/client.ts
+++ b/web/src/lib/server/mcp/client.ts
@@ -30,11 +30,25 @@ const MAX_RESPONSE_BYTES = 1024 * 1024
 const REMOTE_MCP_HTTP_TIMEOUT_MS = 20_000
 const MCP_PROTOCOL_VERSION = '2024-11-05'
 
-export function isRemoteMcpBlockedIp(address: string): boolean {
+export interface RemoteMcpIpPolicy {
+    /// Allow RFC1918 private IPv4 (10/8, 172.16/12, 192.168/16) destinations.
+    /// Used for admin-declared internal endpoints (e.g. the Windshift internal
+    /// URL) that are deliberately hosted on a private network. Loopback,
+    /// link-local/metadata, and every other reserved range stay blocked.
+    allowPrivate?: boolean
+}
+
+function isRfc1918Address(parts: number[]): boolean {
+    const [a, b] = parts
+    return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168)
+}
+
+export function isRemoteMcpBlockedIp(address: string, policy: RemoteMcpIpPolicy = {}): boolean {
     const family = net.isIP(address)
     if (family === 4) {
         const parts = address.split('.').map((p) => Number.parseInt(p, 10))
         const [a, b, c] = parts
+        if (policy.allowPrivate && isRfc1918Address(parts)) return false
         return (
             a === 0 ||
             a === 10 ||
@@ -94,30 +108,40 @@ export function validateRemoteMcpUrl(endpointUrl: string): URL {
 
 type PinnedAddress = { address: string; family: 4 | 6 }
 
-async function resolveAllowedRemoteMcpAddresses(url: URL): Promise<PinnedAddress[]> {
+async function resolveAllowedRemoteMcpAddresses(
+    url: URL,
+    policy: RemoteMcpIpPolicy = {},
+): Promise<PinnedAddress[]> {
     const records = await lookup(url.hostname, { all: true, verbatim: true })
     if (records.length === 0) throw error(400, 'Endpoint host did not resolve')
-    if (records.some((record) => isRemoteMcpBlockedIp(record.address))) {
+    if (records.some((record) => isRemoteMcpBlockedIp(record.address, policy))) {
         throw error(400, 'Endpoint resolves to a disallowed network address')
     }
     return records.map((record) => ({ address: record.address, family: record.family as 4 | 6 }))
 }
 
-export async function assertRemoteMcpDestinationAllowed(url: URL): Promise<void> {
-    await resolveAllowedRemoteMcpAddresses(url)
+export async function assertRemoteMcpDestinationAllowed(
+    url: URL,
+    policy: RemoteMcpIpPolicy = {},
+): Promise<void> {
+    await resolveAllowedRemoteMcpAddresses(url, policy)
 }
 
-export async function validateRemoteMcpUrlForCredentialUse(endpointUrl: string): Promise<string> {
+export async function validateRemoteMcpUrlForCredentialUse(
+    endpointUrl: string,
+    policy: RemoteMcpIpPolicy = {},
+): Promise<string> {
     const url = validateRemoteMcpUrl(endpointUrl)
-    await assertRemoteMcpDestinationAllowed(url)
+    await assertRemoteMcpDestinationAllowed(url, policy)
     return url.toString()
 }
 
 export async function fetchWithPinnedRemoteMcpDns(
     url: URL,
     init: RequestInit = {},
+    policy: RemoteMcpIpPolicy = {},
 ): Promise<Response> {
-    const addresses = await resolveAllowedRemoteMcpAddresses(url)
+    const addresses = await resolveAllowedRemoteMcpAddresses(url, policy)
     let next = 0
     const dispatcher = new Agent({
         connect: {

--- a/web/src/lib/server/oauth/connectorOAuth.test.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.test.ts
@@ -7,6 +7,7 @@ import {
     oauthServiceBaseUrl,
     scopesForExistingSourceUserFlow,
     tokenEndpointAuthMethodForConfig,
+    windshiftInternalOrigin,
     type OAuthManifestConfig,
 } from './connectorOAuth'
 
@@ -32,6 +33,38 @@ const baseManifest: OAuthManifestConfig = {
     scope_separator: ' ',
     token_endpoint_auth_method: 'client_secret_post',
 }
+
+describe('windshiftInternalOrigin', () => {
+    const windshiftManifest: OAuthManifestConfig = {
+        ...baseManifest,
+        provider: 'windshift',
+        auth_endpoint: 'https://windshift.example.com/oauth/authorize',
+        token_endpoint: 'http://windshift:8080/api/oauth/token',
+        userinfo_endpoint: 'http://windshift:8080/api/oauth/userinfo',
+        internal_base_url: 'http://windshift:8080/',
+    }
+
+    it('returns the exact origin of the manifest internal route', () => {
+        expect(windshiftInternalOrigin(windshiftManifest)).toBe('http://windshift:8080')
+    })
+
+    it('returns null when no internal route marker is advertised', () => {
+        const { internal_base_url: _marker, ...publicOnly } = windshiftManifest
+        expect(windshiftInternalOrigin(publicOnly)).toBeNull()
+    })
+
+    it('returns null for non-windshift providers even with a marker', () => {
+        expect(
+            windshiftInternalOrigin({ ...baseManifest, internal_base_url: 'http://x:1' }),
+        ).toBeNull()
+    })
+
+    it('returns null for an invalid internal URL', () => {
+        expect(
+            windshiftInternalOrigin({ ...windshiftManifest, internal_base_url: 'not a url' }),
+        ).toBeNull()
+    })
+})
 
 describe('OAuth connector helpers', () => {
     beforeEach(() => {

--- a/web/src/lib/server/oauth/connectorOAuth.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.ts
@@ -187,8 +187,11 @@ async function loadClientCreds(
     return null
 }
 
-function isRemoteMcpProvider(provider: string): boolean {
-    return provider.startsWith('remote_mcp:')
+/// Providers whose OAuth endpoints are admin-configured URLs (remote MCP
+/// servers, Windshift). Server-side fetches to these endpoints must go
+/// through SSRF validation and pinned-DNS resolution.
+function isAdminConfiguredEndpointProvider(provider: string): boolean {
+    return provider.startsWith('remote_mcp:') || provider === 'windshift'
 }
 
 async function remoteMcpCredentialFetch(
@@ -196,7 +199,7 @@ async function remoteMcpCredentialFetch(
     endpoint: string,
     init: RequestInit,
 ): Promise<Response> {
-    if (!isRemoteMcpProvider(provider)) {
+    if (!isAdminConfiguredEndpointProvider(provider)) {
         return fetch(endpoint, {
             ...init,
             signal: init.signal ?? AbortSignal.timeout(20_000),
@@ -222,7 +225,7 @@ async function readLimitedResponseText(response: Response): Promise<string> {
 }
 
 async function readCredentialJson(provider: string, response: Response): Promise<unknown> {
-    if (isRemoteMcpProvider(provider)) return readRemoteMcpLimitedJson(response)
+    if (isAdminConfiguredEndpointProvider(provider)) return readRemoteMcpLimitedJson(response)
     const text = await readLimitedResponseText(response)
     return text.trim() ? JSON.parse(text) : {}
 }
@@ -232,7 +235,7 @@ async function readCredentialText(_provider: string, response: Response): Promis
 }
 
 async function validateRemoteMcpOAuthConfigUrls(config: OAuthManifestConfig): Promise<void> {
-    if (!isRemoteMcpProvider(config.provider)) return
+    if (!isAdminConfiguredEndpointProvider(config.provider)) return
     await validateRemoteMcpUrlForCredentialUse(config.auth_endpoint)
     await validateRemoteMcpUrlForCredentialUse(config.token_endpoint)
     await validateRemoteMcpUrlForCredentialUse(config.userinfo_endpoint)
@@ -679,7 +682,7 @@ export async function exchangeCodeAndIdentify(
 
     await validateRemoteMcpOAuthConfigUrls(config)
     const tokenEndpoint = creds.tokenEndpoint ?? config.token_endpoint
-    if (isRemoteMcpProvider(config.provider)) {
+    if (isAdminConfiguredEndpointProvider(config.provider)) {
         await validateRemoteMcpUrlForCredentialUse(tokenEndpoint)
     }
     logger.info('Starting connector OAuth token exchange', {

--- a/web/src/lib/server/oauth/connectorOAuth.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.ts
@@ -10,6 +10,7 @@ import {
     validateRemoteMcpUrl,
     validateRemoteMcpUrlForCredentialUse,
 } from '../mcp/client'
+import type { RemoteMcpIpPolicy } from '../mcp/client'
 import { OAuthStateManager } from './state'
 import type { OAuthError, OAuthTokens } from './types'
 import { IntegrationType } from '$lib/types'
@@ -194,6 +195,32 @@ function isAdminConfiguredEndpointProvider(provider: string): boolean {
     return provider.startsWith('remote_mcp:') || provider === 'windshift'
 }
 
+/// The exact origin (scheme://host:port) of the admin-configured Windshift
+/// internal URL, or null when unset/invalid. Endpoints on this origin may
+/// resolve to RFC1918 private addresses — the internal URL's purpose is
+/// private networking; every other endpoint must stay publicly routable.
+async function windshiftInternalOrigin(provider: string): Promise<string | null> {
+    if (provider !== 'windshift') return null
+    const row = await getConnectorConfig('windshift')
+    const internalBaseUrl = (row?.config as Record<string, unknown> | undefined)?.internal_base_url
+    if (typeof internalBaseUrl !== 'string' || !internalBaseUrl) return null
+    try {
+        return new URL(internalBaseUrl).origin
+    } catch {
+        return null
+    }
+}
+
+function ssrfPolicyForEndpoint(endpoint: string, internalOrigin: string | null): RemoteMcpIpPolicy {
+    if (!internalOrigin) return {}
+    try {
+        if (new URL(endpoint).origin === internalOrigin) return { allowPrivate: true }
+    } catch {
+        // Not a URL (e.g. a resource identifier): keep strict.
+    }
+    return {}
+}
+
 async function remoteMcpCredentialFetch(
     provider: string,
     endpoint: string,
@@ -205,8 +232,9 @@ async function remoteMcpCredentialFetch(
             signal: init.signal ?? AbortSignal.timeout(20_000),
         })
     }
-    const validated = await validateRemoteMcpUrlForCredentialUse(endpoint)
-    return fetchWithPinnedRemoteMcpDns(validateRemoteMcpUrl(validated), init)
+    const policy = ssrfPolicyForEndpoint(endpoint, await windshiftInternalOrigin(provider))
+    const validated = await validateRemoteMcpUrlForCredentialUse(endpoint, policy)
+    return fetchWithPinnedRemoteMcpDns(validateRemoteMcpUrl(validated), init, policy)
 }
 
 async function readLimitedResponseText(response: Response): Promise<string> {
@@ -236,20 +264,21 @@ async function readCredentialText(_provider: string, response: Response): Promis
 
 async function validateRemoteMcpOAuthConfigUrls(config: OAuthManifestConfig): Promise<void> {
     if (!isAdminConfiguredEndpointProvider(config.provider)) return
-    await validateRemoteMcpUrlForCredentialUse(config.auth_endpoint)
-    await validateRemoteMcpUrlForCredentialUse(config.token_endpoint)
-    await validateRemoteMcpUrlForCredentialUse(config.userinfo_endpoint)
-    if (config.registration_endpoint) {
-        await validateRemoteMcpUrlForCredentialUse(config.registration_endpoint)
-    }
-    if (config.resource) {
-        await validateRemoteMcpUrlForCredentialUse(config.resource)
-    }
+    const internalOrigin = await windshiftInternalOrigin(config.provider)
+    const endpoints = [config.auth_endpoint, config.token_endpoint, config.userinfo_endpoint]
+    if (config.registration_endpoint) endpoints.push(config.registration_endpoint)
+    if (config.resource) endpoints.push(config.resource)
     if (config.protected_resource_metadata_url) {
-        await validateRemoteMcpUrlForCredentialUse(config.protected_resource_metadata_url)
+        endpoints.push(config.protected_resource_metadata_url)
     }
     if (config.authorization_server_metadata_url) {
-        await validateRemoteMcpUrlForCredentialUse(config.authorization_server_metadata_url)
+        endpoints.push(config.authorization_server_metadata_url)
+    }
+    for (const endpoint of endpoints) {
+        await validateRemoteMcpUrlForCredentialUse(
+            endpoint,
+            ssrfPolicyForEndpoint(endpoint, internalOrigin),
+        )
     }
 }
 
@@ -683,7 +712,10 @@ export async function exchangeCodeAndIdentify(
     await validateRemoteMcpOAuthConfigUrls(config)
     const tokenEndpoint = creds.tokenEndpoint ?? config.token_endpoint
     if (isAdminConfiguredEndpointProvider(config.provider)) {
-        await validateRemoteMcpUrlForCredentialUse(tokenEndpoint)
+        await validateRemoteMcpUrlForCredentialUse(
+            tokenEndpoint,
+            ssrfPolicyForEndpoint(tokenEndpoint, await windshiftInternalOrigin(config.provider)),
+        )
     }
     logger.info('Starting connector OAuth token exchange', {
         provider: config.provider,

--- a/web/src/lib/server/oauth/connectorOAuth.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.ts
@@ -44,6 +44,11 @@ export interface OAuthManifestConfig {
     credential_provider?: string | null
     protected_resource_metadata_url?: string | null
     authorization_server_metadata_url?: string | null
+    /// Operator-configured private route (Windshift only): when present, the
+    /// transport endpoints (token/registration/userinfo) are derived from
+    /// this URL and may resolve to RFC1918 addresses. Absent for every other
+    /// provider and when no internal route is configured.
+    internal_base_url?: string | null
 }
 
 /// What flow we're driving — encoded into the OAuth state so the single
@@ -195,14 +200,16 @@ function isAdminConfiguredEndpointProvider(provider: string): boolean {
     return provider.startsWith('remote_mcp:') || provider === 'windshift'
 }
 
-/// The exact origin (scheme://host:port) of the admin-configured Windshift
-/// internal URL, or null when unset/invalid. Endpoints on this origin may
-/// resolve to RFC1918 private addresses — the internal URL's purpose is
-/// private networking; every other endpoint must stay publicly routable.
-async function windshiftInternalOrigin(provider: string): Promise<string | null> {
-    if (provider !== 'windshift') return null
-    const row = await getConnectorConfig('windshift')
-    const internalBaseUrl = (row?.config as Record<string, unknown> | undefined)?.internal_base_url
+/// The exact origin (scheme://host:port) of the operator-configured Windshift
+/// internal route, or null when unset/invalid. The connector advertises it in
+/// the manifest only when WINDSHIFT_INTERNAL_BASE_URL is set, so a manifest
+/// without the marker (public-only deployment) stays strictly public.
+/// Endpoints on this origin may resolve to RFC1918 private addresses — the
+/// internal URL's purpose is private networking; every other endpoint must
+/// stay publicly routable.
+export function windshiftInternalOrigin(config: OAuthManifestConfig): string | null {
+    if (config.provider !== 'windshift') return null
+    const internalBaseUrl = config.internal_base_url
     if (typeof internalBaseUrl !== 'string' || !internalBaseUrl) return null
     try {
         return new URL(internalBaseUrl).origin
@@ -225,6 +232,7 @@ async function remoteMcpCredentialFetch(
     provider: string,
     endpoint: string,
     init: RequestInit,
+    internalOrigin: string | null,
 ): Promise<Response> {
     if (!isAdminConfiguredEndpointProvider(provider)) {
         return fetch(endpoint, {
@@ -232,7 +240,7 @@ async function remoteMcpCredentialFetch(
             signal: init.signal ?? AbortSignal.timeout(20_000),
         })
     }
-    const policy = ssrfPolicyForEndpoint(endpoint, await windshiftInternalOrigin(provider))
+    const policy = ssrfPolicyForEndpoint(endpoint, internalOrigin)
     const validated = await validateRemoteMcpUrlForCredentialUse(endpoint, policy)
     return fetchWithPinnedRemoteMcpDns(validateRemoteMcpUrl(validated), init, policy)
 }
@@ -264,7 +272,7 @@ async function readCredentialText(_provider: string, response: Response): Promis
 
 async function validateRemoteMcpOAuthConfigUrls(config: OAuthManifestConfig): Promise<void> {
     if (!isAdminConfiguredEndpointProvider(config.provider)) return
-    const internalOrigin = await windshiftInternalOrigin(config.provider)
+    const internalOrigin = windshiftInternalOrigin(config)
     const endpoints = [config.auth_endpoint, config.token_endpoint, config.userinfo_endpoint]
     if (config.registration_endpoint) endpoints.push(config.registration_endpoint)
     if (config.resource) endpoints.push(config.resource)
@@ -294,14 +302,19 @@ async function dynamicallyRegisterClient(
     let response: Response
     try {
         await validateRemoteMcpOAuthConfigUrls(config)
-        response = await remoteMcpCredentialFetch(provider, config.registration_endpoint!, {
-            method: 'POST',
-            headers: {
-                'Content-Type': 'application/json',
-                Accept: 'application/json',
+        response = await remoteMcpCredentialFetch(
+            provider,
+            config.registration_endpoint!,
+            {
+                method: 'POST',
+                headers: {
+                    'Content-Type': 'application/json',
+                    Accept: 'application/json',
+                },
+                body: JSON.stringify(dynamicRegistrationPayload(provider, redirectUri, scope)),
             },
-            body: JSON.stringify(dynamicRegistrationPayload(provider, redirectUri, scope)),
-        })
+            windshiftInternalOrigin(config),
+        )
     } catch {
         return null
     }
@@ -714,7 +727,7 @@ export async function exchangeCodeAndIdentify(
     if (isAdminConfiguredEndpointProvider(config.provider)) {
         await validateRemoteMcpUrlForCredentialUse(
             tokenEndpoint,
-            ssrfPolicyForEndpoint(tokenEndpoint, await windshiftInternalOrigin(config.provider)),
+            ssrfPolicyForEndpoint(tokenEndpoint, windshiftInternalOrigin(config)),
         )
     }
     logger.info('Starting connector OAuth token exchange', {
@@ -728,11 +741,16 @@ export async function exchangeCodeAndIdentify(
         resource: config.resource ?? null,
         requestedScopes: state.metadata.requiredScopes,
     })
-    const tokenResp = await remoteMcpCredentialFetch(config.provider, tokenEndpoint, {
-        method: 'POST',
-        headers: tokenHeaders,
-        body: tokenParams.toString(),
-    })
+    const tokenResp = await remoteMcpCredentialFetch(
+        config.provider,
+        tokenEndpoint,
+        {
+            method: 'POST',
+            headers: tokenHeaders,
+            body: tokenParams.toString(),
+        },
+        windshiftInternalOrigin(config),
+    )
     const tokenData = (await readCredentialJson(config.provider, tokenResp).catch(() => ({}))) as
         | OAuthTokens
         | OAuthError
@@ -769,12 +787,17 @@ export async function exchangeCodeAndIdentify(
         return { tokens, state, config, principalEmail: principalEmailOverride, clientCreds: creds }
     }
 
-    const userinfoResp = await remoteMcpCredentialFetch(config.provider, config.userinfo_endpoint, {
-        headers: {
-            Authorization: `Bearer ${tokens.access_token}`,
-            Accept: 'application/json',
+    const userinfoResp = await remoteMcpCredentialFetch(
+        config.provider,
+        config.userinfo_endpoint,
+        {
+            headers: {
+                Authorization: `Bearer ${tokens.access_token}`,
+                Accept: 'application/json',
+            },
         },
-    })
+        windshiftInternalOrigin(config),
+    )
     if (!userinfoResp.ok) {
         const body = await readCredentialText(config.provider, userinfoResp).catch(() => '')
         logger.warn('Connector OAuth userinfo fetch failed', {

--- a/web/src/lib/server/windshift-server-config.test.ts
+++ b/web/src/lib/server/windshift-server-config.test.ts
@@ -23,7 +23,7 @@ describe('validateWindshiftServerUrl', () => {
         ).resolves.toBeUndefined()
     })
 
-    it('rejects loopback and private addresses for the public URL (SSRF)', async () => {
+    it('rejects loopback and private addresses (SSRF)', async () => {
         await expect(
             validateWindshiftServerUrl('Windshift URL', 'http://127.0.0.1:8080'),
         ).rejects.toThrow('Windshift URL is not allowed')
@@ -33,44 +33,6 @@ describe('validateWindshiftServerUrl', () => {
         await expect(
             validateWindshiftServerUrl('Windshift URL', 'http://192.168.1.10:8080'),
         ).rejects.toThrow('Windshift URL is not allowed')
-    })
-
-    it('allows RFC1918 private addresses for the internal URL (allowPrivate)', async () => {
-        await expect(
-            validateWindshiftServerUrl('Windshift internal URL', 'http://192.168.1.10:8080', {
-                allowPrivate: true,
-            }),
-        ).resolves.toBeUndefined()
-        await expect(
-            validateWindshiftServerUrl('Windshift internal URL', 'http://10.0.0.5', {
-                allowPrivate: true,
-            }),
-        ).resolves.toBeUndefined()
-        await expect(
-            validateWindshiftServerUrl('Windshift internal URL', 'http://172.20.0.5:8080', {
-                allowPrivate: true,
-            }),
-        ).resolves.toBeUndefined()
-        await expect(
-            validateWindshiftServerUrl('Windshift internal URL', '', { allowPrivate: true }),
-        ).resolves.toBeUndefined()
-    })
-
-    it('still blocks loopback, metadata, and reserved addresses for the internal URL', async () => {
-        await expect(
-            validateWindshiftServerUrl('Windshift internal URL', 'http://127.0.0.1:8080', {
-                allowPrivate: true,
-            }),
-        ).rejects.toThrow('Windshift internal URL is not allowed')
-        await expect(
-            validateWindshiftServerUrl('Windshift internal URL', 'http://169.254.169.254/', {
-                allowPrivate: true,
-            }),
-        ).rejects.toThrow('Windshift internal URL is not allowed')
-        // Strict by default: private addresses still rejected without allowPrivate.
-        await expect(
-            validateWindshiftServerUrl('Windshift internal URL', 'http://192.168.1.10:8080'),
-        ).rejects.toThrow('Windshift internal URL is not allowed')
     })
 
     it('rejects credentials, fragments, and non-http schemes', async () => {

--- a/web/src/lib/server/windshift-server-config.test.ts
+++ b/web/src/lib/server/windshift-server-config.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { validateWindshiftServerUrl } from './windshift-server-config'
+
+describe('validateWindshiftServerUrl', () => {
+    it('accepts a public https URL', async () => {
+        await expect(
+            validateWindshiftServerUrl('Windshift URL', 'https://8.8.8.8'),
+        ).resolves.toBeUndefined()
+    })
+
+    it('accepts a public http URL', async () => {
+        await expect(
+            validateWindshiftServerUrl('Windshift URL', 'http://1.1.1.1'),
+        ).resolves.toBeUndefined()
+    })
+
+    it('skips empty URLs (optional internal URL)', async () => {
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', ''),
+        ).resolves.toBeUndefined()
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', '   '),
+        ).resolves.toBeUndefined()
+    })
+
+    it('rejects loopback and private addresses (SSRF)', async () => {
+        await expect(
+            validateWindshiftServerUrl('Windshift URL', 'http://127.0.0.1:8080'),
+        ).rejects.toThrow('Windshift URL is not allowed')
+        await expect(
+            validateWindshiftServerUrl('Windshift URL', 'http://169.254.169.254/'),
+        ).rejects.toThrow('Windshift URL is not allowed')
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', 'http://192.168.1.10:8080'),
+        ).rejects.toThrow('Windshift internal URL is not allowed')
+    })
+
+    it('rejects credentials, fragments, and non-http schemes', async () => {
+        await expect(
+            validateWindshiftServerUrl('Windshift URL', 'https://user:pass@8.8.8.8'),
+        ).rejects.toThrow('Windshift URL is not allowed')
+        await expect(
+            validateWindshiftServerUrl('Windshift URL', 'https://8.8.8.8#frag'),
+        ).rejects.toThrow('Windshift URL is not allowed')
+        await expect(validateWindshiftServerUrl('Windshift URL', 'ftp://8.8.8.8')).rejects.toThrow(
+            'Windshift URL is not allowed',
+        )
+    })
+})

--- a/web/src/lib/server/windshift-server-config.test.ts
+++ b/web/src/lib/server/windshift-server-config.test.ts
@@ -23,13 +23,51 @@ describe('validateWindshiftServerUrl', () => {
         ).resolves.toBeUndefined()
     })
 
-    it('rejects loopback and private addresses (SSRF)', async () => {
+    it('rejects loopback and private addresses for the public URL (SSRF)', async () => {
         await expect(
             validateWindshiftServerUrl('Windshift URL', 'http://127.0.0.1:8080'),
         ).rejects.toThrow('Windshift URL is not allowed')
         await expect(
             validateWindshiftServerUrl('Windshift URL', 'http://169.254.169.254/'),
         ).rejects.toThrow('Windshift URL is not allowed')
+        await expect(
+            validateWindshiftServerUrl('Windshift URL', 'http://192.168.1.10:8080'),
+        ).rejects.toThrow('Windshift URL is not allowed')
+    })
+
+    it('allows RFC1918 private addresses for the internal URL (allowPrivate)', async () => {
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', 'http://192.168.1.10:8080', {
+                allowPrivate: true,
+            }),
+        ).resolves.toBeUndefined()
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', 'http://10.0.0.5', {
+                allowPrivate: true,
+            }),
+        ).resolves.toBeUndefined()
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', 'http://172.20.0.5:8080', {
+                allowPrivate: true,
+            }),
+        ).resolves.toBeUndefined()
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', '', { allowPrivate: true }),
+        ).resolves.toBeUndefined()
+    })
+
+    it('still blocks loopback, metadata, and reserved addresses for the internal URL', async () => {
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', 'http://127.0.0.1:8080', {
+                allowPrivate: true,
+            }),
+        ).rejects.toThrow('Windshift internal URL is not allowed')
+        await expect(
+            validateWindshiftServerUrl('Windshift internal URL', 'http://169.254.169.254/', {
+                allowPrivate: true,
+            }),
+        ).rejects.toThrow('Windshift internal URL is not allowed')
+        // Strict by default: private addresses still rejected without allowPrivate.
         await expect(
             validateWindshiftServerUrl('Windshift internal URL', 'http://192.168.1.10:8080'),
         ).rejects.toThrow('Windshift internal URL is not allowed')

--- a/web/src/lib/server/windshift-server-config.ts
+++ b/web/src/lib/server/windshift-server-config.ts
@@ -1,0 +1,29 @@
+import { assertRemoteMcpDestinationAllowed, validateRemoteMcpUrl } from '$lib/server/mcp/client'
+
+function errorDetail(err: unknown): string {
+    if (err && typeof err === 'object') {
+        const body = (err as { body?: unknown }).body
+        if (typeof body === 'string' && body) return body
+        if (body && typeof body === 'object' && 'message' in body) {
+            const message = (body as { message?: unknown }).message
+            if (typeof message === 'string' && message) return message
+        }
+    }
+    return err instanceof Error && err.message ? err.message : 'invalid URL'
+}
+
+/// Validate an admin-entered Windshift server URL (public or internal) using
+/// the same SSRF policy as remote MCP sources: http(s) only, no credentials
+/// or fragment, and the resolved address must not be private or reserved.
+/// Empty strings are allowed (the internal URL is optional). Throws an Error
+/// with a user-facing message when the URL is rejected.
+export async function validateWindshiftServerUrl(label: string, url: string): Promise<void> {
+    const trimmed = url.trim()
+    if (!trimmed) return
+    try {
+        const parsed = validateRemoteMcpUrl(trimmed)
+        await assertRemoteMcpDestinationAllowed(parsed)
+    } catch (err) {
+        throw new Error(`${label} is not allowed: ${errorDetail(err)}`)
+    }
+}

--- a/web/src/lib/server/windshift-server-config.ts
+++ b/web/src/lib/server/windshift-server-config.ts
@@ -1,5 +1,4 @@
 import { assertRemoteMcpDestinationAllowed, validateRemoteMcpUrl } from '$lib/server/mcp/client'
-import type { RemoteMcpIpPolicy } from '$lib/server/mcp/client'
 
 function errorDetail(err: unknown): string {
     if (err && typeof err === 'object') {
@@ -13,24 +12,19 @@ function errorDetail(err: unknown): string {
     return err instanceof Error && err.message ? err.message : 'invalid URL'
 }
 
-/// Validate an admin-entered Windshift server URL (public or internal) using
-/// the same SSRF policy as remote MCP sources: http(s) only, no credentials
-/// or fragment, and the resolved address must not be private or reserved.
-/// The internal URL may pass `{ allowPrivate: true }` since it is deliberately
-/// hosted on a private network (e.g. a docker service name) — this unblocks
-/// RFC1918 addresses only; loopback, link-local/metadata, and reserved ranges
-/// stay rejected. Empty strings are allowed (the internal URL is optional).
-/// Throws an Error with a user-facing message when the URL is rejected.
-export async function validateWindshiftServerUrl(
-    label: string,
-    url: string,
-    policy: RemoteMcpIpPolicy = {},
-): Promise<void> {
+/// Validate the admin-entered Windshift public URL using the same SSRF policy
+/// as remote MCP sources: http(s) only, no credentials or fragment, and the
+/// resolved address must not be private or reserved. The operator-configured
+/// internal route is env-only (WINDSHIFT_INTERNAL_BASE_URL) and is therefore
+/// not validated here; it is re-checked against SSRF at use time from the
+/// connector manifest marker. Throws an Error with a user-facing message when
+/// the URL is rejected.
+export async function validateWindshiftServerUrl(label: string, url: string): Promise<void> {
     const trimmed = url.trim()
     if (!trimmed) return
     try {
         const parsed = validateRemoteMcpUrl(trimmed)
-        await assertRemoteMcpDestinationAllowed(parsed, policy)
+        await assertRemoteMcpDestinationAllowed(parsed)
     } catch (err) {
         throw new Error(`${label} is not allowed: ${errorDetail(err)}`)
     }

--- a/web/src/lib/server/windshift-server-config.ts
+++ b/web/src/lib/server/windshift-server-config.ts
@@ -1,4 +1,5 @@
 import { assertRemoteMcpDestinationAllowed, validateRemoteMcpUrl } from '$lib/server/mcp/client'
+import type { RemoteMcpIpPolicy } from '$lib/server/mcp/client'
 
 function errorDetail(err: unknown): string {
     if (err && typeof err === 'object') {
@@ -15,14 +16,21 @@ function errorDetail(err: unknown): string {
 /// Validate an admin-entered Windshift server URL (public or internal) using
 /// the same SSRF policy as remote MCP sources: http(s) only, no credentials
 /// or fragment, and the resolved address must not be private or reserved.
-/// Empty strings are allowed (the internal URL is optional). Throws an Error
-/// with a user-facing message when the URL is rejected.
-export async function validateWindshiftServerUrl(label: string, url: string): Promise<void> {
+/// The internal URL may pass `{ allowPrivate: true }` since it is deliberately
+/// hosted on a private network (e.g. a docker service name) — this unblocks
+/// RFC1918 addresses only; loopback, link-local/metadata, and reserved ranges
+/// stay rejected. Empty strings are allowed (the internal URL is optional).
+/// Throws an Error with a user-facing message when the URL is rejected.
+export async function validateWindshiftServerUrl(
+    label: string,
+    url: string,
+    policy: RemoteMcpIpPolicy = {},
+): Promise<void> {
     const trimmed = url.trim()
     if (!trimmed) return
     try {
         const parsed = validateRemoteMcpUrl(trimmed)
-        await assertRemoteMcpDestinationAllowed(parsed)
+        await assertRemoteMcpDestinationAllowed(parsed, policy)
     } catch (err) {
         throw new Error(`${label} is not allowed: ${errorDetail(err)}`)
     }

--- a/web/src/routes/(admin)/admin/settings/integrations/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/+page.server.ts
@@ -133,7 +133,6 @@ export const load: PageServerLoad = async ({ locals, fetch }) => {
     const savedWindshiftConfig = savedOAuthConfigByProvider.get('windshift')
     const windshiftConfig = (savedWindshiftConfig?.config ?? {}) as {
         base_url?: string
-        internal_base_url?: string
     }
     let windshiftRegistered = false
     let windshiftManifestBaseUrl: string | null = null

--- a/web/src/routes/(admin)/admin/settings/integrations/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/+page.server.ts
@@ -6,6 +6,7 @@ import {
     callbackUrl,
     isAutoManagedOAuthProvider,
     isClientConfigComplete,
+    oauthServiceBaseUrl,
     tokenEndpointAuthMethodForConfig,
     type OAuthManifestConfig,
 } from '$lib/server/oauth/connectorOAuth'
@@ -126,6 +127,17 @@ export const load: PageServerLoad = async ({ locals, fetch }) => {
     let oauthProviders: OAuthIntegrationProvider[] = []
     const sourceHealth = new Map<string, 'healthy' | 'unhealthy'>()
 
+    // Windshift is a personal OAuth source configured at the server level.
+    // The admin sets the base URLs here; the connector picks them up from
+    // connector_configs via connector-manager.
+    const savedWindshiftConfig = savedOAuthConfigByProvider.get('windshift')
+    const windshiftConfig = (savedWindshiftConfig?.config ?? {}) as {
+        base_url?: string
+        internal_base_url?: string
+    }
+    let windshiftRegistered = false
+    let windshiftManifestBaseUrl: string | null = null
+
     try {
         const [connectorsResponse, sourcesResponse] = await Promise.all([
             fetch(`${config.services.connectorManagerUrl}/connectors`),
@@ -160,6 +172,13 @@ export const load: PageServerLoad = async ({ locals, fetch }) => {
             const oauthManifestByProvider = new Map<string, OAuthManifestConfig>()
 
             for (const connector of connectors) {
+                if (connector.source_type === 'windshift') {
+                    windshiftRegistered = true
+                    const oauth = connector.manifest?.oauth
+                    if (oauth?.auth_endpoint) {
+                        windshiftManifestBaseUrl = oauthServiceBaseUrl(oauth.auth_endpoint)
+                    }
+                }
                 if (connector.manifest?.integration_type === IntegrationType.REMOTE_MCP) continue
                 const connectorId = connector.manifest?.connector_id ?? connector.source_type
                 if (!integrationMap.has(connectorId)) {
@@ -279,5 +298,10 @@ export const load: PageServerLoad = async ({ locals, fetch }) => {
         oauthProviders,
         oauthRedirectUri: callbackUrl(),
         mcpTab,
+        windshiftConfig,
+        windshiftRegistered,
+        // Effective URL when the connector is serving via env-var fallback
+        // (deployments that predate the UI setting).
+        windshiftEffectiveBaseUrl: windshiftConfig.base_url ?? windshiftManifestBaseUrl,
     }
 }

--- a/web/src/routes/(admin)/admin/settings/integrations/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/+page.svelte
@@ -26,6 +26,7 @@
     import notionLogo from '$lib/images/icons/notion.svg'
     import linearLogo from '$lib/images/icons/linear.svg'
     import githubLogo from '$lib/images/icons/github.svg'
+    import windshiftLogo from '$lib/images/icons/windshift.png'
     import nextcloudLogo from '$lib/images/icons/nextcloud.svg'
     import paperlessLogo from '$lib/images/icons/paperless.svg'
     import imapLogo from '$lib/images/icons/imap.svg'
@@ -62,6 +63,7 @@
     import PaperlessConnectorSetup from '$lib/components/paperless-connector-setup.svelte'
     import NextcloudConnectorSetup from '$lib/components/nextcloud-connector-setup.svelte'
     import DarwinboxConnectorSetup from '$lib/components/darwinbox-connector-setup.svelte'
+    import WindshiftServerSetup from '$lib/components/windshift-server-setup.svelte'
     import OAuthClientConfigDialog from '$lib/components/oauth-integrations/oauth-client-config-dialog.svelte'
     import { Badge } from '$lib/components/ui/badge'
     import { AuthType, SourceType } from '$lib/types'
@@ -507,6 +509,80 @@
                     {/if}
                 </div>
 
+                <!-- Windshift server (personal OAuth source, server-level config) -->
+                {#if data.windshiftRegistered}
+                    <div class="space-y-4">
+                        <div>
+                            <h2 class="text-xl font-semibold">Windshift server</h2>
+                            <p class="text-muted-foreground text-sm">
+                                Windshift is a personal OAuth source: users connect it from My
+                                Integrations. Configure the Windshift server URL here — no env vars
+                                required.
+                            </p>
+                        </div>
+
+                        <Card class="flex flex-col">
+                            <CardHeader>
+                                <CardTitle class="flex items-center gap-3">
+                                    <div
+                                        class="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200/70 bg-white/95 shadow-sm">
+                                        <img
+                                            src={windshiftLogo}
+                                            alt="Windshift"
+                                            class="h-6 w-6 object-contain" />
+                                    </div>
+                                    Windshift
+                                </CardTitle>
+                                <CardDescription>
+                                    Base URL of the Windshift instance Omni talks to. OAuth client
+                                    registration is automatic (DCR + PKCE); there is no client
+                                    secret to configure.
+                                </CardDescription>
+                            </CardHeader>
+                            <CardContent class="flex-1 space-y-2">
+                                {#if data.windshiftConfig.base_url}
+                                    <div class="text-sm">
+                                        <span class="text-muted-foreground">Windshift URL:</span>
+                                        <code
+                                            class="bg-muted ml-2 rounded px-1.5 py-0.5 text-xs break-all">
+                                            {data.windshiftConfig.base_url}
+                                        </code>
+                                    </div>
+                                    {#if data.windshiftConfig.internal_base_url}
+                                        <div class="text-sm">
+                                            <span class="text-muted-foreground">Internal URL:</span>
+                                            <code
+                                                class="bg-muted ml-2 rounded px-1.5 py-0.5 text-xs break-all">
+                                                {data.windshiftConfig.internal_base_url}
+                                            </code>
+                                        </div>
+                                    {/if}
+                                {:else if data.windshiftEffectiveBaseUrl}
+                                    <div class="text-sm">
+                                        <span class="text-muted-foreground"
+                                            >Serving via env fallback:</span>
+                                        <code
+                                            class="bg-muted ml-2 rounded px-1.5 py-0.5 text-xs break-all">
+                                            {data.windshiftEffectiveBaseUrl}
+                                        </code>
+                                    </div>
+                                {:else}
+                                    <Badge variant="outline">Not configured</Badge>
+                                {/if}
+                            </CardContent>
+                            <CardFooter>
+                                <Button
+                                    size="sm"
+                                    variant={data.windshiftConfig.base_url ? 'outline' : 'default'}
+                                    class="cursor-pointer"
+                                    onclick={() => (activeSetup = 'windshift')}>
+                                    {data.windshiftConfig.base_url ? 'Edit' : 'Configure'}
+                                </Button>
+                            </CardFooter>
+                        </Card>
+                    </div>
+                {/if}
+
                 <!-- Available Integrations Section -->
                 <div class="space-y-4">
                     <div>
@@ -760,6 +836,13 @@
 
 <DarwinboxConnectorSetup
     open={activeSetup === 'darwinbox'}
+    onSuccess={handleSetupSuccess}
+    onCancel={closeSetup} />
+
+<WindshiftServerSetup
+    open={activeSetup === 'windshift'}
+    baseUrl={data.windshiftConfig.base_url ?? ''}
+    internalBaseUrl={data.windshiftConfig.internal_base_url ?? ''}
     onSuccess={handleSetupSuccess}
     onCancel={closeSetup} />
 

--- a/web/src/routes/(admin)/admin/settings/integrations/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/+page.svelte
@@ -548,15 +548,6 @@
                                             {data.windshiftConfig.base_url}
                                         </code>
                                     </div>
-                                    {#if data.windshiftConfig.internal_base_url}
-                                        <div class="text-sm">
-                                            <span class="text-muted-foreground">Internal URL:</span>
-                                            <code
-                                                class="bg-muted ml-2 rounded px-1.5 py-0.5 text-xs break-all">
-                                                {data.windshiftConfig.internal_base_url}
-                                            </code>
-                                        </div>
-                                    {/if}
                                 {:else if data.windshiftEffectiveBaseUrl}
                                     <div class="text-sm">
                                         <span class="text-muted-foreground"
@@ -842,7 +833,6 @@
 <WindshiftServerSetup
     open={activeSetup === 'windshift'}
     baseUrl={data.windshiftConfig.base_url ?? ''}
-    internalBaseUrl={data.windshiftConfig.internal_base_url ?? ''}
     onSuccess={handleSetupSuccess}
     onCancel={closeSetup} />
 

--- a/web/src/routes/(app)/settings/integrations/+page.server.ts
+++ b/web/src/routes/(app)/settings/integrations/+page.server.ts
@@ -19,12 +19,22 @@ export const load: PageServerLoad = async ({ locals }) => {
 
     const googleConnectorConfig = await getConnectorConfigPublic('google')
 
-    let windshiftBaseUrl: string | null = null
-    try {
-        const oauth = await getOAuthManifestForSourceType(SourceType.WINDSHIFT)
-        if (oauth?.auth_endpoint) windshiftBaseUrl = oauthServiceBaseUrl(oauth.auth_endpoint)
-    } catch (err) {
-        locals.logger.warn('Failed to load the Windshift connector URL', err)
+    // The Windshift server URL is an admin setting stored in connector_configs.
+    // Fall back to the connector manifest (env-var based deployments) until the
+    // admin configures it in the UI.
+    const windshiftConnectorConfig = await getConnectorConfigPublic('windshift')
+    const storedWindshiftBaseUrl = windshiftConnectorConfig?.config?.base_url
+    let windshiftBaseUrl: string | null =
+        typeof storedWindshiftBaseUrl === 'string' && storedWindshiftBaseUrl.trim().length > 0
+            ? storedWindshiftBaseUrl
+            : null
+    if (!windshiftBaseUrl) {
+        try {
+            const oauth = await getOAuthManifestForSourceType(SourceType.WINDSHIFT)
+            if (oauth?.auth_endpoint) windshiftBaseUrl = oauthServiceBaseUrl(oauth.auth_endpoint)
+        } catch (err) {
+            locals.logger.warn('Failed to load the Windshift connector URL', err)
+        }
     }
 
     const userSources = (await sourcesRepository.getByUserId(locals.user.id)).filter((source) =>

--- a/web/src/routes/api/connector-configs/+server.ts
+++ b/web/src/routes/api/connector-configs/+server.ts
@@ -49,6 +49,9 @@ export const POST: RequestHandler = async ({ locals, request }) => {
                 typeof nextConfig.internal_base_url === 'string'
                     ? nextConfig.internal_base_url
                     : '',
+                // The internal URL is deliberately hosted on a private network
+                // (e.g. a docker service name) — allow RFC1918 destinations.
+                { allowPrivate: true },
             )
         } catch (err) {
             throw error(

--- a/web/src/routes/api/connector-configs/+server.ts
+++ b/web/src/routes/api/connector-configs/+server.ts
@@ -36,27 +36,22 @@ export const POST: RequestHandler = async ({ locals, request }) => {
         nextConfig.oauth_client_secret = existingConfig.oauth_client_secret
     }
 
-    // Windshift base URLs are admin-entered and fetched by the server (OAuth
+    // Windshift's public URL is admin-entered and fetched by the server (OAuth
     // endpoints, MCP) — enforce the same SSRF policy as remote MCP sources.
+    // The internal route is env-only (WINDSHIFT_INTERNAL_BASE_URL); it is no
+    // longer UI/API-configurable, so reject it here and drop stale values.
     if (provider === 'windshift') {
+        const baseUrl = nextConfig.base_url
+        if (typeof baseUrl !== 'string' || !baseUrl.trim()) {
+            throw error(400, 'Windshift URL is required')
+        }
+        delete nextConfig.internal_base_url
         try {
-            await validateWindshiftServerUrl(
-                'Windshift URL',
-                typeof nextConfig.base_url === 'string' ? nextConfig.base_url : '',
-            )
-            await validateWindshiftServerUrl(
-                'Windshift internal URL',
-                typeof nextConfig.internal_base_url === 'string'
-                    ? nextConfig.internal_base_url
-                    : '',
-                // The internal URL is deliberately hosted on a private network
-                // (e.g. a docker service name) — allow RFC1918 destinations.
-                { allowPrivate: true },
-            )
+            await validateWindshiftServerUrl('Windshift URL', baseUrl)
         } catch (err) {
             throw error(
                 400,
-                err instanceof Error ? err.message : 'Windshift server URLs are not allowed',
+                err instanceof Error ? err.message : 'Windshift server URL is not allowed',
             )
         }
     }

--- a/web/src/routes/api/connector-configs/+server.ts
+++ b/web/src/routes/api/connector-configs/+server.ts
@@ -5,6 +5,7 @@ import {
     getConnectorConfig,
     upsertConnectorConfig,
 } from '$lib/server/db/connector-configs'
+import { validateWindshiftServerUrl } from '$lib/server/windshift-server-config'
 
 export const GET: RequestHandler = async ({ locals }) => {
     if (!locals.user) {
@@ -33,6 +34,28 @@ export const POST: RequestHandler = async ({ locals, request }) => {
 
     if (!config.oauth_client_secret && existingConfig.oauth_client_secret) {
         nextConfig.oauth_client_secret = existingConfig.oauth_client_secret
+    }
+
+    // Windshift base URLs are admin-entered and fetched by the server (OAuth
+    // endpoints, MCP) — enforce the same SSRF policy as remote MCP sources.
+    if (provider === 'windshift') {
+        try {
+            await validateWindshiftServerUrl(
+                'Windshift URL',
+                typeof nextConfig.base_url === 'string' ? nextConfig.base_url : '',
+            )
+            await validateWindshiftServerUrl(
+                'Windshift internal URL',
+                typeof nextConfig.internal_base_url === 'string'
+                    ? nextConfig.internal_base_url
+                    : '',
+            )
+        } catch (err) {
+            throw error(
+                400,
+                err instanceof Error ? err.message : 'Windshift server URLs are not allowed',
+            )
+        }
     }
 
     const result = await upsertConnectorConfig(provider, nextConfig, locals.user.id)


### PR DESCRIPTION
- Windshift base URLs are now managed in the admin UI (Settings > Integrations) and stored in `connector_configs`; the connector reads them via connector-manager, with `WINDSHIFT_BASE_URL` env vars kept as a fallback for legacy deployments
- Add `SdkClient.getConnectorConfig` so TypeScript connectors can fetch admin-managed connector configs
- Default `WINDSHIFT_CONNECTOR_PORT` and `EMBEDDING_MODEL` in docker-compose so unset vars no longer emit compose WARN lines for users not running the windshift/local-embeddings services
- Remove the Windshift base URL vars from `.env.example` and update the connector README to describe the UI-based setup