### PR TITLE
fix(ai): skip OAuth prompt for org-only connectors like darwinbox

### DIFF
--- a/services/ai/tests/unit/test_oauth_required.py
+++ b/services/ai/tests/unit/test_oauth_required.py
@@ -66,6 +66,56 @@ async def test_manifest_preserves_undeclared_and_explicit_empty_action_scopes():
     assert by_name["explicit_empty"].required_scopes == []
 
 
+@pytest.mark.asyncio
+async def test_manifest_oauth_field_populates_supports_user_oauth():
+    source_darwinbox = Source(
+        id="src-db",
+        source_type="darwinbox",
+        name="Darwinbox",
+        is_active=True,
+        is_deleted=False,
+    )
+    source_gmail = Source(
+        id="src-gm",
+        source_type="gmail",
+        name="Gmail",
+        is_active=True,
+        is_deleted=False,
+    )
+    handler = ConnectorToolHandler(
+        connector_manager_url="http://cm.test",
+        user_id="user-1",
+        prefetched_sources=[source_darwinbox, source_gmail],
+    )
+    manifests = [
+        {
+            "source_type": "darwinbox",
+            "healthy": True,
+            "manifest": {
+                "actions": [{"name": "get_my_leave_balance"}],
+            },
+        },
+        {
+            "source_type": "gmail",
+            "healthy": True,
+            "manifest": {
+                "oauth": {"provider": "google"},
+                "actions": [{"name": "send_email"}],
+            },
+        },
+    ]
+
+    with respx.mock(assert_all_called=True) as mock:
+        mock.get("http://cm.test/connectors").mock(
+            return_value=Response(200, json=manifests)
+        )
+        actions = await handler._fetch_actions()
+
+    by_name = {action.action_name: action for action in actions}
+    assert by_name["get_my_leave_balance"].supports_user_oauth is False
+    assert by_name["send_email"].supports_user_oauth is True
+
+
 def _register_action(handler: ConnectorToolHandler, source_id: str) -> None:
     """Force a fake gmail__send_email action so the handler can dispatch."""
     handler._actions["gmail__send_email"] = ConnectorAction(
@@ -81,11 +131,40 @@ def _register_action(handler: ConnectorToolHandler, source_id: str) -> None:
 
 
 class _CredentialConnection:
-    def __init__(self, credential: dict) -> None:
+    def __init__(
+        self, credential: dict | _QueryRoutingConnection
+    ) -> None:
         self.credential = credential
 
-    async def fetchrow(self, _query: str, *_args: object) -> dict:
+    async def fetchrow(self, query: str, *_args: object) -> dict | None:
+        if isinstance(self.credential, _QueryRoutingConnection):
+            return await self.credential.fetchrow(query, *_args)
         return self.credential
+
+
+class _QueryRoutingConnection:
+    """Routes fetchrow calls by SQL shape so a single mock connection can
+    answer the user-credential, source, and org-credential queries that
+    `check_oauth_required` issues when no per-user row exists."""
+
+    def __init__(
+        self,
+        user_credential: dict | None,
+        source_row: dict | None,
+        org_credential: dict | None,
+    ) -> None:
+        self.user_credential = user_credential
+        self.source_row = source_row
+        self.org_credential = org_credential
+
+    async def fetchrow(self, query: str, *_args: object) -> dict | None:
+        if "user_id IS NULL" in query:
+            return self.org_credential
+        if "FROM service_credentials" in query:
+            return self.user_credential
+        if "FROM sources" in query:
+            return self.source_row
+        raise AssertionError(f"unexpected query: {query}")
 
 
 class _AcquireConnection:
@@ -197,6 +276,94 @@ class TestConnectorHandlerOAuthRequired:
         )
 
         assert payload is None
