### PR TITLE
fix(chat): persist stream errors on failed assistant turns to survive reloads

### DIFF
--- a/services/ai/db/messages.py
+++ b/services/ai/db/messages.py
@@ -5,7 +5,7 @@ import asyncpg
 from asyncpg import Pool
 import json
 
-from .models import ChatMessage
+from .models import ChatMessage, ChatMessageError
 from .connection import get_db_pool
 
 
@@ -86,8 +86,58 @@ class MessagesRepository:
                 message_id,
             )
 
+    async def update_error(
+        self, message_id: str, error: Optional[ChatMessageError] = None
+    ) -> None:
+        """Set the `error` column for a chat_messages row.
+
+        Used to mark an assistant turn as failed when no partial content was
+        produced (so the row carries the error without a content update).
+        """
+        pool = await self._get_pool()
+        serialized = _sanitize_jsonb_value(error)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE chat_messages SET error = $1 WHERE id = $2",
+                json.dumps(serialized) if serialized is not None else None,
+                message_id,
+            )
+
+    async def finalize_error(
+        self,
+        message_id: str,
+        message: Dict[str, Any],
+        error: ChatMessageError,
+    ) -> None:
+        """Finalize an assistant row as a failed turn in one atomic UPDATE.
+
+        Writes `message` (partial content), the derived BM25 `content_text`,
+        and `error` together so an interrupted stream can never leave partial
+        content without its error (or vice versa).
+        """
+        pool = await self._get_pool()
+        message = _sanitize_jsonb_value(message)
+        content_text = _extract_content_text(message)
+        serialized_error = _sanitize_jsonb_value(error)
+        async with pool.acquire() as conn:
+            await conn.execute(
+                """
+                UPDATE chat_messages
+                SET message = $1, content_text = $2, error = $3
+                WHERE id = $4
+                """,
+                json.dumps(message),
+                content_text,
+                json.dumps(serialized_error),
+                message_id,
+            )
+
     async def create(
-        self, chat_id: str, message: Dict[str, Any], parent_id: Optional[str] = None
+        self,
+        chat_id: str,
+        message: Dict[str, Any],
+        parent_id: Optional[str] = None,
+        error: Optional[ChatMessageError] = None,
     ) -> ChatMessage:
         """Create a new message in a chat"""
         pool = await self._get_pool()
@@ -103,14 +153,15 @@ class MessagesRepository:
 
         message = _sanitize_jsonb_value(message)
         content_text = _extract_content_text(message)
+        serialized_error = _sanitize_jsonb_value(error)
 
         async with pool.acquire() as conn:
             next_seq = await conn.fetchval(seq_query, chat_id)
 
             query = """
-                INSERT INTO chat_messages (id, chat_id, message_seq_num, message, parent_id, content_text, created_at)
-                VALUES ($1, $2, $3, $4, $5, $6, NOW())
-                RETURNING id, chat_id, message_seq_num, message, parent_id, created_at
+                INSERT INTO chat_messages (id, chat_id, message_seq_num, message, parent_id, content_text, error, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, NOW())
+                RETURNING id, chat_id, message_seq_num, message, parent_id, content_text, error, created_at
             """
 
             row = await conn.fetchrow(
@@ -121,6 +172,7 @@ class MessagesRepository:
                 json.dumps(message),
                 parent_id,
                 content_text,
+                json.dumps(serialized_error) if serialized_error is not None else None,
             )
 
         return ChatMessage.from_row(dict(row))
@@ -143,7 +195,7 @@ class MessagesRepository:
         pool = await self._get_pool()
 
         query = """
-            SELECT id, chat_id, message_seq_num, message, parent_id, created_at
+            SELECT id, chat_id, message_seq_num, message, parent_id, error, created_at
             FROM chat_messages
             WHERE chat_id = $1
             ORDER BY message_seq_num
@@ -165,7 +217,7 @@ class MessagesRepository:
         query = """
             WITH RECURSIVE walk_up AS (
                 -- Start from the latest leaf (no children, highest seq num)
-                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.created_at
+                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.error, cm.created_at
                 FROM (
                     SELECT *
                     FROM chat_messages
@@ -181,7 +233,7 @@ class MessagesRepository:
                 UNION ALL
 
                 -- Walk up to root via parent_id
-                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.created_at
+                SELECT cm.id, cm.chat_id, cm.message_seq_num, cm.message, cm.parent_id, cm.error, cm.created_at
                 FROM chat_messages cm
                 JOIN walk_up wu ON cm.id = wu.parent_id
             )

--- a/services/ai/db/models.py
+++ b/services/ai/db/models.py
@@ -4,7 +4,7 @@ from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
-from typing import Any, cast
+from typing import Any, NotRequired, TypedDict, cast
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from crypto import decrypt_config
@@ -429,6 +429,20 @@ class Source:
         )
 
 
