### PR TITLE
feat(google): sync shared drives with direct service account auth

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -1,0 +1,55 @@
+# Google Connector
+
+Indexes Google Workspace content into Omni: Google Drive, Gmail, and Google
+Chat. Configuration is managed through the Omni admin UI at
+`/admin/settings/integrations`.
+
+## Authentication
+
+The connector supports two auth modes, selected per source in the setup UI:
+
+### Domain-wide delegation (default)
+
+The existing flow: a service account with domain-wide delegation impersonates
+Workspace users (`sub` claim) and uses the Admin SDK for user/group discovery.
+Requires admin email, domain, and DWD scopes. Used for org-wide Drive, Gmail,
+and Chat sync.
+
+### Service account direct (shared drives, no DWD)
+
+A plain service account (no DWD, no Admin SDK scopes, no `sub` impersonation)
+syncs selected shared drives with their inherited ACLs.
+
+Google-side setup:
+
+1. Create a service account key (IAM & Admin → Service Accounts → Keys).
+2. In each shared drive → **Manage members**, add the service account email
+   (`<name>@<project>.iam.gserviceaccount.com`) as **Content manager**
+   (`fileOrganizer`) or **Manager** (`organizer`) — required, fail-closed.
+3. Verify your Workspace external-sharing policy permits adding
+   `*.iam.gserviceaccount.com` to shared drives. The SA is an external
+   principal, so a scoped OU / trust-rule exception may be needed. If the
+   policy cannot allow the SA at all, use OAuth or DWD with an internal user
+   instead.
+
+Behavior:
+
+- Only `drive.readonly` scope; source config selects the mode with
+  `auth_mode: "service_account_direct"` and one or more
+  `folder_path_filters` entries of kind `shared_drive_root`.
+- Documents carry the drive-level member list as permissions
+  (`public`/`users`/`groups`); the SA's own email is excluded.
+- ACLs are fingerprinted each run; a membership change triggers a full drive
+  re-traversal so existing documents get the new ACLs.
+- Polling only — no webhook registration. Google Groups on the drive map to
+  `groups` but group members are undergranted in v1 (group membership comes
+  from Admin SDK sync, unavailable here). Prefer drives with direct
+  user/domain/anyone members.
+- Per-file overrides outside the drive are not resolved; drive-level ACLs
+  apply. Switching an existing DWD source to SA-direct is not supported —
+  create a new source.
+
+The setup dialog has two tabs (DWD | Shared drive no-DWD); SA-direct is
+Drive-only and validates the SA's role on every selected drive before the
+source is created. The drive settings page repeats that validation before
+Save.

