### PR TITLE
fix(ai): sanitize tool schemas before sending to Gemini

### DIFF
--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -47,14 +47,6 @@ def _gemini_status_code(e: BaseException) -> int | None:
     return e.code if isinstance(e, APIError) else None
 
 
-def _gemini_context_overflow(e: BaseException) -> bool:
-    return (
-        isinstance(e, APIError)
-        and e.code == 400
-        and "too many tokens" in str(e).lower()
-    )
-
-
 logger = logging.getLogger(__name__)
 
 THOUGHT_SIGNATURE_KEY = "_gemini_thought_signature"
@@ -468,7 +460,6 @@ class GeminiProvider(LLMProvider):
                 model=model or self.model_name,
                 status_code=_gemini_status_code(e),
                 cause=e,
-                is_context_overflow=_gemini_context_overflow(e),
             ) from e
 
     async def generate_response(
@@ -513,7 +504,6 @@ class GeminiProvider(LLMProvider):
                 model=model or self.model_name,
                 status_code=_gemini_status_code(e),
                 cause=e,
-                is_context_overflow=_gemini_context_overflow(e),
             ) from e
 
     async def health_check(

--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -48,12 +48,70 @@ def _gemini_status_code(e: BaseException) -> int | None:
 
 
 def _gemini_context_overflow(e: BaseException) -> bool:
-    return isinstance(e, APIError) and e.code == 400 and "too many tokens" in str(e).lower()
+    return (
+        isinstance(e, APIError)
+        and e.code == 400
+        and "too many tokens" in str(e).lower()
+    )
 
 
 logger = logging.getLogger(__name__)
 
 THOUGHT_SIGNATURE_KEY = "_gemini_thought_signature"
+
+# Fields the Gemini Schema proto accepts and whose wire names match what the
+# genai SDK emits. The SDK validates `parameters` dicts into its `Schema` model
+# and serializes the request with model_dump()'s default by_alias=False, so any
+# Schema field whose Python name differs from its wire name (additionalProperties,
+# anyOf, minItems, ...) reaches the API in snake_case and is rejected with
+# "Unknown name \"additional_properties\" ... 400 INVALID_ARGUMENT". Connector
+# action schemas commonly declare `additionalProperties: false`, so we strip
+# every key outside this set before building FunctionDeclarations.
+_GEMINI_SCHEMA_SAFE_FIELDS = frozenset(
+    {
+        "type",
+        "format",
+        "description",
+        "nullable",
+        "enum",
+        "default",
+        "items",
+        "properties",
+        "required",
+        "minimum",
+        "maximum",
+        "example",
+        "pattern",
+        "title",
+        "ref",
+        "defs",
+    }
+)
+
+
+def _sanitize_schema_for_gemini(schema: Any) -> Any:
+    """Restrict a tool input_schema to keys Gemini's Schema proto can round-trip.
+
+    Recurses into ``properties`` (property names are preserved) and ``items``,
+    dropping JSON-Schema keywords the Gemini API does not accept and fields the
+    genai SDK serializes with snake_case names.
+    """
+    if isinstance(schema, dict):
+        sanitized: dict[str, Any] = {}
+        for key, value in schema.items():
+            if key not in _GEMINI_SCHEMA_SAFE_FIELDS:
+                continue
+            if key == "properties" and isinstance(value, dict):
+                sanitized[key] = {
+                    name: _sanitize_schema_for_gemini(prop_schema)
+                    for name, prop_schema in value.items()
+                }
+            else:
+                sanitized[key] = _sanitize_schema_for_gemini(value)
+        return sanitized
+    if isinstance(schema, list):
+        return [_sanitize_schema_for_gemini(item) for item in schema]
+    return schema
 
 
 def _convert_tools_to_gemini(tools: list[dict[str, Any]]) -> list[types.Tool]:
@@ -64,7 +122,7 @@ def _convert_tools_to_gemini(tools: list[dict[str, Any]]) -> list[types.Tool]:
             types.FunctionDeclaration(
                 name=tool["name"],
                 description=tool.get("description", ""),
-                parameters=tool.get("input_schema"),
+                parameters=_sanitize_schema_for_gemini(tool.get("input_schema")),
             )
         )
     return [types.Tool(function_declarations=declarations)]