+class ChatMessageError(TypedDict):
+    """Error payload persisted on the ``chat_messages.error`` column.
+
+    Mirrors the wire shape of the SSE ``stream_error`` event (see
+    ``streaming.persist.StreamErrorEvent``) so persisted and streamed errors
+    stay structurally identical.
+    """
+
+    message: str
+    provider: NotRequired[str]
+    model: NotRequired[str]
+    statusCode: NotRequired[int | None]
+
+
 @dataclass
 class ChatMessage:
     id: str
@@ -437,12 +451,16 @@ class ChatMessage:
     message: dict[str, Any]  # Full JSONB message content
     created_at: datetime
     parent_id: str | None = None
+    error: ChatMessageError | None = None
 
     @classmethod
     def from_row(cls, row: dict) -> "ChatMessage":
         """Create ChatMessage from database row"""
         if isinstance(row["message"], str):
             row["message"] = json.loads(row["message"])
+        error = row.get("error")
+        if isinstance(error, str):
+            error = json.loads(error) if error else None
         return cls(
             id=row["id"],
             chat_id=row["chat_id"],
@@ -450,6 +468,7 @@ class ChatMessage:
             message=row["message"],
             created_at=row["created_at"],
             parent_id=row.get("parent_id"),
+            error=error,
         )
 
     def to_dict(self) -> dict:
@@ -460,5 +479,6 @@ class ChatMessage:
             "message_seq_num": self.message_seq_num,
             "message": self.message,
             "parent_id": self.parent_id,
+            "error": self.error,
             "created_at": self.created_at.isoformat(),
         }

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -52,6 +52,7 @@ from streaming.persist import (
     oauth_event,
     parse_tool_call_inputs,
     partial_assistant_message,
+    save_error_sse,
     sse_event,
     stream_error_sse,
 )
@@ -524,6 +525,7 @@ async def prepare_and_stream_chat(
             exc,
             exc_info=True,
         )
+        yield save_error_sse(exc)
         yield stream_error_sse(exc)
     finally:
         continue_compaction.set()
