### PR TITLE
fix(ai): handle Anthropic thinking blocks in stream to avoid empty tool_use ids

### DIFF
--- a/services/ai/agents/executor.py
+++ b/services/ai/agents/executor.py
@@ -117,9 +117,7 @@ async def _resolve_llm_provider(state: AppState, agent: Agent) -> ResolvedModel:
         raise RuntimeError("Agent has no model configured")
     resolved = await state.provider_cache.resolve_for_model(agent.model_id)
     if resolved is None:
-        raise RuntimeError(
-            f"Agent model {agent.model_id} is no longer available"
-        )
+        raise RuntimeError(f"Agent model {agent.model_id} is no longer available")
     return resolved
 
 
@@ -533,7 +531,9 @@ async def _run_agent_loop(
     agent_user_groups = None
     if agent_user_email and not is_org_agent:
         try:
-            agent_user_groups = await GroupRepository().find_groups_for_user(agent_user_email)
+            agent_user_groups = await GroupRepository().find_groups_for_user(
+                agent_user_email
+            )
         except Exception:
             logger.error(
                 "Group lookup failed for agent user %s — failing closed",
@@ -670,6 +670,23 @@ async def _run_agent_loop(
                                     input="",
                                 )
                             )
+                        elif event.content_block.type == "thinking":
+                            # Keep provider block indexes aligned so tool input
+                            # deltas land on the right block.
+                            content_blocks.append(
+                                ThinkingBlockParam(
+                                    type="thinking",
+                                    thinking=event.content_block.thinking,
+                                    signature=event.content_block.signature,
+                                )
+                            )
+                        elif event.content_block.type == "redacted_thinking":
+                            content_blocks.append(
+                                RedactedThinkingBlockParam(
+                                    type="redacted_thinking",
+                                    data=event.content_block.data,
+                                )
+                            )
                     elif event.type == "content_block_delta":
                         if event.delta.type == "text_delta":
                             if event.index < len(content_blocks):
@@ -677,15 +694,35 @@ async def _run_agent_loop(
                                     TextBlockParam, content_blocks[event.index]
                                 )
                                 text_block["text"] += event.delta.text
-                        elif event.delta.type == "input_json_delta" and event.index < len(
-                            content_blocks
+                        elif (
+                            event.delta.type == "input_json_delta"
+                            and event.index < len(content_blocks)
                         ):
                             tool_block = cast(
                                 ToolUseBlockParam, content_blocks[event.index]
                             )
                             tool_block["input"] = (
-                                cast(str, tool_block["input"]) + event.delta.partial_json
+                                cast(str, tool_block["input"])
+                                + event.delta.partial_json
                             )
+                        elif event.delta.type == "thinking_delta" and event.index < len(
+                            content_blocks
+                        ):
+                            thinking_block = cast(
+                                ThinkingBlockParam, content_blocks[event.index]
+                            )
+                            thinking_block["thinking"] = (
+                                cast(str, thinking_block.get("thinking", ""))
+                                + event.delta.thinking
+                            )
+                        elif (
+                            event.delta.type == "signature_delta"
+                            and event.index < len(content_blocks)
+                        ):
+                            thinking_block = cast(
+                                ThinkingBlockParam, content_blocks[event.index]
+                            )
+                            thinking_block["signature"] = event.delta.signature
                     elif event.type == "message_stop":
                         break
                 break

--- a/services/ai/providers/anthropic.py
+++ b/services/ai/providers/anthropic.py
@@ -97,6 +97,8 @@ class AnthropicProvider(LLMProvider):
         system_prompt: str | None = None,
         *,
         model: str | None = None,
+        thinking: dict[str, Any] | None = None,
+        output_config: dict[str, Any] | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         """Stream response from Anthropic Claude API."""
         try:
@@ -118,6 +120,12 @@ class AnthropicProvider(LLMProvider):
                 "max_tokens": max_tokens or 8192,
                 "stream": True,
             }
+
+            if thinking is not None:
+                request_params["thinking"] = thinking
+
+            if output_config is not None:
+                request_params["output_config"] = output_config
 
             # Add tools if provided
             if tools:

--- a/services/ai/services/compaction.py
+++ b/services/ai/services/compaction.py
@@ -65,7 +65,8 @@ class CompactionBudget:
         max_output_tokens: int | None = None,
     ) -> "CompactionBudget":
         return cls(
-            context_window_tokens=context_window_tokens or DEFAULT_CONTEXT_WINDOW_TOKENS,
+            context_window_tokens=context_window_tokens
+            or DEFAULT_CONTEXT_WINDOW_TOKENS,
             max_output_tokens=max_output_tokens or DEFAULT_OUTPUT_RESERVE_TOKENS,
         )
 
@@ -135,12 +136,19 @@ class ConversationCompactor:
                             total_chars += len(block.get("text", ""))
                         elif block.get("type") == "document":
                             source = block.get("source")
-                            if isinstance(source, dict) and source.get("type") == "text":
+                            if (
+                                isinstance(source, dict)
+                                and source.get("type") == "text"
+                            ):
                                 data = source.get("data")
                                 if isinstance(data, str):
                                     total_chars += len(data)
                         elif block.get("type") == "tool_use":
                             total_chars += len(json.dumps(block.get("input", {})))
+                        elif block.get("type") == "thinking":
+                            total_chars += len(block.get("thinking", ""))
+                        elif block.get("type") == "redacted_thinking":
+                            total_chars += len(block.get("data", ""))
                         elif block.get("type") == "tool_result":
                             result_content = block.get("content", "")
                             if isinstance(result_content, str):
@@ -210,7 +218,9 @@ class ConversationCompactor:
         if context_window_tokens is None:
             # Preserve env override semantics until provider-specific resolution is
             # wired everywhere. Later calls pass provider context explicitly.