@@ -237,7 +295,9 @@ class GeminiProvider(LLMProvider):
                 )
                 return self._context_window_info
         except Exception as e:
-            logger.debug("Failed to fetch Gemini model metadata for %s: %s", self.model, e)
+            logger.debug(
+                "Failed to fetch Gemini model metadata for %s: %s", self.model, e
+            )
         self._context_window_info = await super().get_context_window_tokens()
         return self._context_window_info
 

--- a/services/ai/tests/integration/test_providers_api/test_gemini.py
+++ b/services/ai/tests/integration/test_providers_api/test_gemini.py
@@ -29,6 +29,28 @@ _WEATHER_TOOL = {
     },
 }
 
+# Mirrors a connector action schema (e.g. darwinbox) that declares
+# `additionalProperties: false`. The genai SDK serializes that key as the
+# snake_case `additional_properties`, which the Gemini API rejects with a 400
+# INVALID_ARGUMENT — the provider must strip it before sending. Keeping it in
+# the live round trip guards that path end-to-end: if sanitization regresses,
+# this request 400s before a single event streams.
+_DARWINBOX_STYLE_TOOL = {
+    "name": "darwinbox__get_attendance",
+    "description": "Get attendance for the calling employee.",
+    "input_schema": {
+        "type": "object",
+        "properties": {
+            "from_date": {"type": "string"},
+            "to_date": {"type": "string"},
+            "month": {"type": "string"},
+        },
+        "additionalProperties": False,
+    },
+}
+
+_TOOLS = [_WEATHER_TOOL, _DARWINBOX_STYLE_TOOL]
+
 
 class TestGemini:
     async def test_stream(self) -> None:
@@ -39,6 +61,10 @@ class TestGemini:
         ``_gemini_thought_signature`` sidecar on the ``tool_use`` block,
         which must survive the rebuild and round trip.  The follow-up
         request must be accepted by the API.