--- a/connectors/google/src/auth.rs
+++ b/connectors/google/src/auth.rs
@@ -50,6 +50,7 @@ pub struct GoogleServiceAccountKey {
 #[derive(Debug, Serialize)]
 struct GoogleJwtClaims {
     iss: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
     sub: Option<String>,
     scope: String,
     aud: String,
@@ -122,9 +123,16 @@ impl ServiceAccountAuth {
         let now = Utc::now();
         let exp = now + Duration::hours(1);
 
+        // Self-auth: when the requested subject is the service account's own
+        // client_email, omit the `sub` claim entirely so Google issues a token
+        // for the service account itself rather than impersonating a user.
+        // This is the SA-direct mode (no domain-wide delegation).
+        let subject = (impersonate_user != self.service_account.client_email)
+            .then(|| impersonate_user.to_string());
+
         let claims = GoogleJwtClaims {
             iss: self.service_account.client_email.clone(),
-            sub: Some(impersonate_user.to_string()),
+            sub: subject,
             scope: self.scopes.join(" "),
             aud: self.service_account.token_uri.clone(),
             exp: exp.timestamp(),
@@ -200,6 +208,18 @@ impl ServiceAccountAuth {
         debug!("Token cached for user: {}", impersonate_user);
 
         Ok(token_response.access_token)
+    }
+
+    /// Get an access token for the service account itself (no `sub` claim,
+    /// no impersonation). Used by SA-direct mode.
+    pub async fn get_self_access_token(&self) -> Result<String> {
+        self.get_access_token(&self.service_account.client_email)
+            .await
+    }
+
+    /// The service account's own email address.
+    pub fn client_email(&self) -> &str {
+        &self.service_account.client_email
     }
 
     pub async fn validate(&self, test_user: &str) -> Result<()> {
@@ -375,6 +395,15 @@ impl GoogleAuth {
         match self {
             GoogleAuth::ServiceAccount(sa) => sa.get_access_token(user_email).await,
             GoogleAuth::OAuth(oauth) => oauth.get_access_token(user_email).await,
+        }
+    }
+
+    /// Get a token for the service account itself (no `sub` claim). Only valid
+    /// for service-account auth; OAuth has no self-token concept.
+    pub async fn get_self_access_token(&self) -> Result<String> {
+        match self {
+            GoogleAuth::ServiceAccount(sa) => sa.get_self_access_token().await,
+            GoogleAuth::OAuth(_) => Err(anyhow!("self-token not supported for OAuth")),
         }
     }
 
@@ -757,6 +786,73 @@ mod tests {
         assert!(result.is_err());
         let err = result.err().unwrap();
         assert!(err.to_string().contains("Invalid key type"));
+    }
+
+    #[test]
+    fn test_self_auth_omits_sub_claim() {
+        // Self-auth (passing client_email as the subject) must serialize the
+        // JWT WITHOUT a `sub` claim — Google rejects `"sub": null`.
+        let claims = GoogleJwtClaims {
+            iss: "sa@project.iam.gserviceaccount.com".to_string(),
+            sub: None,
+            scope: "https://www.googleapis.com/auth/drive.readonly".to_string(),
+            aud: "https://oauth2.googleapis.com/token".to_string(),
+            exp: 1_700_000_000,
+            iat: 1_699_999_400,
+        };
+        let serialized = serde_json::to_value(&claims).unwrap();
+        assert!(
+            serialized.get("sub").is_none(),
+            "self-auth JWT must not contain a sub claim, got {:?}",
+            serialized
+        );
+    }
+
+    #[test]
+    fn test_impersonated_claims_include_sub() {
+        let claims = GoogleJwtClaims {
+            iss: "sa@project.iam.gserviceaccount.com".to_string(),
+            sub: Some("admin@example.com".to_string()),
+            scope: "https://www.googleapis.com/auth/drive.readonly".to_string(),
+            aud: "https://oauth2.googleapis.com/token".to_string(),
+            exp: 1_700_000_000,
+            iat: 1_699_999_400,
+        };
+        let serialized = serde_json::to_value(&claims).unwrap();
+        assert_eq!(
+            serialized.get("sub").and_then(|v| v.as_str()),
+            Some("admin@example.com")
+        );
+    }
+
+    #[test]
+    fn test_client_email_matches_self_auth_condition() {
+        // The `sub` is omitted exactly when the requested subject equals the
+        // service account's own client_email.
+        let sa = GoogleServiceAccountKey {
+            key_type: "service_account".to_string(),
+            project_id: "p".to_string(),
+            private_key_id: "k".to_string(),
+            private_key: "-----BEGIN RSA PRIVATE KEY-----\ntest\n-----END RSA PRIVATE KEY-----\n"
+                .to_string(),
+            client_email: "sa@project.iam.gserviceaccount.com".to_string(),
+            client_id: "1".to_string(),
+            auth_uri: "https://accounts.google.com/o/oauth2/auth".to_string(),
+            token_uri: "https://oauth2.googleapis.com/token".to_string(),
+            auth_provider_x509_cert_url: "https://www.googleapis.com/oauth2/v1/certs".to_string(),
+            client_x509_cert_url: "https://www.googleapis.com/robot/v1/metadata/x509/sa"
+                .to_string(),
+        };
+        assert!(
+            !(sa.client_email != sa.client_email),
+            "self-auth comparison must be false for identical emails"
+        );
+        let subject =
+            ("admin@example.com" != sa.client_email).then(|| "admin@example.com".to_string());
+        assert!(subject.is_some(), "real user impersonation keeps sub");
+        let self_subject =
+            (sa.client_email.as_str() != sa.client_email.as_str()).then(|| sa.client_email.clone());
+        assert!(self_subject.is_none(), "self-auth drops sub");
     }
 
     #[test]

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -10,7 +10,8 @@ use crate::drive::DriveClient;
 use crate::gmail::{MessageFormat, MessagePart};
 use crate::models::{
     DriveFolderDiscoveryEntry, DriveFolderDiscoveryResponse, GoogleAuthMode, GoogleDirectoryUser,
-    GoogleSourceConfig, GoogleSyncCheckpoint, SearchUsersResponse,
+    GoogleSourceConfig, GoogleSyncCheckpoint, SearchUsersResponse, SharedDriveAccessResponse,
+    SharedDriveAccessResult,
 };
 use crate::sync::SyncManager;
 use anyhow::{Context, Result, anyhow};
@@ -129,6 +130,22 @@ pub struct ParsedAttachmentDocId {
     pub rfc822_msgid: String,
     pub filename: String,
     pub size: u64,
+}
+
+/// Params for the `discover_folders` connector action.
+#[derive(Debug, Default, Deserialize)]
+struct DiscoverFoldersParams {
+    #[serde(default)]
+    auth_mode: Option<GoogleAuthMode>,
+}
+
+/// Params for the `validate_shared_drive_access` connector action.
+#[derive(Debug, Default, Deserialize)]
+struct ValidateSharedDriveAccessParams {
+    #[serde(default)]
+    auth_mode: Option<GoogleAuthMode>,
+    #[serde(default)]
+    drive_ids: Vec<String>,
 }
 
 fn parse_attachment_doc_id(composite: &str) -> Result<ParsedAttachmentDocId> {
@@ -825,11 +842,9 @@ impl GoogleConnector {
             .into_response());
         }
 
-        let auth_mode = params
-            .get("auth_mode")
-            .and_then(|v| v.as_str())
-            .unwrap_or("domain_wide_delegation");
-        let is_sa_direct = auth_mode == "service_account_direct";
+        // Fail loudly on malformed params rather than guessing.
+        let params: DiscoverFoldersParams = serde_json::from_value(params)?;
+        let is_sa_direct = params.auth_mode == Some(GoogleAuthMode::ServiceAccountDirect);
 
         let auth = crate::auth::create_service_auth(creds, SourceType::GoogleDrive)?;
         let google_auth = crate::auth::GoogleAuth::ServiceAccount(auth);
@@ -917,28 +932,16 @@ impl GoogleConnector {
             .into_response());
         }
 
-        let auth_mode = params
-            .get("auth_mode")
-            .and_then(|v| v.as_str())
-            .unwrap_or("domain_wide_delegation");
-        if auth_mode != "service_account_direct" {
+        // Fail loudly on malformed params rather than guessing.
+        let params: ValidateSharedDriveAccessParams = serde_json::from_value(params)?;
+        if params.auth_mode != Some(GoogleAuthMode::ServiceAccountDirect) {
             return Ok(ActionResponse::failure(
                 "validate_shared_drive_access requires auth_mode=service_account_direct"
                     .to_string(),
             )
             .into_response());
         }
-
-        let drive_ids: Vec<String> = params
-            .get("drive_ids")
-            .and_then(|v| v.as_array())
-            .map(|arr| {
-                arr.iter()
-                    .filter_map(|v| v.as_str().map(String::from))
-                    .collect()
-            })
-            .unwrap_or_default();
-        if drive_ids.is_empty() {
+        if params.drive_ids.is_empty() {
             return Ok(ActionResponse::failure(
                 "validate_shared_drive_access requires at least one drive_id".to_string(),
             )
@@ -954,8 +957,8 @@ impl GoogleConnector {
         let access_token = google_auth.get_self_access_token().await?;
 
         let mut results = Vec::new();
-        for drive_id in &drive_ids {
-            let entry = match self
+        for drive_id in &params.drive_ids {
+            let result = match self
                 .sync_manager
                 .drive_client()
                 .list_drive_permissions(&access_token, drive_id)
@@ -964,31 +967,32 @@ impl GoogleConnector {
                 Ok(permissions) => {
                     match crate::models::validate_sa_drive_access(drive_id, &permissions, &sa_email)
                     {
-                        Ok(role) => serde_json::json!({
-                            "drive_id": drive_id,
-                            "ok": true,
-                            "role": role,
-                            "error": null,
-                        }),
-                        Err(e) => serde_json::json!({
-                            "drive_id": drive_id,
-                            "ok": false,
-                            "role": null,
-                            "error": e.to_string(),
-                        }),
+                        Ok(role) => SharedDriveAccessResult {
+                            drive_id: drive_id.clone(),
+                            ok: true,
+                            role: Some(role),
+                            error: None,
+                        },
+                        Err(e) => SharedDriveAccessResult {
+                            drive_id: drive_id.clone(),
+                            ok: false,
+                            role: None,
+                            error: Some(e.to_string()),
+                        },
                     }
                 }
-                Err(e) => serde_json::json!({
-                    "drive_id": drive_id,
-                    "ok": false,
-                    "role": null,
-                    "error": format!("Failed to read drive ACLs: {}", e),
-                }),
+                Err(e) => SharedDriveAccessResult {
+                    drive_id: drive_id.clone(),
+                    ok: false,
+                    role: None,
+                    error: Some(format!("Failed to read drive ACLs: {}", e)),
+                },
             };
-            results.push(entry);
+            results.push(result);
         }
 
-        Ok(ActionResponse::success(serde_json::json!({ "drives": results })).into_response())
+        let response = SharedDriveAccessResponse { drives: results };
+        Ok(ActionResponse::success(serde_json::to_value(response)?).into_response())
     }
 }
 

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -3,17 +3,17 @@ use std::time::{Duration, Instant};
 
 use crate::admin::AdminClient;
 use crate::auth::{
-    create_service_auth, get_domain_from_credentials, GoogleCredentialPayload,
-    GoogleOAuthCredentials,
+    GoogleCredentialPayload, GoogleOAuthCredentials, create_service_auth,
+    get_domain_from_credentials,
 };
 use crate::drive::DriveClient;
 use crate::gmail::{MessageFormat, MessagePart};
 use crate::models::{
-    DriveFolderDiscoveryEntry, DriveFolderDiscoveryResponse, GoogleDirectoryUser,
-    GoogleSyncCheckpoint, SearchUsersResponse,
+    DriveFolderDiscoveryEntry, DriveFolderDiscoveryResponse, GoogleAuthMode, GoogleDirectoryUser,
+    GoogleSourceConfig, GoogleSyncCheckpoint, SearchUsersResponse,
 };
 use crate::sync::SyncManager;
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use async_trait::async_trait;
 use axum::response::Response;
 use omni_connector_sdk::{
@@ -23,7 +23,7 @@ use omni_connector_sdk::{
     SyncRequestValidationError, SyncType,
 };
 use serde::Deserialize;
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use std::collections::HashMap;
 use tokio::process::Command;
 use tokio::sync::RwLock;
@@ -814,7 +814,7 @@ impl GoogleConnector {
 
     async fn execute_discover_folders(
         &self,
-        _params: JsonValue,
+        params: JsonValue,
         creds: &ServiceCredential,
     ) -> Result<axum::response::Response> {
         // Only JWT secrets are supported for shared-drive discovery.
@@ -825,20 +825,35 @@ impl GoogleConnector {
             .into_response());
         }
 
-        let principal_email = creds
-            .principal_email
-            .as_deref()
-            .ok_or_else(|| anyhow!("Missing principal_email in credentials"))?;
+        let auth_mode = params
+            .get("auth_mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("domain_wide_delegation");
+        let is_sa_direct = auth_mode == "service_account_direct";
 
         let auth = crate::auth::create_service_auth(creds, SourceType::GoogleDrive)?;
-
         let google_auth = crate::auth::GoogleAuth::ServiceAccount(auth);
+
+        // SA-direct discovery uses the SA self-token (no impersonation); DWD
+        // discovery impersonates the configured principal email.
+        let user_email = if is_sa_direct {
+            match &google_auth {
+                crate::auth::GoogleAuth::ServiceAccount(sa) => sa.client_email().to_string(),
+                crate::auth::GoogleAuth::OAuth(_) => unreachable!(),
+            }
+        } else {
+            creds
+                .principal_email
+                .as_deref()
+                .ok_or_else(|| anyhow!("Missing principal_email in credentials"))?
+                .to_string()
+        };
 
         // 1. List all shared drives
         let drives_response = self
             .sync_manager
             .drive_client()
-            .list_drives(&google_auth, principal_email)
+            .list_drives(&google_auth, &user_email)
             .await?;
 
         let mut items: Vec<DriveFolderDiscoveryEntry> = Vec::new();
@@ -854,29 +869,31 @@ impl GoogleConnector {
             });
         }
 
-        // 3. For each shared drive, list top-level folder children.
-        // Any failure propagates so the admin gets an actionable error.
-        for drive in &drives_response.drives {
-            let folders = self
-                .sync_manager
-                .drive_client()
-                .list_folder_children(&google_auth, principal_email, &drive.id, &drive.id)
-                .await
-                .with_context(|| {
-                    format!(
-                        "Failed to list folder children for shared drive '{}' ({})",
-                        drive.name, drive.id
-                    )
-                })?;
+        // 3. For each shared drive, list top-level folder children (DWD only).
+        // SA-direct v1 selects whole drives only — no top-level folder listing.
+        if !is_sa_direct {
+            for drive in &drives_response.drives {
+                let folders = self
+                    .sync_manager
+                    .drive_client()
+                    .list_folder_children(&google_auth, &user_email, &drive.id, &drive.id)
+                    .await
+                    .with_context(|| {
+                        format!(
+                            "Failed to list folder children for shared drive '{}' ({})",
+                            drive.name, drive.id
+                        )
+                    })?;
 
-            for folder in &folders.files {
-                items.push(DriveFolderDiscoveryEntry {
-                    id: folder.id.clone(),
-                    name: folder.name.clone(),
-                    path: format!("/{}/{}", drive.name, folder.name),
-                    drive_id: drive.id.clone(),
-                    kind: "folder".to_string(),
-                });
+                for folder in &folders.files {
+                    items.push(DriveFolderDiscoveryEntry {
+                        id: folder.id.clone(),
+                        name: folder.name.clone(),
+                        path: format!("/{}/{}", drive.name, folder.name),
+                        drive_id: drive.id.clone(),
+                        kind: "folder".to_string(),
+                    });
+                }
             }
         }
 
@@ -884,11 +901,100 @@ impl GoogleConnector {
 
         Ok(ActionResponse::success(serde_json::to_value(result)?).into_response())
     }
+
+    /// Validate that a service account can read ACLs (Content manager/Manager)
+    /// for every selected shared drive. Used by the setup UI before source
+    /// creation and re-checked at sync start.
+    async fn execute_validate_shared_drive_access(
+        &self,
+        params: JsonValue,
+        creds: &ServiceCredential,
+    ) -> Result<axum::response::Response> {
+        if creds.auth_type != AuthType::Jwt {
+            return Ok(ActionResponse::failure(
+                "validate_shared_drive_access requires JWT credentials".to_string(),
+            )
+            .into_response());
+        }
+
+        let auth_mode = params
+            .get("auth_mode")
+            .and_then(|v| v.as_str())
+            .unwrap_or("domain_wide_delegation");
+        if auth_mode != "service_account_direct" {
+            return Ok(ActionResponse::failure(
+                "validate_shared_drive_access requires auth_mode=service_account_direct"
+                    .to_string(),
+            )
+            .into_response());
+        }
+
+        let drive_ids: Vec<String> = params
+            .get("drive_ids")
+            .and_then(|v| v.as_array())
+            .map(|arr| {
+                arr.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        if drive_ids.is_empty() {
+            return Ok(ActionResponse::failure(
+                "validate_shared_drive_access requires at least one drive_id".to_string(),
+            )
+            .into_response());
+        }
+
+        let auth = crate::auth::create_service_auth(creds, SourceType::GoogleDrive)?;
+        let google_auth = crate::auth::GoogleAuth::ServiceAccount(auth);
+        let sa_email = match &google_auth {
+            crate::auth::GoogleAuth::ServiceAccount(sa) => sa.client_email().to_string(),
+            crate::auth::GoogleAuth::OAuth(_) => unreachable!(),
+        };
+        let access_token = google_auth.get_self_access_token().await?;
+
+        let mut results = Vec::new();
+        for drive_id in &drive_ids {
+            let entry = match self
+                .sync_manager
+                .drive_client()
+                .list_drive_permissions(&access_token, drive_id)
+                .await
+            {
+                Ok(permissions) => {
+                    match crate::models::validate_sa_drive_access(drive_id, &permissions, &sa_email)
+                    {
+                        Ok(role) => serde_json::json!({
+                            "drive_id": drive_id,
+                            "ok": true,
+                            "role": role,
+                            "error": null,
+                        }),
+                        Err(e) => serde_json::json!({
+                            "drive_id": drive_id,
+                            "ok": false,
+                            "role": null,
+                            "error": e.to_string(),
+                        }),
+                    }
+                }
+                Err(e) => serde_json::json!({
+                    "drive_id": drive_id,
+                    "ok": false,
+                    "role": null,
+                    "error": format!("Failed to read drive ACLs: {}", e),
+                }),
+            };
+            results.push(entry);
+        }
+
+        Ok(ActionResponse::success(serde_json::json!({ "drives": results })).into_response())
+    }
 }
 
 #[async_trait]
 impl Connector for GoogleConnector {
-    type Config = JsonValue;
+    type Config = GoogleSourceConfig;
     type Credentials = GoogleCredentialPayload;
     type State = GoogleSyncCheckpoint;
 
@@ -994,8 +1100,39 @@ impl Connector for GoogleConnector {
                 mode: omni_connector_sdk::ActionMode::Read,
                 input_schema: json!({
                     "type": "object",
-                    "properties": {},
+                    "properties": {
+                        "auth_mode": {
+                            "type": "string",
+                            "enum": ["domain_wide_delegation", "service_account_direct"],
+                            "description": "Auth mode. SA-direct returns shared-drive roots only."
+                        }
+                    },
                     "required": []
+                }),
+                required_scopes: None,
+                source_types: vec![SourceType::GoogleDrive],
+                admin_only: true,
+                hidden: true,
+            },
+            ActionDefinition {
+                name: "validate_shared_drive_access".to_string(),
+                description:
+                    "Validate that the service account can read ACLs (Content manager/Manager) for every selected shared drive."
+                        .to_string(),
+                mode: omni_connector_sdk::ActionMode::Read,
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "auth_mode": {
+                            "type": "string",
+                            "enum": ["service_account_direct"]
+                        },
+                        "drive_ids": {
+                            "type": "array",
+                            "items": { "type": "string" }
+                        }
+                    },
+                    "required": ["auth_mode", "drive_ids"]
                 }),
                 required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive],
@@ -1180,8 +1317,26 @@ impl Connector for GoogleConnector {
             )));
         }
 
+        // Deserialize the typed source config once. Unknown keys are tolerated;
+        // malformed known fields and cross-field violations fail fast.
+        let config: GoogleSourceConfig =
+            serde_json::from_value(source.config.clone()).map_err(|e| {
+                SyncRequestValidationError::BadRequest(format!(
+                    "Invalid Google source config: {}",
+                    e
+                ))
+            })?;
+        let native_source_type = SourceType::try_from(source.source_type.as_str())
+            .map_err(SyncRequestValidationError::BadRequest)?;
+
         match creds.auth_type {
             omni_connector_sdk::AuthType::OAuth => {
+                if config.auth_mode == GoogleAuthMode::ServiceAccountDirect {
+                    return Err(SyncRequestValidationError::BadRequest(
+                        "service_account_direct requires JWT service-account credentials, not OAuth"
+                            .to_string(),
+                    ));
+                }
                 let oauth_credentials: GoogleOAuthCredentials =
                     serde_json::from_value(creds.credentials.clone()).map_err(|e| {
                         SyncRequestValidationError::BadRequest(format!(
@@ -1202,20 +1357,27 @@ impl Connector for GoogleConnector {
                 }
             }
             _ => {
-                let native_source_type = SourceType::try_from(source.source_type.as_str())
+                // Cross-field validation (SA-direct rules, Drive-only, root-only
+                // filters, JWT requirement).
+                config
+                    .validate(native_source_type, creds.auth_type)
                     .map_err(SyncRequestValidationError::BadRequest)?;
-                create_service_auth(creds, native_source_type).map_err(|e| {
-                    SyncRequestValidationError::BadRequest(format!(
-                        "Invalid Google service-account credentials: {}",
-                        e
-                    ))
-                })?;
-                get_domain_from_credentials(creds).map_err(|e| {
-                    SyncRequestValidationError::BadRequest(format!(
-                        "Invalid Google service-account config: {}",
-                        e
-                    ))
-                })?;
+
+                if config.auth_mode == GoogleAuthMode::DomainWideDelegation {
+                    // DWD still requires domain + valid service-account creds.
+                    create_service_auth(creds, native_source_type).map_err(|e| {
+                        SyncRequestValidationError::BadRequest(format!(
+                            "Invalid Google service-account credentials: {}",
+                            e
+                        ))
+                    })?;
+                    get_domain_from_credentials(creds).map_err(|e| {
+                        SyncRequestValidationError::BadRequest(format!(
+                            "Invalid Google service-account config: {}",
+                            e
+                        ))
+                    })?;
+                }
             }
         }
 
@@ -1255,6 +1417,10 @@ impl Connector for GoogleConnector {
             "fetch_file" => self.execute_fetch_file(params, &creds).await,
             "search_users" => self.execute_search_users(params, &creds).await,
             "discover_folders" => self.execute_discover_folders(params, &creds).await,
+            "validate_shared_drive_access" => {
+                self.execute_validate_shared_drive_access(params, &creds)
+                    .await
+            }
             "google_workspace_schema" => self.execute_gws_schema(params).await,
             "google_workspace_call" => self.execute_gws_call(params, &creds).await,
             _ => {
@@ -1283,12 +1449,12 @@ mod tests {
     use crate::sync::SyncManager;
 
     use super::{
+        GMAIL_MODIFY_SCOPE, GMAIL_READ_SCOPE, GMAIL_SEND_SCOPE, GOOGLE_DOCS_SCOPE,
+        GOOGLE_DRIVE_READ_SCOPE, GOOGLE_DRIVE_WRITE_SCOPE, GOOGLE_SHEETS_SCOPE,
+        GOOGLE_SLIDES_SCOPE, GoogleConnector, GwsCallRequest, GwsSchemaRequest,
         build_attachment_doc_id, build_gws_call_args, build_gws_schema_args,
         file_name_with_extension, gws_action_response, gws_required_action_scopes,
-        missing_gws_call_scopes, parse_attachment_doc_id, GoogleConnector, GwsCallRequest,
-        GwsSchemaRequest, GMAIL_MODIFY_SCOPE, GMAIL_READ_SCOPE, GMAIL_SEND_SCOPE,
-        GOOGLE_DOCS_SCOPE, GOOGLE_DRIVE_READ_SCOPE, GOOGLE_DRIVE_WRITE_SCOPE, GOOGLE_SHEETS_SCOPE,
-        GOOGLE_SLIDES_SCOPE,
+        missing_gws_call_scopes, parse_attachment_doc_id,
     };
 
     fn test_connector() -> GoogleConnector {
@@ -1364,12 +1530,16 @@ mod tests {
 
         assert_eq!(creds.auth_type, AuthType::Jwt);
         let scopes = creds.config["scopes"].as_array().expect("scopes");
-        assert!(scopes
-            .iter()
-            .any(|s| s == "https://www.googleapis.com/auth/drive.readonly"));
-        assert!(scopes
-            .iter()
-            .any(|s| s == "https://www.googleapis.com/auth/gmail.readonly"));
+        assert!(
+            scopes
+                .iter()
+                .any(|s| s == "https://www.googleapis.com/auth/drive.readonly")
+        );
+        assert!(
+            scopes
+                .iter()
+                .any(|s| s == "https://www.googleapis.com/auth/gmail.readonly")
+        );
         assert!(scopes.iter().any(|s| s == GOOGLE_DOCS_SCOPE));
         assert!(scopes.iter().any(|s| s == GOOGLE_SHEETS_SCOPE));
         assert!(scopes.iter().any(|s| s == GOOGLE_SLIDES_SCOPE));
@@ -1493,9 +1663,10 @@ mod tests {
     fn gws_required_action_scopes_rejects_unsupported_services() {
         let err = gws_required_action_scopes("calendar").unwrap_err();
 
-        assert!(err
-            .to_string()
-            .contains("Unsupported Google Workspace service"));
+        assert!(
+            err.to_string()
+                .contains("Unsupported Google Workspace service")
+        );
     }
 
     #[test]

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -1,4 +1,4 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use reqwest::Client;
 use serde::Deserialize;
 use std::env;
@@ -9,11 +9,11 @@ use tracing::{debug, warn};
 use std::collections::HashMap;
 
 use crate::auth::{
-    classify_google_api_error, execute_with_auth_retry, google_max_retries, ApiResult, GoogleAuth,
+    ApiResult, GoogleAuth, classify_google_api_error, execute_with_auth_retry, google_max_retries,
 };
 use crate::models::{
-    DriveChangesResponse, GoogleDriveFile, GooglePresentation, WebhookChannel,
-    WebhookChannelResponse,
+    DriveChangesResponse, GoogleDriveFile, GoogleDrivePermission, GooglePresentation,
+    WebhookChannel, WebhookChannelResponse,
 };
 use omni_connector_sdk::{RateLimiter, RetryableError};
 
@@ -34,6 +34,13 @@ const SHEETS_API_BASE: &str = "https://sheets.googleapis.com/v4";
 const SLIDES_API_BASE: &str = "https://slides.googleapis.com/v1";
 const DEFAULT_GOOGLE_SHEETS_MAX_INDEXED_ROWS: usize = 1000;
 const DEFAULT_GOOGLE_DRIVE_MAX_DOWNLOAD_BYTES: usize = 50 * 1024 * 1024;
+
+/// `fields` projection for file listings — includes `driveId` so shared-drive
+/// files can be attributed to their drive (observability + SA-direct metadata).
+const FILES_FIELDS: &str = "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,driveId,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))";
+
+/// `fields` projection for changes listings — mirrors `FILES_FIELDS`.
+const CHANGES_FIELDS: &str = "nextPageToken,newStartPageToken,changes(changeType,removed,file(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,driveId,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress)),fileId,time)";
 
 fn build_files_query(activity_after: Option<&str>) -> String {
     let mut query_parts = vec!["trashed=false".to_string()];
@@ -190,57 +197,63 @@ impl DriveClient {
             let page_token = page_token.clone();
             let modified_after = modified_after.clone();
             async move {
-            let url = format!("{}/files", drive_api_base().as_str());
+                let url = format!("{}/files", drive_api_base().as_str());
 
-            let query = build_files_query(modified_after.as_deref());
+                let query = build_files_query(modified_after.as_deref());
 
-            let mut params = vec![
-                ("pageSize", "100"),
-                ("fields", "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))"),
-                ("q", query.as_str()),
-                ("orderBy", "modifiedTime desc"),
-                ("includeItemsFromAllDrives", "true"),
-                ("supportsAllDrives", "true"),
-            ];
+                let mut params = vec![
+                    ("pageSize", "100"),
+                    ("fields", FILES_FIELDS),
+                    ("q", query.as_str()),
+                    ("orderBy", "modifiedTime desc"),
+                    ("includeItemsFromAllDrives", "true"),
+                    ("supportsAllDrives", "true"),
+                ];
 
-            if let Some(ref page_token) = page_token {
-                params.push(("pageToken", page_token));
-            }
-
-            debug!("[GOOGLE API CALL] list_files for user {}, page_token {:?}", user_email, page_token);
-            let response = self
-                .client
-                .get(&url)
-                .bearer_auth(&token)
-                .query(&params)
-                .send()
-                .await
-                .with_context(|| format!("Failed to send list_files request for user {}", user_email))?;
-
-            let status = response.status();
-            debug!("Drive list_files response status: {}", status);
-
-            if !status.is_success() {
-                return classify_google_api_error(response, "Failed to list files").await;
-            }
-
-            let response_text = response.text().await?;
-            debug!("Drive API raw response: {}", response_text);
-
-            let parsed_response = match serde_json::from_str(&response_text) {
-                Ok(parsed_response) => parsed_response,
-                Err(e) => {
-                    return Ok(ApiResult::OtherError(anyhow!(
-                        "Failed to parse Drive API response: {}. Raw response: {}",
-                        e,
-                        response_text
-                    )));
+                if let Some(ref page_token) = page_token {
+                    params.push(("pageToken", page_token));
                 }
-            };
 
-            Ok(ApiResult::Success(parsed_response))
+                debug!(
+                    "[GOOGLE API CALL] list_files for user {}, page_token {:?}",
+                    user_email, page_token
+                );
+                let response = self
+                    .client
+                    .get(&url)
+                    .bearer_auth(&token)
+                    .query(&params)
+                    .send()
+                    .await
+                    .with_context(|| {
+                        format!("Failed to send list_files request for user {}", user_email)
+                    })?;
+
+                let status = response.status();
+                debug!("Drive list_files response status: {}", status);
+
+                if !status.is_success() {
+                    return classify_google_api_error(response, "Failed to list files").await;
+                }
+
+                let response_text = response.text().await?;
+                debug!("Drive API raw response: {}", response_text);
+
+                let parsed_response = match serde_json::from_str(&response_text) {
+                    Ok(parsed_response) => parsed_response,
+                    Err(e) => {
+                        return Ok(ApiResult::OtherError(anyhow!(
+                            "Failed to parse Drive API response: {}. Raw response: {}",
+                            e,
+                            response_text
+                        )));
+                    }
+                };
+
+                Ok(ApiResult::Success(parsed_response))
             }
-        }).await
+        })
+        .await
     }
 
     pub async fn get_file_content(
@@ -1107,10 +1120,7 @@ impl DriveClient {
             ("includeItemsFromAllDrives", "true"),
             ("supportsAllDrives", "true"),
             ("includeRemoved", "true"),
-            (
-                "fields",
-                "nextPageToken,newStartPageToken,changes(changeType,removed,file(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress)),fileId,time)",
-            ),
+            ("fields", CHANGES_FIELDS),
         ];
         if let Some(did) = drive_id {
             params.push(("driveId", did));
@@ -1248,7 +1258,7 @@ impl DriveClient {
 
                 let mut params: Vec<(&str, &str)> = vec![
                     ("pageSize", "100"),
-                    ("fields", "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))"),
+                    ("fields", FILES_FIELDS),
                     ("q", query.as_str()),
                     ("orderBy", "modifiedTime desc"),
                     ("supportsAllDrives", "true"),
@@ -1260,7 +1270,10 @@ impl DriveClient {
                     params.push(("pageToken", pt));
                 }
 
-                debug!("[GOOGLE API CALL] list_files_in_drive drive={}, page_token={:?}", drive_id, page_token);
+                debug!(
+                    "[GOOGLE API CALL] list_files_in_drive drive={}, page_token={:?}",
+                    drive_id, page_token
+                );
                 let response = self
                     .client
                     .get(&url)
@@ -1272,20 +1285,110 @@ impl DriveClient {
 
                 let status = response.status();
                 if !status.is_success() {
-                    return classify_google_api_error(response, "Failed to list files in drive").await;
+                    return classify_google_api_error(response, "Failed to list files in drive")
+                        .await;
                 }
 
                 let response_text = response.text().await?;
-                let parsed: FilesListResponse = serde_json::from_str(&response_text).map_err(|e| {
-                    anyhow!(
-                        "Failed to parse drive-scoped file list response: {}. Raw: {}",
-                        e, response_text
-                    )
-                })?;
+                let parsed: FilesListResponse =
+                    serde_json::from_str(&response_text).map_err(|e| {
+                        anyhow!(
+                            "Failed to parse drive-scoped file list response: {}. Raw: {}",
+                            e,
+                            response_text
+                        )
+                    })?;
 
                 Ok(ApiResult::Success(parsed))
             }
-        }).await
+        })
+        .await
+    }
+
+    /// List a shared drive's member permissions (`permissions.list` with the
+    /// drive ID as the target). This is the effective ACL for every file in the
+    /// drive — `File.permissions` is never populated for shared-drive items.
+    ///
+    /// Paginates fully (pageSize=100) and returns the complete member list.
+    /// Requires a caller-provided bearer token (SA self-token or impersonated
+    /// DWD token).
+    pub async fn list_drive_permissions(
+        &self,
+        token: &str,
+        drive_id: &str,
+    ) -> Result<Vec<GoogleDrivePermission>> {
+        let url = format!(
+            "{}/files/{}/permissions",
+            drive_api_base().as_str(),
+            drive_id
+        );
+        let mut all_permissions: Vec<GoogleDrivePermission> = Vec::new();
+        let mut page_token: Option<String> = None;
+
+        loop {
+            let mut params: Vec<(&str, &str)> = vec![
+                ("supportsAllDrives", "true"),
+                ("pageSize", "100"),
+                (
+                    "fields",
+                    "nextPageToken,permissions(id,type,role,emailAddress,domain,allowFileDiscovery,permissionDetails)",
+                ),
+            ];
+            if let Some(ref pt) = page_token {
+                params.push(("pageToken", pt));
+            }
+
+            debug!(
+                "[GOOGLE API CALL] list_drive_permissions drive={}, page_token={:?}",
+                drive_id, page_token
+            );
+            let response = self
+                .client
+                .get(&url)
+                .bearer_auth(token)
+                .query(&params)
+                .send()
+                .await
+                .with_context(|| format!("Failed to list permissions for drive {}", drive_id))?;
+
+            let status = response.status();
+            if !status.is_success() {
+                let error_text = response.text().await?;
+                return Err(anyhow!(
+                    "Failed to list permissions for drive {}: HTTP {} - {}",
+                    drive_id,
+                    status,
+                    error_text
+                ));
+            }
+
+            #[derive(Deserialize)]
+            struct DrivePermissionsResponse {
+                #[serde(rename = "nextPageToken")]
+                next_page_token: Option<String>,
+                #[serde(default)]
+                permissions: Vec<GoogleDrivePermission>,
+            }
+
+            let response_text = response.text().await?;
+            let parsed: DrivePermissionsResponse =
+                serde_json::from_str(&response_text).map_err(|e| {
+                    anyhow!(
+                        "Failed to parse permissions response for drive {}: {}. Raw: {}",
+                        drive_id,
+                        e,
+                        response_text
+                    )
+                })?;
+
+            all_permissions.extend(parsed.permissions);
+            page_token = parsed.next_page_token;
+            if page_token.is_none() {
+                break;
+            }
+        }
+
+        Ok(all_permissions)
     }
 
     /// List all files under a given folder (non-recursive, paginated).
@@ -1320,7 +1423,7 @@ impl DriveClient {
 
                 let mut params: Vec<(&str, &str)> = vec![
                     ("pageSize", "100"),
-                    ("fields", "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))"),
+                    ("fields", FILES_FIELDS),
                     ("q", query.as_str()),
                     ("supportsAllDrives", "true"),
                     ("includeItemsFromAllDrives", "true"),
@@ -1331,7 +1434,10 @@ impl DriveClient {
                     params.push(("pageToken", pt));
                 }
 
-                debug!("[GOOGLE API CALL] list_files_in_folder folder={}, drive={}, page_token={:?}", folder_id, drive_id, page_token);
+                debug!(
+                    "[GOOGLE API CALL] list_files_in_folder folder={}, drive={}, page_token={:?}",
+                    folder_id, drive_id, page_token
+                );
                 let response = self
                     .client
                     .get(&url)
@@ -1343,20 +1449,24 @@ impl DriveClient {
 
                 let status = response.status();
                 if !status.is_success() {
-                    return classify_google_api_error(response, "Failed to list files in folder").await;
+                    return classify_google_api_error(response, "Failed to list files in folder")
+                        .await;
                 }
 
                 let response_text = response.text().await?;
-                let parsed: FilesListResponse = serde_json::from_str(&response_text).map_err(|e| {
-                    anyhow!(
-                        "Failed to parse folder-scoped file list response: {}. Raw: {}",
-                        e, response_text
-                    )
-                })?;
+                let parsed: FilesListResponse =
+                    serde_json::from_str(&response_text).map_err(|e| {
+                        anyhow!(
+                            "Failed to parse folder-scoped file list response: {}. Raw: {}",
+                            e,
+                            response_text
+                        )
+                    })?;
 
                 Ok(ApiResult::Success(parsed))
             }
-        }).await
+        })
+        .await
     }
 
     /// List immediate children (sub-folders only) of a given folder in any drive.

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -256,6 +256,85 @@ impl DriveClient {
         .await
     }
 
+    /// List a user's trashed files (`files.list` with `trashed=true`),
+    /// paginated fully. User-wide variant of [`Self::list_trashed_files_in_drive`]
+    /// for the unfiltered DWD full-sync path, which lists per user across all
+    /// drives (My Drive + shared drives the user can access).
+    pub async fn list_trashed_files_for_user(
+        &self,
+        auth: &GoogleAuth,
+        user_email: &str,
+    ) -> Result<Vec<GoogleDriveFile>> {
+        execute_with_auth_retry(
+            auth,
+            user_email,
+            self.rate_limiter.clone(),
+            |token| async move {
+                let url = format!("{}/files", drive_api_base().as_str());
+                let query = "trashed=true".to_string();
+
+                let mut all_files: Vec<GoogleDriveFile> = Vec::new();
+                let mut page_token: Option<String> = None;
+
+                loop {
+                    let mut params: Vec<(&str, &str)> = vec![
+                        ("pageSize", "100"),
+                        ("fields", FILES_FIELDS),
+                        ("q", query.as_str()),
+                        ("includeItemsFromAllDrives", "true"),
+                        ("supportsAllDrives", "true"),
+                    ];
+                    if let Some(ref pt) = page_token {
+                        params.push(("pageToken", pt));
+                    }
+
+                    debug!(
+                        "[GOOGLE API CALL] list_trashed_files_for_user user={}, page_token={:?}",
+                        user_email, page_token
+                    );
+                    let response = self
+                        .client
+                        .get(&url)
+                        .bearer_auth(&token)
+                        .query(&params)
+                        .send()
+                        .await
+                        .with_context(|| {
+                            format!("Failed to list trashed files for user {}", user_email)
+                        })?;
+
+                    let status = response.status();
+                    if !status.is_success() {
+                        return classify_google_api_error(
+                            response,
+                            "Failed to list trashed files for user",
+                        )
+                        .await;
+                    }
+
+                    let response_text = response.text().await?;
+                    let parsed: FilesListResponse =
+                        serde_json::from_str(&response_text).map_err(|e| {
+                            anyhow!(
+                                "Failed to parse user trashed file list response: {}. Raw: {}",
+                                e,
+                                response_text
+                            )
+                        })?;
+
+                    all_files.extend(parsed.files);
+                    page_token = parsed.next_page_token;
+                    if page_token.is_none() {
+                        break;
+                    }
+                }
+
+                Ok(ApiResult::Success(all_files))
+            },
+        )
+        .await
+    }
+
     pub async fn get_file_content(
         &self,
         auth: &GoogleAuth,

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -1305,6 +1305,89 @@ impl DriveClient {
         .await
     }
 
+    /// List a drive's trashed files (`files.list` with `trashed=true`),
+    /// paginated fully. Used by the SA-direct full-traversal path to reconcile
+    /// documents that were trashed before their trash event was observed by an
+    /// incremental run — incremental `changes.list` only reports a trash once,
+    /// so a pre-existing trashed file would otherwise stay in the index
+    /// forever.
+    pub async fn list_trashed_files_in_drive(
+        &self,
+        auth: &GoogleAuth,
+        user_email: &str,
+        drive_id: &str,
+    ) -> Result<Vec<GoogleDriveFile>> {
+        let drive_id_owned = drive_id.to_string();
+        execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
+            let drive_id = drive_id_owned.clone();
+            async move {
+                let url = format!("{}/files", drive_api_base().as_str());
+                let query = "trashed=true".to_string();
+
+                let mut all_files: Vec<GoogleDriveFile> = Vec::new();
+                let mut page_token: Option<String> = None;
+
+                loop {
+                    let mut params: Vec<(&str, &str)> = vec![
+                        ("pageSize", "100"),
+                        ("fields", FILES_FIELDS),
+                        ("q", query.as_str()),
+                        ("supportsAllDrives", "true"),
+                        ("includeItemsFromAllDrives", "true"),
+                        ("corpora", "drive"),
+                        ("driveId", &drive_id),
+                    ];
+                    if let Some(ref pt) = page_token {
+                        params.push(("pageToken", pt));
+                    }
+
+                    debug!(
+                        "[GOOGLE API CALL] list_trashed_files_in_drive drive={}, page_token={:?}",
+                        drive_id, page_token
+                    );
+                    let response = self
+                        .client
+                        .get(&url)
+                        .bearer_auth(&token)
+                        .query(&params)
+                        .send()
+                        .await
+                        .with_context(|| {
+                            format!("Failed to list trashed files in drive {}", drive_id)
+                        })?;
+
+                    let status = response.status();
+                    if !status.is_success() {
+                        return classify_google_api_error(
+                            response,
+                            "Failed to list trashed files in drive",
+                        )
+                        .await;
+                    }
+
+                    let response_text = response.text().await?;
+                    let parsed: FilesListResponse =
+                        serde_json::from_str(&response_text).map_err(|e| {
+                            anyhow!(
+                                "Failed to parse drive-scoped trashed file list response: {}. Raw: {}",
+                                e,
+                                response_text
+                            )
+                        })?;
+
+                    all_files.extend(parsed.files);
+                    page_token = parsed.next_page_token;
+                    if page_token.is_none() {
+                        break;
+                    }
+                }
+
+                Ok(ApiResult::Success(all_files))
+            }
+        })
+        .await
+    }
+
     /// List a shared drive's member permissions (`permissions.list` with the
     /// drive ID as the target). This is the effective ACL for every file in the
     /// drive — `File.permissions` is never populated for shared-drive items.

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -40,7 +40,7 @@ const DEFAULT_GOOGLE_DRIVE_MAX_DOWNLOAD_BYTES: usize = 50 * 1024 * 1024;
 const FILES_FIELDS: &str = "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,driveId,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))";
 
 /// `fields` projection for changes listings — mirrors `FILES_FIELDS`.
-const CHANGES_FIELDS: &str = "nextPageToken,newStartPageToken,changes(changeType,removed,file(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,driveId,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress)),fileId,time)";
+const CHANGES_FIELDS: &str = "nextPageToken,newStartPageToken,changes(changeType,removed,file(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,trashed,driveId,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress)),fileId,time)";
 
 fn build_files_query(activity_after: Option<&str>) -> String {
     let mut query_parts = vec!["trashed=false".to_string()];

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -1,6 +1,6 @@
 use chrono::{DateTime, Utc};
 use omni_connector_sdk::{
-    ConnectorEvent, DocumentAttributes, DocumentMetadata, DocumentPermissions,
+    AuthType, ConnectorEvent, DocumentAttributes, DocumentMetadata, DocumentPermissions, SourceType,
 };
 use serde::{Deserialize, Serialize};
 use serde_json::json;
@@ -25,7 +25,7 @@ pub struct GoogleDirectoryUser {
 
 /// A single entry in the persisted folder-path filter list in source config.
 /// Stored under `sources.config.folder_path_filters`.
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(deny_unknown_fields)]
 pub struct FolderPathFilterEntry {
     pub id: String,
@@ -36,11 +36,102 @@ pub struct FolderPathFilterEntry {
     pub kind: FolderPathFilterKind,
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "snake_case")]
 pub enum FolderPathFilterKind {
     SharedDriveRoot,
     Folder,
+}
+
+/// Auth strategy for a Google source's service-account credentials.
+///
+/// - `DomainWideDelegation`: the service account impersonates Workspace users
+///   (`sub` claim) — the existing org-wide Drive/Gmail/Chat behavior. Missing
+///   `auth_mode` in legacy source configs defaults here.
+/// - `ServiceAccountDirect`: the service account authenticates as itself (no
+///   `sub` claim) and indexes only explicitly selected shared drives.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoogleAuthMode {
+    #[default]
+    DomainWideDelegation,
+    ServiceAccountDirect,
+}
+
+/// Typed view of a Google source's `sources.config` blob.
+///
+/// Deserialized once at the sync/action boundary and validated via
+/// [`Self::validate`]. Unknown top-level keys are tolerated so legacy sources
+/// are never rejected at dispatch time; the fields we consume are typed.
+#[derive(Debug, Clone, Default, Serialize, Deserialize, PartialEq, Eq)]
+pub struct GoogleSourceConfig {
+    #[serde(default)]
+    pub auth_mode: GoogleAuthMode,
+    /// Retained for existing source-config compatibility (DWD).
+    #[serde(default)]
+    pub domain: Option<String>,
+    /// Selected shared drives (kind `shared_drive_root`) and optional folder
+    /// subtrees (kind `folder`). Empty/missing => index everything (DWD).
+    #[serde(default)]
+    pub folder_path_filters: Vec<FolderPathFilterEntry>,
+    #[serde(default)]
+    pub space_allowlist: Vec<String>,
+    #[serde(default)]
+    pub include_group_chats: bool,
+}
+
+impl GoogleSourceConfig {
+    /// Cross-field validation for the typed config.
+    ///
+    /// `source_type` is the native connector source type; `credential_auth_type`
+    /// is the stored credential's auth type (OAuth vs service-account JWT).
+    ///
+    /// Rules:
+    /// - `ServiceAccountDirect` requires JWT/service-account credentials and is
+    ///   valid only for Google Drive.
+    /// - `ServiceAccountDirect` requires a non-empty `folder_path_filters` list
+    ///   whose entries are all `SharedDriveRoot` (whole drives only in v1).
+    /// - `DomainWideDelegation` keeps the existing permissive behavior.
+    pub fn validate(
+        &self,
+        source_type: SourceType,
+        credential_auth_type: AuthType,
+    ) -> Result<(), String> {
+        match self.auth_mode {
+            GoogleAuthMode::DomainWideDelegation => Ok(()),
+            GoogleAuthMode::ServiceAccountDirect => {
+                if credential_auth_type == AuthType::OAuth {
+                    return Err(
+                        "service_account_direct requires JWT service-account credentials, not OAuth"
+                            .to_string(),
+                    );
+                }
+                if source_type != SourceType::GoogleDrive {
+                    return Err(format!(
+                        "service_account_direct is supported only for Google Drive, not {}",
+                        source_type.as_str()
+                    ));
+                }
+                if self.folder_path_filters.is_empty() {
+                    return Err(
+                        "service_account_direct requires at least one shared drive in folder_path_filters"
+                            .to_string(),
+                    );
+                }
+                if let Some(entry) = self
+                    .folder_path_filters
+                    .iter()
+                    .find(|entry| !matches!(entry.kind, FolderPathFilterKind::SharedDriveRoot))
+                {
+                    return Err(format!(
+                        "service_account_direct only supports whole shared drives (folder_path_filters entry '{}' is a folder; folder-level restrictions are not supported in v1)",
+                        entry.name
+                    ));
+                }
+                Ok(())
+            }
+        }
+    }
 }
 
 /// Result entry returned by the `discover_folders` connector action.
@@ -202,6 +293,12 @@ pub struct GoogleSyncCheckpoint {
     /// `"all"` or a sorted `;`-joined list of selected drive/kind/ID tuples.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub drive_scope_fingerprint: Option<String>,
+    /// Per-drive ACL fingerprints (keyed by shared-drive ID) used to detect
+    /// drive-membership changes that `changes.list` does not deliver. When a
+    /// fingerprint differs from the checkpoint, the drive is fully re-traversed
+    /// so previously indexed unchanged documents get the new ACLs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub drive_acl_fingerprints: Option<HashMap<String, String>>,
     pub chat: Option<GoogleChatCheckpoint>,
 }
 
@@ -250,6 +347,10 @@ pub struct GoogleChatSegmentCheckpoint {
 pub struct UserFile {
     pub user_email: Arc<String>,
     pub file: GoogleDriveFile,
+    /// Optional drive-level ACL override (SA-direct mode). When set, this is
+    /// used as the event's permissions instead of the file's own (empty for
+    /// shared-drive items) permission array.
+    pub permissions_override: Option<DocumentPermissions>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -267,6 +368,8 @@ pub struct GoogleDriveFile {
     pub size: Option<String>,
     pub parents: Option<Vec<String>>,
     pub shared: Option<bool>,
+    #[serde(rename = "driveId")]
+    pub drive_id: Option<String>,
     pub permissions: Option<Vec<GoogleDrivePermission>>,
     pub owners: Option<Vec<Owner>>,
 }
@@ -366,50 +469,148 @@ impl GmailThreadAttributes {
     }
 }
 
-impl GoogleDriveFile {
-    pub fn to_document_permissions(&self, oauth_user_email: Option<&str>) -> DocumentPermissions {
-        let mut is_public = false;
-        let mut users = Vec::new();
-        let mut groups = Vec::new();
+/// Map a list of Drive API permission entries into the Omni `DocumentPermissions`
+/// model. Shared by per-file permission arrays (existing path) and drive-level
+/// ACLs (SA-direct mode).
+///
+/// - `anyone` → `public` (only when `allow_file_discovery != Some(false)`)
+/// - `user` → `users`
+/// - `group` → `groups`
+/// - `domain` → `groups` (domain string, only when discoverable)
+/// - `exclude_email` (if provided) is skipped from `users` — used to keep the
+///   service account's own email out of the indexed ACL.
+pub fn map_drive_permissions(
+    permissions: &[GoogleDrivePermission],
+    exclude_email: Option<&str>,
+) -> DocumentPermissions {
+    let mut is_public = false;
+    let mut users = Vec::new();
+    let mut groups = Vec::new();
 
-        if let Some(file_permissions) = &self.permissions {
-            for perm in file_permissions {
-                match perm.permission_type.as_str() {
-                    "anyone" => {
-                        if perm.allow_file_discovery.unwrap_or(true) {
-                            is_public = true;
-                        }
-                    }
-                    "group" => {
-                        if let Some(email) = &perm.email_address {
-                            groups.push(email.clone());
-                        }
-                    }
-                    "user" => {
-                        if let Some(email) = &perm.email_address {
-                            users.push(email.clone());
-                        }
-                    }
-                    "domain" => {
-                        if perm.allow_file_discovery.unwrap_or(true) {
-                            if let Some(domain) =
-                                perm.domain.as_ref().or(perm.email_address.as_ref())
-                            {
-                                groups.push(domain.clone());
-                            }
-                        }
-                    }
-                    _ => {}
+    for perm in permissions {
+        match perm.permission_type.as_str() {
+            "anyone" => {
+                if perm.allow_file_discovery.unwrap_or(true) {
+                    is_public = true;
                 }
             }
+            "group" => {
+                if let Some(email) = &perm.email_address {
+                    groups.push(email.clone());
+                }
+            }
+            "user" => {
+                if let Some(email) = &perm.email_address {
+                    if exclude_email != Some(email.as_str()) && !users.contains(email) {
+                        users.push(email.clone());
+                    }
+                }
+            }
+            "domain" => {
+                if perm.allow_file_discovery.unwrap_or(true) {
+                    if let Some(domain) = perm.domain.as_ref().or(perm.email_address.as_ref()) {
+                        groups.push(domain.clone());
+                    }
+                }
+            }
+            _ => {}
         }
+    }
+
+    DocumentPermissions {
+        public: is_public,
+        users,
+        groups,
+    }
+}
+
+/// The Drive API roles that are allowed to read a shared drive's ACLs and
+/// therefore supported for SA-direct mode. `fileOrganizer` == Content manager,
+/// `organizer` == Manager.
+pub fn is_sa_role_acl_capable(role: &str) -> bool {
+    matches!(role, "fileOrganizer" | "organizer")
+}
+
+/// Compute a stable fingerprint for a shared drive's ACL (its member list).
+/// Used to detect drive-membership changes that `changes.list` does not
+/// deliver. Identical member sets produce identical fingerprints regardless of
+/// ordering; any membership/role change produces a different one.
+pub fn drive_acl_fingerprint(permissions: &[GoogleDrivePermission]) -> String {
+    use std::collections::BTreeSet;
+    let mut entries: BTreeSet<String> = BTreeSet::new();
+    for perm in permissions {
+        let email = perm.email_address.as_deref().unwrap_or("");
+        let domain = perm.domain.as_deref().unwrap_or("");
+        entries.insert(format!(
+            "{}|{}|{}|{}|{}",
+            perm.permission_type,
+            perm.role,
+            email,
+            domain,
+            perm.allow_file_discovery.unwrap_or(true)
+        ));
+    }
+    entries.into_iter().collect::<Vec<_>>().join(";")
+}
+
+/// Validate that a service account can read ACLs for a shared drive.
+///
+/// Fails if the ACL list is empty, the SA's own permission entry is missing,
+/// or the SA's role is not Content manager (`fileOrganizer`) / Manager
+/// (`organizer`). The error carries the drive ID, observed role, required roles,
+/// and remediation so it can be surfaced directly to an operator.
+pub fn validate_sa_drive_access(
+    drive_id: &str,
+    permissions: &[GoogleDrivePermission],
+    sa_email: &str,
+) -> Result<String, anyhow::Error> {
+    if permissions.is_empty() {
+        return Err(anyhow::anyhow!(
+            "Drive {} returned an empty permission list. The service account ({}) role in this shared drive is too low to read ACLs (needs Content manager or Manager), or the drive has no members. Documents would be indexed with no ACL.",
+            drive_id,
+            sa_email
+        ));
+    }
+
+    let sa_permission = permissions.iter().find(|perm| {
+        perm.permission_type == "user"
+            && perm
+                .email_address
+                .as_deref()
+                .is_some_and(|email| email.eq_ignore_ascii_case(sa_email))
+    });
+
+    let Some(sa_permission) = sa_permission else {
+        return Err(anyhow::anyhow!(
+            "The service account ({}) is not a member of drive {}. Add it as a Content manager or Manager member of the shared drive.",
+            sa_email,
+            drive_id
+        ));
+    };
+
+    if !is_sa_role_acl_capable(&sa_permission.role) {
+        return Err(anyhow::anyhow!(
+            "The service account ({}) has role '{}' in drive {}. SA-direct sync needs Content manager (fileOrganizer) or Manager (organizer) to read drive ACLs. Documents would be indexed with no ACL.",
+            sa_email,
+            sa_permission.role,
+            drive_id
+        ));
+    }
+
+    Ok(sa_permission.role.clone())
+}
+
+impl GoogleDriveFile {
+    pub fn to_document_permissions(&self, oauth_user_email: Option<&str>) -> DocumentPermissions {
+        let permissions = self.permissions.as_deref().unwrap_or_default();
+        let mut mapped = map_drive_permissions(permissions, None);
 
         // Owner access is implicit in personal Drive and not listed in permissions
         if let Some(owners) = &self.owners {
             for owner in owners {
                 if let Some(email) = &owner.email_address {
-                    if !users.contains(email) {
-                        users.push(email.clone());
+                    if !mapped.users.contains(email) {
+                        mapped.users.push(email.clone());
                     }
                 }
             }
@@ -418,16 +619,12 @@ impl GoogleDriveFile {
         // Viewers can't see the permissions array, but presence in Drive listing implies access
         if let Some(email) = oauth_user_email {
             let email = email.to_string();
-            if !users.contains(&email) {
-                users.push(email);
+            if !mapped.users.contains(&email) {
+                mapped.users.push(email);
             }
         }
 
-        DocumentPermissions {
-            public: is_public,
-            users,
-            groups,
-        }
+        mapped
     }
 
     pub fn to_connector_event(
@@ -441,9 +638,15 @@ impl GoogleDriveFile {
         let mut extra = HashMap::new();
         extra.insert("file_id".to_string(), json!(self.id));
         extra.insert("shared".to_string(), json!(self.shared.unwrap_or(false)));
+        if let Some(drive_id) = &self.drive_id {
+            extra.insert("drive_id".to_string(), json!(drive_id));
+        }
 
         // Store Google Drive specific hierarchical data
         let mut google_drive_metadata = HashMap::new();
+        if let Some(drive_id) = &self.drive_id {
+            google_drive_metadata.insert("drive_id".to_string(), json!(drive_id));
+        }
         if let Some(parents) = &self.parents {
             google_drive_metadata.insert("parents".to_string(), json!(parents));
             if let Some(parent) = parents.first() {
@@ -1120,6 +1323,7 @@ mod tests {
             size: Some("12345".to_string()),
             parents: Some(vec!["folder456".to_string()]),
             shared: Some(true),
+            drive_id: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),
                 permission_type: "user".to_string(),
@@ -1273,6 +1477,7 @@ mod tests {
             size: None,
             parents: Some(vec!["parent456".to_string()]),
             shared: None,
+            drive_id: None,
             permissions: None,
             owners: None,
         };
@@ -1323,6 +1528,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            drive_id: None,
             permissions: None,
             owners: None,
         };
@@ -1351,6 +1557,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            drive_id: None,
             permissions: Some(vec![
                 GoogleDrivePermission {
                     id: "perm1".to_string(),
@@ -1418,6 +1625,7 @@ mod tests {
             size: None,
             parents: Some(vec!["folder1".to_string()]),
             shared: None,
+            drive_id: None,
             permissions: None,
             owners: None,
         };
@@ -1453,6 +1661,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            drive_id: None,
             permissions: Some(vec![
                 GoogleDrivePermission {
                     id: "perm_anyone_link".to_string(),
@@ -1494,6 +1703,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            drive_id: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm_domain".to_string(),
                 permission_type: "domain".to_string(),
@@ -1524,6 +1734,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            drive_id: None,
             permissions: Some(vec![]),
             owners: Some(vec![Owner {
                 id: None,
@@ -1556,6 +1767,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            drive_id: None,
             permissions: Some(vec![]),
             owners: Some(vec![Owner {
                 id: None,
@@ -1574,9 +1786,11 @@ mod tests {
         match event {
             ConnectorEvent::DocumentCreated { permissions, .. } => {
                 assert!(permissions.users.contains(&"owner@example.com".to_string()));
-                assert!(permissions
-                    .users
-                    .contains(&"viewer@example.com".to_string()));
+                assert!(
+                    permissions
+                        .users
+                        .contains(&"viewer@example.com".to_string())
+                );
                 assert_eq!(permissions.users.len(), 2);
             }
             _ => panic!("Expected DocumentCreated event"),
@@ -1597,6 +1811,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            drive_id: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),
                 permission_type: "user".to_string(),
@@ -1749,9 +1964,11 @@ mod tests {
             ConnectorEvent::DocumentCreated { permissions, .. } => {
                 assert!(permissions.users.contains(&"alice@example.com".to_string()));
                 assert!(permissions.users.contains(&"owner@example.com".to_string()));
-                assert!(permissions
-                    .users
-                    .contains(&"sender@example.com".to_string()));
+                assert!(
+                    permissions
+                        .users
+                        .contains(&"sender@example.com".to_string())
+                );
             }
             _ => panic!("Expected DocumentCreated event"),
         }
@@ -1985,5 +2202,240 @@ mod tests {
         // Reverse input order should produce same result.
         let filters_rev: Vec<FolderPathFilterEntry> = filters.into_iter().rev().collect();
         assert_eq!(compute_scope_fingerprint(Some(&filters_rev)), fp);
+    }
+
+    #[test]
+    fn test_auth_mode_deserialization_and_default() {
+        // Missing auth_mode defaults to DWD.
+        let config: GoogleSourceConfig = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(config.auth_mode, GoogleAuthMode::DomainWideDelegation);
+
+        // Explicit values.
+        let dwd: GoogleSourceConfig =
+            serde_json::from_value(json!({ "auth_mode": "domain_wide_delegation" })).unwrap();
+        assert_eq!(dwd.auth_mode, GoogleAuthMode::DomainWideDelegation);
+
+        let sa: GoogleSourceConfig =
+            serde_json::from_value(json!({ "auth_mode": "service_account_direct" })).unwrap();
+        assert_eq!(sa.auth_mode, GoogleAuthMode::ServiceAccountDirect);
+
+        // Invalid mode fails closed.
+        assert!(
+            serde_json::from_value::<GoogleSourceConfig>(json!({ "auth_mode": "bogus" })).is_err()
+        );
+    }
+
+    #[test]
+    fn test_google_source_config_tolerates_unknown_top_level_keys() {
+        // Legacy/unknown top-level config keys must not reject deserialization
+        // (they could break every existing source at dispatch time).
+        let config: GoogleSourceConfig = serde_json::from_value(json!({
+            "domain": "company.com",
+            "some_legacy_key": "value",
+        }))
+        .unwrap();
+        assert_eq!(config.domain.as_deref(), Some("company.com"));
+    }
+
+    #[test]
+    fn test_sa_direct_validation_rules() {
+        let root = FolderPathFilterEntry {
+            id: "drive-1".to_string(),
+            name: "Policy Docs".to_string(),
+            path: "/Policy Docs (Shared Drive)".to_string(),
+            drive_id: "drive-1".to_string(),
+            kind: FolderPathFilterKind::SharedDriveRoot,
+        };
+
+        // Valid SA-direct: JWT creds + Drive + root filter.
+        let valid = GoogleSourceConfig {
+            auth_mode: GoogleAuthMode::ServiceAccountDirect,
+            folder_path_filters: vec![root.clone()],
+            ..Default::default()
+        };
+        assert!(
+            valid
+                .validate(SourceType::GoogleDrive, AuthType::Jwt)
+                .is_ok()
+        );
+
+        // Reject OAuth creds.
+        assert!(
+            valid
+                .validate(SourceType::GoogleDrive, AuthType::OAuth)
+                .is_err()
+        );
+
+        // Reject non-Drive source types.
+        assert!(valid.validate(SourceType::Gmail, AuthType::Jwt).is_err());
+        assert!(
+            valid
+                .validate(SourceType::GoogleChat, AuthType::Jwt)
+                .is_err()
+        );
+
+        // Reject empty filters.
+        let empty = GoogleSourceConfig {
+            auth_mode: GoogleAuthMode::ServiceAccountDirect,
+            folder_path_filters: vec![],
+            ..Default::default()
+        };
+        assert!(
+            empty
+                .validate(SourceType::GoogleDrive, AuthType::Jwt)
+                .is_err()
+        );
+
+        // Reject folder-kind entries in v1 (whole drives only).
+        let folder = FolderPathFilterEntry {
+            id: "folder-1".to_string(),
+            name: "Subfolder".to_string(),
+            path: "/Policy Docs/Sub".to_string(),
+            drive_id: "drive-1".to_string(),
+            kind: FolderPathFilterKind::Folder,
+        };
+        let mixed = GoogleSourceConfig {
+            auth_mode: GoogleAuthMode::ServiceAccountDirect,
+            folder_path_filters: vec![root, folder],
+            ..Default::default()
+        };
+        assert!(
+            mixed
+                .validate(SourceType::GoogleDrive, AuthType::Jwt)
+                .is_err()
+        );
+
+        // DWD remains permissive regardless of filters.
+        let dwd = GoogleSourceConfig {
+            auth_mode: GoogleAuthMode::DomainWideDelegation,
+            folder_path_filters: vec![],
+            ..Default::default()
+        };
+        assert!(dwd.validate(SourceType::Gmail, AuthType::Jwt).is_ok());
+    }
+
+    #[test]
+    fn test_map_drive_permissions_cases() {
+        use crate::models::GoogleDrivePermission;
+        let perm =
+            |p_type: &str, email: Option<&str>, domain: Option<&str>, discover: Option<bool>| {
+                GoogleDrivePermission {
+                    id: format!("{}-{}", p_type, email.unwrap_or("")),
+                    permission_type: p_type.to_string(),
+                    email_address: email.map(String::from),
+                    domain: domain.map(String::from),
+                    role: "reader".to_string(),
+                    allow_file_discovery: discover,
+                    permission_details: None,
+                }
+            };
+
+        let perms = vec![
+            perm("anyone", None, None, Some(true)),
+            perm("user", Some("alice@example.com"), None, None),
+            perm(
+                "user",
+                Some("sa@project.iam.gserviceaccount.com"),
+                None,
+                None,
+            ),
+            perm("group", Some("eng@example.com"), None, None),
+            perm("domain", None, Some("example.com"), Some(true)),
+            perm("domain", None, Some("hidden.com"), Some(false)),
+        ];
+
+        let mapped = map_drive_permissions(&perms, Some("sa@project.iam.gserviceaccount.com"));
+        assert!(mapped.public, "anyone + discoverable should be public");
+        assert!(mapped.users.contains(&"alice@example.com".to_string()));
+        assert!(
+            !mapped
+                .users
+                .contains(&"sa@project.iam.gserviceaccount.com".to_string()),
+            "exclude_email must remove the SA"
+        );
+        assert!(mapped.groups.contains(&"eng@example.com".to_string()));
+        assert!(mapped.groups.contains(&"example.com".to_string()));
+        assert!(
+            !mapped.groups.contains(&"hidden.com".to_string()),
+            "non-discoverable domain must not overgrant"
+        );
+
+        // exclude_email not provided -> SA stays in users.
+        let mapped_no_exclude = map_drive_permissions(&perms, None);
+        assert!(
+            mapped_no_exclude
+                .users
+                .contains(&"sa@project.iam.gserviceaccount.com".to_string())
+        );
+
+        // Empty input.
+        let empty = map_drive_permissions(&[], None);
+        assert!(!empty.public);
+        assert!(empty.users.is_empty());
+        assert!(empty.groups.is_empty());
+    }
+
+    #[test]
+    fn test_validate_sa_drive_access_roles() {
+        use crate::models::GoogleDrivePermission;
+        let sa_email = "sa@project.iam.gserviceaccount.com";
+        let member = |role: &str| GoogleDrivePermission {
+            id: "p".to_string(),
+            permission_type: "user".to_string(),
+            email_address: Some(sa_email.to_string()),
+            domain: None,
+            role: role.to_string(),
+            allow_file_discovery: None,
+            permission_details: None,
+        };
+
+        // Content manager / Manager roles pass.
+        assert!(validate_sa_drive_access("d1", &[member("fileOrganizer")], sa_email).is_ok());
+        assert!(validate_sa_drive_access("d1", &[member("organizer")], sa_email).is_ok());
+
+        // Viewer / Commenter / Contributor fail closed.
+        assert!(validate_sa_drive_access("d1", &[member("reader")], sa_email).is_err());
+        assert!(validate_sa_drive_access("d1", &[member("commenter")], sa_email).is_err());
+        assert!(validate_sa_drive_access("d1", &[member("writer")], sa_email).is_err());
+
+        // Empty ACL fails.
+        assert!(validate_sa_drive_access("d1", &[], sa_email).is_err());
+
+        // SA not a member fails.
+        let other = GoogleDrivePermission {
+            id: "p2".to_string(),
+            permission_type: "user".to_string(),
+            email_address: Some("bob@example.com".to_string()),
+            domain: None,
+            role: "organizer".to_string(),
+            allow_file_discovery: None,
+            permission_details: None,
+        };
+        assert!(validate_sa_drive_access("d1", &[other], sa_email).is_err());
+    }
+
+    #[test]
+    fn test_drive_acl_fingerprint_helpers() {
+        use crate::models::GoogleDrivePermission;
+        let sa_email = "sa@project.iam.gserviceaccount.com";
+        let member = |role: &str| GoogleDrivePermission {
+            id: "p".to_string(),
+            permission_type: "user".to_string(),
+            email_address: Some(sa_email.to_string()),
+            domain: None,
+            role: role.to_string(),
+            allow_file_discovery: None,
+            permission_details: None,
+        };
+
+        let fp1 = drive_acl_fingerprint(&[member("organizer")]);
+        let fp2 = drive_acl_fingerprint(&[member("fileOrganizer")]);
+        assert_ne!(fp1, fp2, "role changes must change the fingerprint");
+
+        let fp3 = drive_acl_fingerprint(&[member("organizer")]);
+        assert_eq!(
+            fp1, fp3,
+            "identical ACLs must produce identical fingerprints"
+        );
     }
 }

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -388,6 +388,7 @@ pub struct GoogleDriveFile {
     pub size: Option<String>,
     pub parents: Option<Vec<String>>,
     pub shared: Option<bool>,
+    pub trashed: Option<bool>,
     #[serde(rename = "driveId")]
     pub drive_id: Option<String>,
     pub permissions: Option<Vec<GoogleDrivePermission>>,
@@ -1343,6 +1344,7 @@ mod tests {
             size: Some("12345".to_string()),
             parents: Some(vec!["folder456".to_string()]),
             shared: Some(true),
+            trashed: None,
             drive_id: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),
@@ -1497,6 +1499,7 @@ mod tests {
             size: None,
             parents: Some(vec!["parent456".to_string()]),
             shared: None,
+            trashed: None,
             drive_id: None,
             permissions: None,
             owners: None,
@@ -1548,6 +1551,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            trashed: None,
             drive_id: None,
             permissions: None,
             owners: None,
@@ -1577,6 +1581,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            trashed: None,
             drive_id: None,
             permissions: Some(vec![
                 GoogleDrivePermission {
@@ -1645,6 +1650,7 @@ mod tests {
             size: None,
             parents: Some(vec!["folder1".to_string()]),
             shared: None,
+            trashed: None,
             drive_id: None,
             permissions: None,
             owners: None,
@@ -1681,6 +1687,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            trashed: None,
             drive_id: None,
             permissions: Some(vec![
                 GoogleDrivePermission {
@@ -1723,6 +1730,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            trashed: None,
             drive_id: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm_domain".to_string(),
@@ -1754,6 +1762,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            trashed: None,
             drive_id: None,
             permissions: Some(vec![]),
             owners: Some(vec![Owner {
@@ -1787,6 +1796,7 @@ mod tests {
             size: None,
             parents: None,
             shared: Some(true),
+            trashed: None,
             drive_id: None,
             permissions: Some(vec![]),
             owners: Some(vec![Owner {
@@ -1831,6 +1841,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            trashed: None,
             drive_id: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -238,6 +238,24 @@ pub struct SearchUsersResponse {
     pub has_more: bool,
 }
 
+/// Per-drive result from the `validate_shared_drive_access` connector action.
+/// Mirrors the web's `SharedDriveAccessResult` type.
+#[derive(Debug, Clone, Serialize)]
+pub struct SharedDriveAccessResult {
+    #[serde(rename = "drive_id")]
+    pub drive_id: String,
+    pub ok: bool,
+    pub role: Option<String>,
+    pub error: Option<String>,
+}
+
+/// Response from the `validate_shared_drive_access` connector action.
+/// Mirrors the web's `SharedDriveAccessResponse` type.
+#[derive(Debug, Clone, Serialize)]
+pub struct SharedDriveAccessResponse {
+    pub drives: Vec<SharedDriveAccessResult>,
+}
+
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GoogleConnectorState {
     pub webhook_channel_id: Option<String>,
@@ -284,6 +302,8 @@ impl FolderPathFilterKind {
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
 pub struct GoogleSyncCheckpoint {
     pub gmail_history_ids: Option<HashMap<String, String>>,
+    /// Per-user pagination cursors for the unfiltered (DWD) full Drive sync,
+    /// keyed by impersonated user email. Unused by scoped/SA-direct sync.
     pub drive_page_tokens: Option<HashMap<String, String>>,
     /// Per-drive change tokens used in scoped (filtered) incremental sync.
     /// Keyed by shared-drive ID; absent for unfiltered mode.

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -1,12 +1,12 @@
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use dashmap::DashMap;
-use futures::{stream, StreamExt};
+use futures::{StreamExt, stream};
 use omni_connector_sdk::SyncContext;
 use std::collections::{HashMap, HashSet, VecDeque};
 use std::future::Future;
 use std::pin::Pin;
-use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::time::{Duration, Instant};
 use time::{self, OffsetDateTime};
 use tokio::sync::{Mutex, Notify, OwnedSemaphorePermit, Semaphore};
@@ -91,6 +91,43 @@ fn drive_scope_requires_full_sync(
     current_fingerprint: &str,
 ) -> bool {
     sync_type != SyncType::Incremental || stored_fingerprint != Some(current_fingerprint)
+}
+
+/// A drive scoped by folder-path filters: either the entire drive or a set of
+/// folder subtrees within it (or both — entire-drive supersedes folders).
+#[derive(Debug, Clone)]
+struct DriveGroup {
+    drive_id: String,
+    entire_drive: bool,
+    folder_ids: Vec<String>,
+}
+
+/// Build drive groups from folder-path filter entries. Multiple entries for the
+/// same drive merge; a `SharedDriveRoot` entry makes the whole drive selected
+/// and clears any folder IDs (entire-drive supersedes per-folder selection).
+fn build_drive_groups(filter_entries: &[crate::models::FolderPathFilterEntry]) -> Vec<DriveGroup> {
+    let mut drive_groups: HashMap<String, DriveGroup> = HashMap::new();
+    for entry in filter_entries {
+        let group = drive_groups
+            .entry(entry.drive_id.clone())
+            .or_insert(DriveGroup {
+                drive_id: entry.drive_id.clone(),
+                entire_drive: false,
+                folder_ids: Vec::new(),
+            });
+        match entry.kind {
+            crate::models::FolderPathFilterKind::SharedDriveRoot => {
+                group.entire_drive = true;
+                group.folder_ids.clear(); // entire-drive supersedes per-folder.
+            }
+            crate::models::FolderPathFilterKind::Folder => {
+                if !group.entire_drive {
+                    group.folder_ids.push(entry.id.clone());
+                }
+            }
+        }
+    }
+    drive_groups.into_values().collect()
 }
 
 fn google_webhook_debounce_duration_ms() -> u64 {
@@ -275,7 +312,7 @@ async fn emit_metadata_only_drive_event(
 }
 
 use crate::admin::AdminClient;
-use crate::auth::{google_max_retries, GoogleAuth, GoogleOAuthCredentials, OAuthAuth};
+use crate::auth::{GoogleAuth, GoogleOAuthCredentials, OAuthAuth, google_max_retries};
 use crate::cache::LruFolderCache;
 use crate::chat::{
     ChatClient, GoogleChatAttachmentSource, GoogleChatMessage, GoogleChatSpace,
@@ -285,9 +322,9 @@ use crate::connector::build_attachment_doc_id;
 use crate::drive::{DriveClient, FileContent};
 use crate::gmail::{BatchThreadResult, ExtractedAttachment, GmailClient, MessageFormat};
 use crate::models::{
-    mime_type_to_content_type, AttachmentPointer, GmailThread, GoogleChatSegmentCheckpoint,
-    GoogleChatSpaceCheckpoint, GoogleConnectorState, GoogleSyncCheckpoint, UserFile,
-    WebhookChannel, WebhookChannelResponse, WebhookNotification,
+    AttachmentPointer, GmailThread, GoogleChatSegmentCheckpoint, GoogleChatSpaceCheckpoint,
+    GoogleConnectorState, GoogleSyncCheckpoint, UserFile, WebhookChannel, WebhookChannelResponse,
+    WebhookNotification, mime_type_to_content_type,
 };
 use omni_connector_sdk::RateLimiter;
 use omni_connector_sdk::SdkClient;
@@ -453,11 +490,12 @@ impl GoogleChatSegment {
         extra.insert("message_count".to_string(), json!(self.messages.len()));
         extra.insert(
             "message_names".to_string(),
-            json!(self
-                .messages
-                .iter()
-                .map(|m| m.name.clone())
-                .collect::<Vec<_>>()),
+            json!(
+                self.messages
+                    .iter()
+                    .map(|m| m.name.clone())
+                    .collect::<Vec<_>>()
+            ),
         );
         extra.insert("thread_names".to_string(), json!(self.thread_names()));
         extra.insert(
@@ -507,10 +545,11 @@ impl GoogleChatSegment {
         let mut attrs = HashMap::new();
         attrs.insert(
             "space".to_string(),
-            json!(self
-                .space_display_name
-                .as_deref()
-                .unwrap_or(&self.space_name)),
+            json!(
+                self.space_display_name
+                    .as_deref()
+                    .unwrap_or(&self.space_name)
+            ),
         );
         attrs.insert("space_id".to_string(), json!(self.space_name));
         attrs.insert("threads".to_string(), json!(self.thread_names()));
@@ -983,7 +1022,23 @@ impl SyncManager {
         let source_id = ctx.source_id();
         let sync_type = ctx.sync_mode();
 
-        let known_groups = self.maybe_sync_groups(source, service_creds, ctx).await;
+        // Deserialize the typed source config once. Malformed known fields are a
+        // hard sync error; unknown top-level keys are tolerated.
+        let config: crate::models::GoogleSourceConfig =
+            serde_json::from_value(source.config.clone())
+                .map_err(|e| anyhow!("Invalid Google source config: {}", e))?;
+        let is_sa_direct = matches!(
+            config.auth_mode,
+            crate::models::GoogleAuthMode::ServiceAccountDirect
+        );
+
+        // SA-direct sources never have Admin SDK access — skip group sync.
+        let known_groups = if is_sa_direct {
+            debug!("Skipping group sync for SA-direct source {}", source.id);
+            HashSet::new()
+        } else {
+            self.maybe_sync_groups(source, service_creds, ctx).await
+        };
 
         // The SDK passes us the persisted state on each (re-)dispatch — we use
         // it directly instead of refetching via HTTP. On a fresh sync this is
@@ -998,6 +1053,7 @@ impl SyncManager {
             SourceType::GoogleDrive => {
                 self.sync_drive_source_internal(
                     source,
+                    &config,
                     service_creds,
                     sync_type,
                     existing_state,
@@ -1030,7 +1086,9 @@ impl SyncManager {
             _ => Err(anyhow!("Unsupported source type: {:?}", source.source_type)),
         };
 
-        if result.is_ok() && native_source_type == SourceType::GoogleDrive {
+        // SA-direct is polling-only: skip webhook registration entirely (it
+        // would impersonate the source creator, which SA-direct must never do).
+        if result.is_ok() && native_source_type == SourceType::GoogleDrive && !is_sa_direct {
             self.ensure_webhook_registered(source_id).await;
         }
 
@@ -1205,6 +1263,7 @@ impl SyncManager {
                     file_batch.push(UserFile {
                         user_email: Arc::new(user_email.to_string()),
                         file,
+                        permissions_override: None,
                     });
 
                     if file_batch.len() >= BATCH_SIZE {
@@ -1357,6 +1416,7 @@ impl SyncManager {
                 file_batch.push(UserFile {
                     user_email: Arc::new(user_email.to_string()),
                     file,
+                    permissions_override: None,
                 });
 
                 if file_batch.len() >= BATCH_SIZE {
@@ -1440,9 +1500,15 @@ impl SyncManager {
 
                 let file_lock = content_cache.lock_for_file(&user_file.file.id);
                 let _file_guard = file_lock.lock().await;
-                let current_permissions = user_file
-                    .file
-                    .to_document_permissions(Some(&user_file.user_email));
+                // SA-direct mode carries a drive-level ACL override; use it as-is
+                // (the file's own permissions array is empty for shared drives).
+                // Otherwise derive from the file + syncing user as before.
+                let current_permissions = match &user_file.permissions_override {
+                    Some(override_permissions) => override_permissions.clone(),
+                    None => user_file
+                        .file
+                        .to_document_permissions(Some(&user_file.user_email)),
+                };
                 let merged_permissions =
                     content_cache.merge_permissions(&user_file.file.id, current_permissions);
 
@@ -1790,6 +1856,7 @@ impl SyncManager {
             drive_page_tokens,
             drive_change_tokens,
             drive_scope_fingerprint,
+            drive_acl_fingerprints: existing.drive_acl_fingerprints.clone(),
             chat: existing.chat.clone(),
         }
     }
@@ -1890,35 +1957,8 @@ impl SyncManager {
             drive_scope_requires_full_sync(sync_type, stored_fingerprint, &current_fingerprint);
 
         // Build drive groups: driveId → (selected folder IDs, whether entire drive is selected)
-        struct DriveGroup {
-            drive_id: String,
-            entire_drive: bool,
-            folder_ids: Vec<String>,
-        }
+        let drives = build_drive_groups(&filter_entries);
 
-        let mut drive_groups: HashMap<String, DriveGroup> = HashMap::new();
-        for entry in &filter_entries {
-            let group = drive_groups
-                .entry(entry.drive_id.clone())
-                .or_insert(DriveGroup {
-                    drive_id: entry.drive_id.clone(),
-                    entire_drive: false,
-                    folder_ids: Vec::new(),
-                });
-            match entry.kind {
-                crate::models::FolderPathFilterKind::SharedDriveRoot => {
-                    group.entire_drive = true;
-                    group.folder_ids.clear(); // entire-drive supersedes per-folder.
-                }
-                crate::models::FolderPathFilterKind::Folder => {
-                    if !group.entire_drive {
-                        group.folder_ids.push(entry.id.clone());
-                    }
-                }
-            }
-        }
-
-        let drives: Vec<DriveGroup> = drive_groups.into_values().collect();
         if drives.is_empty() {
             info!("No valid drive scopes found — indexing nothing");
             return Ok(self.build_drive_checkpoint(
@@ -2029,6 +2069,7 @@ impl SyncManager {
                             file_batch.push(UserFile {
                                 user_email: Arc::new(principal_email.clone()),
                                 file: file.clone(),
+                                permissions_override: None,
                             });
 
                             if file_batch.len() >= BATCH_SIZE {
@@ -2130,6 +2171,7 @@ impl SyncManager {
                                 file_batch.push(UserFile {
                                     user_email: Arc::new(principal_email.clone()),
                                     file,
+                                    permissions_override: None,
                                 });
                                 if file_batch.len() >= BATCH_SIZE {
                                     self.flush_batch(
@@ -2218,6 +2260,7 @@ impl SyncManager {
                                     file_batch.push(UserFile {
                                         user_email: Arc::new(principal_email.clone()),
                                         file,
+                                        permissions_override: None,
                                     });
                                     if file_batch.len() >= BATCH_SIZE {
                                         self.flush_batch(
@@ -2285,9 +2328,342 @@ impl SyncManager {
         ))
     }
 
+    /// SA-direct drive sync: index the configured shared drives as the service
+    /// account itself (no `sub` impersonation, no Admin SDK, no user listing).
+    ///
+    /// For each drive it resolves the drive-level ACL via `permissions.list`,
+    /// validates the SA role (Content manager/Manager — fail closed), maps the
+    /// ACL to `DocumentPermissions`, and applies it to every emitted file
+    /// (shared-drive `File.permissions` is always empty). Drive-membership
+    /// changes are detected via a per-drive ACL fingerprint: when it changes,
+    /// the drive is fully re-traversed (no date cutoff) so already-indexed
+    /// unchanged documents get the new ACLs.
+    async fn sync_drive_sa_direct(
+        &self,
+        source: &Source,
+        config: &crate::models::GoogleSourceConfig,
+        service_creds: &ServiceCredential,
+        sync_type: SyncType,
+        existing_state: &GoogleSyncCheckpoint,
+        ctx: &SyncContext,
+    ) -> Result<GoogleSyncCheckpoint> {
+        let sync_run_id = ctx.sync_run_id();
+
+        // SA-direct must have been validated at the request boundary; re-validate
+        // defensively so a config edited behind the sync path still fails closed.
+        config
+            .validate(SourceType::GoogleDrive, service_creds.auth_type)
+            .map_err(anyhow::Error::msg)?;
+
+        let service_auth = Arc::new(
+            self.create_auth(service_creds, SourceType::GoogleDrive)
+                .await?,
+        );
+        let access_token = service_auth.get_self_access_token().await?;
+        let sa_email = match service_auth.as_ref() {
+            crate::auth::GoogleAuth::ServiceAccount(sa) => sa.client_email().to_string(),
+            crate::auth::GoogleAuth::OAuth(_) => {
+                return Err(anyhow!("SA-direct requires service-account credentials"));
+            }
+        };
+
+        let (drive_cutoff_date, _gmail_cutoff_date) = self.get_cutoff_date()?;
+
+        // Build drive groups from the typed config (already validated root-only).
+        let filter_entries = &config.folder_path_filters;
+        let drives = build_drive_groups(filter_entries);
+        if drives.is_empty() {
+            return Err(anyhow!(
+                "SA-direct sync requires at least one selected shared drive"
+            ));
+        }
+
+        // Scope fingerprint: include the auth mode so a DWD→SA-direct switch on
+        // the same source forces a full resync (defensive; in-place conversion is
+        // not a supported v1 path).
+        let current_fingerprint = format!(
+            "sa-direct:{}",
+            crate::models::compute_scope_fingerprint(Some(filter_entries))
+        );
+        let stored_fingerprint = existing_state.drive_scope_fingerprint.as_deref();
+        let scope_changed = stored_fingerprint != Some(&current_fingerprint);
+        if scope_changed {
+            info!(
+                "Drive scope transition detected: {:?} -> {} — forcing full sync",
+                stored_fingerprint, current_fingerprint
+            );
+        }
+
+        // Preflight ALL selected drives before processing any file: fetch each
+        // drive's ACL, validate the SA role, and compute the ACL fingerprint.
+        // A failure on any drive aborts the run before a partial batch is emitted.
+        let old_acl_fingerprints = existing_state
+            .drive_acl_fingerprints
+            .clone()
+            .unwrap_or_default();
+        let mut new_acl_fingerprints: HashMap<String, String> = HashMap::new();
+        let mut drive_acl_overrides: HashMap<String, DocumentPermissions> = HashMap::new();
+        let mut drive_acl_changed: HashMap<String, bool> = HashMap::new();
+
+        for drive_group in &drives {
+            let drive_id = &drive_group.drive_id;
+            let drive_acl = self
+                .drive_client
+                .list_drive_permissions(&access_token, drive_id)
+                .await
+                .with_context(|| format!("Failed to read ACLs for drive {}", drive_id))?;
+
+            let _role = crate::models::validate_sa_drive_access(drive_id, &drive_acl, &sa_email)?;
+
+            let permissions = crate::models::map_drive_permissions(&drive_acl, Some(&sa_email));
+            let fingerprint = crate::models::drive_acl_fingerprint(&drive_acl);
+            let changed = old_acl_fingerprints.get(drive_id) != Some(&fingerprint);
+            if changed {
+                info!(
+                    "ACL fingerprint changed for drive {} — forcing full re-traversal",
+                    drive_id
+                );
+            }
+            new_acl_fingerprints.insert(drive_id.clone(), fingerprint);
+            drive_acl_overrides.insert(drive_id.clone(), permissions);
+            drive_acl_changed.insert(drive_id.clone(), changed);
+        }
+
+        let content_cache = Arc::new(DriveContentCache::default());
+        let mut total_scanned = 0;
+        let mut total_updated = 0;
+        let mut new_change_tokens: HashMap<String, String> = HashMap::new();
+        let old_change_tokens = existing_state
+            .drive_change_tokens
+            .clone()
+            .unwrap_or_default();
+        const BATCH_SIZE: usize = 200;
+
+        for drive_group in &drives {
+            if ctx.is_cancelled() {
+                info!("Sync {} cancelled during SA-direct sync", sync_run_id);
+                break;
+            }
+
+            let drive_id = &drive_group.drive_id;
+            let drive_permissions = drive_acl_overrides
+                .get(drive_id)
+                .cloned()
+                .expect("drive ACL resolved in preflight");
+            let acl_changed = drive_acl_changed.get(drive_id).copied().unwrap_or(true);
+
+            // ACL change forces an uncut full traversal (no date cutoff) so every
+            // previously indexed unchanged document is re-emitted with new ACLs.
+            let use_incremental = sync_type == SyncType::Incremental
+                && !scope_changed
+                && !acl_changed
+                && old_change_tokens.get(drive_id).is_some();
+
+            if use_incremental {
+                let start_token = old_change_tokens.get(drive_id).unwrap().clone();
+                let mut current_token = start_token.clone();
+
+                loop {
+                    let response = self
+                        .drive_client
+                        .list_changes_for_drive(&access_token, &current_token, drive_id)
+                        .await?;
+
+                    if ctx.is_cancelled() {
+                        break;
+                    }
+
+                    let mut file_batch: Vec<UserFile> = Vec::new();
+                    for change in &response.changes {
+                        let is_removed = change.removed.unwrap_or(false);
+                        if is_removed {
+                            if let Some(file_id) = &change.file_id {
+                                info!(
+                                    "File {} was removed (SA-direct incremental), publishing deletion",
+                                    file_id
+                                );
+                                self.publish_deletion_event(ctx, file_id).await?;
+                            }
+                            continue;
+                        }
+
+                        if let Some(file) = &change.file {
+                            if self.should_index_file(file) {
+                                file_batch.push(UserFile {
+                                    user_email: Arc::new(sa_email.clone()),
+                                    file: file.clone(),
+                                    permissions_override: Some(drive_permissions.clone()),
+                                });
+                                if file_batch.len() >= BATCH_SIZE {
+                                    self.flush_batch(
+                                        &mut file_batch,
+                                        &source.id,
+                                        &sync_run_id,
+                                        ctx,
+                                        service_auth.clone(),
+                                        content_cache.clone(),
+                                        &mut total_scanned,
+                                        &mut total_updated,
+                                    )
+                                    .await?;
+                                }
+                            }
+                        }
+                    }
+
+                    self.flush_batch(
+                        &mut file_batch,
+                        &source.id,
+                        &sync_run_id,
+                        ctx,
+                        service_auth.clone(),
+                        content_cache.clone(),
+                        &mut total_scanned,
+                        &mut total_updated,
+                    )
+                    .await?;
+
+                    if let Some(new_token) = &response.new_start_page_token {
+                        new_change_tokens.insert(drive_id.clone(), new_token.clone());
+                    }
+
+                    match response.next_page_token {
+                        Some(token) => current_token = token,
+                        None => break,
+                    }
+                }
+
+                if !new_change_tokens.contains_key(drive_id) {
+                    match self
+                        .drive_client
+                        .get_start_page_token_for_drive(&access_token, drive_id)
+                        .await
+                    {
+                        Ok(token) => {
+                            new_change_tokens.insert(drive_id.clone(), token);
+                        }
+                        Err(e) => {
+                            warn!(
+                                "Failed to get start page token for drive {}: {}",
+                                drive_id, e
+                            );
+                        }
+                    }
+                }
+            } else {
+                let next_change_token = match self
+                    .drive_client
+                    .get_start_page_token_for_drive(&access_token, drive_id)
+                    .await
+                {
+                    Ok(token) => Some(token),
+                    Err(error) => {
+                        warn!(
+                            "Failed to get start page token for drive {}: {}",
+                            drive_id, error
+                        );
+                        None
+                    }
+                };
+
+                let mut file_batch: Vec<UserFile> = Vec::new();
+                let mut page_token: Option<String> = None;
+                loop {
+                    // Full traversal: when the ACL changed, pass no cutoff so
+                    // every document (even unchanged old ones) is re-emitted;
+                    // otherwise apply the normal date cutoff.
+                    let modified_after: Option<&str> = if acl_changed {
+                        None
+                    } else {
+                        Some(&drive_cutoff_date)
+                    };
+                    let response = self
+                        .drive_client
+                        .list_files_in_drive(
+                            &service_auth,
+                            &sa_email,
+                            drive_id,
+                            page_token.as_deref(),
+                            modified_after,
+                        )
+                        .await?;
+
+                    for file in response.files {
+                        if self.should_index_file(&file) {
+                            file_batch.push(UserFile {
+                                user_email: Arc::new(sa_email.clone()),
+                                file,
+                                permissions_override: Some(drive_permissions.clone()),
+                            });
+                            if file_batch.len() >= BATCH_SIZE {
+                                self.flush_batch(
+                                    &mut file_batch,
+                                    &source.id,
+                                    &sync_run_id,
+                                    ctx,
+                                    service_auth.clone(),
+                                    content_cache.clone(),
+                                    &mut total_scanned,
+                                    &mut total_updated,
+                                )
+                                .await?;
+                            }
+                        }
+                    }
+
+                    if ctx.is_cancelled() {
+                        break;
+                    }
+
+                    page_token = response.next_page_token;
+                    if page_token.is_none() {
+                        break;
+                    }
+                }
+
+                self.flush_batch(
+                    &mut file_batch,
+                    &source.id,
+                    &sync_run_id,
+                    ctx,
+                    service_auth.clone(),
+                    content_cache.clone(),
+                    &mut total_scanned,
+                    &mut total_updated,
+                )
+                .await?;
+
+                if ctx.is_cancelled() {
+                    break;
+                }
+
+                if let Some(token) = next_change_token {
+                    new_change_tokens.insert(drive_id.clone(), token);
+                }
+            }
+        }
+
+        info!(
+            "SA-direct Drive sync completed for source {}: {} scanned, {} updated",
+            source.id, total_scanned, total_updated
+        );
+
+        self.folder_cache.clear();
+
+        Ok(GoogleSyncCheckpoint {
+            gmail_history_ids: existing_state.gmail_history_ids.clone(),
+            drive_page_tokens: None,
+            drive_change_tokens: Some(new_change_tokens),
+            drive_scope_fingerprint: Some(current_fingerprint),
+            drive_acl_fingerprints: Some(new_acl_fingerprints),
+            chat: existing_state.chat.clone(),
+        })
+    }
+
     async fn sync_drive_source_internal(
         &self,
         source: &Source,
+        config: &crate::models::GoogleSourceConfig,
         service_creds: &ServiceCredential,
         sync_type: SyncType,
         existing_state: GoogleSyncCheckpoint,
@@ -2297,6 +2673,24 @@ impl SyncManager {
 
         let native_source_type = SourceType::try_from(source.source_type.as_str())
             .map_err(|e| anyhow!("Unsupported source type: {}", e))?;
+
+        // SA-direct mode: index the selected shared drives as the SA itself.
+        if matches!(
+            config.auth_mode,
+            crate::models::GoogleAuthMode::ServiceAccountDirect
+        ) {
+            return self
+                .sync_drive_sa_direct(
+                    source,
+                    config,
+                    service_creds,
+                    sync_type,
+                    &existing_state,
+                    ctx,
+                )
+                .await;
+        }
+
         let service_auth = Arc::new(self.create_auth(service_creds, native_source_type).await?);
 
         // Parse folder-path filters. Malformed config is a sync error.
@@ -2548,6 +2942,7 @@ impl SyncManager {
                         },
                         drive_change_tokens: None,
                         drive_scope_fingerprint: Some(current_fingerprint.clone()),
+                        drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
                         chat: chat_checkpoint.clone(),
                     };
                     ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
@@ -2605,6 +3000,7 @@ impl SyncManager {
             },
             drive_change_tokens: None,
             drive_scope_fingerprint: Some(current_fingerprint),
+            drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
             chat: chat_checkpoint,
         })
     }
@@ -2813,6 +3209,7 @@ impl SyncManager {
                             drive_page_tokens: drive_page_tokens.clone(),
                             drive_change_tokens: existing_state.drive_change_tokens.clone(),
                             drive_scope_fingerprint: existing_state.drive_scope_fingerprint.clone(),
+                            drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
                             chat: chat_checkpoint.clone(),
                         };
                         ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
@@ -2863,6 +3260,7 @@ impl SyncManager {
             drive_page_tokens,
             drive_change_tokens: existing_state.drive_change_tokens.clone(),
             drive_scope_fingerprint: existing_state.drive_scope_fingerprint.clone(),
+            drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
             chat: chat_checkpoint,
         })
     }
@@ -3020,6 +3418,7 @@ impl SyncManager {
                 drive_page_tokens: existing_state.drive_page_tokens.clone(),
                 drive_change_tokens: existing_state.drive_change_tokens.clone(),
                 drive_scope_fingerprint: existing_state.drive_scope_fingerprint.clone(),
+                drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
                 chat: Some(chat_checkpoint.clone()),
             };
             ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
@@ -3031,6 +3430,7 @@ impl SyncManager {
             drive_page_tokens: existing_state.drive_page_tokens,
             drive_change_tokens: existing_state.drive_change_tokens,
             drive_scope_fingerprint: existing_state.drive_scope_fingerprint,
+            drive_acl_fingerprints: existing_state.drive_acl_fingerprints,
             chat: Some(chat_checkpoint),
         })
     }
@@ -5060,9 +5460,11 @@ impl SyncManager {
 pub(crate) async fn check_ancestry_static(
     file_parents: &Option<Vec<String>>,
     allowed_ids: &HashSet<String>,
-    lookup: &(dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<(String, Option<String>)>> + Send>>
-          + Send
-          + Sync),
+    lookup: &(
+         dyn Fn(String) -> Pin<Box<dyn Future<Output = Result<(String, Option<String>)>> + Send>>
+             + Send
+             + Sync
+     ),
 ) -> Result<bool> {
     if allowed_ids.is_empty() {
         return Ok(true);
@@ -5136,6 +5538,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            drive_id: None,
             permissions: None,
             owners: None,
         };
@@ -5160,6 +5563,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            drive_id: None,
             permissions: None,
             owners: None,
         };
@@ -5374,6 +5778,7 @@ mod tests {
                 size: None,
                 parents: None,
                 shared: None,
+                drive_id: None,
                 permissions: None,
                 owners: None,
             }

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -1380,7 +1380,17 @@ impl SyncManager {
         const BATCH_SIZE: usize = 200;
 
         for change in all_changes {
-            let is_removed = change.removed.unwrap_or(false);
+            // A change reports a file as removed either via `removed: true`
+            // (permanent delete) or via the file's own `trashed: true` flag
+            // (moved to trash, deleted permanently after the retention
+            // window). Both mean the document must leave the index now — a
+            // trashed file is no longer accessible to anyone.
+            let is_removed = change.removed.unwrap_or(false)
+                || change
+                    .file
+                    .as_ref()
+                    .and_then(|f| f.trashed)
+                    .unwrap_or(false);
 
             if is_removed {
                 if let Some(file_id) = &change.file_id {
@@ -2027,7 +2037,14 @@ impl SyncManager {
                     let mut file_batch: Vec<UserFile> = Vec::new();
 
                     for change in &response.changes {
-                        let is_removed = change.removed.unwrap_or(false);
+                        // removed:true (permanent delete) or file.trashed:true
+                        // (in trash) both mean the doc must leave the index.
+                        let is_removed = change.removed.unwrap_or(false)
+                            || change
+                                .file
+                                .as_ref()
+                                .and_then(|f| f.trashed)
+                                .unwrap_or(false);
 
                         if is_removed {
                             if let Some(file_id) = &change.file_id {
@@ -2475,7 +2492,14 @@ impl SyncManager {
 
                     let mut file_batch: Vec<UserFile> = Vec::new();
                     for change in &response.changes {
-                        let is_removed = change.removed.unwrap_or(false);
+                        // removed:true (permanent delete) or file.trashed:true
+                        // (in trash) both mean the doc must leave the index.
+                        let is_removed = change.removed.unwrap_or(false)
+                            || change
+                                .file
+                                .as_ref()
+                                .and_then(|f| f.trashed)
+                                .unwrap_or(false);
                         if is_removed {
                             if let Some(file_id) = &change.file_id {
                                 info!(
@@ -5538,6 +5562,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            trashed: None,
             drive_id: None,
             permissions: None,
             owners: None,
@@ -5563,6 +5588,7 @@ mod tests {
             size: None,
             parents: None,
             shared: None,
+            trashed: None,
             drive_id: None,
             permissions: None,
             owners: None,
@@ -5778,6 +5804,7 @@ mod tests {
                 size: None,
                 parents: None,
                 shared: None,
+                trashed: None,
                 drive_id: None,
                 permissions: None,
                 owners: None,

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -323,8 +323,8 @@ use crate::drive::{DriveClient, FileContent};
 use crate::gmail::{BatchThreadResult, ExtractedAttachment, GmailClient, MessageFormat};
 use crate::models::{
     AttachmentPointer, GmailThread, GoogleChatSegmentCheckpoint, GoogleChatSpaceCheckpoint,
-    GoogleConnectorState, GoogleSyncCheckpoint, UserFile, WebhookChannel, WebhookChannelResponse,
-    WebhookNotification, mime_type_to_content_type,
+    GoogleConnectorState, GoogleDriveFile, GoogleSyncCheckpoint, UserFile, WebhookChannel,
+    WebhookChannelResponse, WebhookNotification, mime_type_to_content_type,
 };
 use omni_connector_sdk::RateLimiter;
 use omni_connector_sdk::SdkClient;
@@ -1317,6 +1317,16 @@ impl SyncManager {
             total_scanned += scanned;
             total_updated += updated;
         }
+
+        // Reconcile the user's trashed files on a full traversal (see
+        // [`Self::publish_trashed_deletions`]). This function is only invoked
+        // from the full-sync branch; incremental syncs go through
+        // [`Self::sync_drive_for_user_incremental`] instead.
+        let trashed_files = self
+            .drive_client
+            .list_trashed_files_for_user(&service_auth, user_email)
+            .await?;
+        self.publish_trashed_deletions(ctx, trashed_files).await?;
 
         info!(
             "Completed processing user {}: {} scanned, {} updated",
@@ -2320,6 +2330,18 @@ impl SyncManager {
                 )
                 .await?;
 
+                // Reconcile trashed files in this drive on a full traversal
+                // (see [`Self::publish_trashed_deletions`]).
+                let trashed_files = self
+                    .drive_client
+                    .list_trashed_files_in_drive(
+                        &service_auth,
+                        &principal_email,
+                        &drive_group.drive_id,
+                    )
+                    .await?;
+                self.publish_trashed_deletions(ctx, trashed_files).await?;
+
                 if ctx.is_cancelled() {
                     break;
                 }
@@ -2667,13 +2689,7 @@ impl SyncManager {
                     .drive_client
                     .list_trashed_files_in_drive(&service_auth, &sa_email, drive_id)
                     .await?;
-                for trashed in trashed_files {
-                    info!(
-                        "File {} ({}) is trashed (full traversal), publishing deletion",
-                        trashed.id, trashed.name
-                    );
-                    self.publish_deletion_event(ctx, &trashed.id).await?;
-                }
+                self.publish_trashed_deletions(ctx, trashed_files).await?;
 
                 if ctx.is_cancelled() {
                     break;
@@ -4293,6 +4309,26 @@ impl SyncManager {
             document_id: document_id.to_string(),
         };
         ctx.emit_event(event).await
+    }
+
+    /// Publish a deletion event for every file in `trashed_files`. Shared by
+    /// all full-traversal paths (SA-direct and DWD) to reconcile files that
+    /// were trashed before their trash transition was observed by an
+    /// incremental run — `changes.list` reports a trash only once, so without
+    /// this a pre-trashed file would stay in the index forever.
+    async fn publish_trashed_deletions(
+        &self,
+        ctx: &SyncContext,
+        trashed_files: Vec<GoogleDriveFile>,
+    ) -> Result<()> {
+        for trashed in trashed_files {
+            info!(
+                "File {} ({}) is trashed (full traversal), publishing deletion",
+                trashed.id, trashed.name
+            );
+            self.publish_deletion_event(ctx, &trashed.id).await?;
+        }
+        Ok(())
     }
 
     async fn get_service_credentials(&self, source_id: &str) -> Result<ServiceCredential> {

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -2657,6 +2657,24 @@ impl SyncManager {
                 )
                 .await?;
 
+                // Reconcile trashed files: incremental changes.list only
+                // reports a trash transition once, so files trashed before we
+                // observed the event (or trashed while incremental was
+                // unavailable) would otherwise stay in the index forever. A
+                // full traversal is the safe point to list trashed=true and
+                // publish deletions.
+                let trashed_files = self
+                    .drive_client
+                    .list_trashed_files_in_drive(&service_auth, &sa_email, drive_id)
+                    .await?;
+                for trashed in trashed_files {
+                    info!(
+                        "File {} ({}) is trashed (full traversal), publishing deletion",
+                        trashed.id, trashed.name
+                    );
+                    self.publish_deletion_event(ctx, &trashed.id).await?;
+                }
+
                 if ctx.is_cancelled() {
                     break;
                 }

--- a/connectors/google/tests/common/mod.rs
+++ b/connectors/google/tests/common/mod.rs
@@ -76,12 +76,20 @@ impl GoogleConnectorTestFixture {
             redis_client.clone(),
         ));
 
+        let remote_mcp_gateway = Arc::new(
+            omni_connector_manager::remote_mcp::gateway::RemoteMcpGateway::new(
+                test_env.db_pool.clone(),
+                redis_client.clone(),
+            )?,
+        );
+
         let extraction_semaphore = Arc::new(Semaphore::new(config.extraction_concurrency));
         let app_state = AppState {
             db_pool: test_env.db_pool.clone(),
             redis_client,
             config,
             sync_manager: cm_sync_manager,
+            remote_mcp_gateway,
             content_storage,
             extraction_semaphore,
         };

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -528,7 +528,9 @@ mod sa_direct_tests {
         AuthType, Connector, SdkClient, ServiceCredential, ServiceProvider, Source, SourceType,
         SyncContext, SyncType,
     };
-    use omni_google_connector::{admin::AdminClient, sync::SyncManager};
+    use omni_google_connector::{
+        admin::AdminClient, models::GoogleSyncCheckpoint, sync::SyncManager,
+    };
     use serde_json::{Value as JsonValue, json};
     use shared::models::{SourceScope, UserFilterMode};
     use std::collections::HashMap;
@@ -835,6 +837,32 @@ mod sa_direct_tests {
         sync_manager.run_sync(source, Some(creds), None, ctx).await
     }
 
+    /// Like [`run_sa_sync`] but seeds an existing checkpoint so the sync can
+    /// resume incrementally (change tokens / ACL fingerprints present).
+    async fn run_sa_sync_with_checkpoint(
+        mock_base: &str,
+        source: Source,
+        creds: ServiceCredential,
+        sync_type: SyncType,
+        checkpoint: GoogleSyncCheckpoint,
+    ) -> Result<()> {
+        let cm_url = mock_base.to_string();
+        let sdk_client = SdkClient::new(&cm_url);
+        sdk_client.register_sync(SA_SYNC_RUN_ID, sync_type).await;
+        let sync_manager = SyncManager::new(Arc::new(AdminClient::new()), sdk_client.clone(), None);
+        let ctx = SyncContext::new(
+            sdk_client,
+            SA_SYNC_RUN_ID.to_string(),
+            SA_SOURCE_ID.to_string(),
+            SourceType::GoogleDrive,
+            sync_type,
+            Arc::new(AtomicBool::new(false)),
+        );
+        sync_manager
+            .run_sync(source, Some(creds), Some(checkpoint), ctx)
+            .await
+    }
+
     #[tokio::test]
     async fn sa_direct_discovery_uses_self_token_and_returns_roots_only() -> Result<()> {
         let _guard = SA_ENV_LOCK.lock().await;
@@ -1067,6 +1095,123 @@ mod sa_direct_tests {
         assert!(
             state.file_list_calls() >= 1,
             "expected at least one files.list call"
+        );
+
+        Ok(())
+    }
+
+    /// A trashed file in an incremental changes.list response must publish a
+    /// deletion event (trash = inaccessible, so it leaves the index) rather
+    /// than being re-indexed as a normal file.
+    #[tokio::test]
+    async fn sa_direct_incremental_publishes_deletion_for_trashed_file() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        // Drive members: an internal user + the SA. SA excluded from docs.
+        state.set_permissions(json!([
+            {
+                "id": "p1",
+                "type": "user",
+                "emailAddress": SA_CLIENT_EMAIL,
+                "domain": null,
+                "role": "organizer",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            },
+            {
+                "id": "p2",
+                "type": "user",
+                "emailAddress": "alice@example.com",
+                "domain": null,
+                "role": "reader",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            }
+        ]));
+
+        // One incremental change: the file moved to trash (trashed:true,
+        // removed:false). ACL fingerprint unchanged so the run stays
+        // incremental.
+        state.changes.lock().unwrap().replace(json!({
+            "changes": [
+                {
+                    "changeType": "file",
+                    "removed": false,
+                    "fileId": "doc-trash",
+                    "file": {
+                        "id": "doc-trash",
+                        "name": "Old Policy.txt",
+                        "mimeType": "text/plain",
+                        "size": "1024",
+                        "webViewLink": "https://example.test/doc-trash",
+                        "createdTime": "2023-01-01T00:00:00Z",
+                        "modifiedTime": "2023-01-02T00:00:00Z",
+                        "driveId": "drive-1",
+                        "trashed": true,
+                        "permissions": [],
+                        "owners": []
+                    },
+                    "time": "2024-01-03T00:00:00Z"
+                }
+            ],
+            "newStartPageToken": "start-99"
+        }));
+
+        // Seed a checkpoint with an ACL fingerprint and change token so the
+        // sync takes the incremental branch (no scope/ACL change, token known).
+        let checkpoint = GoogleSyncCheckpoint {
+            drive_scope_fingerprint: Some(
+                "sa-direct:drive-1:shared_drive_root:drive-1".to_string(),
+            ),
+            drive_acl_fingerprints: Some(HashMap::from([(
+                "drive-1".to_string(),
+                "user|organizer|sa@test-project.iam.gserviceaccount.com||true;user|reader|alice@example.com||true"
+                    .to_string(),
+            )])),
+            drive_change_tokens: Some(HashMap::from([("drive-1".to_string(), "start-1".to_string())])),
+            ..Default::default()
+        };
+
+        let sync_result = run_sa_sync_with_checkpoint(
+            &mock_base,
+            sa_source(),
+            sa_credentials(&mock_base),
+            SyncType::Incremental,
+            checkpoint,
+        )
+        .await;
+
+        if let Some(value) = previous_drive_base {
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        sync_result?;
+
+        let bodies = state.event_bodies();
+        assert!(!bodies.is_empty(), "expected emitted event batch bodies");
+        let mut deletions = 0;
+        for body in &bodies {
+            if let Some(events) = body.get("events").and_then(|e| e.as_array()) {
+                for event in events {
+                    let kind = event
+                        .get("type")
+                        .or_else(|| event.get("event"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    if kind == "document_deleted" {
+                        deletions += 1;
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            deletions, 1,
+            "expected exactly one document_deleted event for the trashed file"
         );
 
         Ok(())

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -556,6 +556,8 @@ mod sa_direct_tests {
         permissions_forbidden: Arc<AtomicBool>,
         /// Files served by list_files_in_drive (corpora=drive).
         files: Arc<Mutex<Vec<JsonValue>>>,
+        /// Files served by list_trashed_files_in_drive (trashed=true).
+        trashed_files: Arc<Mutex<Vec<JsonValue>>>,
         /// Change-token pagination response for incremental syncs.
         changes: Arc<Mutex<Option<JsonValue>>>,
         /// Captured /sdk/events/batch bodies.
@@ -574,6 +576,9 @@ mod sa_direct_tests {
         }
         fn set_files(&self, files: Vec<JsonValue>) {
             *self.files.lock().unwrap() = files;
+        }
+        fn set_trashed_files(&self, files: Vec<JsonValue>) {
+            *self.trashed_files.lock().unwrap() = files;
         }
         fn file_list_calls(&self) -> usize {
             self.file_list_calls.load(Ordering::SeqCst)
@@ -690,7 +695,17 @@ mod sa_direct_tests {
         Query(query): Query<HashMap<String, String>>,
     ) -> Json<JsonValue> {
         state.file_list_calls.fetch_add(1, Ordering::SeqCst);
-        let files = state.files.lock().unwrap().clone();
+        // trashed=true queries serve the trashed-file set for full-traversal
+        // reconciliation; everything else serves the live file set.
+        let is_trashed_query = query
+            .get("q")
+            .map(|q| q.contains("trashed=true"))
+            .unwrap_or(false);
+        let files = if is_trashed_query {
+            state.trashed_files.lock().unwrap().clone()
+        } else {
+            state.files.lock().unwrap().clone()
+        };
         // If a modifiedTime cutoff is present, filter the mocked files so we
         // can distinguish a cutoff crawl from an uncut full traversal.
         let files: Vec<JsonValue> = if let Some(q) = query.get("q") {
@@ -1212,6 +1227,117 @@ mod sa_direct_tests {
         assert_eq!(
             deletions, 1,
             "expected exactly one document_deleted event for the trashed file"
+        );
+
+        Ok(())
+    }
+
+    /// A full traversal must reconcile pre-existing trashed files: files
+    /// trashed before their trash transition was observed by an incremental
+    /// run never reappear in changes.list, so the full path lists trashed=true
+    /// and publishes deletions for them.
+    #[tokio::test]
+    async fn sa_direct_full_traversal_reconciles_pre_trashed_files() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        // Drive members: an internal user + the SA. SA excluded from docs.
+        state.set_permissions(json!([
+            {
+                "id": "p1",
+                "type": "user",
+                "emailAddress": SA_CLIENT_EMAIL,
+                "domain": null,
+                "role": "organizer",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            },
+            {
+                "id": "p2",
+                "type": "user",
+                "emailAddress": "alice@example.com",
+                "domain": null,
+                "role": "reader",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            }
+        ]));
+
+        // The drive holds one live file plus one file that was trashed before
+        // the last incremental run (its trash transition is already consumed,
+        // so it never reappears in changes.list).
+        state.set_files(vec![json!({
+            "id": "live-1",
+            "name": "Live Doc.txt",
+            "mimeType": "text/plain",
+            "size": "1024",
+            "webViewLink": "https://example.test/live-1",
+            "createdTime": "2024-01-01T00:00:00Z",
+            "modifiedTime": "2024-01-02T00:00:00Z",
+            "driveId": "drive-1",
+            "permissions": [],
+            "owners": []
+        })]);
+        state.set_trashed_files(vec![json!({
+            "id": "pre-trashed",
+            "name": "Old Doc.txt",
+            "mimeType": "text/plain",
+            "size": "512",
+            "webViewLink": "https://example.test/pre-trashed",
+            "createdTime": "2022-01-01T00:00:00Z",
+            "modifiedTime": "2022-06-01T00:00:00Z",
+            "driveId": "drive-1",
+            "trashed": true,
+            "permissions": [],
+            "owners": []
+        })]);
+
+        // Full sync, no prior state.
+        let sync_result = run_sa_sync(
+            &mock_base,
+            sa_source(),
+            sa_credentials(&mock_base),
+            SyncType::Full,
+        )
+        .await;
+
+        if let Some(value) = previous_drive_base {
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        sync_result?;
+
+        let bodies = state.event_bodies();
+        assert!(!bodies.is_empty(), "expected emitted event batch bodies");
+        let mut deletions = 0;
+        let mut created = 0;
+        for body in &bodies {
+            if let Some(events) = body.get("events").and_then(|e| e.as_array()) {
+                for event in events {
+                    let kind = event
+                        .get("type")
+                        .or_else(|| event.get("event"))
+                        .and_then(|t| t.as_str())
+                        .unwrap_or("");
+                    match kind {
+                        "document_deleted" => deletions += 1,
+                        "document_created" => created += 1,
+                        _ => {}
+                    }
+                }
+            }
+        }
+        assert_eq!(
+            deletions, 1,
+            "expected one document_deleted event for the pre-trashed file"
+        );
+        assert!(
+            created >= 1,
+            "expected the live file to be re-indexed during full traversal"
         );
 
         Ok(())

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -379,6 +379,7 @@ mod drive_buffer_budget_tests {
             .route("/sdk/sync/:sync_run_id/scanned", post(ok_json))
             .route("/sdk/sync/:sync_run_id/updated", post(ok_json))
             .route("/sdk/sync/:sync_run_id/complete", post(ok_json))
+            .route("/sdk/sync/:sync_run_id/checkpoint", put(ok_json))
             .route("/sdk/source/:source_id/connector-state", put(ok_json));
 
         let listener = TcpListener::bind("127.0.0.1:0").await?;
@@ -410,7 +411,8 @@ mod drive_buffer_budget_tests {
         Source {
             id: SOURCE_ID.to_string(),
             name: "Google Drive Budget Test".to_string(),
-            source_type: SourceType::GoogleDrive,
+            source_type: SourceType::GoogleDrive.to_string(),
+            integration_type: shared::models::IntegrationType::Connector,
             config: json!({}),
             is_active: true,
             is_deleted: false,
@@ -504,6 +506,567 @@ mod drive_buffer_budget_tests {
             "max declared in-flight bytes ({}) exceeded budget ({})",
             drive_state.max_active_declared_bytes.load(Ordering::SeqCst),
             BUDGET_BYTES
+        );
+
+        Ok(())
+    }
+}
+
+// ============================================================================
+// SA-direct shared-drive sync tests (mock Drive + mock token endpoint)
+// ============================================================================
+
+mod sa_direct_tests {
+    use anyhow::Result;
+    use axum::{
+        Router,
+        extract::{Path, Query, State},
+        response::Json,
+        routing::{get, post, put},
+    };
+    use omni_connector_sdk::{
+        AuthType, Connector, SdkClient, ServiceCredential, ServiceProvider, Source, SourceType,
+        SyncContext, SyncType,
+    };
+    use omni_google_connector::{admin::AdminClient, sync::SyncManager};
+    use serde_json::{Value as JsonValue, json};
+    use shared::models::{SourceScope, UserFilterMode};
+    use std::collections::HashMap;
+    use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+    use std::sync::{Arc, Mutex};
+    use time::OffsetDateTime;
+    use tokio::net::TcpListener;
+
+    const SA_SOURCE_ID: &str = "google-drive-sa-source";
+    const SA_SYNC_RUN_ID: &str = "google-drive-sa-sync";
+    const SA_CLIENT_EMAIL: &str = "sa@test-project.iam.gserviceaccount.com";
+
+    static SA_ENV_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
+    const TEST_RSA_KEY: &str = "-----BEGIN PRIVATE KEY-----\nMIIEvQIBADANBgkqhkiG9w0BAQEFAASCBKcwggSjAgEAAoIBAQDCfecBkmeBi4Av\ne6rZMd3DJe4TJDXXe8XG6KKHbaAPWY7Zidzsr630LFu1hOLWOQj3N5c9ufdI9d8G\nNT7mCrypOMBLHgo9T9X+Zebb2hQEarcUUwku0gURPh6WXoVWrJHwxsGdfoGixpPG\nfHyE5fX/EWniHhpcBTIRNOX6zgjuE7FaOMLoo8FzNyVzkRZwhCb/7G782x4t37kA\nLIGtwy7l4qbc8MN75eF5lPPYuSbTG85hbSQUlhDpZhruZjm5SL+F+cuOt++RX18I\nMoJRNCjrR+tmpGTkNVBdILVRSVAvwmFXG5Ve5PIXDvDmHWr+z5wFv1aobyGE/xG2\nu1K2Ip6/AgMBAAECggEABGOg/fkW2uaSCwBId8RXU9scR1RO3sENUpLXcCT6Mr57\nqc8hrDm+vD7wBuWr1NfOqv2XLS5wNTZPRS2YcMqXPV5pgIh6BK4zjx0vm5CNWRgr\nb4r8LxFQSfZT7GLPsYgNdxiVL/+13z2KAjW2/azO42W6NP8m6yK24YqHEiTqMK05\nA6En5B3sfa/xIV4eLMu1LG3q0r0S3Ja1yUOM9jl/xDJ3a4OddJyoDc90spU486Fv\nvgvhmE7acbbM4GLclSKzJxvDizxkIS5HX54uUWBJUl5YbbFE8qOs5dp7p50yvDjR\n49RCTV+FbEyZNG88DwiloRDAjEOgP8qDI4r2XaRXSQKBgQDpLwvoKfcy5ht+c7kZ\nz5WccJbu1+RfxIAr3Haob34QP6SJFdNbnd3dKzQDWRESEdyWJrkVj1BMu3tpbNz9\n6+F4qW1f9WGLJltFhod2hd1oDSzNycGopT55cCD8ZyJJ61kfilDI7zcLNAph73nQ\nh12zxFdnk5hqfHaybxKV/mktGwKBgQDVhav8Ru2Ij3TTQb98uupkdNXjuwz375eR\nTFQDhB5ZYSOzKGKlnwHX6hJEyWgeTN0DWnGm+uVl65S9EhyJ3cxPuOgLiLtp26B6\nG8uZHMJ3tdVlQ/hCwKx9sWPaejBPlarWt9KQnF34OhQMnvrBXYhLUA15jO7b1E0D\ntLAyJCEjLQKBgD01h0ea9HOc6WypDdaToe8dstDhROZKm2ZoCZGvKoUzX4pIe2Ga\nL+nldFLIp2152NBlO8JIC0kJEZ0b4WqZ52aX+sjsjX1MRTsb1CUtgG/WvYMLSdVu\nAtc3ssDuhZanu45G7WvBN06ui2cnyG8PiW4txM/Ac4rIPxQZieRrksovAoGAOJXs\nNjc1y/L4quPJs2x1oZm09V0k2rAMIt1vhl8FC/rKUzhorCuveWD25nPZu+3yxGi7\npdzn3lLIYDLkjUTSWG5QUH4z7KHfrXygQDt27fKqUuPobwhQrh7Mr6GiG/U2CSE+\nFETcQmRh29Zl7cizzgGxEH1g77Ebl9fSufcJMSECgYEAjuuLUaeho5ghZ2bNPxuy\nWtXImSWim+x0CmEm/M4rWuSXyJsGBh4t+PUytnlLfJR3tgvpmZ4soKgjLraBbB62\nMfMYC1T5eAXdf9wkc0ZA+Qu8VTFWZg+QalHd32+wFEQ5IzFZjgLECjy74l3/DNlt\nB7w63Vg5YmJRvkNWTgb3sLY=\n-----END PRIVATE KEY-----\n";
+
+    /// A configurable mock of the subset of Drive + token endpoints SA-direct uses.
+    #[derive(Clone, Default)]
+    struct SaMockState {
+        /// The ACL member list served for every drive (overridable per test).
+        permissions: Arc<Mutex<Option<JsonValue>>>,
+        /// Whether the permissions endpoint returns 403 (e.g. Viewer role).
+        permissions_forbidden: Arc<AtomicBool>,
+        /// Files served by list_files_in_drive (corpora=drive).
+        files: Arc<Mutex<Vec<JsonValue>>>,
+        /// Change-token pagination response for incremental syncs.
+        changes: Arc<Mutex<Option<JsonValue>>>,
+        /// Captured /sdk/events/batch bodies.
+        event_bodies: Arc<Mutex<Vec<JsonValue>>>,
+        /// Count of /drive/v3/files list calls (to detect uncut full traversal).
+        file_list_calls: Arc<AtomicUsize>,
+    }
+
+    impl SaMockState {
+        fn set_permissions(&self, perms: JsonValue) {
+            *self.permissions.lock().unwrap() = Some(perms);
+        }
+        fn set_permissions_forbidden(&self, forbidden: bool) {
+            self.permissions_forbidden
+                .store(forbidden, Ordering::SeqCst);
+        }
+        fn set_files(&self, files: Vec<JsonValue>) {
+            *self.files.lock().unwrap() = files;
+        }
+        fn file_list_calls(&self) -> usize {
+            self.file_list_calls.load(Ordering::SeqCst)
+        }
+        fn event_bodies(&self) -> Vec<JsonValue> {
+            self.event_bodies.lock().unwrap().clone()
+        }
+    }
+
+    async fn spawn_sa_mock() -> Result<(String, SaMockState)> {
+        let state = SaMockState::default();
+        // Seed default drive files.
+        state.set_files(vec![
+            json!({
+                "id": "doc-1",
+                "name": "Policy 2025.txt",
+                "mimeType": "text/plain",
+                "size": "1024",
+                "webViewLink": "https://example.test/doc-1",
+                "createdTime": "2024-01-01T00:00:00Z",
+                "modifiedTime": "2024-01-02T00:00:00Z",
+                "driveId": "drive-1",
+                "permissions": [],
+                "owners": []
+            }),
+            json!({
+                "id": "doc-2",
+                "name": "Policy 2024.txt",
+                "mimeType": "text/plain",
+                "size": "2048",
+                "webViewLink": "https://example.test/doc-2",
+                "createdTime": "2023-01-01T00:00:00Z",
+                "modifiedTime": "2023-06-01T00:00:00Z",
+                "driveId": "drive-1",
+                "permissions": [],
+                "owners": []
+            }),
+        ]);
+
+        let app = Router::new()
+            .route("/token", post(issue_token))
+            .route("/drive/v3/drives", get(list_drives_mock))
+            .route(
+                "/drive/v3/files/:drive_id/permissions",
+                get(list_permissions_mock),
+            )
+            .route("/drive/v3/files/:file_id", get(get_file_mock))
+            .route("/drive/v3/files", get(list_files_mock))
+            .route(
+                "/drive/v3/changes/startPageToken",
+                get(start_page_token_mock),
+            )
+            .route("/drive/v3/changes", get(list_changes_mock))
+            .route("/sdk/events/batch", post(capture_events))
+            .route("/sdk/content", post(store_content_mock))
+            .route("/sdk/sync/:sync_run_id/scanned", post(ok_json))
+            .route("/sdk/sync/:sync_run_id/updated", post(ok_json))
+            .route("/sdk/sync/:sync_run_id/complete", post(ok_json))
+            .route("/sdk/sync/:sync_run_id/checkpoint", put(put_ok))
+            .route("/sdk/source/:source_id/connector-state", put(put_ok))
+            .route("/sdk/connector-configs/:provider", get(connector_config_ok))
+            .with_state(state.clone());
+
+        let listener = TcpListener::bind("127.0.0.1:0").await?;
+        let addr = listener.local_addr()?;
+        tokio::spawn(async move {
+            axum::serve(listener, app).await.ok();
+        });
+
+        Ok((format!("http://{}", addr), state))
+    }
+
+    async fn issue_token() -> Json<JsonValue> {
+        Json(json!({
+            "access_token": "sa-access-token",
+            "expires_in": 3600
+        }))
+    }
+
+    async fn list_drives_mock() -> Json<JsonValue> {
+        Json(json!({
+            "drives": [
+                { "id": "drive-1", "name": "Policy Docs" },
+                { "id": "drive-2", "name": "Team Wiki" }
+            ]
+        }))
+    }
+
+    async fn get_file_mock(Query(query): Query<HashMap<String, String>>) -> Json<JsonValue> {
+        if query.get("alt").map(String::as_str) == Some("media") {
+            return Json(json!("content for file"));
+        }
+        Json(json!({ "id": "doc-1", "name": "Policy.txt", "mimeType": "text/plain" }))
+    }
+
+    async fn list_permissions_mock(
+        State(state): State<SaMockState>,
+        Path(_drive_id): Path<String>,
+    ) -> Json<JsonValue> {
+        if state.permissions_forbidden.load(Ordering::SeqCst) {
+            return Json(json!({
+                "error": { "code": 403, "message": "Forbidden", "status": "PERMISSION_DENIED" }
+            }));
+        }
+        let perms = state.permissions.lock().unwrap().clone();
+        match perms {
+            Some(perms) => Json(json!({ "permissions": perms })),
+            None => Json(json!({ "permissions": [] })),
+        }
+    }
+
+    async fn list_files_mock(
+        State(state): State<SaMockState>,
+        Query(query): Query<HashMap<String, String>>,
+    ) -> Json<JsonValue> {
+        state.file_list_calls.fetch_add(1, Ordering::SeqCst);
+        let files = state.files.lock().unwrap().clone();
+        // If a modifiedTime cutoff is present, filter the mocked files so we
+        // can distinguish a cutoff crawl from an uncut full traversal.
+        let files: Vec<JsonValue> = if let Some(q) = query.get("q") {
+            if q.contains("modifiedTime") || q.contains("createdTime") {
+                files
+                    .into_iter()
+                    .filter(|f| f["modifiedTime"].as_str().unwrap_or("") >= "2024-01-01T00:00:00Z")
+                    .collect()
+            } else {
+                files
+            }
+        } else {
+            files
+        };
+        Json(json!({ "files": files }))
+    }
+
+    async fn start_page_token_mock() -> Json<JsonValue> {
+        Json(json!({ "startPageToken": "start-1" }))
+    }
+
+    async fn list_changes_mock(State(state): State<SaMockState>) -> Json<JsonValue> {
+        let changes = state.changes.lock().unwrap().clone();
+        match changes {
+            Some(changes) => Json(changes),
+            None => Json(json!({ "changes": [], "newStartPageToken": "start-2" })),
+        }
+    }
+
+    async fn capture_events(
+        State(state): State<SaMockState>,
+        body: Json<JsonValue>,
+    ) -> Json<JsonValue> {
+        state.event_bodies.lock().unwrap().push(body.0.clone());
+        Json(json!({}))
+    }
+
+    async fn store_content_mock() -> Json<JsonValue> {
+        Json(json!({ "content_id": "content-id" }))
+    }
+
+    async fn ok_json() -> Json<JsonValue> {
+        Json(json!({}))
+    }
+
+    async fn put_ok(State(_state): State<SaMockState>) -> Json<JsonValue> {
+        Json(json!({}))
+    }
+
+    async fn connector_config_ok() -> Json<JsonValue> {
+        Json(json!({
+            "oauth_client_id": "test-client-id",
+            "oauth_client_secret": "test-client-secret"
+        }))
+    }
+
+    fn sa_source() -> Source {
+        let now = OffsetDateTime::now_utc();
+        Source {
+            id: SA_SOURCE_ID.to_string(),
+            name: "Google Drive SA Direct".to_string(),
+            source_type: SourceType::GoogleDrive.to_string(),
+            integration_type: shared::models::IntegrationType::Connector,
+            config: json!({
+                "auth_mode": "service_account_direct",
+                "folder_path_filters": [
+                    {
+                        "id": "drive-1",
+                        "name": "Policy Docs",
+                        "path": "/Policy Docs (Shared Drive)",
+                        "driveId": "drive-1",
+                        "kind": "shared_drive_root"
+                    }
+                ]
+            }),
+            is_active: true,
+            is_deleted: false,
+            scope: SourceScope::Org,
+            user_filter_mode: UserFilterMode::All,
+            user_whitelist: None,
+            user_blacklist: None,
+            connector_state: None,
+            checkpoint: None,
+            sync_interval_seconds: None,
+            created_at: now,
+            updated_at: now,
+            created_by: "admin-id".to_string(),
+        }
+    }
+
+    fn sa_credentials(mock_base: &str) -> ServiceCredential {
+        let now = OffsetDateTime::now_utc();
+        let sa_key = json!({
+            "type": "service_account",
+            "project_id": "test-project",
+            "private_key_id": "key123",
+            "private_key": TEST_RSA_KEY,
+            "client_email": SA_CLIENT_EMAIL,
+            "client_id": "123456789",
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": format!("{}/token", mock_base),
+            "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+            "client_x509_cert_url": "https://www.googleapis.com/robot/v1/metadata/x509/sa"
+        });
+        ServiceCredential {
+            id: "credential-id".to_string(),
+            source_id: SA_SOURCE_ID.to_string(),
+            user_id: None,
+            provider: ServiceProvider::Google,
+            auth_type: AuthType::Jwt,
+            principal_email: None,
+            credentials: json!({ "service_account_key": sa_key.to_string() }),
+            config: json!({
+                "scopes": ["https://www.googleapis.com/auth/drive.readonly"]
+            }),
+            expires_at: None,
+            last_validated_at: None,
+            created_at: now,
+            updated_at: now,
+        }
+    }
+
+    /// Run an SA-direct sync against the mock. The mock state is owned by the
+    /// test (shared via Arc with the router), so the sync runs inline and the
+    /// caller inspects `state` afterwards.
+    async fn run_sa_sync(
+        mock_base: &str,
+        source: Source,
+        creds: ServiceCredential,
+        sync_type: SyncType,
+    ) -> Result<()> {
+        let cm_url = mock_base.to_string();
+        let sdk_client = SdkClient::new(&cm_url);
+        sdk_client.register_sync(SA_SYNC_RUN_ID, sync_type).await;
+        let sync_manager = SyncManager::new(Arc::new(AdminClient::new()), sdk_client.clone(), None);
+        let ctx = SyncContext::new(
+            sdk_client,
+            SA_SYNC_RUN_ID.to_string(),
+            SA_SOURCE_ID.to_string(),
+            SourceType::GoogleDrive,
+            sync_type,
+            Arc::new(AtomicBool::new(false)),
+        );
+        sync_manager.run_sync(source, Some(creds), None, ctx).await
+    }
+
+    #[tokio::test]
+    async fn sa_direct_discovery_uses_self_token_and_returns_roots_only() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, _state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        let connector = omni_google_connector::connector::GoogleConnector::new(
+            Arc::new(SyncManager::new(
+                Arc::new(AdminClient::new()),
+                SdkClient::new(&mock_base),
+                None,
+            )),
+            Arc::new(AdminClient::new()),
+        );
+
+        // SA-direct discovery: no principal email/domain required; roots only.
+        let creds = sa_credentials(&mock_base);
+        let response = connector
+            .execute_action(
+                "discover_folders",
+                json!({ "auth_mode": "service_account_direct" }),
+                Some(creds),
+                None,
+                None,
+            )
+            .await?;
+
+        if let Some(value) = previous_drive_base {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        let status = response.status();
+        let body: JsonValue = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .map(|bytes| serde_json::from_slice(&bytes).unwrap_or(json!({})))?;
+        assert_eq!(status, 200, "discovery should succeed: {}", body);
+        let items = body["result"]["items"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(items.len(), 2, "expected 2 shared drives: {}", body);
+        for item in &items {
+            assert_eq!(
+                item["kind"].as_str(),
+                Some("shared_drive_root"),
+                "SA-direct discovery must return roots only: {}",
+                body
+            );
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn validate_shared_drive_access_multi_drive() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        let connector = omni_google_connector::connector::GoogleConnector::new(
+            Arc::new(SyncManager::new(
+                Arc::new(AdminClient::new()),
+                SdkClient::new(&mock_base),
+                None,
+            )),
+            Arc::new(AdminClient::new()),
+        );
+
+        // SA is a Manager on the drive.
+        state.set_permissions(json!([
+            {
+                "id": "p1",
+                "type": "user",
+                "emailAddress": SA_CLIENT_EMAIL,
+                "domain": null,
+                "role": "organizer",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            }
+        ]));
+        let ok_response = connector
+            .execute_action(
+                "validate_shared_drive_access",
+                json!({ "auth_mode": "service_account_direct", "drive_ids": ["drive-1"] }),
+                Some(sa_credentials(&mock_base)),
+                None,
+                None,
+            )
+            .await?;
+        let ok_body: JsonValue = axum::body::to_bytes(ok_response.into_body(), usize::MAX)
+            .await
+            .map(|bytes| serde_json::from_slice(&bytes).unwrap_or(json!({})))?;
+        let drives = ok_body["result"]["drives"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(drives.len(), 1);
+        assert_eq!(drives[0]["ok"], json!(true), "{}", ok_body);
+        assert_eq!(drives[0]["role"].as_str(), Some("organizer"));
+
+        // Viewer role fails closed.
+        state.set_permissions(json!([
+            {
+                "id": "p1",
+                "type": "user",
+                "emailAddress": SA_CLIENT_EMAIL,
+                "domain": null,
+                "role": "reader",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            }
+        ]));
+        let fail_response = connector
+            .execute_action(
+                "validate_shared_drive_access",
+                json!({ "auth_mode": "service_account_direct", "drive_ids": ["drive-1"] }),
+                Some(sa_credentials(&mock_base)),
+                None,
+                None,
+            )
+            .await?;
+        let fail_body: JsonValue = axum::body::to_bytes(fail_response.into_body(), usize::MAX)
+            .await
+            .map(|bytes| serde_json::from_slice(&bytes).unwrap_or(json!({})))?;
+        let fail_drives = fail_body["result"]["drives"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert_eq!(fail_drives[0]["ok"], json!(false), "{}", fail_body);
+        assert!(
+            fail_drives[0]["error"]
+                .as_str()
+                .unwrap_or("")
+                .contains("role"),
+            "{}",
+            fail_body
+        );
+
+        if let Some(value) = previous_drive_base {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn sa_direct_full_sync_applies_drive_acl() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        // Drive members: an internal user + a domain grant. SA excluded.
+        state.set_permissions(json!([
+            {
+                "id": "p1",
+                "type": "user",
+                "emailAddress": SA_CLIENT_EMAIL,
+                "domain": null,
+                "role": "organizer",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            },
+            {
+                "id": "p2",
+                "type": "user",
+                "emailAddress": "alice@example.com",
+                "domain": null,
+                "role": "writer",
+                "allowFileDiscovery": null,
+                "permissionDetails": null
+            },
+            {
+                "id": "p3",
+                "type": "domain",
+                "emailAddress": null,
+                "domain": "example.com",
+                "role": "reader",
+                "allowFileDiscovery": true,
+                "permissionDetails": null
+            }
+        ]));
+
+        // Run the sync inline against the mock.
+        let sync_result = run_sa_sync(
+            &mock_base,
+            sa_source(),
+            sa_credentials(&mock_base),
+            SyncType::Full,
+        )
+        .await;
+
+        if let Some(value) = previous_drive_base {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        sync_result?;
+
+        let bodies = state.event_bodies();
+        assert!(!bodies.is_empty(), "expected emitted event batch bodies");
+        // Find DocumentCreated events and assert ACLs.
+        let mut found = 0;
+        for body in &bodies {
+            if let Some(events) = body.get("events").and_then(|e| e.as_array()) {
+                for event in events {
+                    if event.get("type").and_then(|t| t.as_str()) == Some("document_created")
+                        || event.get("event").and_then(|e| e.as_str()) == Some("document_created")
+                    {
+                        found += 1;
+                    }
+                }
+            }
+        }
+        assert!(found >= 1, "expected at least one document_created event");
+        assert!(
+            state.file_list_calls() >= 1,
+            "expected at least one files.list call"
         );
 
         Ok(())

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -280,6 +280,8 @@ mod drive_buffer_budget_tests {
         active_declared_bytes: Arc<AtomicUsize>,
         max_active_declared_bytes: Arc<AtomicUsize>,
         budget_breached: Arc<AtomicBool>,
+        /// Count of trashed=true file-list queries (full-traversal trash reconciliation).
+        trashed_query_calls: Arc<AtomicUsize>,
     }
 
     impl MockDriveState {
@@ -323,7 +325,20 @@ mod drive_buffer_budget_tests {
         Ok((format!("http://{}", addr), state))
     }
 
-    async fn list_files() -> Json<JsonValue> {
+    async fn list_files(
+        State(state): State<MockDriveState>,
+        Query(query): Query<HashMap<String, String>>,
+    ) -> Json<JsonValue> {
+        // trashed=true queries serve nothing; count them so the unfiltered
+        // DWD full-sync trash reconciliation is observable in tests.
+        if query
+            .get("q")
+            .map(|q| q.contains("trashed=true"))
+            .unwrap_or(false)
+        {
+            state.trashed_query_calls.fetch_add(1, Ordering::SeqCst);
+            return Json(json!({ "files": [] }));
+        }
         let files: Vec<JsonValue> = MOCK_FILES
             .iter()
             .map(|file| {
@@ -506,6 +521,10 @@ mod drive_buffer_budget_tests {
             "max declared in-flight bytes ({}) exceeded budget ({})",
             drive_state.max_active_declared_bytes.load(Ordering::SeqCst),
             BUDGET_BYTES
+        );
+        assert!(
+            drive_state.trashed_query_calls.load(Ordering::SeqCst) >= 1,
+            "expected the unfiltered DWD full sync to reconcile trashed files"
         );
 
         Ok(())

--- a/web/src/lib/components/google-drive-folder-selector.svelte
+++ b/web/src/lib/components/google-drive-folder-selector.svelte
@@ -18,6 +18,7 @@
         disabled = false,
         label = 'Folders to index',
         description = 'Select specific shared drives or top-level folders to index. Leave empty to index everything.',
+        onSelectedChange = undefined as ((selected: FolderPathFilter[]) => void) | undefined,
     }: {
         sourceId?: string
         serviceAccountJson?: string
@@ -28,6 +29,7 @@
         disabled?: boolean
         label?: string
         description?: string
+        onSelectedChange?: (selected: FolderPathFilter[]) => void
     } = $props()
 
     const isSaDirect = $derived(authMode === 'service_account_direct')
@@ -101,6 +103,7 @@
         // after initialization. On initial mount, pre-loaded selected items
         // from persisted config are preserved.
         selected = []
+        onSelectedChange?.(selected)
 
         // Reset discovery state.
         searchQuery = ''
@@ -284,6 +287,7 @@
                 kind: item.kind === 'folder' ? 'folder' : 'shared_drive_root',
             },
         ]
+        onSelectedChange?.(selected)
         searchQuery = ''
         showDropdown = false
         filteredItems = allItems
@@ -292,6 +296,7 @@
 
     function removeItem(id: string) {
         selected = selected.filter((s) => s.id !== id)
+        onSelectedChange?.(selected)
     }
 
     function handleRetry() {

--- a/web/src/lib/components/google-drive-folder-selector.svelte
+++ b/web/src/lib/components/google-drive-folder-selector.svelte
@@ -13,6 +13,7 @@
         serviceAccountJson = '',
         principalEmail = '',
         domain = '',
+        authMode = 'domain_wide_delegation' as 'domain_wide_delegation' | 'service_account_direct',
         selected = $bindable([] as FolderPathFilter[]),
         disabled = false,
         label = 'Folders to index',
@@ -22,11 +23,14 @@
         serviceAccountJson?: string
         principalEmail?: string
         domain?: string
+        authMode?: 'domain_wide_delegation' | 'service_account_direct'
         selected?: FolderPathFilter[]
         disabled?: boolean
         label?: string
         description?: string
     } = $props()
+
+    const isSaDirect = $derived(authMode === 'service_account_direct')
 
     // Internal state
     let searchQuery = $state('')
@@ -65,6 +69,7 @@
             sa: serviceAccountJson,
             pe: principalEmail,
             dm: domain,
+            am: authMode,
             sid: sourceId,
         }),
     )
@@ -124,12 +129,18 @@
             rv = currentRequestVersion
         }
 
-        if (!serviceAccountJson || !principalEmail || !domain) {
+        if (!serviceAccountJson) {
             if (!sourceId) {
                 isLoading = false
                 return
             }
             // Stored-credential path: use sourceId even without transient creds.
+        }
+
+        // SA-direct needs only the SA key (no principal/domain); DWD needs all.
+        if (!isSaDirect && serviceAccountJson && (!principalEmail || !domain)) {
+            isLoading = false
+            return
         }
 
         // Abort any prior in-flight request.
@@ -148,17 +159,18 @@
         try {
             let response: Response
 
-            if (serviceAccountJson && principalEmail && domain) {
+            if (serviceAccountJson && (isSaDirect || (principalEmail && domain))) {
                 // Invoke the connector directly with transient credentials.
                 response = await fetch('/api/connectors/google_drive/action', {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         action: 'discover_folders',
-                        params: {},
+                        params: isSaDirect ? { auth_mode: 'service_account_direct' } : {},
                         serviceAccountJson,
                         principalEmail,
                         domain,
+                        authMode,
                     }),
                     signal,
                 })
@@ -169,7 +181,7 @@
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
                         action: 'discover_folders',
-                        params: {},
+                        params: isSaDirect ? { auth_mode: 'service_account_direct' } : {},
                     }),
                     signal,
                 })
@@ -232,11 +244,15 @@
 
     function filterItems(query: string) {
         if (!query.trim()) {
-            filteredItems = allItems
+            filteredItems = isSaDirect
+                ? allItems.filter((item) => item.kind === 'shared_drive_root')
+                : allItems
             return
         }
         const q = query.trim().toLowerCase()
-        filteredItems = allItems.filter(
+        filteredItems = (
+            isSaDirect ? allItems.filter((item) => item.kind === 'shared_drive_root') : allItems
+        ).filter(
             (item) =>
                 !selected.some((s) => s.id === item.id) &&
                 (item.name.toLowerCase().includes(q) ||
@@ -256,6 +272,8 @@
 
     function selectItem(item: DriveFolderDiscoveryEntry) {
         if (selected.some((s) => s.id === item.id)) return
+        // SA-direct v1 is whole-drives only — never select folder-kind items.
+        if (isSaDirect && item.kind !== 'shared_drive_root') return
         selected = [
             ...selected,
             {

--- a/web/src/lib/components/google-service-account-form.svelte
+++ b/web/src/lib/components/google-service-account-form.svelte
@@ -43,8 +43,8 @@
 
     {#if isSaDirect}
         <p class="text-muted-foreground text-sm">
-            The service account will authenticate as itself — no user impersonation, no domain-wide
-            delegation. Add the service account email to each shared drive as
+            The service account will authenticate as itself without domain-wide delegation. Add the
+            service account email to each shared drive as
             <span class="font-medium">Content manager</span> or
             <span class="font-medium">Manager</span>.
         </p>

--- a/web/src/lib/components/google-service-account-form.svelte
+++ b/web/src/lib/components/google-service-account-form.svelte
@@ -12,6 +12,9 @@
         // 'sa-direct' hides the admin-email/domain fields and shows
         // non-impersonation guidance. Defaults to DWD behavior.
         mode?: 'dwd' | 'sa-direct'
+        // Hide the SA-direct explanation paragraph when the surrounding page
+        // already explains the mode (e.g. a banner on the settings page).
+        showSaDirectInfo?: boolean
     }
 
     let {
@@ -21,6 +24,7 @@
         hasStoredKey = false,
         disabled = false,
         mode = 'dwd',
+        showSaDirectInfo = true,
     }: Props = $props()
 
     const isSaDirect = $derived(mode === 'sa-direct')
@@ -42,12 +46,14 @@
     </div>
 
     {#if isSaDirect}
-        <p class="text-muted-foreground text-sm">
-            The service account will authenticate as itself without domain-wide delegation. Add the
-            service account email to each shared drive as
-            <span class="font-medium">Content manager</span> or
-            <span class="font-medium">Manager</span>.
-        </p>
+        {#if showSaDirectInfo}
+            <p class="text-muted-foreground text-sm">
+                The service account will authenticate as itself without domain-wide delegation. Add
+                the service account email to each shared drive as
+                <span class="font-medium">Content manager</span> or
+                <span class="font-medium">Manager</span>.
+            </p>
+        {/if}
     {:else}
         <div class="space-y-2">
             <Label for="principal-email">Admin Email</Label>
@@ -60,8 +66,7 @@
                 {disabled}
                 required />
             <p class="text-muted-foreground text-sm">
-                The admin user email that the service account will impersonate to access Google
-                Workspace APIs.
+                The admin user the service account impersonates to access Google Workspace APIs.
             </p>
         </div>
 
@@ -76,8 +81,7 @@
                 {disabled}
                 required />
             <p class="text-muted-foreground text-sm">
-                Your Google Workspace domain (e.g., company.com). The service account will
-                impersonate all users in this domain.
+                Your Google Workspace domain (e.g., company.com).
             </p>
         </div>
     {/if}

--- a/web/src/lib/components/google-service-account-form.svelte
+++ b/web/src/lib/components/google-service-account-form.svelte
@@ -9,6 +9,9 @@
         domain?: string
         hasStoredKey?: boolean
         disabled?: boolean
+        // 'sa-direct' hides the admin-email/domain fields and shows
+        // non-impersonation guidance. Defaults to DWD behavior.
+        mode?: 'dwd' | 'sa-direct'
     }
 
     let {
@@ -17,7 +20,10 @@
         domain = $bindable(''),
         hasStoredKey = false,
         disabled = false,
+        mode = 'dwd',
     }: Props = $props()
+
+    const isSaDirect = $derived(mode === 'sa-direct')
 </script>
 
 <div class="space-y-4">
@@ -35,35 +41,44 @@
         </p>
     </div>
 
-    <div class="space-y-2">
-        <Label for="principal-email">Admin Email</Label>
-        <Input
-            id="principal-email"
-            name="principalEmail"
-            bind:value={principalEmail}
-            placeholder="admin@yourdomain.com"
-            type="email"
-            {disabled}
-            required />
+    {#if isSaDirect}
         <p class="text-muted-foreground text-sm">
-            The admin user email that the service account will impersonate to access Google
-            Workspace APIs.
+            The service account will authenticate as itself — no user impersonation, no domain-wide
+            delegation. Add the service account email to each shared drive as
+            <span class="font-medium">Content manager</span> or
+            <span class="font-medium">Manager</span>.
         </p>
-    </div>
+    {:else}
+        <div class="space-y-2">
+            <Label for="principal-email">Admin Email</Label>
+            <Input
+                id="principal-email"
+                name="principalEmail"
+                bind:value={principalEmail}
+                placeholder="admin@yourdomain.com"
+                type="email"
+                {disabled}
+                required />
+            <p class="text-muted-foreground text-sm">
+                The admin user email that the service account will impersonate to access Google
+                Workspace APIs.
+            </p>
+        </div>
 
-    <div class="space-y-2">
-        <Label for="domain">Organization Domain</Label>
-        <Input
-            id="domain"
-            name="domain"
-            bind:value={domain}
-            placeholder="yourdomain.com"
-            type="text"
-            {disabled}
-            required />
-        <p class="text-muted-foreground text-sm">
-            Your Google Workspace domain (e.g., company.com). The service account will impersonate
-            all users in this domain.
-        </p>
-    </div>
+        <div class="space-y-2">
+            <Label for="domain">Organization Domain</Label>
+            <Input
+                id="domain"
+                name="domain"
+                bind:value={domain}
+                placeholder="yourdomain.com"
+                type="text"
+                {disabled}
+                required />
+            <p class="text-muted-foreground text-sm">
+                Your Google Workspace domain (e.g., company.com). The service account will
+                impersonate all users in this domain.
+            </p>
+        </div>
+    {/if}
 </div>

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -242,7 +242,7 @@
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({
                 scope: 'org',
-                name: 'Google Drive — Shared Drive Sync',
+                name: 'Google Drive',
                 sourceType: 'google_drive',
                 config: driveConfig,
             }),

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -4,8 +4,12 @@
     import { Label } from '$lib/components/ui/label'
     import { Checkbox } from '$lib/components/ui/checkbox'
     import * as Card from '$lib/components/ui/card'
+    import * as Tabs from '$lib/components/ui/tabs'
+    import * as Alert from '$lib/components/ui/alert'
+    import { Loader2, CheckCircle2, XCircle, AlertCircle } from '@lucide/svelte'
     import { AuthType } from '$lib/types'
-    import type { FolderPathFilter } from '$lib/types'
+    import type { FolderPathFilter, GoogleAuthMode } from '$lib/types'
+    import type { SharedDriveAccessResponse } from '$lib/types'
     import { toast } from 'svelte-sonner'
     import { goto } from '$app/navigation'
     import googleDriveLogo from '$lib/images/icons/google-drive.svg'
@@ -22,7 +26,10 @@
 
     let { open = false, onSuccess, onCancel }: Props = $props()
 
-    // Service Account form state
+    // Active tab: 'dwd' (domain-wide delegation) | 'sa-direct' (shared drive, no DWD)
+    let activeTab = $state<GoogleAuthMode>('domain_wide_delegation')
+
+    // Shared DWD form state
     let serviceAccountJson = $state('')
     let principalEmail = $state('')
     let domain = $state('')
@@ -31,6 +38,17 @@
     let connectChat = $state(false)
     let isSubmitting = $state(false)
     let driveFolderFilters = $state<FolderPathFilter[]>([])
+
+    // SA-direct form state (kept separate so switching tabs preserves each)
+    let saServiceAccountJson = $state('')
+    let saDriveFilters = $state<FolderPathFilter[]>([])
+    // Per-drive validation: drive_id -> { pending, ok, role, error }
+    let accessValidation = $state<
+        Record<string, { pending: boolean; ok: boolean; role: string | null; error: string | null }>
+    >({})
+    let isValidating = $state(false)
+    let validationAbort: AbortController | null = null
+    let validationGeneration = $state(0)
 
     // Credential-context guard: clear selected folder filters whenever the
     // credential inputs change after initialization so filters from one set
@@ -55,172 +73,159 @@
         }
     })
 
+    // SA-direct guard: when the SA key changes, clear discovered drives and
+    // any prior validation state so stale selections can't be submitted.
+    let prevSaKey = $state('')
+    let saInitialized = $state(false)
+    $effect(() => {
+        if (!saInitialized) {
+            saInitialized = true
+            prevSaKey = saServiceAccountJson
+            return
+        }
+        if (saServiceAccountJson !== prevSaKey) {
+            prevSaKey = saServiceAccountJson
+            saDriveFilters = []
+            accessValidation = {}
+            validationAbort?.abort()
+            validationAbort = null
+        }
+    })
+
+    // Switch to SA-direct tab: force Drive-only.
+    function selectTab(tab: GoogleAuthMode) {
+        activeTab = tab
+        if (tab === 'service_account_direct') {
+            connectDrive = true
+            connectGmail = false
+            connectChat = false
+        }
+    }
+
+    // Re-run access validation whenever the SA key or selected drives change.
+    $effect(() => {
+        if (activeTab !== 'service_account_direct') return
+        if (!saServiceAccountJson.trim() || saDriveFilters.length === 0) {
+            accessValidation = {}
+            isSubmitting = false
+            return
+        }
+        validateAccess(saServiceAccountJson, saDriveFilters)
+    })
+
+    async function validateAccess(saJson: string, filters: FolderPathFilter[]) {
+        const generation = ++validationGeneration
+        validationAbort?.abort()
+        const controller = new AbortController()
+        validationAbort = controller
+        isValidating = true
+
+        // Mark all drives pending.
+        const pending: Record<
+            string,
+            { pending: boolean; ok: boolean; role: string | null; error: string | null }
+        > = {}
+        for (const f of filters) {
+            pending[f.driveId] = { pending: true, ok: false, role: null, error: null }
+        }
+        accessValidation = pending
+
+        try {
+            const response = await fetch('/api/connectors/google_drive/action', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    action: 'validate_shared_drive_access',
+                    params: {
+                        drive_ids: filters.map((f) => f.driveId),
+                    },
+                    serviceAccountJson: saJson,
+                    authMode: 'service_account_direct',
+                }),
+                signal: controller.signal,
+            })
+            if (generation !== validationGeneration) return
+            if (!response.ok) {
+                const errBody = await response.json().catch(() => ({}))
+                const msg = errBody.error || errBody.message || 'Failed to validate drive access'
+                for (const f of filters) {
+                    pending[f.driveId] = {
+                        pending: false,
+                        ok: false,
+                        role: null,
+                        error: msg,
+                    }
+                }
+                accessValidation = { ...pending }
+                return
+            }
+            const body = (await response.json()) as {
+                status?: string
+                result?: SharedDriveAccessResponse
+            }
+            const statusOk = body?.status === 'ok' || body?.status === 'success'
+            const drives = body?.result?.drives ?? []
+            if (statusOk && drives.length > 0) {
+                const next: typeof pending = {}
+                for (const d of drives) {
+                    next[d.drive_id] = {
+                        pending: false,
+                        ok: Boolean(d.ok),
+                        role: d.role,
+                        error: d.error,
+                    }
+                }
+                accessValidation = next
+            } else {
+                for (const f of filters) {
+                    pending[f.driveId] = {
+                        pending: false,
+                        ok: false,
+                        role: null,
+                        error: 'Drive access could not be verified',
+                    }
+                }
+                accessValidation = { ...pending }
+            }
+        } catch (err) {
+            if (generation !== validationGeneration) return
+            if (err instanceof DOMException && err.name === 'AbortError') return
+            for (const f of filters) {
+                pending[f.driveId] = {
+                    pending: false,
+                    ok: false,
+                    role: null,
+                    error: 'Network error while validating drive access',
+                }
+            }
+            accessValidation = { ...pending }
+        } finally {
+            if (generation === validationGeneration) {
+                isValidating = false
+            }
+        }
+    }
+
+    const allDrivesValidated = $derived(
+        saDriveFilters.length > 0 &&
+            saDriveFilters.every((f) => {
+                const v = accessValidation[f.driveId]
+                return v && !v.pending && v.ok
+            }),
+    )
+
+    const validationInProgress = $derived(
+        saDriveFilters.some((f) => accessValidation[f.driveId]?.pending),
+    )
+
     async function handleSubmit() {
         isSubmitting = true
         try {
-            if (!connectDrive && !connectGmail && !connectChat) {
-                throw new Error('Please select at least one service to connect')
+            if (activeTab === 'service_account_direct') {
+                await handleSaDirectSubmit()
+                return
             }
-
-            if (!serviceAccountJson.trim()) {
-                throw new Error('Service account JSON is required')
-            }
-
-            if (!principalEmail.trim()) {
-                throw new Error('Admin email is required')
-            }
-
-            if (!domain.trim()) {
-                throw new Error('Organization domain is required')
-            }
-
-            // Validate JSON
-            try {
-                JSON.parse(serviceAccountJson)
-            } catch {
-                throw new Error('Invalid JSON format')
-            }
-
-            const credentials = { service_account_key: serviceAccountJson }
-
-            // Base config shared by all Google services (domain only).
-            const baseConfig: Record<string, unknown> = {
-                domain: domain || null,
-            }
-
-            // Drive-specific config with optional folder filters.
-            const driveConfig: Record<string, unknown> = {
-                domain: domain || null,
-            }
-            if (driveFolderFilters.length > 0) {
-                driveConfig.folder_path_filters = driveFolderFilters
-            }
-
-            const authType = AuthType.JWT
-            const provider = 'google'
-
-            if (connectDrive) {
-                const driveSourceResponse = await fetch('/api/sources', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        scope: 'org',
-                        name: 'Google Drive',
-                        sourceType: 'google_drive',
-                        config: driveConfig,
-                    }),
-                })
-
-                if (!driveSourceResponse.ok) {
-                    throw new Error('Failed to create Google Drive source')
-                }
-
-                const driveSource = await driveSourceResponse.json()
-
-                const driveCredentialsResponse = await fetch('/api/service-credentials', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        sourceId: driveSource.id,
-                        provider: provider,
-                        authType: authType,
-                        principalEmail: principalEmail || null,
-                        credentials,
-                        config: driveConfig,
-                    }),
-                })
-
-                if (!driveCredentialsResponse.ok) {
-                    throw new Error('Failed to create Google Drive service credentials')
-                }
-            }
-
-            if (connectGmail) {
-                const gmailSourceResponse = await fetch('/api/sources', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        scope: 'org',
-                        name: 'Gmail',
-                        sourceType: 'gmail',
-                        config: baseConfig,
-                    }),
-                })
-
-                if (!gmailSourceResponse.ok) {
-                    throw new Error('Failed to create Gmail source')
-                }
-
-                const gmailSource = await gmailSourceResponse.json()
-
-                const gmailCredentialsResponse = await fetch('/api/service-credentials', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        sourceId: gmailSource.id,
-                        provider: provider,
-                        authType: authType,
-                        principalEmail: principalEmail || null,
-                        credentials: credentials,
-                        config: baseConfig,
-                    }),
-                })
-
-                if (!gmailCredentialsResponse.ok) {
-                    throw new Error('Failed to create Gmail service credentials')
-                }
-            }
-
-            if (connectChat) {
-                const chatSourceResponse = await fetch('/api/sources', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        scope: 'org',
-                        name: 'Google Chat',
-                        sourceType: 'google_chat',
-                        config: baseConfig,
-                    }),
-                })
-
-                if (!chatSourceResponse.ok) {
-                    throw new Error('Failed to create Google Chat source')
-                }
-
-                const chatSource = await chatSourceResponse.json()
-
-                const chatCredentialsResponse = await fetch('/api/service-credentials', {
-                    method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        sourceId: chatSource.id,
-                        provider: provider,
-                        authType: authType,
-                        principalEmail: principalEmail || null,
-                        credentials: credentials,
-                        config: baseConfig,
-                    }),
-                })
-
-                if (!chatCredentialsResponse.ok) {
-                    throw new Error('Failed to create Google Chat service credentials')
-                }
-            }
-
-            toast.success('Google Workspace connected successfully!')
-
-            // Reset form
-            serviceAccountJson = ''
-            principalEmail = ''
-            domain = ''
-
-            // Call success callback if provided
-            if (onSuccess) {
-                onSuccess()
-            } else {
-                // Default behavior: redirect to integrations page
-                await goto('/admin/settings/integrations')
-            }
+            await handleDwdSubmit()
         } catch (error: any) {
             console.error('Error setting up Google Workspace:', error)
             toast.error(error.message || 'Failed to set up Google Workspace')
@@ -229,13 +234,254 @@
         }
     }
 
-    function handleCancel() {
+    async function handleSaDirectSubmit() {
+        // Defensive: never create Gmail/Chat sources in SA-direct mode.
+        if (connectGmail || connectChat) {
+            throw new Error('Shared drive (no DWD) setup is Drive-only')
+        }
+        if (!saServiceAccountJson.trim()) {
+            throw new Error('Service account JSON is required')
+        }
+        try {
+            JSON.parse(saServiceAccountJson)
+        } catch {
+            throw new Error('Invalid JSON format')
+        }
+        if (saDriveFilters.length === 0) {
+            throw new Error('Select at least one shared drive to index')
+        }
+        if (!allDrivesValidated) {
+            throw new Error(
+                'Wait for every selected shared drive to pass access validation (Content manager or Manager required)',
+            )
+        }
+
+        const driveConfig: Record<string, unknown> = {
+            auth_mode: 'service_account_direct',
+            folder_path_filters: saDriveFilters,
+        }
+
+        // Create ONLY a Google Drive source.
+        const driveSourceResponse = await fetch('/api/sources', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                scope: 'org',
+                name: 'Google Drive — Shared Drive Sync',
+                sourceType: 'google_drive',
+                config: driveConfig,
+            }),
+        })
+        if (!driveSourceResponse.ok) {
+            const errBody = await driveSourceResponse.json().catch(() => ({}))
+            throw new Error(errBody.message || 'Failed to create Google Drive source')
+        }
+        const driveSource = await driveSourceResponse.json()
+
+        const credConfig: Record<string, unknown> = {
+            scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+        }
+        const credentialsResponse = await fetch('/api/service-credentials', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                sourceId: driveSource.id,
+                provider: 'google',
+                authType: AuthType.JWT,
+                principalEmail: null,
+                credentials: { service_account_key: saServiceAccountJson },
+                config: credConfig,
+            }),
+        })
+        if (!credentialsResponse.ok) {
+            throw new Error('Failed to create Google Drive service credentials')
+        }
+
+        toast.success('Shared drive connected successfully!')
+        resetForm()
+        if (onSuccess) {
+            onSuccess()
+        } else {
+            await goto('/admin/settings/integrations')
+        }
+    }
+
+    async function handleDwdSubmit() {
+        if (!connectDrive && !connectGmail && !connectChat) {
+            throw new Error('Please select at least one service to connect')
+        }
+
+        if (!serviceAccountJson.trim()) {
+            throw new Error('Service account JSON is required')
+        }
+
+        if (!principalEmail.trim()) {
+            throw new Error('Admin email is required')
+        }
+
+        if (!domain.trim()) {
+            throw new Error('Organization domain is required')
+        }
+
+        try {
+            JSON.parse(serviceAccountJson)
+        } catch {
+            throw new Error('Invalid JSON format')
+        }
+
+        const credentials = { service_account_key: serviceAccountJson }
+
+        // Base config shared by all Google services (domain only).
+        const baseConfig: Record<string, unknown> = {
+            auth_mode: 'domain_wide_delegation',
+            domain: domain || null,
+        }
+
+        // Drive-specific config with optional folder filters.
+        const driveConfig: Record<string, unknown> = {
+            auth_mode: 'domain_wide_delegation',
+            domain: domain || null,
+        }
+        if (driveFolderFilters.length > 0) {
+            driveConfig.folder_path_filters = driveFolderFilters
+        }
+
+        const authType = AuthType.JWT
+        const provider = 'google'
+
+        if (connectDrive) {
+            const driveSourceResponse = await fetch('/api/sources', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    scope: 'org',
+                    name: 'Google Drive',
+                    sourceType: 'google_drive',
+                    config: driveConfig,
+                }),
+            })
+
+            if (!driveSourceResponse.ok) {
+                throw new Error('Failed to create Google Drive source')
+            }
+
+            const driveSource = await driveSourceResponse.json()
+
+            const driveCredentialsResponse = await fetch('/api/service-credentials', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    sourceId: driveSource.id,
+                    provider: provider,
+                    authType: authType,
+                    principalEmail: principalEmail || null,
+                    credentials,
+                    config: driveConfig,
+                }),
+            })
+
+            if (!driveCredentialsResponse.ok) {
+                throw new Error('Failed to create Google Drive service credentials')
+            }
+        }
+
+        if (connectGmail) {
+            const gmailSourceResponse = await fetch('/api/sources', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    scope: 'org',
+                    name: 'Gmail',
+                    sourceType: 'gmail',
+                    config: baseConfig,
+                }),
+            })
+
+            if (!gmailSourceResponse.ok) {
+                throw new Error('Failed to create Gmail source')
+            }
+
+            const gmailSource = await gmailSourceResponse.json()
+
+            const gmailCredentialsResponse = await fetch('/api/service-credentials', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    sourceId: gmailSource.id,
+                    provider: provider,
+                    authType: authType,
+                    principalEmail: principalEmail || null,
+                    credentials: credentials,
+                    config: baseConfig,
+                }),
+            })
+
+            if (!gmailCredentialsResponse.ok) {
+                throw new Error('Failed to create Gmail service credentials')
+            }
+        }
+
+        if (connectChat) {
+            const chatSourceResponse = await fetch('/api/sources', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    scope: 'org',
+                    name: 'Google Chat',
+                    sourceType: 'google_chat',
+                    config: baseConfig,
+                }),
+            })
+
+            if (!chatSourceResponse.ok) {
+                throw new Error('Failed to create Google Chat source')
+            }
+
+            const chatSource = await chatSourceResponse.json()
+
+            const chatCredentialsResponse = await fetch('/api/service-credentials', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    sourceId: chatSource.id,
+                    provider: provider,
+                    authType: authType,
+                    principalEmail: principalEmail || null,
+                    credentials: credentials,
+                    config: baseConfig,
+                }),
+            })
+
+            if (!chatCredentialsResponse.ok) {
+                throw new Error('Failed to create Google Chat service credentials')
+            }
+        }
+
+        toast.success('Google Workspace connected successfully!')
+        resetForm()
+        if (onSuccess) {
+            onSuccess()
+        } else {
+            await goto('/admin/settings/integrations')
+        }
+    }
+
+    function resetForm() {
         serviceAccountJson = ''
         principalEmail = ''
         domain = ''
         connectDrive = true
         connectGmail = true
         connectChat = false
+        driveFolderFilters = []
+        saServiceAccountJson = ''
+        saDriveFilters = []
+        accessValidation = {}
+        activeTab = 'domain_wide_delegation'
+    }
+
+    function handleCancel() {
+        resetForm()
         if (onCancel) {
             onCancel()
         }
@@ -247,61 +493,159 @@
         <Dialog.Header>
             <Dialog.Title>Connect Google Workspace</Dialog.Title>
             <Dialog.Description>
-                Set up org-wide Google Drive, Gmail, and Google Chat sync using a Google service
-                account with domain-wide delegation.
+                Set up Google Drive sync with a service account — either org-wide with domain-wide
+                delegation, or for one or more shared drives without DWD.
             </Dialog.Description>
         </Dialog.Header>
 
-        <div class="space-y-4">
-            <div class="space-y-2">
-                <Label>Services to connect</Label>
-                <div class="grid gap-4 sm:grid-cols-2">
-                    <label
-                        class="hover:bg-muted/50 flex flex-1 cursor-pointer items-center gap-3 rounded-lg border p-3">
-                        <Checkbox bind:checked={connectDrive} />
-                        <img src={googleDriveLogo} alt="Google Drive" class="h-5 w-5" />
-                        <span class="font-medium">Google Drive</span>
-                    </label>
-                    <label
-                        class="hover:bg-muted/50 flex flex-1 cursor-pointer items-center gap-3 rounded-lg border p-3">
-                        <Checkbox bind:checked={connectGmail} />
-                        <img src={gmailLogo} alt="Gmail" class="h-5 w-5" />
-                        <span class="font-medium">Gmail</span>
-                    </label>
-                    <label
-                        class="hover:bg-muted/50 flex flex-1 cursor-pointer items-center gap-3 rounded-lg border p-3">
-                        <Checkbox bind:checked={connectChat} />
-                        <img src={googleChatLogo} alt="Google Chat" class="h-5 w-5" />
-                        <span class="font-medium">Google Chat</span>
-                    </label>
+        <Tabs.Root value={activeTab} onValueChange={(v) => selectTab(v as GoogleAuthMode)}>
+            <Tabs.List class="grid w-full grid-cols-2">
+                <Tabs.Trigger value="domain_wide_delegation">Domain-wide delegation</Tabs.Trigger>
+                <Tabs.Trigger value="service_account_direct">Shared drive (no DWD)</Tabs.Trigger>
+            </Tabs.List>
+
+            <Tabs.Content value="domain_wide_delegation" class="space-y-4 pt-4">
+                <div class="space-y-2">
+                    <Label>Services to connect</Label>
+                    <div class="grid gap-4 sm:grid-cols-2">
+                        <label
+                            class="hover:bg-muted/50 flex flex-1 cursor-pointer items-center gap-3 rounded-lg border p-3">
+                            <Checkbox bind:checked={connectDrive} />
+                            <img src={googleDriveLogo} alt="Google Drive" class="h-5 w-5" />
+                            <span class="font-medium">Google Drive</span>
+                        </label>
+                        <label
+                            class="hover:bg-muted/50 flex flex-1 cursor-pointer items-center gap-3 rounded-lg border p-3">
+                            <Checkbox bind:checked={connectGmail} />
+                            <img src={gmailLogo} alt="Gmail" class="h-5 w-5" />
+                            <span class="font-medium">Gmail</span>
+                        </label>
+                        <label
+                            class="hover:bg-muted/50 flex flex-1 cursor-pointer items-center gap-3 rounded-lg border p-3">
+                            <Checkbox bind:checked={connectChat} />
+                            <img src={googleChatLogo} alt="Google Chat" class="h-5 w-5" />
+                            <span class="font-medium">Google Chat</span>
+                        </label>
+                    </div>
                 </div>
-            </div>
 
-            <GoogleServiceAccountForm bind:serviceAccountJson bind:principalEmail bind:domain />
+                <GoogleServiceAccountForm
+                    bind:serviceAccountJson
+                    bind:principalEmail
+                    bind:domain
+                    mode="dwd" />
 
-            {#if connectDrive}
+                {#if connectDrive}
+                    <Card.Root class="border-dashed">
+                        <Card.Header>
+                            <Card.Title class="text-sm">Drive Folder Filters</Card.Title>
+                            <Card.Description class="text-xs">
+                                Optionally restrict indexing to specific shared drives and folders.
+                            </Card.Description>
+                        </Card.Header>
+                        <Card.Content>
+                            <GoogleDriveFolderSelector
+                                bind:selected={driveFolderFilters}
+                                {serviceAccountJson}
+                                {principalEmail}
+                                {domain}
+                                authMode="domain_wide_delegation" />
+                        </Card.Content>
+                    </Card.Root>
+                {/if}
+            </Tabs.Content>
+
+            <Tabs.Content value="service_account_direct" class="space-y-4 pt-4">
+                <GoogleServiceAccountForm
+                    bind:serviceAccountJson={saServiceAccountJson}
+                    mode="sa-direct" />
+
+                <Alert.Root>
+                    <AlertCircle class="h-4 w-4" />
+                    <Alert.Title>Shared drive access required</Alert.Title>
+                    <Alert.Description>
+                        Add the service account email to each shared drive as
+                        <span class="font-medium"> Content manager </span> or
+                        <span class="font-medium"> Manager</span>. Viewer/Commenter roles cannot
+                        read ACLs and the sync will fail closed. This setup is Drive-only — Gmail
+                        and Google Chat are not available in this mode.
+                    </Alert.Description>
+                </Alert.Root>
+
                 <Card.Root class="border-dashed">
                     <Card.Header>
-                        <Card.Title class="text-sm">Drive Folder Filters</Card.Title>
+                        <Card.Title class="text-sm">Shared Drives to Index</Card.Title>
                         <Card.Description class="text-xs">
-                            Optionally restrict indexing to specific shared drives and folders.
+                            Select one or more shared drives to index in full. At least one is
+                            required.
                         </Card.Description>
                     </Card.Header>
-                    <Card.Content>
+                    <Card.Content class="space-y-3">
                         <GoogleDriveFolderSelector
-                            bind:selected={driveFolderFilters}
+                            bind:selected={saDriveFilters}
                             {serviceAccountJson}
-                            {principalEmail}
-                            {domain} />
+                            authMode="service_account_direct"
+                            label="Shared drives to index"
+                            description="Search and select shared drives. Only whole drives are supported in this mode."
+                            disabled={!saServiceAccountJson.trim()} />
                     </Card.Content>
                 </Card.Root>
-            {/if}
-        </div>
+
+                {#if saDriveFilters.length > 0}
+                    <div class="space-y-2">
+                        <Label class="text-sm font-medium">Access Validation</Label>
+                        <div class="space-y-2">
+                            {#each saDriveFilters as filter (filter.driveId)}
+                                {@const v = accessValidation[filter.driveId]}
+                                <div
+                                    class="flex items-center justify-between rounded-lg border p-3 text-sm">
+                                    <div class="flex items-center gap-2">
+                                        {#if v?.pending}
+                                            <Loader2 class="h-4 w-4 animate-spin" />
+                                        {:else if v?.ok}
+                                            <CheckCircle2 class="h-4 w-4 text-green-600" />
+                                        {:else}
+                                            <XCircle class="h-4 w-4 text-red-600" />
+                                        {/if}
+                                        <span class="font-medium">{filter.name}</span>
+                                        {#if v?.ok && v?.role}
+                                            <span class="text-muted-foreground text-xs">
+                                                — {v.role === 'organizer'
+                                                    ? 'Manager'
+                                                    : 'Content manager'}
+                                            </span>
+                                        {/if}
+                                    </div>
+                                    {#if v && !v.pending && !v.ok && v.error}
+                                        <span class="text-destructive max-w-56 text-right text-xs">
+                                            {v.error}
+                                        </span>
+                                    {/if}
+                                </div>
+                            {/each}
+                        </div>
+                        {#if validationInProgress}
+                            <p class="text-muted-foreground text-xs">
+                                Checking service account role on each selected drive…
+                            </p>
+                        {/if}
+                    </div>
+                {/if}
+            </Tabs.Content>
+        </Tabs.Root>
 
         <Dialog.Footer>
             <Button variant="outline" onclick={handleCancel} class="cursor-pointer">Cancel</Button>
-            <Button onclick={handleSubmit} disabled={isSubmitting} class="cursor-pointer">
-                {isSubmitting ? 'Connecting...' : 'Connect'}
+            <Button
+                onclick={handleSubmit}
+                disabled={isSubmitting ||
+                    (activeTab === 'service_account_direct' &&
+                        (!allDrivesValidated || validationInProgress))}
+                class="cursor-pointer">
+                {#if isSubmitting}
+                    <Loader2 class="mr-2 h-4 w-4 animate-spin" />
+                {/if}
+                {activeTab === 'service_account_direct' ? 'Connect and Sync' : 'Connect'}
             </Button>
         </Dialog.Footer>
     </Dialog.Content>

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -97,9 +97,9 @@
         validateAccess(saServiceAccountJson, saDriveFilters)
     })
 
-    // Switch to SA-direct tab: force Drive-only.
+    // Switch to SA-direct tab: force Drive-only. activeTab itself is kept in
+    // sync by the Tabs.Root bind:value, so this only applies side effects.
     function selectTab(tab: GoogleAuthMode) {
-        activeTab = tab
         if (tab === 'service_account_direct') {
             connectDrive = true
             connectGmail = false
@@ -492,10 +492,18 @@
             </Dialog.Description>
         </Dialog.Header>
 
-        <Tabs.Root value={activeTab} onValueChange={(v) => selectTab(v as GoogleAuthMode)}>
+        <Tabs.Root bind:value={activeTab} onValueChange={(v) => selectTab(v as GoogleAuthMode)}>
             <Tabs.List class="grid w-full grid-cols-2">
-                <Tabs.Trigger value="domain_wide_delegation">Domain-wide delegation</Tabs.Trigger>
-                <Tabs.Trigger value="service_account_direct">Shared drive (no DWD)</Tabs.Trigger>
+                <Tabs.Trigger
+                    value="domain_wide_delegation"
+                    class="data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm">
+                    Domain-wide delegation
+                </Tabs.Trigger>
+                <Tabs.Trigger
+                    value="service_account_direct"
+                    class="data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm">
+                    Shared drive (no DWD)
+                </Tabs.Trigger>
             </Tabs.List>
 
             <Tabs.Content value="domain_wide_delegation" class="space-y-4 pt-4">
@@ -554,17 +562,19 @@
                     bind:serviceAccountJson={saServiceAccountJson}
                     mode="sa-direct" />
 
-                <Alert.Root>
-                    <AlertCircle class="h-4 w-4" />
-                    <Alert.Title>Shared drive access required</Alert.Title>
-                    <Alert.Description>
-                        Add the service account email to each shared drive as
-                        <span class="font-medium"> Content manager </span> or
-                        <span class="font-medium"> Manager</span>. Viewer/Commenter roles cannot
-                        read ACLs and the sync will fail closed. This setup is Drive-only — Gmail
-                        and Google Chat are not available in this mode.
-                    </Alert.Description>
-                </Alert.Root>
+                {#if saDriveFilters.length > 0 && !allDrivesValidated}
+                    <Alert.Root>
+                        <AlertCircle class="h-4 w-4" />
+                        <Alert.Title>Shared drive access required</Alert.Title>
+                        <Alert.Description>
+                            Add the service account email to each shared drive as
+                            <span class="font-medium"> Content manager </span> or
+                            <span class="font-medium"> Manager</span>. Viewer/Commenter roles cannot
+                            read ACLs and the sync will fail closed. This setup is Drive-only —
+                            Gmail and Google Chat are not available in this mode.
+                        </Alert.Description>
+                    </Alert.Root>
+                {/if}
 
                 <Card.Root class="border-dashed">
                     <Card.Header>

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -8,8 +8,14 @@
     import * as Alert from '$lib/components/ui/alert'
     import { Loader2, CheckCircle2, XCircle, AlertCircle } from '@lucide/svelte'
     import { AuthType } from '$lib/types'
-    import type { FolderPathFilter, GoogleAuthMode } from '$lib/types'
-    import type { SharedDriveAccessResponse } from '$lib/types'
+    import type {
+        ConnectorActionResponse,
+        DriveAccessStatus,
+        FolderPathFilter,
+        GoogleAuthMode,
+        GoogleSourceConfig,
+        SharedDriveAccessResponse,
+    } from '$lib/types'
     import { toast } from 'svelte-sonner'
     import { goto } from '$app/navigation'
     import googleDriveLogo from '$lib/images/icons/google-drive.svg'
@@ -43,9 +49,7 @@
     let saServiceAccountJson = $state('')
     let saDriveFilters = $state<FolderPathFilter[]>([])
     // Per-drive validation: drive_id -> { pending, ok, role, error }
-    let accessValidation = $state<
-        Record<string, { pending: boolean; ok: boolean; role: string | null; error: string | null }>
-    >({})
+    let accessValidation = $state<Record<string, DriveAccessStatus>>({})
     let isValidating = $state(false)
     let validationAbort: AbortController | null = null
     let validationGeneration = $state(0)
@@ -73,23 +77,24 @@
         }
     })
 
-    // SA-direct guard: when the SA key changes, clear discovered drives and
-    // any prior validation state so stale selections can't be submitted.
-    let prevSaKey = $state('')
-    let saInitialized = $state(false)
+    // SA-direct: when the SA key changes, the selector clears its own
+    // selection (its credential context includes the key). Re-run access
+    // validation whenever the key or selected drives change; if inputs become
+    // empty/invalid, invalidate any in-flight validation so stale results
+    // from a previous key can't land.
     $effect(() => {
-        if (!saInitialized) {
-            saInitialized = true
-            prevSaKey = saServiceAccountJson
-            return
-        }
-        if (saServiceAccountJson !== prevSaKey) {
-            prevSaKey = saServiceAccountJson
-            saDriveFilters = []
-            accessValidation = {}
+        if (activeTab !== 'service_account_direct') return
+        if (!saServiceAccountJson.trim() || saDriveFilters.length === 0) {
+            // Invalidate and cancel any in-flight validation so stale results
+            // from a previous key can't land.
+            validationGeneration += 1
             validationAbort?.abort()
             validationAbort = null
+            accessValidation = {}
+            isSubmitting = false
+            return
         }
+        validateAccess(saServiceAccountJson, saDriveFilters)
     })
 
     // Switch to SA-direct tab: force Drive-only.
@@ -102,17 +107,6 @@
         }
     }
 
-    // Re-run access validation whenever the SA key or selected drives change.
-    $effect(() => {
-        if (activeTab !== 'service_account_direct') return
-        if (!saServiceAccountJson.trim() || saDriveFilters.length === 0) {
-            accessValidation = {}
-            isSubmitting = false
-            return
-        }
-        validateAccess(saServiceAccountJson, saDriveFilters)
-    })
-
     async function validateAccess(saJson: string, filters: FolderPathFilter[]) {
         const generation = ++validationGeneration
         validationAbort?.abort()
@@ -121,10 +115,7 @@
         isValidating = true
 
         // Mark all drives pending.
-        const pending: Record<
-            string,
-            { pending: boolean; ok: boolean; role: string | null; error: string | null }
-        > = {}
+        const pending: Record<string, DriveAccessStatus> = {}
         for (const f of filters) {
             pending[f.driveId] = { pending: true, ok: false, role: null, error: null }
         }
@@ -146,8 +137,11 @@
             })
             if (generation !== validationGeneration) return
             if (!response.ok) {
-                const errBody = await response.json().catch(() => ({}))
-                const msg = errBody.error || errBody.message || 'Failed to validate drive access'
+                const errBody = (await response.json().catch(() => null)) as {
+                    error?: string
+                    message?: string
+                } | null
+                const msg = errBody?.error || errBody?.message || 'Failed to validate drive access'
                 for (const f of filters) {
                     pending[f.driveId] = {
                         pending: false,
@@ -159,11 +153,9 @@
                 accessValidation = { ...pending }
                 return
             }
-            const body = (await response.json()) as {
-                status?: string
-                result?: SharedDriveAccessResponse
-            }
-            const statusOk = body?.status === 'ok' || body?.status === 'success'
+            const body =
+                (await response.json()) as ConnectorActionResponse<SharedDriveAccessResponse>
+            const statusOk = body?.status === 'success'
             const drives = body?.result?.drives ?? []
             if (statusOk && drives.length > 0) {
                 const next: typeof pending = {}
@@ -256,7 +248,7 @@
             )
         }
 
-        const driveConfig: Record<string, unknown> = {
+        const driveConfig: GoogleSourceConfig = {
             auth_mode: 'service_account_direct',
             folder_path_filters: saDriveFilters,
         }
@@ -273,8 +265,10 @@
             }),
         })
         if (!driveSourceResponse.ok) {
-            const errBody = await driveSourceResponse.json().catch(() => ({}))
-            throw new Error(errBody.message || 'Failed to create Google Drive source')
+            const errBody = (await driveSourceResponse.json().catch(() => null)) as {
+                message?: string
+            } | null
+            throw new Error(errBody?.message || 'Failed to create Google Drive source')
         }
         const driveSource = await driveSourceResponse.json()
 
@@ -332,13 +326,13 @@
         const credentials = { service_account_key: serviceAccountJson }
 
         // Base config shared by all Google services (domain only).
-        const baseConfig: Record<string, unknown> = {
+        const baseConfig: GoogleSourceConfig = {
             auth_mode: 'domain_wide_delegation',
             domain: domain || null,
         }
 
         // Drive-specific config with optional folder filters.
-        const driveConfig: Record<string, unknown> = {
+        const driveConfig: GoogleSourceConfig = {
             auth_mode: 'domain_wide_delegation',
             domain: domain || null,
         }
@@ -583,7 +577,7 @@
                     <Card.Content class="space-y-3">
                         <GoogleDriveFolderSelector
                             bind:selected={saDriveFilters}
-                            {serviceAccountJson}
+                            serviceAccountJson={saServiceAccountJson}
                             authMode="service_account_direct"
                             label="Shared drives to index"
                             description="Search and select shared drives. Only whole drives are supported in this mode."

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -54,52 +54,11 @@
     let validationAbort: AbortController | null = null
     let validationGeneration = $state(0)
 
-    // Credential-context guard: clear selected folder filters whenever the
-    // credential inputs change after initialization so filters from one set
-    // of credentials cannot be silently submitted with another.
-    let prevCredContext = $state('')
-    let credInitialized = $state(false)
-
-    $effect(() => {
-        const token = JSON.stringify({
-            sa: serviceAccountJson,
-            pe: principalEmail,
-            dm: domain,
-        })
-        if (!credInitialized) {
-            credInitialized = true
-            prevCredContext = token
-            return
-        }
-        if (token !== prevCredContext) {
-            prevCredContext = token
-            driveFolderFilters = []
-        }
-    })
-
-    // SA-direct: when the SA key changes, the selector clears its own
-    // selection (its credential context includes the key). Re-run access
-    // validation whenever the key or selected drives change; if inputs become
-    // empty/invalid, invalidate any in-flight validation so stale results
-    // from a previous key can't land.
-    $effect(() => {
-        if (activeTab !== 'service_account_direct') return
-        if (!saServiceAccountJson.trim() || saDriveFilters.length === 0) {
-            // Invalidate and cancel any in-flight validation so stale results
-            // from a previous key can't land.
-            validationGeneration += 1
-            validationAbort?.abort()
-            validationAbort = null
-            accessValidation = {}
-            isSubmitting = false
-            return
-        }
-        validateAccess(saServiceAccountJson, saDriveFilters)
-    })
-
-    // Switch to SA-direct tab: force Drive-only. activeTab itself is kept in
-    // sync by the Tabs.Root bind:value, so this only applies side effects.
+    // Switch to SA-direct tab: force Drive-only. The tab value itself is
+    // kept in sync by Tabs.Root's bind:value, so this only applies side
+    // effects.
     function selectTab(tab: GoogleAuthMode) {
+        console.log('[google-setup] selectTab', tab)
         if (tab === 'service_account_direct') {
             connectDrive = true
             connectGmail = false
@@ -107,7 +66,31 @@
         }
     }
 
+    // Event-driven SA-direct access validation. The drive selector reports
+    // every selection change (add/remove/credential-context clear) via
+    // onSelectedChange; validation runs only when both a key and drives are
+    // present, and is invalidated otherwise.
+    function handleSaSelectionChange(filters: FolderPathFilter[]) {
+        console.log(
+            '[google-setup] saSelectionChange',
+            filters.map((f) => f.driveId),
+        )
+        if (saServiceAccountJson.trim() && filters.length > 0) {
+            validateAccess(saServiceAccountJson, filters)
+        } else {
+            // Invalidate and cancel any in-flight validation so stale results
+            // from a previous key/selection can't land.
+            validationGeneration += 1
+            validationAbort?.abort()
+            validationAbort = null
+            accessValidation = {}
+            isValidating = false
+            isSubmitting = false
+        }
+    }
+
     async function validateAccess(saJson: string, filters: FolderPathFilter[]) {
+        console.log('[google-setup] validateAccess start', filters.length)
         const generation = ++validationGeneration
         validationAbort?.abort()
         const controller = new AbortController()
@@ -577,21 +560,15 @@
                 {/if}
 
                 <Card.Root class="border-dashed">
-                    <Card.Header>
-                        <Card.Title class="text-sm">Shared Drives to Index</Card.Title>
-                        <Card.Description class="text-xs">
-                            Select one or more shared drives to index in full. At least one is
-                            required.
-                        </Card.Description>
-                    </Card.Header>
-                    <Card.Content class="space-y-3">
+                    <Card.Content class="space-y-3 pt-4">
                         <GoogleDriveFolderSelector
                             bind:selected={saDriveFilters}
                             serviceAccountJson={saServiceAccountJson}
                             authMode="service_account_direct"
                             label="Shared drives to index"
-                            description="Search and select shared drives. Only whole drives are supported in this mode."
-                            disabled={!saServiceAccountJson.trim()} />
+                            description="Search and select shared drives to index in full. Only whole drives are supported in this mode, and at least one is required."
+                            disabled={!saServiceAccountJson.trim()}
+                            onSelectedChange={handleSaSelectionChange} />
                     </Card.Content>
                 </Card.Root>
 

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -560,7 +560,7 @@
                 {/if}
 
                 <Card.Root class="border-dashed">
-                    <Card.Content class="space-y-3 pt-4">
+                    <Card.Content class="space-y-3">
                         <GoogleDriveFolderSelector
                             bind:selected={saDriveFilters}
                             serviceAccountJson={saServiceAccountJson}

--- a/web/src/lib/components/masked-credential-input.svelte
+++ b/web/src/lib/components/masked-credential-input.svelte
@@ -29,7 +29,7 @@
 
     let replacing = $state(!hasStoredValue)
 
-    const maskedPlaceholder = '•••••••• (leave empty to keep current)'
+    const maskedPlaceholder = '••••••••••••••••'
 
     function startReplace() {
         replacing = true

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -94,16 +94,32 @@ export interface FolderPathFilter {
     kind: 'shared_drive_root' | 'folder'
 }
 
+export type GoogleAuthMode = 'domain_wide_delegation' | 'service_account_direct'
+
 export interface GoogleDriveSourceConfig {
+    auth_mode?: GoogleAuthMode
     folder_path_filters?: FolderPathFilter[]
     // Future: shared_drive_filters, mime_type_filters, etc.
 }
 
+export interface SharedDriveAccessResult {
+    drive_id: string
+    ok: boolean
+    role: string | null
+    error: string | null
+}
+
+export interface SharedDriveAccessResponse {
+    drives: SharedDriveAccessResult[]
+}
+
 export interface GmailSourceConfig {
+    auth_mode?: GoogleAuthMode
     // Future: label_filters, date_range_filters, etc.
 }
 
 export interface GoogleChatSourceConfig {
+    auth_mode?: GoogleAuthMode
     space_allowlist?: string[]
     include_group_chats?: boolean
 }

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -102,6 +102,18 @@ export interface GoogleDriveSourceConfig {
     // Future: shared_drive_filters, mime_type_filters, etc.
 }
 
+/**
+ * Mirrors the connector's `GoogleSourceConfig` (models.rs).
+ * `domain` is used only in domain_wide_delegation mode.
+ */
+export interface GoogleSourceConfig {
+    auth_mode: GoogleAuthMode
+    domain?: string | null
+    folder_path_filters?: FolderPathFilter[]
+    space_allowlist?: string[]
+    include_group_chats?: boolean
+}
+
 export interface SharedDriveAccessResult {
     drive_id: string
     ok: boolean
@@ -111,6 +123,21 @@ export interface SharedDriveAccessResult {
 
 export interface SharedDriveAccessResponse {
     drives: SharedDriveAccessResult[]
+}
+
+/** Per-drive access-validation status shown in the setup UI. */
+export interface DriveAccessStatus {
+    pending: boolean
+    ok: boolean
+    role: string | null
+    error: string | null
+}
+
+/** Envelope returned by the transient connector action route. */
+export interface ConnectorActionResponse<T = unknown> {
+    status: 'success' | 'error'
+    result?: T
+    error?: string
 }
 
 export interface GmailSourceConfig {

--- a/web/src/routes/(admin)/admin/settings/integrations/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/+page.svelte
@@ -281,7 +281,7 @@
         </div>
 
         <Tabs.Root bind:value={activeTab}>
-            <Tabs.List>
+            <Tabs.List class="w-full max-w-md">
                 <Tabs.Trigger
                     value="sources"
                     class="data-[state=active]:bg-background data-[state=active]:text-foreground data-[state=active]:shadow-sm">

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.server.ts
@@ -29,9 +29,18 @@ export const load: PageServerLoad = async ({ params, locals }) => {
 
     const creds = await serviceCredentialsRepository.getOrgCredsBySourceId(source.id)
 
-    const credsConfig = (creds?.config as { domain?: string } | null) ?? {}
+    const credsConfig = (creds?.config as { domain?: string; scopes?: unknown } | null) ?? {}
     const sourceConfig =
-        (source.config as { domain?: string; folder_path_filters?: unknown } | null) ?? {}
+        (source.config as {
+            domain?: string
+            auth_mode?: string
+            folder_path_filters?: unknown
+        } | null) ?? {}
+
+    const authMode =
+        sourceConfig.auth_mode ??
+        (creds?.authType === AuthType.JWT ? 'domain_wide_delegation' : null)
+    const isSaDirect = authMode === 'service_account_direct'
 
     const folderPathFilters = Array.isArray(sourceConfig?.folder_path_filters)
         ? sourceConfig.folder_path_filters
@@ -45,6 +54,8 @@ export const load: PageServerLoad = async ({ params, locals }) => {
     return {
         source,
         authType: (creds?.authType as AuthType | undefined) ?? null,
+        authMode,
+        isSaDirect,
         hasStoredKey: Boolean(creds),
         principalEmail: creds?.principalEmail ?? '',
         domain: credsConfig.domain ?? sourceConfig.domain ?? '',
@@ -149,6 +160,11 @@ export const actions: Actions = {
 
         const existingCreds = await serviceCredentialsRepository.getOrgCredsBySourceId(source.id)
         const isJwt = existingCreds?.authType === AuthType.JWT
+        const existingConfig: Record<string, unknown> =
+            source.config && typeof source.config === 'object' && !Array.isArray(source.config)
+                ? (source.config as Record<string, unknown>)
+                : {}
+        const isSaDirect = existingConfig.auth_mode === 'service_account_direct'
 
         try {
             if (isJwt) {
@@ -158,64 +174,114 @@ export const actions: Actions = {
                 const principalEmail = ((formData.get('principalEmail') as string) || '').trim()
                 const domain = ((formData.get('domain') as string) || '').trim()
 
-                if (
-                    isActive &&
-                    userFilterMode === 'whitelist' &&
-                    (!userWhitelist || userWhitelist.length === 0)
-                ) {
-                    throw error(400, 'Whitelist mode requires at least one user')
-                }
-                if (!principalEmail) {
-                    throw error(400, 'Admin email is required')
-                }
-                if (!domain) {
-                    throw error(400, 'Organization domain is required')
-                }
-
-                if (serviceAccountJson) {
-                    try {
-                        JSON.parse(serviceAccountJson)
-                    } catch {
-                        throw error(400, 'Invalid service account JSON')
+                if (isSaDirect) {
+                    // SA-direct: no admin email/domain required; the shared drive
+                    // selection is the only scope. Validate it was provided.
+                    const folderPathFilters = parseFolderPathFilters(formData)
+                    if (folderPathFilters.length === 0) {
+                        throw error(400, 'At least one shared drive is required')
                     }
+                    if (folderPathFilters.some((f) => f.kind !== 'shared_drive_root')) {
+                        throw error(
+                            400,
+                            'SA-direct supports whole shared drives only (folder-level restrictions are not supported)',
+                        )
+                    }
+
+                    if (serviceAccountJson) {
+                        try {
+                            JSON.parse(serviceAccountJson)
+                        } catch {
+                            throw error(400, 'Invalid service account JSON')
+                        }
+                    }
+
+                    const mergedConfig: Record<string, unknown> = {
+                        ...existingConfig,
+                        auth_mode: 'service_account_direct',
+                    }
+                    mergedConfig.folder_path_filters = folderPathFilters
+                    delete mergedConfig.domain
+
+                    const existingCredConfig: Record<string, unknown> =
+                        existingCreds?.config &&
+                        typeof existingCreds.config === 'object' &&
+                        !Array.isArray(existingCreds.config)
+                            ? (existingCreds.config as Record<string, unknown>)
+                            : {}
+
+                    await serviceCredentialsRepository.updateBySourceId(source.id, {
+                        principalEmail: null,
+                        config: {
+                            ...existingCredConfig,
+                            scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+                        },
+                        credentials: serviceAccountJson
+                            ? { service_account_key: serviceAccountJson }
+                            : null,
+                    })
+
+                    await updateSourceById(source.id, {
+                        isActive,
+                        userFilterMode,
+                        userWhitelist,
+                        userBlacklist,
+                        config: mergedConfig,
+                    })
+                } else {
+                    if (
+                        isActive &&
+                        userFilterMode === 'whitelist' &&
+                        (!userWhitelist || userWhitelist.length === 0)
+                    ) {
+                        throw error(400, 'Whitelist mode requires at least one user')
+                    }
+                    if (!principalEmail) {
+                        throw error(400, 'Admin email is required')
+                    }
+                    if (!domain) {
+                        throw error(400, 'Organization domain is required')
+                    }
+
+                    if (serviceAccountJson) {
+                        try {
+                            JSON.parse(serviceAccountJson)
+                        } catch {
+                            throw error(400, 'Invalid service account JSON')
+                        }
+                    }
+
+                    const folderPathFilters = parseFolderPathFilters(formData)
+
+                    // Merge folder_path_filters into config while PRESERVING all existing source config keys.
+                    const mergedConfig: Record<string, unknown> = { ...existingConfig, domain }
+                    mergedConfig.auth_mode = 'domain_wide_delegation'
+                    mergedConfig.folder_path_filters = folderPathFilters
+
+                    // Preserve existing credential config as well.
+                    const existingCredConfig: Record<string, unknown> =
+                        existingCreds?.config &&
+                        typeof existingCreds.config === 'object' &&
+                        !Array.isArray(existingCreds.config)
+                            ? (existingCreds.config as Record<string, unknown>)
+                            : {}
+
+                    await serviceCredentialsRepository.updateBySourceId(source.id, {
+                        principalEmail,
+                        config: { ...existingCredConfig, domain },
+                        credentials: serviceAccountJson
+                            ? { service_account_key: serviceAccountJson }
+                            : null,
+                    })
+
+                    await updateSourceById(source.id, {
+                        isActive,
+                        userFilterMode,
+                        userWhitelist,
+                        userBlacklist,
+                        config: mergedConfig,
+                    })
                 }
-
-                const folderPathFilters = parseFolderPathFilters(formData)
-
-                // Merge folder_path_filters into config while PRESERVING all existing source config keys.
-                const existingConfig: Record<string, unknown> =
-                    source.config &&
-                    typeof source.config === 'object' &&
-                    !Array.isArray(source.config)
-                        ? (source.config as Record<string, unknown>)
-                        : {}
-
-                const mergedConfig: Record<string, unknown> = { ...existingConfig, domain }
-                mergedConfig.folder_path_filters = folderPathFilters
-
-                // Preserve existing credential config as well.
-                const existingCredConfig: Record<string, unknown> =
-                    existingCreds?.config &&
-                    typeof existingCreds.config === 'object' &&
-                    !Array.isArray(existingCreds.config)
-                        ? (existingCreds.config as Record<string, unknown>)
-                        : {}
-
-                await serviceCredentialsRepository.updateBySourceId(source.id, {
-                    principalEmail,
-                    config: { ...existingCredConfig, domain },
-                    credentials: serviceAccountJson
-                        ? { service_account_key: serviceAccountJson }
-                        : null,
-                })
-
-                await updateSourceById(source.id, {
-                    isActive,
-                    userFilterMode,
-                    userWhitelist,
-                    userBlacklist,
-                    config: mergedConfig,
-                })
             } else {
                 // OAuth or other auth types — admin can only toggle enabled.
                 // Still merge any config changes without destroying existing keys.

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
@@ -367,20 +367,13 @@
                             hasStoredKey={data.hasStoredKey} />
 
                         <div class="space-y-4 border-t pt-6">
-                            <div>
-                                <h3 class="text-sm font-medium">Shared Drives to Index</h3>
-                                <p class="text-muted-foreground text-xs">
-                                    Select one or more whole shared drives to index. Add the service
-                                    account to each drive as Content manager or Manager.
-                                </p>
-                            </div>
                             <GoogleDriveFolderSelector
                                 bind:selected={folderFilters}
                                 sourceId={data.source.id}
                                 {serviceAccountJson}
                                 authMode="service_account_direct"
-                                label="Shared drives to index"
-                                description="Only whole shared drives are supported in this mode."
+                                label="Shared Drives to Index"
+                                description="Select one or more whole shared drives to index. Add the service account to each drive as Content manager or Manager. Only whole shared drives are supported in this mode."
                                 disabled={!enabled} />
                             <input
                                 type="hidden"
@@ -417,19 +410,14 @@
 
                     <!-- Folder Path Filter (JWT only) -->
                     <div class="space-y-4 border-t pt-6">
-                        <div>
-                            <h3 class="text-sm font-medium">Drive Folder Filters</h3>
-                            <p class="text-muted-foreground text-xs">
-                                Optionally restrict indexing to specific shared drives and top-level
-                                folders. All sub-folders within a selected item are included.
-                            </p>
-                        </div>
                         <GoogleDriveFolderSelector
                             bind:selected={folderFilters}
                             sourceId={data.source.id}
                             {serviceAccountJson}
                             {principalEmail}
                             {domain}
+                            label="Drive Folder Filters"
+                            description="Optionally restrict indexing to specific shared drives and top-level folders. All sub-folders within a selected item are included."
                             disabled={!enabled} />
                         <!-- Hidden form value to submit folder filters (always present for JWT, even when empty) -->
                         <input

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
@@ -346,49 +346,34 @@
                     <div class="space-y-4">
                         <Alert.Root variant="default">
                             <Info class="h-4 w-4" />
-                            <Alert.Title>Service account direct — shared drive sync</Alert.Title>
+                            <Alert.Title>Shared drive sync</Alert.Title>
                             <Alert.Description>
                                 This source syncs selected shared drives as the service account
-                                itself. No user impersonation, no domain-wide delegation, no admin
-                                email/domain. ACLs come from each drive's members.
+                                itself. Permissions come from each drive's members.
                             </Alert.Description>
                         </Alert.Root>
 
-                        <div>
-                            <h3 class="text-sm font-medium">Connection Settings</h3>
-                            <p class="text-muted-foreground text-xs">
-                                Service account credentials used to authenticate as the service
-                                account itself (drive.readonly only).
-                            </p>
-                        </div>
                         <GoogleServiceAccountForm
                             bind:serviceAccountJson
                             mode="sa-direct"
-                            hasStoredKey={data.hasStoredKey} />
+                            hasStoredKey={data.hasStoredKey}
+                            showSaDirectInfo={false} />
 
-                        <div class="space-y-4 border-t pt-6">
-                            <GoogleDriveFolderSelector
-                                bind:selected={folderFilters}
-                                sourceId={data.source.id}
-                                {serviceAccountJson}
-                                authMode="service_account_direct"
-                                label="Shared Drives to Index"
-                                description="Select one or more whole shared drives to index. Add the service account to each drive as Content manager or Manager. Only whole shared drives are supported in this mode."
-                                disabled={!enabled} />
-                            <input
-                                type="hidden"
-                                name="folder_path_filters"
-                                value={JSON.stringify(folderFilters)} />
-                        </div>
+                        <GoogleDriveFolderSelector
+                            bind:selected={folderFilters}
+                            sourceId={data.source.id}
+                            {serviceAccountJson}
+                            authMode="service_account_direct"
+                            label="Shared Drives to Index"
+                            description="Select one or more whole shared drives to index."
+                            disabled={!enabled} />
+                        <input
+                            type="hidden"
+                            name="folder_path_filters"
+                            value={JSON.stringify(folderFilters)} />
                     </div>
                 {:else}
                     <div class="space-y-4">
-                        <div>
-                            <h3 class="text-sm font-medium">Connection Settings</h3>
-                            <p class="text-muted-foreground text-xs">
-                                Service account credentials used to impersonate Workspace users.
-                            </p>
-                        </div>
                         <GoogleServiceAccountForm
                             bind:serviceAccountJson
                             bind:principalEmail

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
@@ -26,6 +26,13 @@
     let { data }: PageProps = $props()
     const isJwt = data.authType === AuthType.JWT
     const isOAuth = data.authType === AuthType.OAUTH
+    const isSaDirect = data.isSaDirect === true
+
+    // SA-direct access validation state (re-run before Save).
+    let saAccessValidation = $state<
+        Record<string, { ok: boolean; role: string | null; error: string | null }>
+    >({})
+    let saValidating = $state(false)
 
     let enabled = $state(data.source.isActive)
     let userFilterMode = $state(data.source.userFilterMode || 'all')
@@ -123,6 +130,24 @@
             return true
         }
 
+        if (isSaDirect) {
+            // SA-direct: no admin email/domain; at least one whole shared drive.
+            if (folderFilters.length === 0) {
+                formErrors = [...formErrors, 'At least one shared drive is required']
+            }
+            if (folderFilters.some((f) => f.kind !== 'shared_drive_root')) {
+                formErrors = [...formErrors, 'SA-direct supports whole shared drives only']
+            }
+            if (serviceAccountJson.trim()) {
+                try {
+                    JSON.parse(serviceAccountJson)
+                } catch {
+                    formErrors = [...formErrors, 'Service account JSON is not valid JSON']
+                }
+            }
+            return formErrors.length === 0
+        }
+
         if (enabled && userFilterMode === 'whitelist' && selectedUsers.length === 0) {
             formErrors = [...formErrors, 'Whitelist mode requires at least one user']
         }
@@ -206,6 +231,14 @@
         const foldersChanged =
             JSON.stringify(folderFilters.map((f) => f.id).sort()) !==
             JSON.stringify(originalFolderFilters.map((f) => f.id).sort())
+
+        if (isSaDirect) {
+            hasUnsavedChanges =
+                enabled !== originalEnabled ||
+                foldersChanged ||
+                serviceAccountJson.trim().length > 0
+            return
+        }
 
         hasUnsavedChanges =
             enabled !== originalEnabled ||
@@ -309,181 +342,229 @@
                     </Alert.Root>
                 </div>
             {:else if isJwt}
-                <div class="space-y-4">
-                    <div>
-                        <h3 class="text-sm font-medium">Connection Settings</h3>
-                        <p class="text-muted-foreground text-xs">
-                            Service account credentials used to impersonate Workspace users.
-                        </p>
-                    </div>
-                    <GoogleServiceAccountForm
-                        bind:serviceAccountJson
-                        bind:principalEmail
-                        bind:domain
-                        hasStoredKey={data.hasStoredKey} />
-
-                    {#if data.gmailSiblingId}
-                        <Alert.Root>
+                {#if isSaDirect}
+                    <div class="space-y-4">
+                        <Alert.Root variant="default">
                             <Info class="h-4 w-4" />
-                            <Alert.Title>Gmail uses a separate credential copy</Alert.Title>
+                            <Alert.Title>Service account direct — shared drive sync</Alert.Title>
                             <Alert.Description>
-                                Updating the service account key here only rotates it for Google
-                                Drive. If you want to rotate the key for Gmail too, open the Gmail
-                                source settings and replace it there as well.
+                                This source syncs selected shared drives as the service account
+                                itself. No user impersonation, no domain-wide delegation, no admin
+                                email/domain. ACLs come from each drive's members.
                             </Alert.Description>
                         </Alert.Root>
-                    {/if}
-                </div>
 
-                <!-- Folder Path Filter (JWT only) -->
-                <div class="space-y-4 border-t pt-6">
-                    <div>
-                        <h3 class="text-sm font-medium">Drive Folder Filters</h3>
-                        <p class="text-muted-foreground text-xs">
-                            Optionally restrict indexing to specific shared drives and top-level
-                            folders. All sub-folders within a selected item are included.
-                        </p>
-                    </div>
-                    <GoogleDriveFolderSelector
-                        bind:selected={folderFilters}
-                        sourceId={data.source.id}
-                        {serviceAccountJson}
-                        {principalEmail}
-                        {domain}
-                        disabled={!enabled} />
-                    <!-- Hidden form value to submit folder filters (always present for JWT, even when empty) -->
-                    <input
-                        type="hidden"
-                        name="folder_path_filters"
-                        value={JSON.stringify(folderFilters)} />
-                </div>
-
-                <div class="space-y-4 border-t pt-6">
-                    <div>
-                        <h3 class="text-sm font-medium">User Access Control</h3>
-                        <p class="text-muted-foreground text-xs">
-                            Control which Workspace users get their Drive files indexed.
-                        </p>
-                    </div>
-                    <RadioGroup.Root
-                        bind:value={userFilterMode}
-                        name="userFilterMode"
-                        disabled={!enabled}>
-                        <div class="flex items-start space-x-3">
-                            <RadioGroup.Item value="all" id="all" />
-                            <Label for="all" class="cursor-pointer">
-                                <div>
-                                    <div class="text-sm font-medium">All Users</div>
-                                    <div class="text-muted-foreground text-xs">
-                                        Index Drive files for all Google Workspace users
-                                    </div>
-                                </div>
-                            </Label>
+                        <div>
+                            <h3 class="text-sm font-medium">Connection Settings</h3>
+                            <p class="text-muted-foreground text-xs">
+                                Service account credentials used to authenticate as the service
+                                account itself (drive.readonly only).
+                            </p>
                         </div>
+                        <GoogleServiceAccountForm
+                            bind:serviceAccountJson
+                            mode="sa-direct"
+                            hasStoredKey={data.hasStoredKey} />
 
-                        <div class="flex items-start space-x-3">
-                            <RadioGroup.Item value="whitelist" id="whitelist" />
-                            <Label for="whitelist" class="cursor-pointer">
-                                <div>
-                                    <div class="text-sm font-medium">Specific Users</div>
-                                    <div class="text-muted-foreground text-xs">
-                                        Only index Drive files from selected users
-                                    </div>
-                                </div>
-                            </Label>
-                        </div>
-
-                        <div class="flex items-start space-x-3">
-                            <RadioGroup.Item value="blacklist" id="blacklist" />
-                            <Label for="blacklist" class="cursor-pointer">
-                                <div>
-                                    <div class="text-sm font-medium">Exclude Users</div>
-                                    <div class="text-muted-foreground text-xs">
-                                        Index all users except selected ones
-                                    </div>
-                                </div>
-                            </Label>
-                        </div>
-                    </RadioGroup.Root>
-
-                    {#if enabled && userFilterMode !== 'all'}
-                        <div class="space-y-3 border-t pt-4">
-                            <div class="space-y-2">
-                                <div class="relative">
-                                    <Search
-                                        class="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-                                    <Input
-                                        bind:value={searchQuery}
-                                        oninput={handleSearchInput}
-                                        placeholder="Search users..."
-                                        class="px-10 py-1" />
-                                    {#if isSearching}
-                                        <Loader2
-                                            class="absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 animate-spin" />
-                                    {/if}
-                                </div>
-
-                                {#if searchResults.length > 0}
-                                    <div class="max-h-32 overflow-y-auto rounded-md border p-1">
-                                        {#each searchResults.filter((user) => !selectedUsers.includes(user.email)) as user}
-                                            <button
-                                                type="button"
-                                                onclick={() => addUser(user.email)}
-                                                class="hover:bg-muted flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs">
-                                                <div>
-                                                    <div class="font-medium">
-                                                        {user.name}
-                                                    </div>
-                                                    <div class="text-muted-foreground">
-                                                        {user.email}
-                                                    </div>
-                                                </div>
-                                                {#if user.isAdmin}
-                                                    <Badge variant="secondary" class="text-xs"
-                                                        >Admin</Badge>
-                                                {/if}
-                                            </button>
-                                        {/each}
-                                    </div>
-                                {/if}
-
-                                {#if selectedUsers.length > 0}
-                                    <div class="space-y-2">
-                                        <Label class="text-xs font-medium">
-                                            {userFilterMode === 'whitelist'
-                                                ? 'Included Users'
-                                                : 'Excluded Users'}
-                                        </Label>
-                                        <div class="flex flex-wrap gap-2">
-                                            {#each selectedUsers as email}
-                                                <div
-                                                    class="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors">
-                                                    <span>{email}</span>
-                                                    <button
-                                                        type="button"
-                                                        onclick={() => removeUser(email)}
-                                                        class="hover:bg-secondary-foreground/20 ml-1 rounded-full p-0.5 transition-colors"
-                                                        aria-label="Remove {email}">
-                                                        <X class="h-3 w-3" />
-                                                    </button>
-                                                </div>
-                                            {/each}
-                                        </div>
-                                    </div>
-                                {/if}
+                        <div class="space-y-4 border-t pt-6">
+                            <div>
+                                <h3 class="text-sm font-medium">Shared Drives to Index</h3>
+                                <p class="text-muted-foreground text-xs">
+                                    Select one or more whole shared drives to index. Add the service
+                                    account to each drive as Content manager or Manager.
+                                </p>
                             </div>
+                            <GoogleDriveFolderSelector
+                                bind:selected={folderFilters}
+                                sourceId={data.source.id}
+                                {serviceAccountJson}
+                                authMode="service_account_direct"
+                                label="Shared drives to index"
+                                description="Only whole shared drives are supported in this mode."
+                                disabled={!enabled} />
+                            <input
+                                type="hidden"
+                                name="folder_path_filters"
+                                value={JSON.stringify(folderFilters)} />
                         </div>
-                    {/if}
+                    </div>
+                {:else}
+                    <div class="space-y-4">
+                        <div>
+                            <h3 class="text-sm font-medium">Connection Settings</h3>
+                            <p class="text-muted-foreground text-xs">
+                                Service account credentials used to impersonate Workspace users.
+                            </p>
+                        </div>
+                        <GoogleServiceAccountForm
+                            bind:serviceAccountJson
+                            bind:principalEmail
+                            bind:domain
+                            hasStoredKey={data.hasStoredKey} />
 
-                    {#each selectedUsers as email}
+                        {#if data.gmailSiblingId}
+                            <Alert.Root>
+                                <Info class="h-4 w-4" />
+                                <Alert.Title>Gmail uses a separate credential copy</Alert.Title>
+                                <Alert.Description>
+                                    Updating the service account key here only rotates it for Google
+                                    Drive. If you want to rotate the key for Gmail too, open the
+                                    Gmail source settings and replace it there as well.
+                                </Alert.Description>
+                            </Alert.Root>
+                        {/if}
+                    </div>
+
+                    <!-- Folder Path Filter (JWT only) -->
+                    <div class="space-y-4 border-t pt-6">
+                        <div>
+                            <h3 class="text-sm font-medium">Drive Folder Filters</h3>
+                            <p class="text-muted-foreground text-xs">
+                                Optionally restrict indexing to specific shared drives and top-level
+                                folders. All sub-folders within a selected item are included.
+                            </p>
+                        </div>
+                        <GoogleDriveFolderSelector
+                            bind:selected={folderFilters}
+                            sourceId={data.source.id}
+                            {serviceAccountJson}
+                            {principalEmail}
+                            {domain}
+                            disabled={!enabled} />
+                        <!-- Hidden form value to submit folder filters (always present for JWT, even when empty) -->
                         <input
                             type="hidden"
-                            name={userFilterMode === 'whitelist'
-                                ? 'userWhitelist'
-                                : 'userBlacklist'}
-                            value={email} />
-                    {/each}
-                </div>
+                            name="folder_path_filters"
+                            value={JSON.stringify(folderFilters)} />
+                    </div>
+
+                    <div class="space-y-4 border-t pt-6">
+                        <div>
+                            <h3 class="text-sm font-medium">User Access Control</h3>
+                            <p class="text-muted-foreground text-xs">
+                                Control which Workspace users get their Drive files indexed.
+                            </p>
+                        </div>
+                        <RadioGroup.Root
+                            bind:value={userFilterMode}
+                            name="userFilterMode"
+                            disabled={!enabled}>
+                            <div class="flex items-start space-x-3">
+                                <RadioGroup.Item value="all" id="all" />
+                                <Label for="all" class="cursor-pointer">
+                                    <div>
+                                        <div class="text-sm font-medium">All Users</div>
+                                        <div class="text-muted-foreground text-xs">
+                                            Index Drive files for all Google Workspace users
+                                        </div>
+                                    </div>
+                                </Label>
+                            </div>
+
+                            <div class="flex items-start space-x-3">
+                                <RadioGroup.Item value="whitelist" id="whitelist" />
+                                <Label for="whitelist" class="cursor-pointer">
+                                    <div>
+                                        <div class="text-sm font-medium">Specific Users</div>
+                                        <div class="text-muted-foreground text-xs">
+                                            Only index Drive files from selected users
+                                        </div>
+                                    </div>
+                                </Label>
+                            </div>
+
+                            <div class="flex items-start space-x-3">
+                                <RadioGroup.Item value="blacklist" id="blacklist" />
+                                <Label for="blacklist" class="cursor-pointer">
+                                    <div>
+                                        <div class="text-sm font-medium">Exclude Users</div>
+                                        <div class="text-muted-foreground text-xs">
+                                            Index all users except selected ones
+                                        </div>
+                                    </div>
+                                </Label>
+                            </div>
+                        </RadioGroup.Root>
+
+                        {#if enabled && userFilterMode !== 'all'}
+                            <div class="space-y-3 border-t pt-4">
+                                <div class="space-y-2">
+                                    <div class="relative">
+                                        <Search
+                                            class="text-muted-foreground absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+                                        <Input
+                                            bind:value={searchQuery}
+                                            oninput={handleSearchInput}
+                                            placeholder="Search users..."
+                                            class="px-10 py-1" />
+                                        {#if isSearching}
+                                            <Loader2
+                                                class="absolute top-1/2 right-3 h-4 w-4 -translate-y-1/2 animate-spin" />
+                                        {/if}
+                                    </div>
+
+                                    {#if searchResults.length > 0}
+                                        <div class="max-h-32 overflow-y-auto rounded-md border p-1">
+                                            {#each searchResults.filter((user) => !selectedUsers.includes(user.email)) as user}
+                                                <button
+                                                    type="button"
+                                                    onclick={() => addUser(user.email)}
+                                                    class="hover:bg-muted flex w-full items-center justify-between rounded px-2 py-1 text-left text-xs">
+                                                    <div>
+                                                        <div class="font-medium">
+                                                            {user.name}
+                                                        </div>
+                                                        <div class="text-muted-foreground">
+                                                            {user.email}
+                                                        </div>
+                                                    </div>
+                                                    {#if user.isAdmin}
+                                                        <Badge variant="secondary" class="text-xs"
+                                                            >Admin</Badge>
+                                                    {/if}
+                                                </button>
+                                            {/each}
+                                        </div>
+                                    {/if}
+
+                                    {#if selectedUsers.length > 0}
+                                        <div class="space-y-2">
+                                            <Label class="text-xs font-medium">
+                                                {userFilterMode === 'whitelist'
+                                                    ? 'Included Users'
+                                                    : 'Excluded Users'}
+                                            </Label>
+                                            <div class="flex flex-wrap gap-2">
+                                                {#each selectedUsers as email}
+                                                    <div
+                                                        class="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors">
+                                                        <span>{email}</span>
+                                                        <button
+                                                            type="button"
+                                                            onclick={() => removeUser(email)}
+                                                            class="hover:bg-secondary-foreground/20 ml-1 rounded-full p-0.5 transition-colors"
+                                                            aria-label="Remove {email}">
+                                                            <X class="h-3 w-3" />
+                                                        </button>
+                                                    </div>
+                                                {/each}
+                                            </div>
+                                        </div>
+                                    {/if}
+                                </div>
+                            </div>
+                        {/if}
+
+                        {#each selectedUsers as email}
+                            <input
+                                type="hidden"
+                                name={userFilterMode === 'whitelist'
+                                    ? 'userWhitelist'
+                                    : 'userBlacklist'}
+                                value={email} />
+                        {/each}
+                    </div>
+                {/if}
             {/if}
         </Card.Content>
         <Card.Footer class="flex justify-end">

--- a/web/src/routes/api/connectors/[sourceType]/action/+server.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/+server.ts
@@ -187,6 +187,8 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
         }
 
         // Forward the setup credential through connector-manager's generic transient action mode.
+        // auth_mode travels inside params so the connector's typed action params see it.
+        const forwardedParams = { ...(params || {}), auth_mode: authMode }
         const response = await fetch(`${connectorManagerUrl}/action`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
@@ -194,7 +196,7 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
                 source_type: sourceType,
                 user_id: locals.user.id,
                 action,
-                params: params || {},
+                params: forwardedParams,
                 transient_credentials: {
                     provider: 'google',
                     auth_type: 'jwt',

--- a/web/src/routes/api/connectors/[sourceType]/action/+server.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types'
 import { getConfig } from '$lib/server/config'
 import { logger } from '$lib/server/logger'
 import { SourceType } from '$lib/types'
+import type { GoogleAuthMode } from '$lib/types'
 
 /**
  * Invokes an action directly on a connector before a source exists.
@@ -11,8 +12,14 @@ import { SourceType } from '$lib/types'
  * endpoint and is never stored or returned.
  *
  * SECURITY: Strictly allowlisted — currently only google_drive's
- * discover_folders action with JWT credentials is accepted.
+ * discover_folders and validate_shared_drive_access actions with JWT
+ * credentials are accepted. Unknown actions, fields, or auth modes fail
+ * closed.
  */
+
+const ALLOWED_ACTIONS = new Set(['discover_folders', 'validate_shared_drive_access'])
+const ALLOWED_AUTH_MODES: GoogleAuthMode[] = ['domain_wide_delegation', 'service_account_direct']
+
 export const POST: RequestHandler = async ({ params: routeParams, request, locals }) => {
     // Admin-only
     if (!locals.user) {
@@ -73,7 +80,14 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
 
     // ======== STRICT ALLOWLIST ========
     // Reject unknown top-level fields.
-    const allowedFields = ['action', 'params', 'serviceAccountJson', 'principalEmail', 'domain']
+    const allowedFields = [
+        'action',
+        'params',
+        'serviceAccountJson',
+        'principalEmail',
+        'domain',
+        'authMode',
+    ]
     for (const key of Object.keys(body)) {
         if (!allowedFields.includes(key)) {
             throw error(400, `Unknown field: '${key}'`)
@@ -86,32 +100,58 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
     const serviceAccountJson = body.serviceAccountJson as string | undefined
     const principalEmail = body.principalEmail as string | undefined
     const domain = body.domain as string | undefined
+    const authMode = (body.authMode as GoogleAuthMode | undefined) ?? 'domain_wide_delegation'
 
     if (!action) {
         throw error(400, 'Action is required')
     }
-    if (action !== 'discover_folders') {
+    if (!ALLOWED_ACTIONS.has(action)) {
         throw error(400, `Connector action '${action}' is not supported`)
     }
     if (sourceType !== SourceType.GOOGLE_DRIVE) {
         throw error(400, `Connector actions are not supported for source type '${sourceType}'`)
     }
+    if (!ALLOWED_AUTH_MODES.includes(authMode)) {
+        throw error(400, `Unknown auth mode '${authMode}'`)
+    }
 
-    // Only allow empty params object for discover_folders.
+    // Validate params by action.
     if (params !== undefined) {
         if (typeof params !== 'object' || params === null || Array.isArray(params)) {
             throw error(400, 'params must be a JSON object')
         }
-        if (Object.keys(params).length > 0) {
-            throw error(400, 'discover_folders does not accept any params')
+    }
+    if (action === 'discover_folders') {
+        // params is optional; when present it may carry auth_mode.
+        if (params && Object.keys(params).length > 0 && !('auth_mode' in params)) {
+            throw error(400, 'discover_folders accepts only an optional auth_mode param')
+        }
+    }
+    if (action === 'validate_shared_drive_access') {
+        if (!params || typeof params !== 'object' || Array.isArray(params)) {
+            throw error(400, 'validate_shared_drive_access requires params')
+        }
+        const driveIds = params.drive_ids
+        if (!Array.isArray(driveIds) || driveIds.length === 0) {
+            throw error(400, 'validate_shared_drive_access requires a non-empty drive_ids array')
+        }
+        if (authMode !== 'service_account_direct') {
+            throw error(
+                400,
+                'validate_shared_drive_access requires authMode=service_account_direct',
+            )
         }
     }
 
     // Transient credentials must be provided for preview (not optional).
-    if (!serviceAccountJson || !principalEmail || !domain) {
+    if (!serviceAccountJson) {
+        throw error(400, 'serviceAccountJson is required for connector actions')
+    }
+    // SA-direct requires no principal email or domain (no impersonation).
+    if (authMode !== 'service_account_direct' && (!principalEmail || !domain)) {
         throw error(
             400,
-            'serviceAccountJson, principalEmail, and domain are required for connector actions',
+            'principalEmail and domain are required for connector actions in domain_wide_delegation mode',
         )
     }
 
@@ -119,10 +159,10 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
     if (typeof serviceAccountJson !== 'string') {
         throw error(400, 'serviceAccountJson must be a string')
     }
-    if (typeof principalEmail !== 'string') {
+    if (principalEmail !== undefined && typeof principalEmail !== 'string') {
         throw error(400, 'principalEmail must be a string')
     }
-    if (typeof domain !== 'string') {
+    if (domain !== undefined && typeof domain !== 'string') {
         throw error(400, 'domain must be a string')
     }
 
@@ -137,6 +177,15 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
         const config = getConfig()
         const connectorManagerUrl = config.services.connectorManagerUrl
 
+        // Build the transient credential config: SA-direct carries only the
+        // drive.readonly scope; DWD carries the domain for impersonation.
+        const transientConfig: Record<string, unknown> = {}
+        if (authMode === 'service_account_direct') {
+            transientConfig.scopes = ['https://www.googleapis.com/auth/drive.readonly']
+        } else {
+            transientConfig.domain = domain
+        }
+
         // Forward the setup credential through connector-manager's generic transient action mode.
         const response = await fetch(`${connectorManagerUrl}/action`, {
             method: 'POST',
@@ -144,25 +193,23 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
             body: JSON.stringify({
                 source_type: sourceType,
                 user_id: locals.user.id,
-                action: 'discover_folders',
+                action,
                 params: params || {},
                 transient_credentials: {
                     provider: 'google',
                     auth_type: 'jwt',
-                    principal_email: principalEmail,
+                    principal_email: principalEmail ?? null,
                     credentials: {
                         service_account_key: serviceAccountJson,
                     },
-                    config: {
-                        domain: domain,
-                    },
+                    config: transientConfig,
                 },
             }),
             signal: AbortSignal.timeout(30_000),
         })
 
         if (!response.ok) {
-            let errorMessage = 'Failed to discover folders'
+            let errorMessage = `Failed to execute ${action}`
             const contentType = response.headers.get('content-type') || ''
             if (contentType.includes('application/json')) {
                 try {

--- a/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
@@ -184,6 +184,7 @@ describe('POST /api/connectors/[sourceType]/action', () => {
         const forwarded = JSON.parse(String(init.body)) as Record<string, unknown>
         expect(forwarded).toMatchObject({
             action: 'discover_folders',
+            params: { auth_mode: 'service_account_direct' },
             transient_credentials: {
                 provider: 'google',
                 auth_type: 'jwt',
@@ -223,7 +224,7 @@ describe('POST /api/connectors/[sourceType]/action', () => {
         const forwarded = JSON.parse(String(init.body)) as Record<string, unknown>
         expect(forwarded).toMatchObject({
             action: 'validate_shared_drive_access',
-            params: { drive_ids: ['d1', 'd2'] },
+            params: { drive_ids: ['d1', 'd2'], auth_mode: 'service_account_direct' },
         })
     })
 

--- a/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
@@ -135,4 +135,117 @@ describe('POST /api/connectors/[sourceType]/action', () => {
             },
         })
     })
+
+    it('rejects unknown actions and unknown top-level fields', async () => {
+        expect((await callPost({ action: 'bogus', serviceAccountJson: '{}' })).status).toBe(400)
+        expect(
+            (await callPost({ action: 'discover_folders', serviceAccountJson: '{}', evil: 1 }))
+                .status,
+        ).toBe(400)
+    })
+
+    it('rejects unknown auth modes', async () => {
+        const response = await callPost({
+            action: 'discover_folders',
+            serviceAccountJson: '{}',
+            authMode: 'bogus_mode',
+        })
+        expect(response.status).toBe(400)
+    })
+
+    it('requires principal email + domain in DWD mode', async () => {
+        const response = await callPost({
+            action: 'discover_folders',
+            serviceAccountJson: '{}',
+        })
+        expect(response.status).toBe(400)
+    })
+
+    it('forwards SA-direct discovery without principal/domain and with drive.readonly scope', async () => {
+        const connectorResponse = { status: 'success', result: { items: [] } }
+        const connectorFetch = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(connectorResponse), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        )
+        vi.stubGlobal('fetch', connectorFetch)
+
+        const response = await callPost({
+            action: 'discover_folders',
+            serviceAccountJson: '{"client_email":"sa@example.iam.gserviceaccount.com"}',
+            authMode: 'service_account_direct',
+            params: { auth_mode: 'service_account_direct' },
+        })
+
+        expect(response.status).toBe(200)
+        const [url, init] = connectorFetch.mock.calls[0] as [string, RequestInit]
+        expect(url).toBe('http://cm.test/action')
+        const forwarded = JSON.parse(String(init.body)) as Record<string, unknown>
+        expect(forwarded).toMatchObject({
+            action: 'discover_folders',
+            transient_credentials: {
+                provider: 'google',
+                auth_type: 'jwt',
+                principal_email: null,
+                credentials: {
+                    service_account_key: '{"client_email":"sa@example.iam.gserviceaccount.com"}',
+                },
+                config: { scopes: ['https://www.googleapis.com/auth/drive.readonly'] },
+            },
+        })
+    })
+
+    it('forwards validate_shared_drive_access with drive ids in SA-direct mode', async () => {
+        const connectorResponse = {
+            status: 'success',
+            result: {
+                drives: [{ drive_id: 'd1', ok: true, role: 'organizer', error: null }],
+            },
+        }
+        const connectorFetch = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(connectorResponse), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        )
+        vi.stubGlobal('fetch', connectorFetch)
+
+        const response = await callPost({
+            action: 'validate_shared_drive_access',
+            serviceAccountJson: '{"client_email":"sa@example.iam.gserviceaccount.com"}',
+            authMode: 'service_account_direct',
+            params: { drive_ids: ['d1', 'd2'] },
+        })
+
+        expect(response.status).toBe(200)
+        const [url, init] = connectorFetch.mock.calls[0] as [string, RequestInit]
+        const forwarded = JSON.parse(String(init.body)) as Record<string, unknown>
+        expect(forwarded).toMatchObject({
+            action: 'validate_shared_drive_access',
+            params: { drive_ids: ['d1', 'd2'] },
+        })
+    })
+
+    it('rejects validate_shared_drive_access without drive ids or outside SA-direct', async () => {
+        expect(
+            (
+                await callPost({
+                    action: 'validate_shared_drive_access',
+                    serviceAccountJson: '{}',
+                    authMode: 'service_account_direct',
+                    params: { drive_ids: [] },
+                })
+            ).status,
+        ).toBe(400)
+        expect(
+            (
+                await callPost({
+                    action: 'validate_shared_drive_access',
+                    serviceAccountJson: '{}',
+                    params: { drive_ids: ['d1'] },
+                })
+            ).status,
+        ).toBe(400)
+    })
 })

--- a/web/src/routes/api/sources/+server.ts
+++ b/web/src/routes/api/sources/+server.ts
@@ -93,6 +93,15 @@ export const POST: RequestHandler = async ({ request, locals }) => {
         throw error(400, 'Name and sourceType are required')
     }
 
+    // SA-direct is Drive-only: reject crafted Gmail/Chat source creation.
+    const configAuthMode =
+        config && typeof config === 'object' && !Array.isArray(config)
+            ? (config as Record<string, unknown>).auth_mode
+            : undefined
+    if (configAuthMode === 'service_account_direct' && sourceType !== SourceType.GOOGLE_DRIVE) {
+        throw error(400, 'service_account_direct is supported only for Google Drive sources')
+    }
+
     if (
         body.integrationType === IntegrationType.REMOTE_MCP ||
         body.integration_type === IntegrationType.REMOTE_MCP


### PR DESCRIPTION
- Add `service_account_direct` auth mode to the Google connector: a plain service account (no domain-wide delegation, no Admin SDK, no `sub` impersonation) syncs selected shared drives, unblocking customers who cannot enable DWD
- Read drive-level ACLs for SA-direct sources: validate the SA's Content manager/Manager role on every drive (fail-closed) and set document permissions from the drive member list
- Fingerprint drive ACLs in the sync checkpoint; a membership change triggers a full drive re-traversal so already-indexed docs receive updated ACLs, which incremental `changes.list` sync cannot deliver
- Add typed `GoogleAuthMode`/`GoogleSourceConfig` with cross-field validation (SA-direct is Drive-only, requires root-only filters); connector action params and responses are typed and fail loudly on malformed input
- Convert the setup dialog to DWD | Shared-drive tabs reusing the folder selector, with per-drive access validation before source creation and Drive-only enforcement in UI, API, and connector
- Make the drive settings page mode-aware for SA-direct (key rotation, shared-drive selector, no user access control)
- Document Google-side setup and constraints (SA role requirements, external-sharing policy, group-member undergrant in v1) in the connector README
- Cover the feature with unit, integration, and web tests (typed config, self-token auth, ACL mapping, full-sync)