-            context_window_tokens = MAX_CONVERSATION_INPUT_TOKENS or DEFAULT_CONTEXT_WINDOW_TOKENS
+            context_window_tokens = (
+                MAX_CONVERSATION_INPUT_TOKENS or DEFAULT_CONTEXT_WINDOW_TOKENS
+            )
         budget = CompactionBudget.from_context_window(
             context_window_tokens, max_output_tokens
         )
@@ -236,7 +246,9 @@ class ConversationCompactor:
         return list(content)
 
     def _has_content_block_type(self, message: MessageParam, block_type: str) -> bool:
-        return any(block["type"] == block_type for block in self._content_blocks(message))
+        return any(
+            block["type"] == block_type for block in self._content_blocks(message)
+        )
 
     def _counts_toward_recent_user_floor(self, message: MessageParam) -> bool:
         if message["role"] != "user":
@@ -256,8 +268,10 @@ class ConversationCompactor:
                 break
             split_point -= 1
 
-        if split_point > 0 and split_point < len(messages) and self._has_content_block_type(
-            messages[split_point - 1], "tool_use"
+        if (
+            split_point > 0
+            and split_point < len(messages)
+            and self._has_content_block_type(messages[split_point - 1], "tool_use")
         ):
             split_point -= 1
 
@@ -281,7 +295,9 @@ class ConversationCompactor:
         if split_point is None:
             return CompactionSplit([], messages, None)
 
-        split_point = self._adjust_split_point_for_tool_boundaries(messages, split_point)
+        split_point = self._adjust_split_point_for_tool_boundaries(
+            messages, split_point
+        )
         old_messages = list(messages[:split_point])
         recent_messages = list(messages[split_point:])
         anchor_index = split_point - 1 if old_messages else None
@@ -317,7 +333,9 @@ class ConversationCompactor:
         )
 
         budget = (
-            CompactionBudget.from_context_window(context_window_tokens, max_output_tokens)
+            CompactionBudget.from_context_window(
+                context_window_tokens, max_output_tokens
+            )
             if context_window_tokens
             else None
         )
@@ -453,7 +471,9 @@ Summary:"""
 
         prompt = self._summary_prompt(messages, previous_summary)
         estimated_input_tokens = self.estimate_text_tokens(prompt)
-        context_window = summarizer_context_window_tokens or DEFAULT_CONTEXT_WINDOW_TOKENS
+        context_window = (
+            summarizer_context_window_tokens or DEFAULT_CONTEXT_WINDOW_TOKENS
+        )
         budget = CompactionBudget.from_context_window(
             context_window, COMPACTION_SUMMARY_MAX_TOKENS
         )
@@ -539,9 +559,11 @@ Summary:"""
         return SummaryResult(
             summary=final_summary.strip(),
             usage=total_usage,
-            estimated_input_tokens=estimated_input_tokens
-            if (estimated_input_tokens := self.estimate_tokens(messages))
-            else 0,
+            estimated_input_tokens=(
+                estimated_input_tokens
+                if (estimated_input_tokens := self.estimate_tokens(messages))
+                else 0
+            ),
             estimated_summary_tokens=self.estimate_text_tokens(final_summary),
             passes=passes,
         )
@@ -652,7 +674,9 @@ Summary:"""
             chat_id=chat_id,
             anchor_message_id=anchor_row.id,
             compacted_through_seq_num=anchor_row.message_seq_num,
-            previous_compaction_id=(latest_compaction.id if has_prior_summary else None),
+            previous_compaction_id=(
+                latest_compaction.id if has_prior_summary else None
+            ),
             summary=summary_result.summary,
             summary_message=dict(summary_message),
             estimated_input_tokens=summary_result.estimated_input_tokens,
@@ -751,7 +775,9 @@ Summary:"""
             run_id=run_id,
             anchor_log_id=anchor_row.id,
             compacted_through_seq_num=anchor_row.message_seq_num,