+
+        The tool list also includes a darwinbox-style schema with
+        ``additionalProperties: false`` (see ``_DARWINBOX_STYLE_TOOL``) to
+        guard the provider's schema sanitization against the real API.
         """
         provider = GeminiProvider(api_key=API_KEY, model=MODEL)
         messages: list[MessageParam] = [
@@ -53,7 +79,7 @@ class TestGemini:
             async for e in provider.stream_response(
                 prompt="",
                 messages=messages,
-                tools=[_WEATHER_TOOL],
+                tools=_TOOLS,
                 max_tokens=512,
             )
         ]
@@ -121,7 +147,7 @@ class TestGemini:
             async for e in provider.stream_response(
                 prompt="",
                 messages=continuation,
-                tools=[_WEATHER_TOOL],
+                tools=_TOOLS,
                 max_tokens=512,
             )
         ]

--- a/services/ai/tests/unit/test_gemini_provider.py
+++ b/services/ai/tests/unit/test_gemini_provider.py
@@ -4,7 +4,7 @@ import json
 
 import pytest
 
-from providers.gemini import _convert_messages_to_gemini
+from providers.gemini import _convert_messages_to_gemini, _convert_tools_to_gemini
 
 pytestmark = pytest.mark.unit
 
@@ -44,6 +44,125 @@ def test_convert_messages_does_not_forward_search_result_extras():
     internal_search_result = messages[0]["content"][0]["content"][0]
     assert internal_search_result["source_type"] == "jira"
     assert internal_search_result["internal_extra"] == "must-not-be-sent"
+
+
+def _darwinbox_style_tools() -> list[dict]:
+    return [
+        {
+            "name": "search_documents",
+            "description": "Search the Omni index",
+            "input_schema": {
+                "type": "object",
+                "properties": {"query": {"type": "string"}},
+                "required": ["query"],
+            },
+        },
+        {
+            "name": "darwinbox__attendance",
+            "description": "Fetch attendance",
+            "input_schema": {
+                "type": "object",
+                "properties": {"year": {"type": "string"}},
+                "additionalProperties": False,
+            },
+        },
+        {
+            "name": "darwinbox__apply_leave",
+            "description": "Apply for leave",
+            "input_schema": {
+                "type": "object",
+                "properties": {
+                    "leave_name": {
+                        "type": "string",
+                        "enum": ["Casual", "Sick"],
+                        "default": "Casual",
+                    },
+                    "tags": {"type": "array", "items": {"type": "string"}},
+                },
+                "required": ["leave_name"],
+                "additionalProperties": False,
+                "additional_properties": False,
+                "minItems": 1,
+                "min_items": 1,
+                "oneOf": [{"type": "string"}],
+                "anyOf": [{"type": "string"}],
+                "$schema": "http://json-schema.org/draft-07/schema#",
+            },
+        },
+    ]
+
+
+def test_convert_tools_strips_schema_keys_gemini_cannot_round_trip():
+    converted = _convert_tools_to_gemini(_darwinbox_style_tools())
+    declarations = converted[0].function_declarations
+    assert [d.name for d in declarations] == [
+        "search_documents",
+        "darwinbox__attendance",
+        "darwinbox__apply_leave",
+    ]
+
+    # model_dump() with default by_alias=False is exactly how the genai SDK
+    # serializes Schema fields to the wire, so any key that survives must be
+    # one the API accepts as-is (no snake_case field names, no extras).
+    dumped = json.dumps(
+        [d.model_dump(mode="json", exclude_none=True) for d in declarations]
+    )
+    assert "additionalProperties" not in dumped
+    assert "additional_properties" not in dumped
+    assert "oneOf" not in dumped
+    assert "anyOf" not in dumped
+    assert "any_of" not in dumped
+    assert "minItems" not in dumped
+    assert "min_items" not in dumped
+    assert "$schema" not in dumped
+
+    params = declarations[2].parameters
+    assert params.type == "OBJECT"
+    assert params.required == ["leave_name"]
+    assert params.properties["leave_name"].enum == ["Casual", "Sick"]
+    assert params.properties["leave_name"].default == "Casual"
+    assert params.properties["tags"].items.type == "STRING"
+
+
+def test_gemini_wire_payload_has_no_snake_case_schema_keys():
+    """Regression test for the 400 INVALID_ARGUMENT on function_declarations[N].parameters.
+
+    Connector action schemas declare ``additionalProperties: false``; the genai
+    SDK validates parameters into its Schema model and serializes it with
+    model_dump(by_alias=False), which turns the field into
+    ``additional_properties`` on the wire. The API rejects that unknown name.
+    """
+    from google import genai
+    from google.genai import types
+    import google.genai._common as _common
+    import google.genai.models as _models
+
+    client = genai.Client(api_key="fake")
+    config = types.GenerateContentConfig(max_output_tokens=4096)
+    config.tools = _convert_tools_to_gemini(_darwinbox_style_tools())
+    parameters = types._GenerateContentParameters(
+        model="gemini-2.5-flash", contents="hi", config=config
+    )
+
+    request_dict = _models._GenerateContentParameters_to_mldev(
+        client, parameters, None, parameters
+    )
+    request_dict.pop("config", None)
+    request_dict = _common.convert_to_dict(request_dict)
+    request_dict = _common.encode_unserializable_types(request_dict)
+    wire = json.dumps(request_dict)
+
+    assert "additional_properties" not in wire
+    assert "additionalProperties" not in wire
+    assert "oneOf" not in wire
+    assert "min_items" not in wire
+
+    tool = request_dict["tools"][0]["functionDeclarations"]
+    attendance = next(d for d in tool if d["name"] == "darwinbox__attendance")
+    assert attendance["parameters"] == {
+        "type": "OBJECT",
+        "properties": {"year": {"type": "STRING"}},
+    }
 
 
 def test_convert_messages_handles_only_user_text_documents():


### PR DESCRIPTION
- Gemini tool calls fail with 400 INVALID_ARGUMENT: the genai SDK serializes Schema fields by field name, so connector action schemas declaring `additionalProperties: false` reach the API as `additional_properties`, which the API rejects.
- Filter each tool `input_schema` down to fields the Gemini Schema proto can round-trip (`type`, `properties`, `required`, `enum`, `minimum`, `maximum`, `default`, etc.) before building function declarations; also protects against other snake_case-mangled keys like `anyOf`/`minItems` and fixes the same bug on the Vertex AI path, which delegates to the Gemini provider.
- Add unit tests asserting the exact wire serialization contains no snake_case keys, and include a darwinbox-style `additionalProperties: false` schema in the live Gemini tool-call integration test (verified against the real API).