### PR TITLE
fix(ai): prevent duplicate tool results in OpenAI-compatible requests

### DIFF
--- a/services/ai/providers/openai_compatible.py
+++ b/services/ai/providers/openai_compatible.py
@@ -253,6 +253,56 @@ def _convert_messages_to_openai(
     return result
 
 
+def validate_openai_tool_message_sequence(
+    messages: list[ChatCompletionMessageParam],
+) -> None:
+    """Validate every assistant ``tool_calls`` batch is fully answered by ``tool``
+    messages before any non-tool message, and each ``tool`` message responds
+    exactly once to a call in the nearest preceding assistant batch.
+
+    Strict OpenAI-compatible endpoints (DeepSeek et al.) reject malformed
+    sequences with an opaque 400; run this pre-dispatch so violations surface as
+    a clear error naming the offending message instead.
+    """
+    pending_tool_call_ids: set[str] = set()
+    for index, message in enumerate(messages):
+        role = message.get("role")
+        if role == "assistant":
+            if pending_tool_call_ids:
+                raise ValueError(
+                    f"Invalid assistant message at index {index}: tool_calls "
+                    f"{sorted(pending_tool_call_ids)} from the preceding assistant "
+                    "message were never answered with tool messages"
+                )
+            pending_tool_call_ids = {
+                tool_call["id"] for tool_call in message.get("tool_calls") or []
+            }
+            continue
+        if role == "tool":
+            tool_call_id = message.get("tool_call_id")
+            if tool_call_id is None or tool_call_id not in pending_tool_call_ids:
+                raise ValueError(
+                    f"Invalid tool message at index {index}: tool_call_id={tool_call_id!r} "
+                    "has no matching tool_calls entry in the preceding assistant message"
+                )
+            pending_tool_call_ids.discard(tool_call_id)
+            continue
+        # Any non-tool message (system/user/developer) closes the current batch:
+        # every tool call of the preceding assistant message must already have
+        # been answered, and later tool messages can no longer pair to it.
+        if pending_tool_call_ids:
+            raise ValueError(
+                f"Invalid {role} message at index {index}: tool_calls "
+                f"{sorted(pending_tool_call_ids)} from the preceding assistant "
+                "message were never answered with tool messages"
+            )
+    if pending_tool_call_ids:
+        raise ValueError(
+            f"Invalid trailing messages: tool_calls {sorted(pending_tool_call_ids)} "
+            "from the final assistant message were never answered with tool messages"
+        )
+
+
 class OpenAICompatibleProvider(LLMProvider):
     """Provider for any OpenAI-compatible Chat Completions endpoint.
 
@@ -314,6 +364,8 @@ class OpenAICompatibleProvider(LLMProvider):
                     f"Sending request with {len(tools)} tools: {[t['name'] for t in tools]}"
                 )
 
+            validate_openai_tool_message_sequence(openai_messages)
+
             stream = await self.client.chat.completions.create(**params)
 
             # Emit message_start
@@ -352,7 +404,9 @@ class OpenAICompatibleProvider(LLMProvider):
                     continue
 
                 delta = chunk.choices[0].delta
-                reasoning_content = _get_passthrough_delta_value(delta, REASONING_CONTENT_KEY)
+                reasoning_content = _get_passthrough_delta_value(
+                    delta, REASONING_CONTENT_KEY
+                )
                 if reasoning_content:
                     reasoning_content_parts.append(reasoning_content)
 

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -35,7 +35,12 @@ from config import (
     DEFAULT_MAX_TOKENS,
     SANDBOX_URL,
 )
-from db import ChatsRepository, CompactionsRepository, MessagesRepository, SkillsRepository
+from db import (
+    ChatsRepository,
+    CompactionsRepository,
+    MessagesRepository,
+    SkillsRepository,
+)
 from db.groups import GroupRepository
 from db.configuration import ConfigurationRepository
 from db.documents import DocumentsRepository
@@ -65,10 +70,10 @@ from state import AppState
 from streaming.generate import (
     active_path_tool_call_ids,
     drop_empty_assistant_messages,
-    latest_intervention_tool_batch_ids,
     message_content_blocks,
     prepare_and_stream_chat,
     repair_interrupted_tool_calls,
+    resumable_batch_ids_for_interventions,
     unanswered_tool_calls,
 )
 from streaming.persist import (
@@ -184,7 +189,9 @@ def _loaded_tools_from_history(
                     if call is None:
                         continue
                     loaded.update(
-                        _loaded_tools_from_meta_call(call["name"], call["input"], connector_handler)
+                        _loaded_tools_from_meta_call(
+                            call["name"], call["input"], connector_handler
+                        )
                     )
                 case _:
                     continue
@@ -519,7 +526,9 @@ def _extract_text_for_title(
 
 
 @router.get("/chat/{chat_id}/stream/status")
-async def stream_status(request: Request, chat_id: str = Path(..., description="Chat thread ID")):
+async def stream_status(
+    request: Request, chat_id: str = Path(..., description="Chat thread ID")
+):
     redis_client = getattr(request.app.state, "redis_client", None)
     messages_repo = MessagesRepository()
     approvals_repo = ToolApprovalsRepository()
@@ -585,9 +594,9 @@ class StreamChatHandler:
         redis_client = request.app.state.redis_client
 
         # Reconnect/resume fast path
-        last_event_id = request.headers.get("last-event-id") or request.query_params.get(
-            "last_event_id"
-        )
+        last_event_id = request.headers.get(
+            "last-event-id"
+        ) or request.query_params.get("last_event_id")
         if redis_client is not None:
             run_active = await redis_client.exists(run_lock_key(chat_id))
             if run_active:
@@ -661,7 +670,9 @@ class StreamChatHandler:
                 if auto_start:
                     chat_messages = []
                 else:
-                    raise HTTPException(status_code=404, detail="No messages found for chat")
+                    raise HTTPException(
+                        status_code=404, detail="No messages found for chat"
+                    )
 
             build_result = await _build_agent_chat_registry(
                 request, agent, is_admin=chat_user.role == "admin"
@@ -672,14 +683,18 @@ class StreamChatHandler:
 
             run_repo = AgentRunRepository()
             runs = await run_repo.list_runs(agent.id, limit=20)
-            active_sources = [s for s in build_result.sources if s.is_active and not s.is_deleted]
+            active_sources = [
+                s for s in build_result.sources if s.is_active and not s.is_deleted
+            ]
 
             memory_provider = request.app.state.memory_provider
             effective_mode = MemoryMode.OFF
             memories = []
             if memory_provider is not None:
                 config_repo = ConfigurationRepository()
-                org_default = (await config_repo.get_global_configuration()).memory_mode_default
+                org_default = (
+                    await config_repo.get_global_configuration()
+                ).memory_mode_default
                 if is_org_agent:
                     effective_mode = org_default
                 elif user_configuration is not None:
@@ -716,13 +731,19 @@ class StreamChatHandler:
                 user_email=user_email,
                 memories=memories if memories else None,
                 user_configuration=user_configuration,
-                include_web_search=getattr(request.app.state, "web_search_provider", None)
+                include_web_search=getattr(
+                    request.app.state, "web_search_provider", None
+                )
                 is not None,
-                include_fetch_web_page=getattr(request.app.state, "web_fetch_provider", None)
+                include_fetch_web_page=getattr(
+                    request.app.state, "web_fetch_provider", None
+                )
                 is not None,
             )
 
-            messages: list[MessageParam] = [MessageParam(**msg.message) for msg in chat_messages]
+            messages: list[MessageParam] = [
+                MessageParam(**msg.message) for msg in chat_messages
+            ]
             needs_start = not messages or messages[-1].get("role") != "user"
             if auto_start and needs_start:
                 messages.append(MessageParam(role="user", content="Go."))
@@ -745,7 +766,9 @@ class StreamChatHandler:
                     is_admin = user.role == "admin"
 
             if not chat_messages:
-                raise HTTPException(status_code=404, detail="No messages found for chat")
+                raise HTTPException(
+                    status_code=404, detail="No messages found for chat"
+                )
 
             messages = [MessageParam(**msg.message) for msg in chat_messages]
 
@@ -789,7 +812,9 @@ class StreamChatHandler:
                 )
             ]
 
-            active_sources = [s for s in build_result.sources if s.is_active and not s.is_deleted]
+            active_sources = [
+                s for s in build_result.sources if s.is_active and not s.is_deleted
+            ]
 
             memory_provider = request.app.state.memory_provider
             memories = []
@@ -797,8 +822,12 @@ class StreamChatHandler:
             if memory_provider is not None and chat.user_id:
                 memory_write_key = user_key(chat.user_id)
                 config_repo = ConfigurationRepository()
-                org_default = (await config_repo.get_global_configuration()).memory_mode_default
-                user_memory_mode = user_configuration.memory_mode if user_configuration else None
+                org_default = (
+                    await config_repo.get_global_configuration()
+                ).memory_mode_default
+                user_memory_mode = (
+                    user_configuration.memory_mode if user_configuration else None
+                )
                 effective_mode = resolve_memory_mode(user_memory_mode, org_default)
                 if effective_mode >= MemoryMode.CHAT:
                     last_user_text = ""
@@ -823,7 +852,9 @@ class StreamChatHandler:
                         )
                         memories = [h.record.text for h in hits if h.record.text]
 
-            loaded_source_ids = _loaded_source_ids(loaded_toolsets, build_result.connector_handler)
+            loaded_source_ids = _loaded_source_ids(
+                loaded_toolsets, build_result.connector_handler
+            )
             system_prompt = build_chat_system_prompt(
                 active_sources,
                 toolsets=build_result.toolsets,
@@ -832,9 +863,13 @@ class StreamChatHandler:
                 user_email=user_email,
                 memories=memories if memories else None,
                 user_configuration=user_configuration,
-                include_web_search=getattr(request.app.state, "web_search_provider", None)
+                include_web_search=getattr(
+                    request.app.state, "web_search_provider", None
+                )
                 is not None,
-                include_fetch_web_page=getattr(request.app.state, "web_fetch_provider", None)
+                include_fetch_web_page=getattr(
+                    request.app.state, "web_fetch_provider", None
+                )
                 is not None,
             )
 
@@ -844,9 +879,24 @@ class StreamChatHandler:
             for approval in pending_interventions
             if approval.tool_call_id is not None
         }
-        preserved_batch_ids = latest_intervention_tool_batch_ids(
+        preserved_batch_ids = resumable_batch_ids_for_interventions(
             messages, intervention_tool_call_ids
         )
+        if intervention_tool_call_ids:
+            # Only the newest terminal intervention batch can ever be resumed;
+            # expire every other intervention so stale records stop bypassing the
+            # no-new-message guard and stop showing up in stream status.
+            kept_interventions = [
+                approval
+                for approval in pending_interventions
+                if approval.tool_call_id in preserved_batch_ids
+            ]
+            for approval in pending_interventions:
+                if approval.tool_call_id not in preserved_batch_ids:
+                    await approvals_repo.update_status(
+                        approval.id, ToolApprovalStatus.EXPIRED, chat.user_id
+                    )
+            pending_interventions = kept_interventions
 
         messages, repaired_tool_calls = repair_interrupted_tool_calls(
             messages, preserve_tool_call_ids=preserved_batch_ids
@@ -867,7 +917,9 @@ class StreamChatHandler:
         # and mentions, so completed-stream reconnects do not refetch.
         last_message_role = messages[-1].get("role") if messages else None
         if not pending_interventions and last_message_role != "user":
-            logger.info(f"Last message is not from user, no processing needed. Chat ID: {chat_id}")
+            logger.info(
+                f"Last message is not from user, no processing needed. Chat ID: {chat_id}"
+            )
 
             async def empty_generator():
                 yield end_of_stream(
@@ -993,7 +1045,9 @@ class StreamChatHandler:
             )
 
         # Single producer per chat
-        got_lock = await redis_client.set(run_lock_key(chat_id), "1", nx=True, ex=_RUN_LOCK_TTL)
+        got_lock = await redis_client.set(
+            run_lock_key(chat_id), "1", nx=True, ex=_RUN_LOCK_TTL
+        )
         if not got_lock:
             return StreamingResponse(
                 consume_run(redis_client, chat_id, last_event_id or "0"),
@@ -1033,7 +1087,9 @@ class StreamChatHandler:
 async def stream_chat(
     request: Request,
     chat_id: str = Path(..., description="Chat thread ID"),
-    auto_start: bool = Query(False, description="Auto-inject initial message for agent chats"),
+    auto_start: bool = Query(
+        False, description="Auto-inject initial message for agent chats"
+    ),
 ):
     return await StreamChatHandler(request, chat_id, auto_start).handle()
 
@@ -1087,7 +1143,9 @@ async def generate_chat_title(
         messages_repo = MessagesRepository()
         chat_messages = await messages_repo.get_by_chat(chat_id)
         if not chat_messages:
-            raise HTTPException(status_code=400, detail="Not enough messages to generate title")
+            raise HTTPException(
+                status_code=400, detail="Not enough messages to generate title"
+            )
 
         conversation_text = ""
         for msg in chat_messages:
@@ -1149,7 +1207,9 @@ async def generate_chat_title(
             f"Failed to generate title for chat {chat_id}: {e}",
             exc_info=True,
         )
-        raise HTTPException(status_code=500, detail=f"Failed to generate title: {str(e)}")
+        raise HTTPException(
+            status_code=500, detail=f"Failed to generate title: {str(e)}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -1183,7 +1243,9 @@ async def download_artifact(
             )
     except httpx.HTTPStatusError as e:
         logger.error(f"Sandbox artifact download failed: {e}")
-        raise HTTPException(status_code=502, detail="Failed to fetch artifact from sandbox")
+        raise HTTPException(
+            status_code=502, detail="Failed to fetch artifact from sandbox"
+        )
     except Exception as e:
         logger.error(f"Artifact download error: {e}")
         raise HTTPException(status_code=500, detail="Internal error fetching artifact")

--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -233,6 +233,49 @@ def latest_intervention_tool_batch_ids(
     return set()
 
 
+def _is_tool_result_message(message: MessageParam) -> bool:
+    blocks = message_content_blocks(message)
+    return (
+        message.get("role") == "user"
+        and bool(blocks)
+        and all(block["type"] == "tool_result" for block in blocks)
+    )
+
+
+def _tool_result_run_end(messages: list[MessageParam], start: int) -> int:
+    """Index just past the contiguous run of tool-result user messages at ``start``."""
+    end = start
+    while end < len(messages) and _is_tool_result_message(messages[end]):
+        end += 1
+    return end
+
+
+def resumable_batch_ids_for_interventions(
+    messages: list[MessageParam],
+    intervention_tool_call_ids: set[str],
+) -> set[str]:
+    """Tool-call ids of the latest intervention batch, only when that batch is
+    still the terminal active turn.
+
+    A batch is terminal when nothing but its own contiguous tool-result messages
+    follow it. If a newer user/assistant turn exists, the batch's calls must not
+    be resumed: appending their results after the newer turn would emit a
+    ``tool`` message that does not directly follow the issuing assistant message,
+    and splicing them into the earlier position would diverge from the persisted
+    history. Such stale calls are instead marked interrupted by
+    ``repair_interrupted_tool_calls`` and the newer turn proceeds.
+    """
+    batch_ids = latest_intervention_tool_batch_ids(messages, intervention_tool_call_ids)
+    if not batch_ids:
+        return set()
+    for index, message in enumerate(messages):
+        if {call["id"] for call in tool_use_blocks(message)} & batch_ids:
+            if _tool_result_run_end(messages, index + 1) == len(messages):
+                return batch_ids
+            return set()
+    return set()
+
+
 def coalesce_adjacent_tool_result_messages(
     messages: list[MessageParam],
 ) -> list[MessageParam]:
@@ -260,6 +303,11 @@ def coalesce_adjacent_tool_result_messages(
     return coalesced
 
 
+_INTERRUPTED_TOOL_RESULT_MARKER = (
+    "did not complete because the previous response was interrupted"
+)
+
+
 def _interrupted_tool_result(tool_use: ToolUseBlockParam) -> ToolResultBlockParam:
     return ToolResultBlockParam(
         type="tool_result",
@@ -268,13 +316,64 @@ def _interrupted_tool_result(tool_use: ToolUseBlockParam) -> ToolResultBlockPara
             {
                 "type": "text",
                 "text": (
-                    f"Tool call {tool_use['name']} did not complete because the previous response was interrupted. "
+                    f"Tool call {tool_use['name']} {_INTERRUPTED_TOOL_RESULT_MARKER}. "
                     "Treat this tool call as failed and retry it if the result is still needed."
                 ),
             }
         ],
         is_error=True,
     )
+
+
+def _joined_result_text(content: object) -> str:
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        parts = [
+            block.get("text", "")
+            for block in content
+            if isinstance(block, dict) and block.get("type") == "text"
+        ]
+        return "\n".join(parts)
+    return ""
+
+
+def strip_synthetic_interrupted_results(
+    messages: list[MessageParam],
+    tool_call_ids: set[str],
+) -> list[MessageParam]:
+    """Drop synthetic interrupted-result placeholders for the given tool call ids.
+
+    Keeps exactly one result per ``tool_call_id`` in the conversation: when a
+    resumed call's real result is about to be appended, any repair placeholder
+    for the same id is removed rather than duplicated. Placeholders only exist
+    in-memory (never persisted), so stripping them leaves the DB history intact.
+    """
+    if not tool_call_ids:
+        return messages
+    stripped: list[MessageParam] = []
+    for message in messages:
+        blocks = message_content_blocks(message)
+        kept = [
+            block
+            for block in blocks
+            if not (
+                block["type"] == "tool_result"
+                and block.get("tool_use_id") in tool_call_ids
+                and block.get("is_error")
+                and _INTERRUPTED_TOOL_RESULT_MARKER
+                in _joined_result_text(block.get("content", ""))
+            )
+        ]
+        if len(kept) == len(blocks):
+            stripped.append(message)
+        elif message.get("role") == "user":
+            # A user message emptied by stripping is dropped entirely.
+            if kept:
+                stripped.append(MessageParam(role="user", content=kept))
+        else:
+            stripped.append(message)
+    return stripped
 
 
 def repair_interrupted_tool_calls(
@@ -293,8 +392,18 @@ def repair_interrupted_tool_calls(
             repaired.append(message)
             continue
 
-        next_message = messages[idx + 1] if idx + 1 < len(messages) else None
-        answered_ids = tool_result_ids(next_message) if next_message else set()
+        # A parallel batch can deliver its results across several consecutive
+        # user messages (e.g. one call delayed behind an approval), so collect
+        # answered ids from the whole contiguous tool-result run rather than only
+        # the immediately-next message; checking just the next message would
+        # mis-mark an already-answered call as interrupted and inject a duplicate
+        # tool result into the next provider request.
+        run_end = _tool_result_run_end(messages, idx + 1)
+        answered_ids = {
+            result_id
+            for result_message in messages[idx + 1 : run_end]
+            for result_id in tool_result_ids(result_message)
+        }
         missing = [
             tool_use
             for tool_use in tool_uses
@@ -307,12 +416,15 @@ def repair_interrupted_tool_calls(
             continue
 
         missing_results = [_interrupted_tool_result(tool_use) for tool_use in missing]
-        if answered_ids and next_message is not None:
-            content = next_message["content"]
+        if answered_ids and run_end > idx + 1:
+            # Partially answered batch: fold the failure placeholders into the
+            # last result message so the batch stays contiguous.
+            last_result_message = messages[run_end - 1]
+            content = last_result_message["content"]
             if isinstance(content, list):
-                next_message = cast(MessageParam, dict(next_message))
-                next_message["content"] = [*content, *missing_results]
-                messages[idx + 1] = next_message
+                last_result_message = cast(MessageParam, dict(last_result_message))
+                last_result_message["content"] = [*content, *missing_results]
+                messages[run_end - 1] = last_result_message
                 repair_count += len(missing_results)
                 continue
 
@@ -643,7 +755,7 @@ async def stream_generator(
         intervention_tool_call_ids = set(approval_interventions_by_tool_call_id) | set(
             oauth_interventions_by_tool_call_id
         )
-        resumable_batch_ids = latest_intervention_tool_batch_ids(
+        resumable_batch_ids = resumable_batch_ids_for_interventions(
             conversation_messages, intervention_tool_call_ids
         )
         resumable_tool_calls = [
@@ -1166,6 +1278,13 @@ async def stream_generator(
                     completed_intervention_ids.add(oauth_intervention.id)
 
             if tool_results:
+                # Exactly one result per tool_call_id: a resumed call's real
+                # result replaces any synthetic interrupted placeholder for the
+                # same id instead of being appended alongside it.
+                conversation_messages = strip_synthetic_interrupted_results(
+                    conversation_messages,
+                    {result["tool_use_id"] for result in tool_results},
+                )
                 tool_result_message = MessageParam(role="user", content=tool_results)
                 conversation_messages.append(tool_result_message)
                 for tool_result in tool_results:

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -1028,9 +1028,9 @@ class TestStreamErrorPersistence:
         ), f"Expected stream_error, got events: {events}"
 
         db_msgs = await MessagesRepository().get_active_path(chat_id)
-        assert len(db_msgs) == 2, (
-            f"Expected user + one finalized error row, got {len(db_msgs)} rows"
-        )
+        assert (
+            len(db_msgs) == 2
+        ), f"Expected user + one finalized error row, got {len(db_msgs)} rows"
         failed = db_msgs[-1]
         assert failed.error is not None, "Error column not persisted"
         assert failed.error["message"] == (
@@ -1170,7 +1170,11 @@ class TestStreamErrorPersistence:
         assert any(
             any(
                 isinstance(b, dict) and b.get("type") == "tool_use"
-                for b in (m.message.get("content") if isinstance(m.message.get("content"), list) else [])
+                for b in (
+                    m.message.get("content")
+                    if isinstance(m.message.get("content"), list)
+                    else []
+                )
             )
             for m in db_msgs
         ), "Expected the tool-call assistant row to remain"
@@ -1216,9 +1220,9 @@ class TestStreamErrorPersistence:
 
         db_msgs = await MessagesRepository().get_active_path(chat_id)
         error_rows = [m for m in db_msgs if m.error is not None]
-        assert len(error_rows) == 1, (
-            f"Expected exactly one error row after replay, got {len(error_rows)}"
-        )
+        assert (
+            len(error_rows) == 1
+        ), f"Expected exactly one error row after replay, got {len(error_rows)}"
 
 
 # =============================================================================
@@ -2779,6 +2783,195 @@ class TestInterventionResume:
         )
         assert abandoned_result["is_error"] is True
         assert "interrupted" in abandoned_result["content"][0]["text"].lower()
+
+    @pytest.mark.asyncio
+    async def test_stale_intervention_is_expired_and_never_resumed(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        """When a newer user message arrives after an approved intervention
+        batch, the batch is treated as interrupted: the tool is not executed and
+        the stale intervention is retired so later reconnects stop bypassing the
+        no-new-message guard."""
+        chat_id, user_id, model_id = seeded_chat
+        messages_repo = MessagesRepository()
+        active_path = await messages_repo.get_active_path(chat_id)
+        intervention = await messages_repo.create(
+            chat_id,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_stale",
+                        "name": "test__stale",
+                        "input": {},
+                    }
+                ],
+            },
+            parent_id=active_path[-1].id,
+        )
+        await messages_repo.create(
+            chat_id,
+            {
+                "role": "user",
+                "content": "Newer question that supersedes the pending call.",
+            },
+            parent_id=intervention.id,
+        )
+        approval = await ToolApprovalsRepository().create_pending(
+            chat_id=chat_id,
+            user_id=user_id,
+            tool_name="test__stale",
+            tool_input={},
+            tool_call_id="toolu_stale",
+        )
+        await ToolApprovalsRepository().update_status(
+            approval.id, ToolApprovalStatus.APPROVED, user_id
+        )
+
+        handler = MultiActionHandler({"test__stale"}, {"test__stale"})
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM([("text", "Got it, switching tasks.")], model_id)
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            events = await collect_sse_events(client, chat_id)
+
+        # The stale call must be repaired, never executed or resumed.
+        assert handler.executions == []
+        assert len(llm.calls) == 1
+        request = llm.calls[0]["messages"]
+        model_blocks = [
+            block
+            for message in request
+            if message["role"] == "user" and isinstance(message.get("content"), list)
+            for block in message["content"]
+            if block.get("type") == "tool_result"
+        ]
+        stale_result = next(
+            block for block in model_blocks if block["tool_use_id"] == "toolu_stale"
+        )
+        assert stale_result["is_error"] is True
+        assert "interrupted" in stale_result["content"][0]["text"].lower()
+        assert any(event_type == "end_of_stream" for event_type, _, _ in events)
+
+        # The stale intervention is retired, so it no longer counts as pending.
+        approvals = await _interventions(
+            chat_id,
+            ToolApprovalType.APPROVAL,
+            {ToolApprovalStatus.EXPIRED},
+        )
+        assert [approval.tool_call_id for approval in approvals] == ["toolu_stale"]
+
+        # A later reconnect without new input short-circuits instead of
+        # generating again.
+        async with _client(app) as client:
+            await collect_sse_events(client, chat_id)
+        assert len(llm.calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_older_stale_intervention_expired_while_newer_batch_resumes(
+        self, seeded_chat, redis_client, redis_keys, monkeypatch
+    ):
+        """When the active branch has both an older stale intervention batch and
+        a newer terminal resumable batch, only the newest batch's intervention
+        survives: the stale one is expired on the first handler run instead of
+        lingering in stream status until a later reconnect."""
+        chat_id, user_id, model_id = seeded_chat
+        messages_repo = MessagesRepository()
+        active_path = await messages_repo.get_active_path(chat_id)
+        stale_msg = await messages_repo.create(
+            chat_id,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_older_stale",
+                        "name": "test__older_stale",
+                        "input": {},
+                    }
+                ],
+            },
+            parent_id=active_path[-1].id,
+        )
+        await messages_repo.create(
+            chat_id,
+            {
+                "role": "assistant",
+                "content": [
+                    {
+                        "type": "tool_use",
+                        "id": "toolu_newer_resume",
+                        "name": "test__newer_resume",
+                        "input": {},
+                    }
+                ],
+            },
+            parent_id=stale_msg.id,
+        )
+        stale_approval = await ToolApprovalsRepository().create_pending(
+            chat_id=chat_id,
+            user_id=user_id,
+            tool_name="test__older_stale",
+            tool_input={},
+            tool_call_id="toolu_older_stale",
+        )
+        resume_approval = await ToolApprovalsRepository().create_pending(
+            chat_id=chat_id,
+            user_id=user_id,
+            tool_name="test__newer_resume",
+            tool_input={},
+            tool_call_id="toolu_newer_resume",
+        )
+        for approval in (stale_approval, resume_approval):
+            await ToolApprovalsRepository().update_status(
+                approval.id, ToolApprovalStatus.APPROVED, user_id
+            )
+
+        handler = MultiActionHandler(
+            {"test__older_stale", "test__newer_resume"},
+            {"test__older_stale", "test__newer_resume"},
+        )
+        _install_scripted_registry(monkeypatch, handler)
+        llm = GatedRecordingLLM([("text", "Done.")], model_id)
+        app = _build_chat_app(llm, redis_client, model_id)
+
+        async with _client(app) as client:
+            await collect_sse_events(client, chat_id)
+
+        # Only the terminal batch executes.
+        assert handler.executions == ["test__newer_resume"]
+
+        # The stale intervention is retired on this run; the resumable one
+        # completed normally.
+        stale = await _interventions(
+            chat_id, ToolApprovalType.APPROVAL, {ToolApprovalStatus.EXPIRED}
+        )
+        assert [approval.tool_call_id for approval in stale] == ["toolu_older_stale"]
+        completed = await _interventions(
+            chat_id, ToolApprovalType.APPROVAL, {ToolApprovalStatus.COMPLETED}
+        )
+        assert [approval.tool_call_id for approval in completed] == [
+            "toolu_newer_resume"
+        ]
+
+        # The stale call is repaired for the model, never executed.
+        request = llm.calls[0]["messages"]
+        model_blocks = [
+            block
+            for message in request
+            if message["role"] == "user" and isinstance(message.get("content"), list)
+            for block in message["content"]
+            if block.get("type") == "tool_result"
+        ]
+        older_result = next(
+            block
+            for block in model_blocks
+            if block["tool_use_id"] == "toolu_older_stale"
+        )
+        assert older_result["is_error"] is True
+        assert "interrupted" in older_result["content"][0]["text"].lower()
 
 
 # =============================================================================

--- a/services/ai/tests/unit/test_openai_compatible_provider.py
+++ b/services/ai/tests/unit/test_openai_compatible_provider.py
@@ -2,10 +2,13 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from providers.openai_compatible import (
     REASONING_CONTENT_KEY,
     _convert_messages_to_openai,
     _get_passthrough_delta_value,
+    validate_openai_tool_message_sequence,
 )
 
 
@@ -113,7 +116,147 @@ def test_get_passthrough_delta_value_reads_pydantic_extra():
     class Delta:
         model_extra = {REASONING_CONTENT_KEY: "reasoning delta"}
 
-    assert _get_passthrough_delta_value(Delta(), REASONING_CONTENT_KEY) == "reasoning delta"
+    assert (
+        _get_passthrough_delta_value(Delta(), REASONING_CONTENT_KEY)
+        == "reasoning delta"
+    )
+
+
+def _assistant_with_tool_calls(tool_call_ids: list[str]) -> dict:
+    return {
+        "role": "assistant",
+        "content": [
+            {
+                "type": "tool_use",
+                "id": tool_id,
+                "name": "search_documents",
+                "input": {},
+            }
+            for tool_id in tool_call_ids
+        ],
+    }
+
+
+def _tool_message(tool_call_id: str) -> dict:
+    return {
+        "role": "tool",
+        "tool_call_id": tool_call_id,
+        "content": "result",
+    }
+
+
+def _openai_assistant_with_tool_calls(tool_call_ids: list[str]) -> dict:
+    """An OpenAI-format assistant message carrying tool_calls (as the validator
+    sees them post-conversion)."""
+    return {
+        "role": "assistant",
+        "content": None,
+        "tool_calls": [
+            {
+                "id": tool_id,
+                "type": "function",
+                "function": {"name": "search_documents", "arguments": "{}"},
+            }
+            for tool_id in tool_call_ids
+        ],
+    }
+
+
+def test_validate_accepts_parallel_tool_messages():
+    converted = _convert_messages_to_openai(
+        [
+            {"role": "user", "content": "hi"},
+            _assistant_with_tool_calls(["call_A", "call_B"]),
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "call_A", "content": "r1"},
+                    {"type": "tool_result", "tool_use_id": "call_B", "content": "r2"},
+                ],
+            },
+            _assistant_with_tool_calls(["call_C"]),
+            {
+                "role": "user",
+                "content": [
+                    {"type": "tool_result", "tool_use_id": "call_C", "content": "r3"}
+                ],
+            },
+        ]
+    )
+
+    validate_openai_tool_message_sequence(converted)
+
+
+def test_validate_rejects_duplicate_tool_call_id():
+    converted = [
+        _openai_assistant_with_tool_calls(["call_A"]),
+        _tool_message("call_A"),
+        _tool_message("call_A"),
+    ]
+
+    with pytest.raises(ValueError, match="no matching tool_calls"):
+        validate_openai_tool_message_sequence(converted)
+
+
+def test_validate_rejects_missing_tool_result_before_user_message():
+    """An assistant batch must be fully satisfied before any non-tool message."""
+    converted = [
+        _openai_assistant_with_tool_calls(["call_A", "call_B"]),
+        _tool_message("call_A"),
+        {"role": "user", "content": "new question"},
+    ]
+
+    with pytest.raises(ValueError, match="never answered"):
+        validate_openai_tool_message_sequence(converted)
+
+
+def test_validate_rejects_tool_call_answered_after_user_message():
+    """A tool message cannot be paired with an assistant batch across a user
+    message boundary."""
+    converted = [
+        _openai_assistant_with_tool_calls(["call_A"]),
+        {"role": "user", "content": "new question"},
+        _tool_message("call_A"),
+    ]
+
+    with pytest.raises(ValueError, match="never answered"):
+        validate_openai_tool_message_sequence(converted)
+
+
+def test_validate_rejects_tool_message_after_user_message():
+    converted = [
+        _openai_assistant_with_tool_calls(["call_A"]),
+        _tool_message("call_A"),
+        {"role": "user", "content": "new question"},
+        _tool_message("call_A"),
+    ]
+
+    with pytest.raises(ValueError, match="no matching tool_calls"):
+        validate_openai_tool_message_sequence(converted)
+
+
+def test_validate_rejects_consecutive_assistant_tool_call_messages():
+    converted = [
+        _openai_assistant_with_tool_calls(["call_A"]),
+        _openai_assistant_with_tool_calls(["call_B"]),
+    ]
+
+    with pytest.raises(ValueError, match="never answered"):
+        validate_openai_tool_message_sequence(converted)
+
+
+def test_validate_rejects_trailing_unanswered_tool_calls():
+    converted = [_openai_assistant_with_tool_calls(["call_A"])]
+
+    with pytest.raises(ValueError, match="never answered"):
+        validate_openai_tool_message_sequence(converted)
+
+
+def test_validate_rejects_tool_message_without_preceding_assistant():
+    converted = [_tool_message("call_A")]
+
+    with pytest.raises(ValueError, match="no matching tool_calls"):
+        validate_openai_tool_message_sequence(converted)
 
 
 def test_convert_messages_includes_user_text_document():
@@ -151,7 +294,10 @@ def test_convert_messages_omits_assistant_and_unsupported_documents():
     converted = _convert_messages_to_openai(
         [
             {"role": "assistant", "content": [text_document]},
-            {"role": "user", "content": [{"type": "text", "text": "safe"}, binary_document]},
+            {
+                "role": "user",
+                "content": [{"type": "text", "text": "safe"}, binary_document],
+            },
         ]
     )
 

--- a/services/ai/tests/unit/test_tool_call_repair.py
+++ b/services/ai/tests/unit/test_tool_call_repair.py
@@ -1,0 +1,236 @@
+"""Unit tests for interrupted-tool-call repair and resume semantics."""
+
+from __future__ import annotations
+
+from anthropic.types import MessageParam
+
+from streaming.generate import (
+    _INTERRUPTED_TOOL_RESULT_MARKER,
+    repair_interrupted_tool_calls,
+    resumable_batch_ids_for_interventions,
+    strip_synthetic_interrupted_results,
+)
+
+
+def _tool_use(tool_id: str, name: str = "search_documents") -> dict:
+    return {"type": "tool_use", "id": tool_id, "name": name, "input": {}}
+
+
+def _tool_result(tool_id: str, content: str = "result") -> dict:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_id,
+        "content": [{"type": "text", "text": content}],
+    }
+
+
+def _interrupted_placeholder(tool_id: str) -> dict:
+    return {
+        "type": "tool_result",
+        "tool_use_id": tool_id,
+        "is_error": True,
+        "content": [
+            {
+                "type": "text",
+                "text": f"Tool call search_documents {_INTERRUPTED_TOOL_RESULT_MARKER}. "
+                "Treat this tool call as failed and retry it if the result is still needed.",
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# repair_interrupted_tool_calls
+# ---------------------------------------------------------------------------
+
+
+def test_repair_does_not_flag_parallel_results_split_across_messages():
+    """A parallel batch whose results are delivered over two consecutive user
+    messages (one call delayed behind an approval) must not be marked
+    interrupted: every call already has exactly one result."""
+    messages: list[MessageParam] = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A"), _tool_use("call_B")],
+        },
+        {"role": "user", "content": [_tool_result("call_A")]},
+        {"role": "user", "content": [_tool_result("call_B")]},
+    ]
+
+    repaired, count = repair_interrupted_tool_calls(messages)
+
+    assert count == 0
+    assert len(repaired) == len(messages)
+    # No synthetic placeholder may be injected anywhere.
+    for message in repaired:
+        content = message["content"]
+        if isinstance(content, list):
+            for block in content:
+                if block["type"] == "tool_result":
+                    assert not block.get("is_error")
+
+
+def test_repair_folds_placeholder_into_last_result_of_partial_batch():
+    """A genuinely interrupted call in a partially answered batch gets a
+    placeholder folded into the batch's last result message so the batch stays
+    contiguous."""
+    messages: list[MessageParam] = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A"), _tool_use("call_B")],
+        },
+        {"role": "user", "content": [_tool_result("call_A")]},
+    ]
+
+    repaired, count = repair_interrupted_tool_calls(messages)
+
+    assert count == 1
+    assert len(repaired) == 3
+    last_message = repaired[-1]
+    blocks = last_message["content"]
+    assert [b["tool_use_id"] for b in blocks] == ["call_A", "call_B"]
+    assert blocks[-1]["is_error"]
+
+
+def test_repair_emits_standalone_placeholder_for_fully_unanswered_batch():
+    messages: list[MessageParam] = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A"), _tool_use("call_B")],
+        },
+    ]
+
+    repaired, count = repair_interrupted_tool_calls(messages)
+
+    assert count == 2
+    assert len(repaired) == 3
+    placeholder_message = repaired[-1]
+    assert placeholder_message["role"] == "user"
+    assert [b["tool_use_id"] for b in placeholder_message["content"]] == [
+        "call_A",
+        "call_B",
+    ]
+
+
+def test_repair_respects_preserved_tool_call_ids():
+    """Intervention-resumed calls are preserved and never placeholder'd."""
+    messages: list[MessageParam] = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A"), _tool_use("call_B")],
+        },
+    ]
+
+    repaired, count = repair_interrupted_tool_calls(
+        messages, preserve_tool_call_ids={"call_A", "call_B"}
+    )
+
+    assert count == 0
+    assert len(repaired) == len(messages)
+
+
+# ---------------------------------------------------------------------------
+# resumable_batch_ids_for_interventions
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_batch_is_resumable():
+    messages: list[MessageParam] = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A"), _tool_use("call_B")],
+        },
+        {"role": "user", "content": [_tool_result("call_A")]},
+    ]
+
+    assert resumable_batch_ids_for_interventions(messages, {"call_B"}) == {
+        "call_A",
+        "call_B",
+    }
+
+
+def test_batch_followed_by_newer_user_message_is_not_resumable():
+    """A newer conversational turn after the batch means the stale call must be
+    marked interrupted instead of resumed with its result appended after the
+    newer turn."""
+    messages: list[MessageParam] = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A"), _tool_use("call_B")],
+        },
+        {"role": "user", "content": [_tool_result("call_A")]},
+        {"role": "user", "content": "actually, do this instead"},
+    ]
+
+    assert resumable_batch_ids_for_interventions(messages, {"call_B"}) == set()
+
+
+def test_no_interventions_means_nothing_resumable():
+    messages: list[MessageParam] = [
+        {"role": "user", "content": "go"},
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A")],
+        },
+    ]
+
+    assert resumable_batch_ids_for_interventions(messages, set()) == set()
+
+
+# ---------------------------------------------------------------------------
+# strip_synthetic_interrupted_results
+# ---------------------------------------------------------------------------
+
+
+def test_strip_removes_merged_placeholder_and_keeps_real_results():
+    messages: list[MessageParam] = [
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A"), _tool_use("call_B")],
+        },
+        {
+            "role": "user",
+            "content": [_tool_result("call_A"), _interrupted_placeholder("call_B")],
+        },
+    ]
+
+    stripped = strip_synthetic_interrupted_results(messages, {"call_B"})
+
+    blocks = stripped[-1]["content"]
+    assert [b["tool_use_id"] for b in blocks] == ["call_A"]
+
+
+def test_strip_drops_standalone_placeholder_message():
+    messages: list[MessageParam] = [
+        {
+            "role": "assistant",
+            "content": [_tool_use("call_A")],
+        },
+        {"role": "user", "content": [_interrupted_placeholder("call_A")]},
+        {"role": "user", "content": "new question"},
+    ]
+
+    stripped = strip_synthetic_interrupted_results(messages, {"call_A"})
+
+    assert len(stripped) == 2
+    assert stripped[-1] == {"role": "user", "content": "new question"}
+
+
+def test_strip_leaves_unrelated_results_untouched():
+    messages: list[MessageParam] = [
+        {
+            "role": "user",
+            "content": [_tool_result("call_X"), _interrupted_placeholder("call_Y")],
+        },
+    ]
+
+    stripped = strip_synthetic_interrupted_results(messages, {"call_Y"})
+
+    blocks = stripped[-1]["content"]
+    assert [b["tool_use_id"] for b in blocks] == ["call_X"]


### PR DESCRIPTION
- Fix interrupted-tool-call repair to scan the full contiguous tool-result run, so parallel results split across consecutive user messages are no longer mis-marked as interrupted; this was injecting a duplicate tool_call_id that strict OpenAI-compatible endpoints like DeepSeek reject with an opaque 400
- Resume only terminal intervention batches and expire every stale intervention, so old approvals stop bypassing the no-new-message guard and lingering in stream status on reconnects
- Replace synthetic interrupted placeholders with real resumed results so each tool_call_id is answered exactly once in the provider payload
- Add a pre-dispatch validator for tool message sequences in the OpenAI-compatible provider, surfacing a clear error naming the offending message instead of the provider's 400