-            previous_compaction_id=(latest_compaction.id if has_prior_summary else None),
+            previous_compaction_id=(
+                latest_compaction.id if has_prior_summary else None
+            ),
             summary=summary_result.summary,
             summary_message=dict(summary_message),
             estimated_input_tokens=summary_result.estimated_input_tokens,

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -17,8 +17,10 @@ from anthropic import MessageStreamEvent
 from anthropic.types import (
     ContentBlockParam,
     MessageParam,
+    RedactedThinkingBlockParam,
     TextBlockParam,
     TextCitationParam,
+    ThinkingBlockParam,
     ToolParam,
     ToolResultBlockParam,
     ToolUseBlockParam,
@@ -794,6 +796,40 @@ async def stream_generator(
                                 cast(str, tool_use_block["input"])
                                 + event.delta.partial_json
                             )
+                        elif event.delta.type == "thinking_delta":
+                            if event.index >= len(content_blocks):
+                                logger.warning(
+                                    f"Received thinking delta for unknown content block index {event.index}, creating new thinking block"
+                                )
+                                content_blocks.append(
+                                    ThinkingBlockParam(
+                                        type="thinking", thinking="", signature=""
+                                    )
+                                )
+                            thinking_block = cast(
+                                ThinkingBlockParam, content_blocks[event.index]
+                            )
+                            thinking_block["thinking"] = (
+                                cast(str, thinking_block.get("thinking", ""))
+                                + event.delta.thinking
+                            )
+                        elif event.delta.type == "signature_delta":
+                            # Anthropic streams the thinking signature separately
+                            # from the block; it is required for multi-turn
+                            # continuity, so carry it onto the thinking block.
+                            if event.index >= len(content_blocks):
+                                logger.warning(
+                                    f"Received signature delta for unknown content block index {event.index}, creating new thinking block"
+                                )
+                                content_blocks.append(
+                                    ThinkingBlockParam(
+                                        type="thinking", thinking="", signature=""
+                                    )
+                                )
+                            signature_block = cast(
+                                ThinkingBlockParam, content_blocks[event.index]
+                            )
+                            signature_block["signature"] = event.delta.signature
                         elif event.delta.type == "citations_delta":
                             if event.index >= len(content_blocks):
                                 logger.warning(
@@ -841,6 +877,37 @@ async def stream_generator(
                                 event.content_block, tool_block, provider_extras
                             )
                             content_blocks.append(tool_block)
+                        elif event.content_block.type == "thinking":
+                            logger.info("Thinking block start")
+                            content_blocks.append(
+                                ThinkingBlockParam(
+                                    type="thinking",
+                                    thinking=event.content_block.thinking,
+                                    signature=event.content_block.signature,
+                                )
+                            )
+                        elif event.content_block.type == "redacted_thinking":
+                            logger.info("Redacted thinking block start")
+                            content_blocks.append(
+                                RedactedThinkingBlockParam(
+                                    type="redacted_thinking",
+                                    data=event.content_block.data,
+                                )
+                            )
+                        else:
+                            # Keep provider content block indexes aligned for any
+                            # block type we don't model, so later deltas land on
+                            # the correct slot instead of synthesizing a bogus
+                            # tool_use block with an empty id.
+                            logger.info(
+                                f"Content block start for unhandled type: {event.content_block.type}"
+                            )
+                            content_blocks.append(
+                                cast(
+                                    ContentBlockParam,
+                                    dict(event.content_block),
+                                )
+                            )
 
                     elif event.type == "citation":
                         logger.info(f"Citation received: {event.citation}")

--- a/services/ai/streaming/persist.py
+++ b/services/ai/streaming/persist.py
@@ -14,6 +14,7 @@ from enum import Enum
 from typing import Any, NotRequired, TypedDict, cast
 
 from anthropic.types import (
+    ContentBlockParam,
     MessageParam,
     TextBlockParam,
     ToolResultBlockParam,
@@ -199,7 +200,7 @@ def approval_required_event(
 
 
 def partial_assistant_message(
-    content_blocks: list[TextBlockParam | ToolUseBlockParam],
+    content_blocks: list[ContentBlockParam],
 ) -> MessageParam | None:
     """Build a ``MessageParam`` from partial content blocks.
 
@@ -207,12 +208,18 @@ def partial_assistant_message(
     tool-use blocks), which lets the caller avoid emitting a ``save_message``
     event for a genuinely empty response.
     """
-    persisted_blocks: list[TextBlockParam | ToolUseBlockParam] = []
+    persisted_blocks: list[ContentBlockParam] = []
     for block in content_blocks:
         if block["type"] == "text":
             text_block = cast(TextBlockParam, block)
             if text_block["text"].strip():
                 persisted_blocks.append(cast(TextBlockParam, dict(text_block)))
+            continue
+
+        if block["type"] in ("thinking", "redacted_thinking"):
+            # Extended-thinking blocks carry the signature Anthropic requires
+            # in later turns of a tool-use conversation; keep them.
+            persisted_blocks.append(cast(ContentBlockParam, dict(block)))
             continue
 
         tool_block = cast(ToolUseBlockParam, dict(block))

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -19,8 +19,11 @@ from anthropic.types import (
     RawMessageDeltaEvent,
     RawMessageStartEvent,
     RawMessageStopEvent,
+    SignatureDelta,
     TextBlock,
     TextDelta,
+    ThinkingBlock,
+    ThinkingDelta,
     ToolUseBlock,
     Usage,
 )
@@ -197,6 +200,67 @@ def tool_call_events(
         ),
     )
     yield RawContentBlockStopEvent(type="content_block_stop", index=0)
+    yield RawMessageDeltaEvent(
+        type="message_delta",
+        delta=Delta(stop_reason="tool_use", stop_sequence=None),
+        usage=MessageDeltaUsage(output_tokens=30),
+    )
+    yield RawMessageStopEvent(type="message_stop")
+
+
+def thinking_tool_call_events(
+    tool_call_json: dict[str, Any],
+    tool_name: str = "search_documents",
+    tool_id: str = "toolu_think",
+):
+    """Yield Anthropic SDK events simulating a tool_use turn on a model that
+    streams an extended-thinking block first.
+
+    Mirrors claude-sonnet-5: a ``thinking`` block occupies index 0 and the
+    tool_use (plus its ``input_json_delta``) live at index 1.  The stream
+    handler must account for the thinking block or the tool input deltas
+    land on a synthesized ``tool_use`` with an empty id (see the
+    ``tool_use.id`` 400 regression).
+    """
+    yield message_start_event()
+    yield RawContentBlockStartEvent(
+        type="content_block_start",
+        index=0,
+        content_block=ThinkingBlock(type="thinking", thinking="", signature=""),
+    )
+    yield RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=0,
+        delta=ThinkingDelta(
+            type="thinking_delta", thinking="Let me reason about this..."
+        ),
+    )
+    # Anthropic streams the thinking signature in its own delta event.
+    yield RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=0,
+        delta=SignatureDelta(type="signature_delta", signature="sig_test_abc"),
+    )
+    yield RawContentBlockStopEvent(type="content_block_stop", index=0)
+    yield RawContentBlockStartEvent(
+        type="content_block_start",
+        index=1,
+        content_block=ToolUseBlock(
+            type="tool_use",
+            id=tool_id,
+            name=tool_name,
+            input={},
+        ),
+    )
+    yield RawContentBlockDeltaEvent(
+        type="content_block_delta",
+        index=1,
+        delta=InputJSONDelta(
+            type="input_json_delta",
+            partial_json=json.dumps(tool_call_json),
+        ),
+    )
+    yield RawContentBlockStopEvent(type="content_block_stop", index=1)
     yield RawMessageDeltaEvent(
         type="message_delta",
         delta=Delta(stop_reason="tool_use", stop_sequence=None),
@@ -421,12 +485,10 @@ def assert_sse_wire(events: list[tuple[str | None, str, str | None]]) -> None:
     """
     seen_ids: list[str] = []
     for idx, (event_type, data, sse_id) in enumerate(events):
-        assert event_type is not None, (
-            f"Event {idx} is missing event: field. data={data!r}"
-        )
-        assert data is not None, (
-            f"Event {idx} (type={event_type}) has no data: line"
-        )
+        assert (
+            event_type is not None
+        ), f"Event {idx} is missing event: field. data={data!r}"
+        assert data is not None, f"Event {idx} (type={event_type}) has no data: line"
         if event_type == "heartbeat":
             # Heartbeats are synthetic and don't carry an id: line.
             continue
@@ -542,6 +604,15 @@ class GatedRecordingLLM:
                     await asyncio.sleep(self._inter_event_delay)
         elif kind == "tool_call":
             for event in tool_call_events(
+                payload["input"],
+                tool_name=payload.get("name", "search_documents"),
+                tool_id=payload.get("id", f"toolu_{call_idx}"),
+            ):
+                yield event
+                if self._inter_event_delay:
+                    await asyncio.sleep(self._inter_event_delay)
+        elif kind == "thinking_tool_call":
+            for event in thinking_tool_call_events(
                 payload["input"],
                 tool_name=payload.get("name", "search_documents"),
                 tool_id=payload.get("id", f"toolu_{call_idx}"),

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -90,15 +90,25 @@ def _build_chat_app(
     app = FastAPI()
     app.state = AppState()
     from provider_cache import ResolvedModel
+
     async def _resolve_for_model(mid: str):
         return ResolvedModel(provider=llm_provider, model_record_id=mid, model_name=mid)
+
     async def _resolve_default():
-        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+        return ResolvedModel(
+            provider=llm_provider, model_record_id=model_id, model_name=model_id
+        )
+
     async def _resolve_secondary_or_default():
-        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+        return ResolvedModel(
+            provider=llm_provider, model_record_id=model_id, model_name=model_id
+        )
+
     app.state.provider_cache.resolve_for_model = _resolve_for_model
     app.state.provider_cache.resolve_default = _resolve_default
-    app.state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
+    app.state.provider_cache.resolve_secondary_or_default = (
+        _resolve_secondary_or_default
+    )
     app.state.searcher_tool = SearcherTool()
     app.state.content_storage = None
     app.state.redis_client = redis_client
@@ -1690,6 +1700,94 @@ class TestMultiTurn:
             "No user message with tool_result found. " "Tool was not executed."
         )
 
+    @pytest.mark.asyncio
+    async def test_thinking_block_keeps_tool_use_index_aligned(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """claude-sonnet-5 streams an extended-thinking block before the
+        tool_use, shifting the tool_use (and its input deltas) to index 1.
+
+        Regression for the Anthropic 400 ``messages.1.content.1.tool_use.id``
+        failure: the stream handler must account for the thinking block, or
+        the tool input deltas land on a synthesized ``tool_use`` with an
+        empty id that gets persisted and replayed to the API.
+        """
+        chat_id, _user_id, model_id = seeded_chat
+
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "thinking_tool_call",
+                    {
+                        "name": "search_documents",
+                        "input": {"query": "leave balance"},
+                        "id": "toolu_think123",
+                    },
+                ),
+                ("text", "Here is your leave balance."),
+            ],
+            model_id,
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            et in ("end_of_stream", "stream_error") for et, _, _ in events
+        ), "No terminal event"
+        assert not any(
+            et == "stream_error" for et, _, _ in events
+        ), f"Stream errored: {[e for e in events if e[0] == 'stream_error']}"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assistant_msgs = [m for m in db_msgs if m.message["role"] == "assistant"]
+        assert len(assistant_msgs) == 2, (
+            f"Expected 2 assistant msgs (tool turn + text turn), "
+            f"got {len(assistant_msgs)}"
+        )
+
+        # The tool turn must contain exactly one tool_use with the real id
+        # and full input — never a synthesized block with an empty id.
+        tool_turn = assistant_msgs[0]
+        tool_uses = [
+            b
+            for b in tool_turn.message.get("content", [])
+            if b.get("type") == "tool_use"
+        ]
+        assert len(tool_uses) == 1, f"Expected exactly 1 tool_use, got {tool_uses}"
+        assert tool_uses[0]["id"] == "toolu_think123", tool_uses[0]
+        assert tool_uses[0]["input"] == {"query": "leave balance"}, tool_uses[0]
+
+        # The thinking block (with its signature) is preserved so Anthropic
+        # can continue the extended-thinking tool-use turn on replay.
+        thinking_blocks = [
+            b
+            for b in tool_turn.message.get("content", [])
+            if b.get("type") == "thinking"
+        ]
+        assert (
+            len(thinking_blocks) == 1
+        ), f"Expected 1 thinking block, got {thinking_blocks}"
+        assert thinking_blocks[0]["signature"] == "sig_test_abc"
+
+        # The second LLM request's history must not contain an empty-id
+        # tool_use, and must still reference the original tool_use id.
+        second_call_messages = llm.calls[1]["messages"]
+        history_tool_uses = [
+            b
+            for m in second_call_messages
+            if isinstance(m.get("content"), list)
+            for b in m["content"]
+            if b.get("type") == "tool_use"
+        ]
+        assert all(
+            tu["id"] for tu in history_tool_uses
+        ), f"Found tool_use with empty id in request history: {history_tool_uses}"
+        assert any(
+            tu["id"] == "toolu_think123" for tu in history_tool_uses
+        ), f"Original tool_use id missing from request history: {history_tool_uses}"
+
 
 # =============================================================================
 # Approval and OAuth intervention resume
@@ -2547,9 +2645,13 @@ class TestStandaloneEndpoints:
 
         assert any(et == "end_of_stream" for et, _, _ in events)
         message_payloads = [
-            json.loads(data) for event_type, data, _ in events if event_type == "message"
+            json.loads(data)
+            for event_type, data, _ in events
+            if event_type == "message"
         ]
-        assert sum(payload["type"] == "message_start" for payload in message_payloads) == 1
+        assert (
+            sum(payload["type"] == "message_start" for payload in message_payloads) == 1
+        )
         assert len(llm.calls) == 2
         retry_messages = llm.calls[1]["messages"]
         assert retry_messages[-1] == {
@@ -2586,12 +2688,16 @@ class TestMentionExpansion:
     request.  Permission denials are handled gracefully.
     """
 
-    async def _cleanup_extra_rows(self, db_pool, source_id: str, content_id: str | None = None):
+    async def _cleanup_extra_rows(
+        self, db_pool, source_id: str, content_id: str | None = None
+    ):
         """Delete source (cascades to documents) and content_blobs before
         ``seeded_chat`` teardown deletes the user."""
         async with db_pool.acquire() as conn:
             if content_id:
-                await conn.execute("DELETE FROM content_blobs WHERE id = $1", content_id)
+                await conn.execute(
+                    "DELETE FROM content_blobs WHERE id = $1", content_id
+                )
             await conn.execute("DELETE FROM sources WHERE id = $1", source_id)
 
     @pytest.mark.asyncio
@@ -2612,21 +2718,31 @@ class TestMentionExpansion:
             await conn.execute(
                 "INSERT INTO sources (id, name, source_type, created_by) "
                 "VALUES ($1, $2, $3, $4)",
-                source_id, "test-source", "google_drive", user_id,
+                source_id,
+                "test-source",
+                "google_drive",
+                user_id,
             )
             content_bytes = document_text.encode("utf-8")
             await conn.execute(
                 "INSERT INTO content_blobs (id, content, size_bytes, storage_backend) "
                 "VALUES ($1, $2, $3, 'postgres')",
-                content_id, content_bytes, len(content_bytes),
+                content_id,
+                content_bytes,
+                len(content_bytes),
             )
             await conn.execute(
                 "INSERT INTO documents (id, source_id, external_id, title, content, "
                 "permissions, content_type, content_id) "
                 "VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)",
-                doc_id, source_id, f"ext-{doc_id}", "Q3 Report", document_text,
+                doc_id,
+                source_id,
+                f"ext-{doc_id}",
+                "Q3 Report",
+                document_text,
                 json.dumps({"public": True, "users": [], "groups": []}),
-                "text/plain", content_id,
+                "text/plain",
+                content_id,
             )
 
         msgs = await MessagesRepository().get_active_path(chat_id)
@@ -2634,13 +2750,15 @@ class TestMentionExpansion:
         async with db_pool.acquire() as conn:
             await conn.execute(
                 "UPDATE chat_messages SET message = $1::jsonb WHERE id = $2",
-                json.dumps({
-                    "role": "user",
-                    "content": [
-                        _mention_block(doc_id, "Q3 Report"),
-                        {"type": "text", "text": "What were the key results?"},
-                    ],
-                }),
+                json.dumps(
+                    {
+                        "role": "user",
+                        "content": [
+                            _mention_block(doc_id, "Q3 Report"),
+                            {"type": "text", "text": "What were the key results?"},
+                        ],
+                    }
+                ),
                 user_msg.id,
             )
 
@@ -2656,10 +2774,14 @@ class TestMentionExpansion:
 
         try:
             terminal = [
-                (e[0], e[1]) for e in events if e[0] in ("end_of_stream", "stream_error")
+                (e[0], e[1])
+                for e in events
+                if e[0] in ("end_of_stream", "stream_error")
             ]
             assert terminal, "Expected a terminal event"
-            assert terminal[-1][0] == "end_of_stream", f"Unexpected terminal: {terminal[-1]}"
+            assert (
+                terminal[-1][0] == "end_of_stream"
+            ), f"Unexpected terminal: {terminal[-1]}"
 
             assert len(llm.calls) >= 1, "Expected at least 1 LLM call"
             provider_messages = llm.calls[0]["messages"]
@@ -2667,28 +2789,32 @@ class TestMentionExpansion:
             assert user_msgs, "Expected at least one user message in provider request"
             last_user = user_msgs[-1]
             content = last_user["content"]
-            assert isinstance(content, list), f"Expected list content, got {type(content)}"
+            assert isinstance(
+                content, list
+            ), f"Expected list content, got {type(content)}"
 
             text_blocks = [
                 b for b in content if isinstance(b, dict) and b.get("type") == "text"
             ]
             label_text = " ".join(b.get("text", "") for b in text_blocks)
-            assert 'Mentioned document: "Q3 Report"' in label_text, (
-                f"Mention label missing. Text blocks: {text_blocks}"
-            )
-            assert f"[_ref:{doc_id}]" in label_text, (
-                f"Document ref missing. Text blocks: {text_blocks}"
-            )
+            assert (
+                'Mentioned document: "Q3 Report"' in label_text
+            ), f"Mention label missing. Text blocks: {text_blocks}"
+            assert (
+                f"[_ref:{doc_id}]" in label_text
+            ), f"Document ref missing. Text blocks: {text_blocks}"
 
             doc_blocks = [
-                b for b in content if isinstance(b, dict) and b.get("type") == "document"
+                b
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "document"
             ]
             if doc_blocks:
                 src = doc_blocks[0].get("source", {})
                 if isinstance(src, dict) and src.get("type") == "text":
-                    assert document_text in src.get("data", ""), (
-                        "Document text not found in expanded document block"
-                    )
+                    assert document_text in src.get(
+                        "data", ""
+                    ), "Document text not found in expanded document block"
         finally:
             await self._cleanup_extra_rows(db_pool, source_id, content_id)
 
@@ -2707,18 +2833,27 @@ class TestMentionExpansion:
             await conn.execute(
                 "INSERT INTO sources (id, name, source_type, created_by) "
                 "VALUES ($1, $2, $3, $4)",
-                source_id, "test-source", "google_drive", user_id,
+                source_id,
+                "test-source",
+                "google_drive",
+                user_id,
             )
             await conn.execute(
                 "INSERT INTO documents (id, source_id, external_id, title, content, "
                 "permissions, content_type) "
                 "VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7)",
-                doc_id, source_id, f"ext-{doc_id}", "Confidential", "secret content",
-                json.dumps({
-                    "public": False,
-                    "users": ["someone-else@x.com"],
-                    "groups": [],
-                }),
+                doc_id,
+                source_id,
+                f"ext-{doc_id}",
+                "Confidential",
+                "secret content",
+                json.dumps(
+                    {
+                        "public": False,
+                        "users": ["someone-else@x.com"],
+                        "groups": [],
+                    }
+                ),
                 "text/plain",
             )
 
@@ -2727,13 +2862,15 @@ class TestMentionExpansion:
         async with db_pool.acquire() as conn:
             await conn.execute(
                 "UPDATE chat_messages SET message = $1::jsonb WHERE id = $2",
-                json.dumps({
-                    "role": "user",
-                    "content": [
-                        _mention_block(doc_id, "Confidential"),
-                        {"type": "text", "text": "Read this?"},
-                    ],
-                }),
+                json.dumps(
+                    {
+                        "role": "user",
+                        "content": [
+                            _mention_block(doc_id, "Confidential"),
+                            {"type": "text", "text": "Read this?"},
+                        ],
+                    }
+                ),
                 user_msg.id,
             )
 
@@ -2747,10 +2884,14 @@ class TestMentionExpansion:
 
         try:
             terminal = [
-                (e[0], e[1]) for e in events if e[0] in ("end_of_stream", "stream_error")
+                (e[0], e[1])
+                for e in events
+                if e[0] in ("end_of_stream", "stream_error")
             ]
             assert terminal, "Expected a terminal event"
-            assert terminal[-1][0] == "end_of_stream", f"Unexpected terminal: {terminal[-1]}"
+            assert (
+                terminal[-1][0] == "end_of_stream"
+            ), f"Unexpected terminal: {terminal[-1]}"
 
             assert len(llm.calls) >= 1, "Expected at least 1 LLM call"
             provider_messages = llm.calls[0]["messages"]
@@ -2791,21 +2932,31 @@ class TestMentionExpansion:
             await conn.execute(
                 "INSERT INTO sources (id, name, source_type, created_by) "
                 "VALUES ($1, $2, $3, $4)",
-                source_id, "test-source", "google_drive", user_id,
+                source_id,
+                "test-source",
+                "google_drive",
+                user_id,
             )
             content_bytes = document_text.encode("utf-8")
             await conn.execute(
                 "INSERT INTO content_blobs (id, content, size_bytes, storage_backend) "
                 "VALUES ($1, $2, $3, 'postgres')",
-                content_id, content_bytes, len(content_bytes),
+                content_id,
+                content_bytes,
+                len(content_bytes),
             )
             await conn.execute(
                 "INSERT INTO documents (id, source_id, external_id, title, content, "
                 "permissions, content_type, content_id) "
                 "VALUES ($1, $2, $3, $4, $5, $6::jsonb, $7, $8)",
-                doc_id, source_id, f"ext-{doc_id}", "Provider Doc", document_text,
+                doc_id,
+                source_id,
+                f"ext-{doc_id}",
+                "Provider Doc",
+                document_text,
                 json.dumps({"public": True, "users": [], "groups": []}),
-                "text/plain", content_id,
+                "text/plain",
+                content_id,
             )
 
         msgs = await MessagesRepository().get_active_path(chat_id)
@@ -2813,13 +2964,15 @@ class TestMentionExpansion:
         async with db_pool.acquire() as conn:
             await conn.execute(
                 "UPDATE chat_messages SET message = $1::jsonb WHERE id = $2",
-                json.dumps({
-                    "role": "user",
-                    "content": [
-                        _mention_block(doc_id, "Provider Doc"),
-                        {"type": "text", "text": "Summarize."},
-                    ],
-                }),
+                json.dumps(
+                    {
+                        "role": "user",
+                        "content": [
+                            _mention_block(doc_id, "Provider Doc"),
+                            {"type": "text", "text": "Summarize."},
+                        ],
+                    }
+                ),
                 user_msg.id,
             )
 
@@ -2856,7 +3009,9 @@ class TestMentionExpansion:
             # content — either as plain text from a document block (which
             # ``extract_text_document`` converts) or directly in a text block.
             doc_blocks = [
-                b for b in content if isinstance(b, dict) and b.get("type") == "document"
+                b
+                for b in content
+                if isinstance(b, dict) and b.get("type") == "document"
             ]
             all_text = label_text
             for db in doc_blocks:

--- a/services/ai/tests/integration/test_providers_api/test_anthropic.py
+++ b/services/ai/tests/integration/test_providers_api/test_anthropic.py
@@ -1,9 +1,17 @@
-"""Integration test for the Anthropic provider — one streaming call."""
+"""Integration test for the Anthropic provider — live tool-call round trip."""
 
+import json
 import os
-import pytest
+import re
 
-from tests.integration.test_providers_api.conftest import require_env, stream_usage, report_usage
+import pytest
+from anthropic.types import MessageParam
+
+from tests.integration.test_providers_api.conftest import (
+    require_env,
+    stream_usage,
+    report_usage,
+)
 from providers.anthropic import AnthropicProvider
 
 pytestmark = pytest.mark.real_llm
@@ -11,17 +19,150 @@ pytestmark = pytest.mark.real_llm
 API_KEY = require_env("TEST_ANTHROPIC_API_KEY")
 MODEL = os.environ.get("TEST_ANTHROPIC_MODEL", "claude-haiku-4-5")
 
+_WEATHER_TOOL = {
+    "name": "get_weather",
+    "description": "Get the current weather for a city.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}
+
+# Force extended thinking with the smallest legal budget so the test
+# deterministically exercises the thinking-block code path (Anthropic
+# requires budget_tokens >= 1024 and < max_tokens).
+_THINKING = {"type": "enabled", "budget_tokens": 1024}
+_MAX_TOKENS = 2048
+
+
+def _rebuild_assistant_blocks(
+    events: list,
+) -> tuple[list[dict], str | None, str | None]:
+    """Rebuild the assistant content blocks exactly as streamed, the way the
+    chat pipeline persists them (thinking + tool_use, in order).
+
+    Returns ``(blocks, tool_use_id, thinking_signature)``.
+    """
+    assistant_blocks: list[dict] = []
+    tool_use_id: str | None = None
+    thinking_sig: str | None = None
+    for event in events:
+        if event.type == "content_block_start":
+            block = event.content_block
+            if block.type == "tool_use":
+                tool_use_id = block.id
+                assistant_blocks.append(
+                    {
+                        "type": "tool_use",
+                        "id": block.id,
+                        "name": block.name,
+                        "input": "",
+                    }
+                )
+            elif block.type == "thinking":
+                assistant_blocks.append(
+                    {"type": "thinking", "thinking": block.thinking, "signature": ""}
+                )
+        elif event.type == "content_block_delta":
+            if event.delta.type == "input_json_delta":
+                tool_block = next(
+                    b for b in assistant_blocks if b["type"] == "tool_use"
+                )
+                tool_block["input"] += event.delta.partial_json
+            elif event.delta.type == "thinking_delta":
+                thinking_block = next(
+                    b for b in assistant_blocks if b["type"] == "thinking"
+                )
+                thinking_block["thinking"] += event.delta.thinking
+            elif event.delta.type == "signature_delta":
+                thinking_sig = event.delta.signature
+                thinking_block = next(
+                    b for b in assistant_blocks if b["type"] == "thinking"
+                )
+                thinking_block["signature"] = event.delta.signature
+    return assistant_blocks, tool_use_id, thinking_sig
+
 
 class TestAnthropic:
-    async def test_stream(self) -> None:
+    @pytest.mark.parametrize(
+        "thinking", [None, _THINKING], ids=["no-thinking", "thinking"]
+    )
+    async def test_stream(self, thinking: dict | None) -> None:
+        """Stream a forced tool call and continue with the tool result.
+
+        With ``thinking`` enabled, the model streams an extended-thinking
+        block before the tool_use, shifting the tool_use (and its input
+        deltas) to a higher content-block index.  The assistant message must
+        be rebuilt from the streamed blocks exactly, and the follow-up
+        request must be accepted by the API — this is the request shape that
+        failed with a 400 on ``tool_use.id`` when an empty id leaked into
+        the persisted history.
+        """
         provider = AnthropicProvider(api_key=API_KEY, model=MODEL)
+        messages: list[MessageParam] = [
+            {
+                "role": "user",
+                "content": "What is the weather in Bangalore? Use the get_weather tool.",
+            }
+        ]
+
         events = [
             e
             async for e in provider.stream_response(
-                "Count from one to three", max_tokens=30
+                prompt="",
+                messages=messages,
+                tools=[_WEATHER_TOOL],
+                max_tokens=_MAX_TOKENS,
+                thinking=thinking,
             )
         ]
         assert events[-1].type == "message_stop"
-        u = stream_usage(events)
+
+        assistant_blocks, tool_use_id, thinking_sig = _rebuild_assistant_blocks(events)
+
+        if thinking is not None:
+            assert thinking_sig, (
+                "Expected a thinking block with a signature "
+                "(thinking was enabled but no thinking block was streamed)"
+            )
+        assert tool_use_id is not None, "Model did not call get_weather"
+        assert re.fullmatch(
+            r"[a-zA-Z0-9_-]+", tool_use_id
+        ), f"Invalid tool_use id: {tool_use_id!r}"
+
+        # The API streams tool input as partial JSON; the pipeline persists
+        # it as a parsed object, which is what the follow-up request sends.
+        tool_block = next(b for b in assistant_blocks if b["type"] == "tool_use")
+        tool_block["input"] = json.loads(tool_block["input"])
+
+        # Continuation with the tool_result — must be accepted by the API.
+        continuation: list[MessageParam] = [
+            messages[0],
+            {"role": "assistant", "content": assistant_blocks},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use_id,
+                        "content": "The weather in Bangalore is sunny and 28C.",
+                    }
+                ],
+            },
+        ]
+        events2 = [
+            e
+            async for e in provider.stream_response(
+                prompt="",
+                messages=continuation,
+                tools=[_WEATHER_TOOL],
+                max_tokens=_MAX_TOKENS,
+                thinking=thinking,
+            )
+        ]
+        assert events2[-1].type == "message_stop"
+
+        u = stream_usage(events) or stream_usage(events2)
         if u:
             report_usage("Anthropic.stream", u[0], u[1])