@@ -1244,9 +1246,14 @@ async def stream_generator(
         raise
     except Exception as e:
         logger.error(f"Failed to generate AI response with tools: {e}", exc_info=True)
+        partial = None
         if not content_blocks_finalized:
             partial = partial_assistant_message(content_blocks)
             if partial is not None:
                 conversation_messages.append(partial)
-                yield f"event: save_message\ndata: {json.dumps(partial)}\n\n"
+        # Persist the failed turn even when the assistant row was already
+        # finalized (e.g. an exception raised during tool preflight/execution
+        # after the tool-call content was saved): ``persist_and_transform``
+        # creates a dedicated error row for it under the current parent.
+        yield save_error_sse(e, partial_message=partial)
         yield stream_error_sse(e)

--- a/services/ai/streaming/persist.py
+++ b/services/ai/streaming/persist.py
@@ -138,6 +138,20 @@ def stream_error_sse(exc: Exception) -> str:
     return sse_event("stream_error", _chat_error_payload(exc))
 
 
+def save_error_sse(exc: Exception, partial_message: MessageParam | None = None) -> str:
+    """Build the internal ``save_error`` event that persists a failed turn.
+
+    ``partial_message`` carries any assistant content streamed before the
+    failure; ``persist_and_transform`` writes it together with the error so the
+    failed turn keeps its partial output. The event is consumed server-side and
+    never forwarded to the browser.
+    """
+    payload: dict[str, Any] = {"error": _chat_error_payload(exc)}
+    if partial_message is not None:
+        payload["message"] = partial_message
+    return sse_event("save_error", payload)
+
+
 def end_of_stream(reason: EndOfStreamReason, *, message: str | None = None) -> str:
     """Build a typed ``end_of_stream`` SSE event string."""
     payload: EndOfStreamEvent = {"reason": reason}
@@ -377,6 +391,47 @@ async def persist_and_transform(gen, chat_id, messages_repo, parent_id):
             except Exception as e:
                 logger.error(
                     f"Failed to persist streamed message for chat {chat_id}: {e}",
+                    exc_info=True,
+                )
+            continue
+
+        if event_type == "save_error":
+            try:
+                payload = json.loads(event_data)
+                error = payload.get("error")
+                partial = payload.get("message")
+                if current_assistant_message_id:
+                    # The turn started streaming (message_start) before it
+                    # failed: finalize that same row atomically with any partial
+                    # content plus the error, so it is never deleted by the
+                    # generator-end cleanup below.
+                    if partial is not None:
+                        await messages_repo.finalize_error(
+                            current_assistant_message_id, partial, error
+                        )
+                    else:
+                        await messages_repo.update_error(
+                            current_assistant_message_id, error
+                        )
+                    current_assistant_message_id = None
+                else:
+                    # The run failed before any message_start (e.g. during
+                    # conversation prep): persist the failed turn as a new
+                    # assistant error row under the current parent.
+                    content = (
+                        partial.get("content", []) if partial is not None else []
+                    )
+                    created = await messages_repo.create(
+                        chat_id,
+                        {"role": "assistant", "content": content},
+                        parent_id=parent_id,
+                        error=error,
+                    )
+                    parent_id = created.id
+                    yield f"event: message_id\ndata: {created.id}\n\n"
+            except Exception as e:
+                logger.error(
+                    f"Failed to persist stream error for chat {chat_id}: {e}",
                     exc_info=True,
                 )
             continue

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -37,6 +37,7 @@ from db.tool_approvals import (
     ToolApprovalType,
 )
 from routers import chat_router
+from services.compaction import ConversationCompactor
 from state import AppState
 from tests.helpers import (
     GatedRecordingLLM,
@@ -922,6 +923,302 @@ class TestLockAndHeartbeat:
             "model": model_id,
             "statusCode": 429,
         }
+
+
+# =============================================================================
+# Stream error persistence
+# =============================================================================
+
+
+class TestStreamErrorPersistence:
+    """A failed turn is persisted as an assistant row with the `error` column
+    set, so a page reload still shows the error."""
+
+    @pytest.mark.asyncio
+    async def test_provider_error_persists_error_column(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """ProviderError before any content → a new assistant error row is
+        persisted with empty content and the error payload matching the
+        stream_error SSE event."""
+        from providers.types import ProviderError, ProviderType
+
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [("text", "unused")],
+            model_id,
+            fail_on_call=0,
+            fail_exc=ProviderError(
+                "Rate limited",
+                provider_type=ProviderType.ANTHROPIC,
+                model=model_id,
+                status_code=429,
+            ),
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        stream_errors = [
+            json.loads(data)
+            for event_type, data, _sid in events
+            if event_type == "stream_error"
+        ]
+        assert stream_errors, f"Expected stream_error, got events: {events}"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        failed = db_msgs[-1]
+        assert failed.message["role"] == "assistant"
+        assert failed.error == stream_errors[-1], (
+            f"Persisted error {failed.error} != stream_error payload "
+            f"{stream_errors[-1]}"
+        )
+        assert failed.message["content"] == []
+        # Only the seeded user message + the failed turn are on the active path.
+        assert len(db_msgs) == 2, f"Expected 2 messages, got {len(db_msgs)}"
+
+    @pytest.mark.asyncio
+    async def test_partial_content_before_error_is_finalized_with_error(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Content streamed before a mid-stream failure is persisted on the
+        SAME row as the error (atomic finalize), and the row survives the
+        generator-end cleanup (no empty duplicate row)."""
+        from anthropic.types import (
+            RawContentBlockDeltaEvent,
+            RawContentBlockStartEvent,
+            TextBlock,
+            TextDelta,
+        )
+
+        from providers.types import ProviderError, ProviderType
+        from tests.helpers import message_start_event
+
+        chat_id, _user_id, model_id = seeded_chat
+
+        class PartialThenFailLLM(GatedRecordingLLM):
+            async def stream_response(self, **kwargs):
+                self.calls.append({"kwargs": kwargs})
+                yield message_start_event()
+                yield RawContentBlockStartEvent(
+                    type="content_block_start",
+                    index=0,
+                    content_block=TextBlock(type="text", text=""),
+                )
+                yield RawContentBlockDeltaEvent(
+                    type="content_block_delta",
+                    index=0,
+                    delta=TextDelta(type="text_delta", text="Partial answer"),
+                )
+                raise ProviderError(
+                    "Connection reset mid-stream",
+                    provider_type=ProviderType.ANTHROPIC,
+                    model=model_id,
+                    status_code=500,
+                )
+
+        llm = PartialThenFailLLM([("text", "unused")], model_id)
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            event_type == "stream_error" for event_type, _d, _sid in events
+        ), f"Expected stream_error, got events: {events}"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assert len(db_msgs) == 2, (
+            f"Expected user + one finalized error row, got {len(db_msgs)} rows"
+        )
+        failed = db_msgs[-1]
+        assert failed.error is not None, "Error column not persisted"
+        assert failed.error["message"] == (
+            "Failed to generate response: Connection reset mid-stream"
+        )
+        text = " ".join(
+            b.get("text", "")
+            for b in failed.message.get("content", [])
+            if b.get("type") == "text"
+        )
+        assert text == "Partial answer", f"Partial content lost: {text!r}"
+
+    @pytest.mark.asyncio
+    async def test_tool_loop_error_uses_last_persisted_parent(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """An error in a later iteration after a completed tool-call turn
+        persists a SEPARATE error row whose parent is the last persisted row,
+        not the request-time parent."""
+        from providers.types import ProviderError, ProviderType
+
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": "search_documents",
+                        "input": {"query": "multi-turn"},
+                        "id": "toolu_mt",
+                    },
+                ),
+                ("text", "unused"),
+            ],
+            model_id,
+            fail_on_call=1,
+            fail_exc=ProviderError(
+                "Upstream timeout",
+                provider_type=ProviderType.ANTHROPIC,
+                model=model_id,
+                status_code=504,
+            ),
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            event_type == "stream_error" for event_type, _d, _sid in events
+        ), f"Expected stream_error, got events: {events}"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        failed = db_msgs[-1]
+        assert failed.error is not None, "Error column not persisted"
+        assert failed.error["statusCode"] == 504
+        # The error row's parent is the tool-result row (last persisted row),
+        # not the seeded user message that was the request-time parent.
+        assert failed.parent_id == db_msgs[-2].id
+        assert db_msgs[-2].message["role"] == "user"
+        assert any(
+            b.get("type") == "tool_result"
+            for b in db_msgs[-2].message.get("content", [])
+        ), "Expected a tool_result row between the tool call and the error"
+
+    @pytest.mark.asyncio
+    async def test_pre_stream_failure_persists_error_row(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        """A failure before any streaming (conversation prep) still persists an
+        assistant error row with empty content."""
+        chat_id, _user_id, model_id = seeded_chat
+
+        monkeypatch.setattr(
+            ConversationCompactor,
+            "prepare_chat_conversation",
+            AsyncMock(side_effect=RuntimeError("compaction failed")),
+        )
+
+        llm = GatedRecordingLLM([("text", "unused")], model_id)
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            event_type == "stream_error" for event_type, _d, _sid in events
+        ), f"Expected stream_error, got events: {events}"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        assert len(db_msgs) == 2, f"Expected user + error row, got {len(db_msgs)}"
+        failed = db_msgs[-1]
+        assert failed.message["role"] == "assistant"
+        assert failed.message["content"] == []
+        assert failed.error is not None
+        assert "compaction failed" in failed.error["message"]
+
+    @pytest.mark.asyncio
+    async def test_tool_execution_error_after_finalized_row_persists_error(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        """An exception during tool execution (after the tool-call assistant
+        row was finalized) still persists a dedicated error row."""
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [
+                (
+                    "tool_call",
+                    {
+                        "name": "search_documents",
+                        "input": {"query": "boom"},
+                        "id": "toolu_boom",
+                    },
+                ),
+            ],
+            model_id,
+        )
+
+        async def _raising_execute(*args, **kwargs):
+            raise RuntimeError("tool execution crashed")
+
+        monkeypatch.setattr(ToolRegistry, "execute", _raising_execute)
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        assert any(
+            event_type == "stream_error" for event_type, _d, _sid in events
+        ), f"Expected stream_error, got events: {events}"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        failed = db_msgs[-1]
+        assert failed.error is not None, "Error column not persisted"
+        assert "tool execution crashed" in failed.error["message"]
+        # The tool-call assistant row from the finalized turn is still present,
+        # and the error row follows it as the new leaf.
+        assert any(
+            any(
+                isinstance(b, dict) and b.get("type") == "tool_use"
+                for b in (m.message.get("content") if isinstance(m.message.get("content"), list) else [])
+            )
+            for m in db_msgs
+        ), "Expected the tool-call assistant row to remain"
+
+    @pytest.mark.asyncio
+    async def test_resume_after_error_does_not_duplicate_error_row(
+        self, seeded_chat, redis_client, redis_keys
+    ):
+        """Replaying the buffered run after a stream_error does not duplicate
+        the persisted error row."""
+        from providers.types import ProviderError, ProviderType
+
+        chat_id, _user_id, model_id = seeded_chat
+        llm = GatedRecordingLLM(
+            [("text", "unused")],
+            model_id,
+            fail_on_call=0,
+            fail_exc=ProviderError(
+                "boom",
+                provider_type=ProviderType.ANTHROPIC,
+                model=model_id,
+                status_code=500,
+            ),
+        )
+
+        app = _build_chat_app(llm, redis_client, model_id)
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+        assert any(
+            event_type == "stream_error" for event_type, _d, _sid in events
+        ), f"Expected stream_error, got events: {events}"
+
+        # Replay the buffered run from just past its first id-carrying event.
+        replay_from = next((sid for _et, _d, sid in events if sid), None)
+        assert replay_from, "First event should carry an SSE id for resume"
+        async with _client(app) as client:
+            replay_events = await collect_sse_events(
+                client, chat_id, headers={"Last-Event-ID": replay_from}
+            )
+        assert any(
+            event_type == "stream_error" for event_type, _d, _sid in replay_events
+        ), f"Replay did not deliver terminal, got: {replay_events}"
+
+        db_msgs = await MessagesRepository().get_active_path(chat_id)
+        error_rows = [m for m in db_msgs if m.error is not None]
+        assert len(error_rows) == 1, (
+            f"Expected exactly one error row after replay, got {len(error_rows)}"
+        )
 
 
 # =============================================================================

--- a/services/migrations/111_add_chat_message_error_column.sql
+++ b/services/migrations/111_add_chat_message_error_column.sql
@@ -1,0 +1,4 @@
+-- Persist chat stream errors on the failed assistant turn's row so they
+-- survive page reloads. The `message` column stays a pure Anthropic
+-- MessageParam; the error lives in its own typed JSONB column.
+ALTER TABLE chat_messages ADD COLUMN error jsonb;

--- a/web/src/lib/server/db/chats.test.ts
+++ b/web/src/lib/server/db/chats.test.ts
@@ -105,6 +105,35 @@ describe('ChatMessageRepository branching', () => {
 
         expect(path.map((m) => m.id)).toEqual([root.id, a.id, bPrime.id])
     })
+
+    it('getActivePath returns empty-content assistant row with its error column', async () => {
+        // A failed assistant turn is persisted as an empty-content assistant
+        // row with the error payload in the dedicated column; a fresh page
+        // load must fetch it (with the error) so the UI can render the alert.
+        const root = await repo.create(chatId, userMsg('hello'))
+        const errorPayload = {
+            message: 'Rate limited',
+            provider: 'anthropic',
+            model: 'test-model',
+            statusCode: 429,
+        }
+        const errorRowId = ulid()
+        await db.insert(schema.chatMessages).values({
+            id: errorRowId,
+            chatId,
+            parentId: root.id,
+            messageSeqNum: root.messageSeqNum + 1,
+            message: { role: 'assistant', content: [] } as MessageParam,
+            error: errorPayload,
+        })
+
+        const path = await repo.getActivePath(chatId)
+
+        expect(path.map((m) => m.id)).toEqual([root.id, errorRowId])
+        const failed = path[1]
+        expect(failed.message).toEqual({ role: 'assistant', content: [] })
+        expect(failed.error).toEqual(errorPayload)
+    })
 })
 
 describe('ChatRepository history and search', () => {

--- a/web/src/lib/server/db/chats.ts
+++ b/web/src/lib/server/db/chats.ts
@@ -375,7 +375,7 @@ export class ChatMessageRepository {
     async getActivePath(chatId: string): Promise<ChatMessage[]> {
         const rows = await this.db.execute<ChatMessage>(sql`
             WITH RECURSIVE walk_up AS (
-                SELECT cm.id, cm.chat_id, cm.parent_id, cm.message_seq_num, cm.message, cm.content_text, cm.created_at
+                SELECT cm.id, cm.chat_id, cm.parent_id, cm.message_seq_num, cm.message, cm.content_text, cm.error, cm.created_at
                 FROM (
                     SELECT *
                     FROM chat_messages
@@ -390,7 +390,7 @@ export class ChatMessageRepository {
 
                 UNION ALL
 
-                SELECT cm.id, cm.chat_id, cm.parent_id, cm.message_seq_num, cm.message, cm.content_text, cm.created_at
+                SELECT cm.id, cm.chat_id, cm.parent_id, cm.message_seq_num, cm.message, cm.content_text, cm.error, cm.created_at
                 FROM chat_messages cm
                 JOIN walk_up wu ON cm.id = wu.parent_id
             )
@@ -400,6 +400,7 @@ export class ChatMessageRepository {
                    message_seq_num AS "messageSeqNum",
                    message,
                    content_text AS "contentText",
+                   error,
                    created_at AS "createdAt"
             FROM walk_up
             ORDER BY message_seq_num

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -10,6 +10,7 @@ import {
     index,
 } from 'drizzle-orm/pg-core'
 import type { MessageParam } from '@anthropic-ai/sdk/resources/messages.js'
+import type { ChatStreamError } from '$lib/types/message.js'
 
 export const user = pgTable('users', {
     id: text('id').primaryKey(),
@@ -205,6 +206,8 @@ export const chatMessages = pgTable('chat_messages', {
     messageSeqNum: integer('message_seq_num').notNull(),
     message: jsonb('message').$type<MessageParam>().notNull(),
     contentText: text('content_text'),
+    // Error payload for a failed assistant turn; null when the turn succeeded.
+    error: jsonb('error').$type<ChatStreamError | null>(),
     createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 })
 

--- a/web/src/lib/types/message.ts
+++ b/web/src/lib/types/message.ts
@@ -129,6 +129,17 @@ export type MentionMessageContent = {
 export type MessageContent = Array<
     TextMessageContent | ToolMessageContent | UploadMessageContent | MentionMessageContent
 >
+
+// Error payload persisted on the `chat_messages.error` column / delivered as
+// SSE `event: stream_error`. Mirrors the AI service's StreamErrorEvent so
+// persisted and streamed errors stay structurally identical.
+export type ChatStreamError = {
+    message: string
+    provider?: string | null
+    model?: string | null
+    statusCode?: number | null
+}
+
 export type ProcessedMessage = {
     id: number
     // IDs of the raw chat_messages rows represented by this display message.
@@ -144,4 +155,6 @@ export type ProcessedMessage = {
     siblingIds?: string[]
     siblingIndex?: number
     createdAt?: Date
+    // Present when the assistant turn failed; rendered as an inline error alert.
+    error?: ChatStreamError | null
 }

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -46,6 +46,7 @@
         OAuthRequiredEvent,
         OmniUploadBlock,
         OmniMentionBlock,
+        ChatStreamError,
     } from '$lib/types/message'
     import { ToolApprovalStatus } from '$lib/types/message'
     import type { MentionedDocument } from '$lib/types/message'
@@ -224,12 +225,7 @@
         }
     }
 
-    type StreamErrorPayload = {
-        message: string
-        provider?: string | null
-        model?: string | null
-        statusCode?: number | null
-    }
+    type StreamErrorPayload = ChatStreamError
 
     async function resumeActiveStreamIfNeeded() {
         if (isStreaming || eventSource) return
@@ -243,20 +239,24 @@
         }
     }
 
+    function streamErrorDetail(error: ChatStreamError): string | null {
+        const detailParts = [
+            error.provider,
+            error.model,
+            error.statusCode ? `HTTP ${error.statusCode}` : null,
+        ].filter((part): part is string => !!part)
+        return detailParts.length ? detailParts.join(' · ') : null
+    }
+
     function streamErrorMessage(event: MessageEvent<string>): {
         message: string
         detail: string | null
     } {
         try {
             const payload = JSON.parse(event.data) as StreamErrorPayload
-            const detailParts = [
-                payload.provider,
-                payload.model,
-                payload.statusCode ? `HTTP ${payload.statusCode}` : null,
-            ].filter((part): part is string => !!part)
             return {
                 message: payload.message,
-                detail: detailParts.length ? detailParts.join(' · ') : null,
+                detail: streamErrorDetail(payload),
             }
         } catch {
             return {
@@ -817,6 +817,7 @@
             parentId: origMsg?.parentId ?? null,
             message,
             contentText: trimmedContent,
+            error: null,
             messageSeqNum: nextMessageSeqNum(chatMessages),
             createdAt: new Date(),
         }
@@ -863,6 +864,10 @@
                           siblingIndex: message.siblingIndex,
                           createdAt: message.createdAt,
                           content: [...lastMessage.content],
+                          // A later error row that merges into this display
+                          // message (e.g. after a tool-call turn) must not lose
+                          // its persisted error.
+                          error: message.error ?? lastMessage.error,
                       }
                     : {
                           id: result.length,
@@ -875,6 +880,7 @@
                           siblingIds: message.siblingIds,
                           siblingIndex: message.siblingIndex,
                           createdAt: message.createdAt,
+                          error: message.error ?? null,
                       }
 
             result =
@@ -1074,6 +1080,7 @@
                         chatMsg.createdAt instanceof Date
                             ? chatMsg.createdAt
                             : new Date(chatMsg.createdAt),
+                    error: chatMsg.error ?? null,
                 }
 
                 const contentBlocks = Array.isArray(message.content)
@@ -1528,6 +1535,7 @@
                             content: [block],
                         },
                         contentText: null,
+                        error: null,
                         messageSeqNum: nextMessageSeqNum(chatMessages),
                         createdAt: new Date(),
                     }
@@ -1675,6 +1683,7 @@
                                 content: data.message.content,
                             },
                             contentText: null,
+                            error: null,
                             messageSeqNum: nextMessageSeqNum(chatMessages),
                             createdAt: new Date(),
                         }
@@ -1966,6 +1975,7 @@
                             content: denialBlocks,
                         },
                         contentText: null,
+                        error: null,
                         messageSeqNum: nextMessageSeqNum(chatMessages),
                         createdAt: new Date(),
                     }
@@ -2080,6 +2090,7 @@
                 content: messageContent,
             } as unknown as ChatMessage['message'],
             contentText: userMsg,
+            error: null,
             messageSeqNum: nextMessageSeqNum(chatMessages),
             createdAt: new Date(),
         }
@@ -2574,6 +2585,20 @@
                                         onOAuthComplete={() => streamResponse(data.chat.id)} />
                                 {/key}
                             </div>
+                            {#if message.error}
+                                <div class="flex px-2">
+                                    <Alert.Root variant="destructive" title={message.error.message}>
+                                        <CircleAlert />
+                                        <Alert.Title>{message.error.message}</Alert.Title>
+                                        {#if streamErrorDetail(message.error)}
+                                            <Alert.Description
+                                                >{streamErrorDetail(
+                                                    message.error,
+                                                )}</Alert.Description>
+                                        {/if}
+                                    </Alert.Root>
+                                </div>
+                            {/if}
                             {#if error && i === processedMessages.length - 1}
                                 <div class="flex px-2">
                                     <Alert.Root variant="destructive" title={error}>


### PR DESCRIPTION
- Persist failed assistant turns in a new `chat_messages.error` jsonb column (migration 111) so stream errors survive page reloads instead of living only in transient SSE state
- Persist errors from the AI service via an internal `save_error` SSE event, atomically finalizing partial content onto the same row and creating a dedicated error row when the turn failed before producing content
- Cover errors raised after a finalized tool-call turn (e.g. during tool preflight/execution) so those failures are persisted too
- Render persisted errors as inline destructive alerts under the errored assistant message on fresh page load, alongside the existing live-transient alerts
- Keep the `message` column a pure Anthropic MessageParam by storing error payloads only in the dedicated column
- Add integration tests for the persistence paths and a web test proving `getActivePath` returns the error column for empty-content error rows