+
+    @pytest.mark.asyncio
+    async def test_org_only_connector_without_user_credential_does_not_require_oauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """Darwinbox-style connectors (no per-user OAuth flow) must not
+        surface an OAuth prompt when the caller lacks a per-user row: the
+        org credential is used and the action executes. Mirrors
+        connector-manager's resolve_missing_user_credential."""
+        handler = ConnectorToolHandler(
+            connector_manager_url="http://cm.test",
+            user_id="user-1",
+        )
+        handler._actions["darwinbox__get_my_leave_balance"] = ConnectorAction(
+            source_id="src-1",
+            source_type="darwinbox",
+            source_name="Darwinbox",
+            action_name="get_my_leave_balance",
+            description="Get leave balances",
+            input_schema={"type": "object", "properties": {}},
+            mode="read",
+            supports_user_oauth=False,
+        )
+        handler._initialized = True
+
+        async def fake_get_db_pool() -> _CredentialPool:
+            return _CredentialPool(
+                _QueryRoutingConnection(
+                    user_credential=None,
+                    source_row={"integration_type": "connector", "config": {}},
+                    org_credential={"provider": "darwinbox"},
+                )
+            )
+
+        monkeypatch.setattr(connector_handler_module, "get_db_pool", fake_get_db_pool)
+
+        payload = await handler.check_oauth_required(
+            "darwinbox__get_my_leave_balance",
+            {},
+            ToolContext(chat_id="c1", user_id="user-1"),
+        )
+
+        assert payload is None
+
+    @pytest.mark.asyncio
+    async def test_oauth_connector_without_user_credential_requires_oauth(
+        self, monkeypatch: pytest.MonkeyPatch
+    ):
+        """OAuth connectors (supports_user_oauth) keep the existing behavior:
+        no per-user row + org credential -> OAuth prompt with the CTA."""
+        handler = ConnectorToolHandler(
+            connector_manager_url="http://cm.test",
+            user_id="user-1",
+        )
+        handler._actions["gmail__send_email"] = ConnectorAction(
+            source_id="src-1",
+            source_type="gmail",
+            source_name="Gmail",
+            action_name="send_email",
+            description="Send an email",
+            input_schema={"type": "object", "properties": {}},
+            mode="write",
+            supports_user_oauth=True,
+        )
+        handler._initialized = True
+
+        async def fake_get_db_pool() -> _CredentialPool:
+            return _CredentialPool(
+                _QueryRoutingConnection(
+                    user_credential=None,
+                    source_row={"integration_type": "connector", "config": {}},
+                    org_credential={"provider": "google"},
+                )
+            )
+
+        monkeypatch.setattr(connector_handler_module, "get_db_pool", fake_get_db_pool)
+
+        payload = await handler.check_oauth_required(
+            "gmail__send_email",
+            {},
+            ToolContext(chat_id="c1", user_id="user-1"),
+        )
+
+        assert payload is not None
+        assert payload.source_id == "src-1"
+        assert payload.source_type == "gmail"
+        assert payload.provider == "google"
+        assert payload.oauth_start_url == "/api/oauth/start?source_id=src-1"
 
     @pytest.mark.asyncio
     async def test_412_response_produces_structured_oauth_required(self):

--- a/services/ai/tools/connector_handler.py
+++ b/services/ai/tools/connector_handler.py
@@ -103,6 +103,10 @@ class ConnectorAction:
     admin_only: bool = False
     hidden: bool = False
     integration_type: str = "connector"
+    # True when the connector declares a per-user OAuth flow (manifest.oauth).
+    # Org-only connectors (e.g. Darwinbox) run actions against the org
+    # credential and must never surface an OAuth prompt.
+    supports_user_oauth: bool = False
 
 
 class ConnectorToolHandler:
@@ -276,6 +280,7 @@ class ConnectorToolHandler:
                             admin_only=action_def.get("admin_only", False),
                             hidden=action_def.get("hidden", False),
                             integration_type=integration_type,
+                            supports_user_oauth=bool(manifest.get("oauth")),
                         )
                     )
 
@@ -489,6 +494,12 @@ class ConnectorToolHandler:
             provider = "remote_mcp"
         else:
             if org_credential is None:
+                return None
+            # Connectors without a per-user OAuth flow (e.g. Darwinbox) run
+            # against the org credential; connector-manager resolves the same
+            # way (`resolve_missing_user_credential`), so an OAuth prompt here
+            # would dead-end an action that would otherwise execute.
+            if not action.supports_user_oauth:
                 return None
             provider = org_credential["provider"]
 


### PR DESCRIPTION
- Gate the pre-execution OAuth check on `manifest.oauth`: omni-ai no longer prompts for per-user auth on connectors like Darwinbox that have no per-user OAuth flow
- Darwinbox actions (e.g. `get_my_leave_balance`) no longer dead-end in a spurious "needs auth" state — connector-manager already runs them against the org credential
- Read `supports_user_oauth` from the same `manifest.oauth` field connector-manager's `resolve_missing_user_credential` uses, keeping both sides' decisions in sync
- Add unit tests for manifest flag population and the org-only vs OAuth decision paths