--- a/services/ai/tests/integration/test_providers_api/test_gemini.py
+++ b/services/ai/tests/integration/test_providers_api/test_gemini.py
@@ -1,9 +1,17 @@
-"""Integration test for the Gemini provider — one streaming call."""
+"""Integration test for the Gemini provider — live tool-call round trip."""
 
+import json
 import os
-import pytest
+import re
 
-from tests.integration.test_providers_api.conftest import require_env, stream_usage, report_usage
+import pytest
+from anthropic.types import MessageParam
+
+from tests.integration.test_providers_api.conftest import (
+    require_env,
+    stream_usage,
+    report_usage,
+)
 from providers.gemini import GeminiProvider
 
 pytestmark = pytest.mark.real_llm
@@ -11,17 +19,114 @@ pytestmark = pytest.mark.real_llm
 API_KEY = require_env("TEST_GEMINI_API_KEY")
 MODEL = os.environ.get("TEST_GEMINI_MODEL", "gemini-2.5-flash")
 
+_WEATHER_TOOL = {
+    "name": "get_weather",
+    "description": "Get the current weather for a city.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}
+
 
 class TestGemini:
     async def test_stream(self) -> None:
+        """Stream a forced function call and continue with the tool result.
+
+        Gemini 3 attaches an opaque ``thought_signature`` to function-call
+        parts (thinking-with-tools); the provider encodes it as the
+        ``_gemini_thought_signature`` sidecar on the ``tool_use`` block,
+        which must survive the rebuild and round trip.  The follow-up
+        request must be accepted by the API.
+        """
         provider = GeminiProvider(api_key=API_KEY, model=MODEL)
+        messages: list[MessageParam] = [
+            {
+                "role": "user",
+                "content": "What is the weather in Bangalore? Use the get_weather tool.",
+            }
+        ]
+
         events = [
             e
             async for e in provider.stream_response(
-                "Count from one to three", max_tokens=30
+                prompt="",
+                messages=messages,
+                tools=[_WEATHER_TOOL],
+                max_tokens=512,
             )
         ]
         assert events[-1].type == "message_stop"
-        u = stream_usage(events)
+
+        # Rebuild the assistant content blocks exactly as streamed, the way
+        # the chat pipeline persists them (text/tool_use, in order).  The
+        # ``_gemini_thought_signature`` sidecar travels on the blocks.
+        assistant_blocks: list[dict] = []
+        tool_use_id: str | None = None
+        for event in events:
+            if event.type == "content_block_start":
+                block = event.content_block
+                if block.type == "tool_use":
+                    tool_use_id = block.id
+                    rebuilt = {
+                        "type": "tool_use",
+                        "id": block.id,
+                        "name": block.name,
+                        "input": "",
+                    }
+                    sig = getattr(block, "_gemini_thought_signature", None)
+                    if sig is not None:
+                        rebuilt["_gemini_thought_signature"] = sig
+                    assistant_blocks.append(rebuilt)
+                elif block.type == "text":
+                    assistant_blocks.append({"type": "text", "text": block.text})
+            elif event.type == "content_block_delta":
+                if event.delta.type == "input_json_delta":
+                    tool_block = next(
+                        b for b in assistant_blocks if b["type"] == "tool_use"
+                    )
+                    tool_block["input"] += event.delta.partial_json
+                elif event.delta.type == "text_delta":
+                    text_block = next(
+                        b for b in assistant_blocks if b["type"] == "text"
+                    )
+                    text_block["text"] += event.delta.text
+
+        assert tool_use_id is not None, "Model did not call get_weather"
+        assert re.fullmatch(
+            r"[a-zA-Z0-9_-]+", tool_use_id
+        ), f"Invalid tool_use id: {tool_use_id!r}"
+
+        tool_block = next(b for b in assistant_blocks if b["type"] == "tool_use")
+        tool_block["input"] = json.loads(tool_block["input"])
+
+        # Continuation with the tool_result — must be accepted by the API.
+        continuation: list[MessageParam] = [
+            messages[0],
+            {"role": "assistant", "content": assistant_blocks},
+            {
+                "role": "user",
+                "content": [
+                    {
+                        "type": "tool_result",
+                        "tool_use_id": tool_use_id,
+                        "content": "The weather in Bangalore is sunny and 28C.",
+                    }
+                ],
+            },
+        ]
+        events2 = [
+            e
+            async for e in provider.stream_response(
+                prompt="",
+                messages=continuation,
+                tools=[_WEATHER_TOOL],
+                max_tokens=512,
+            )
+        ]
+        assert events2[-1].type == "message_stop"
+
+        u = stream_usage(events) or stream_usage(events2)
         if u:
             report_usage("Gemini.stream", u[0], u[1])


### PR DESCRIPTION
- Fix content-index desync in the chat/agent stream loops when Anthropic models stream a thinking block before a tool_use: unhandled thinking blocks shifted block indexes, so tool input deltas landed on a synthetic tool_use with an empty id that the API rejects with a 400 (tool_use.id pattern violation)
- Persist thinking/redacted_thinking blocks with signatures in assistant messages so Anthropic can continue extended-thinking tool-use turns
- Count thinking text in compaction token estimation
- Add a regression integration test for the thinking-before-tool_use event sequence, and rework the live Anthropic/Gemini provider tests to cover tool-call round trips with and without forced thinking