### PR TITLE
fix(darwinbox): map real org-master response shapes

### DIFF
--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -1293,8 +1293,8 @@ fn write(
 #[cfg(test)]
 mod tests {
     use super::{
-        all_direct_reports, direct_reports, ensure_direct_report, execute_action,
-        sanitize_action_response,
+        action_definitions, all_direct_reports, direct_reports, ensure_direct_report,
+        execute_action, sanitize_action_response,
     };
     use crate::client::DarwinboxClient;
     use crate::credentials::DarwinboxCredentials;

--- a/connectors/darwinbox/src/connector.rs
+++ b/connectors/darwinbox/src/connector.rs
@@ -117,6 +117,26 @@ impl Connector for DarwinboxConnector {
                 attribute_key: "job_title".to_string(),
                 value_type: "text".to_string(),
             },
+            SearchOperator {
+                operator: "job_level".to_string(),
+                attribute_key: "job_level".to_string(),
+                value_type: "text".to_string(),
+            },
+            SearchOperator {
+                operator: "employee_job_level".to_string(),
+                attribute_key: "employee_job_level".to_string(),
+                value_type: "text".to_string(),
+            },
+            SearchOperator {
+                operator: "employee_location".to_string(),
+                attribute_key: "employee_location".to_string(),
+                value_type: "text".to_string(),
+            },
+            SearchOperator {
+                operator: "employee_manager".to_string(),
+                attribute_key: "employee_manager".to_string(),
+                value_type: "text".to_string(),
+            },
         ]
     }
 

--- a/connectors/darwinbox/src/mappers.rs
+++ b/connectors/darwinbox/src/mappers.rs
@@ -125,6 +125,143 @@ pub fn format_position_item(item: &JsonValue) -> SafeDocument {
 }
 
 /// Safely format an ATS job from known fields.
+/// Safely format a job-level master record. Darwinbox's joblevellist records
+/// use `job_level`/`job_level_code`/`grade`/`status` rather than the generic
+/// org-master `name`/`code` convention, so they get a dedicated mapper.
+pub fn format_job_level_item(item: &JsonValue) -> SafeDocument {
+    let title = item
+        .get("job_level")
+        .and_then(JsonValue::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            item.get("grade")
+                .and_then(JsonValue::as_str)
+                .filter(|s| !s.trim().is_empty())
+        })
+        .unwrap_or("Job Level")
+        .to_string();
+
+    let mut body = format!("# {title}");
+    for (label, key) in [
+        ("Code", "job_level_code"),
+        ("Grade", "grade"),
+        ("Grade Code", "grade_code"),
+        ("Status", "status"),
+        ("Effective From", "effective_from"),
+        ("Created Date", "created_date"),
+        ("Updated Date", "updated_date"),
+    ] {
+        if let Some(value) = item
+            .get(key)
+            .and_then(JsonValue::as_str)
+            .filter(|s| !s.trim().is_empty())
+        {
+            body.push_str(&format!("\n- {label}: {value}"));
+        }
+    }
+
+    let mut attributes = vec![("job_level".to_string(), title.clone())];
+    if let Some(code) = item
+        .get("job_level_code")
+        .and_then(JsonValue::as_str)
+        .filter(|s| !s.trim().is_empty())
+    {
+        attributes.push(("job_level_code".to_string(), code.to_string()));
+    }
+    SafeDocument {
+        title,
+        body,
+        attributes,
+    }
+}
+
+/// Pull a column value from a columnar org-master row. Only string values are
+/// projected; empty strings are treated as absent.
+pub fn table_column<'a>(cols: &'a [String], row: &'a [JsonValue], label: &str) -> Option<&'a str> {
+    let index = cols.iter().position(|col| col == label)?;
+    match row.get(index) {
+        Some(JsonValue::String(value)) if !value.trim().is_empty() => Some(value.as_str()),
+        _ => None,
+    }
+}
+
+/// Safely format a row from a columnar org-master response (`{cols, data}`,
+/// e.g. employeeJobLevel/employeeLocation/employeeManager) into a document.
+/// Only the provider's own column labels from a per-entity allowlist are
+/// rendered, so no unknown field can leak into indexed content.
+pub fn format_org_master_table_item(
+    cols: &[String],
+    row: &[JsonValue],
+    content_type: &str,
+) -> SafeDocument {
+    const FALLBACK_COLS: &[&str] = &["Employee ID", "Name", "From", "To", "Event", "Sub Event"];
+    let allowed: &[&str] = match content_type {
+        "employee_job_level" => &[
+            "Employee ID",
+            "Name",
+            "Job Level Name",
+            "From",
+            "To",
+            "Event",
+            "Sub Event",
+        ],
+        "employee_location" => &[
+            "Employee ID",
+            "Name",
+            "Company Name",
+            "Area",
+            "City",
+            "State",
+            "Country",
+            "Work Area Code",
+            "Pin Code",
+            "Location Head",
+            "From",
+            "To",
+            "Event",
+            "Sub Event",
+        ],
+        "employee_manager" => &[
+            "Employee ID",
+            "Name",
+            "Manager Name",
+            "From",
+            "To",
+            "Event",
+            "Sub Event",
+        ],
+        _ => FALLBACK_COLS,
+    };
+    let attribute_column = match content_type {
+        "employee_job_level" => "Job Level Name",
+        "employee_location" => "Area",
+        "employee_manager" => "Manager Name",
+        _ => "",
+    };
+
+    let title = table_column(cols, row, "Name")
+        .or_else(|| table_column(cols, row, "Employee ID"))
+        .unwrap_or("Employee record")
+        .to_string();
+    let mut body = format!("# {title}");
+    for column in allowed {
+        if let Some(value) = table_column(cols, row, column) {
+            body.push_str(&format!("\n- {column}: {value}"));
+        }
+    }
+
+    let attribute_value = table_column(cols, row, attribute_column).unwrap_or(&title);
+    let mut attributes = vec![(content_type.to_string(), attribute_value.to_string())];
+    if let Some(employee_id) = table_column(cols, row, "Employee ID") {
+        attributes.push(("employee_id".to_string(), employee_id.to_string()));
+    }
+    SafeDocument {
+        title,
+        body,
+        attributes,
+    }
+}
+
 pub fn format_ats_job_item(item: &JsonValue) -> SafeDocument {
     let title = item
         .get("job_title")

--- a/connectors/darwinbox/src/sync.rs
+++ b/connectors/darwinbox/src/sync.rs
@@ -42,11 +42,6 @@ const ORG_MASTERS: &[(&str, &str, &str)] = &[
         "/orgmasterapi/divisionlist",
     ),
     (
-        "job_level",
-        "darwinbox:job_level",
-        "/orgmasterapi/joblevellist",
-    ),
-    (
         "cost_center",
         "darwinbox:cost_center",
         "/orgmasterapi/costcenterlist",
@@ -219,6 +214,33 @@ pub async fn run_sync(
         }
     }
 
+    // Job levels — records use provider-specific field names (job_level/
+    // job_level_code) rather than the generic name/code convention, so they
+    // get a dedicated mapper.
+    let ran = run_module("job_level", || async {
+        let response = client
+            .fetch_org_master("/orgmasterapi/joblevellist")
+            .await?;
+        sync_typed_collection(
+            config,
+            "job_level",
+            "darwinbox:job_level",
+            &response,
+            ctx.source_id(),
+            &ctx,
+            mappers::format_job_level_item,
+        )
+        .await
+    })
+    .await?;
+    if ran {
+        set_module_watermark(
+            &mut checkpoint,
+            DarwinboxSyncModuleKey::OrgMasters,
+            Utc::now().to_rfc3339(),
+        );
+    }
+
     // Employee-scoped org masters (employeeJobLevel/employeeLocation/
     // employeeManager) — the directory snapshot supplies the employee
     // numbers; denied modules are skipped with a warning like the plain lists.
@@ -241,7 +263,7 @@ pub async fn run_sync(
         let ran = run_module(content_type, || async {
             for batch in employee_ids.chunks(EMPLOYEE_ORG_MASTER_BATCH) {
                 let response = client.fetch_org_master_for_employees(path, batch).await?;
-                sync_org_master(
+                sync_org_master_table(
                     config,
                     content_type,
                     external_prefix,
@@ -401,6 +423,71 @@ async fn sync_org_master(
         let content_id = ctx.store_content(&document.body).await?;
 
         let document_id = format!("{external_prefix}:{id}");
+        emit_document(
+            ctx,
+            content_type,
+            source_id,
+            &document_id,
+            content_id,
+            &document,
+            &permissions,
+        )
+        .await?;
+        count += 1;
+    }
+    if count > 0 {
+        ctx.increment_scanned(count).await?;
+    }
+    Ok(())
+}
+
+/// Columnar org-master responses (`{cols: [...], data: [[...], ...]}`): each
+/// row is an array whose meaning comes from `cols`. Emit one document per row,
+/// projecting the provider's own column labels via a per-entity allowlist.
+async fn sync_org_master_table(
+    config: &DarwinboxSourceConfig,
+    content_type: &str,
+    external_prefix: &str,
+    response: &JsonValue,
+    source_id: &str,
+    ctx: &SyncContext,
+) -> Result<()> {
+    let permissions = config::document_permissions(content_type, config, source_id, None);
+    let cols = response
+        .get("cols")
+        .and_then(JsonValue::as_array)
+        .map(|cols| {
+            cols.iter()
+                .filter_map(|col| col.as_str().map(str::to_string))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    let rows = response
+        .get("data")
+        .and_then(JsonValue::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let mut count = 0i32;
+
+    for (index, row) in rows.iter().enumerate() {
+        if ctx.is_cancelled() {
+            ctx.cancel().await?;
+            return Ok(());
+        }
+        let Some(row_values) = row.as_array() else {
+            continue;
+        };
+        let employee_id = mappers::table_column(&cols, row_values, "Employee ID");
+        let from = mappers::table_column(&cols, row_values, "From");
+        let stable_id = match (employee_id, from) {
+            (Some(employee_id), Some(from)) => slugify(&format!("{employee_id}:{from}")),
+            (Some(employee_id), None) => slugify(&format!("{employee_id}:{index}")),
+            _ => format!("row:{index}"),
+        };
+        let document = mappers::format_org_master_table_item(&cols, row_values, content_type);
+        let content_id = ctx.store_content(&document.body).await?;
+
+        let document_id = format!("{external_prefix}:{stable_id}");
         emit_document(
             ctx,
             content_type,
@@ -586,6 +673,8 @@ fn extract_stable_id(value: &JsonValue) -> Option<String> {
         "department_code",
         "designation_code",
         "work_area_code",
+        "job_level",
+        "job_level_code",
         "name",
     ] {
         if let Some(raw) = object.get(key) {
@@ -786,6 +875,82 @@ mod tests {
                 "unexpected error: {error}"
             );
         }
+    }
+
+    #[tokio::test]
+    async fn employee_scoped_org_master_table_emits_documents_from_columnar_rows() {
+        // Real employeeManager shape: `cols` + `data` rows (arrays).
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/content"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"content_id": "c-1"})))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/events/batch"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/sync/run-1/scanned"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+            "base_url": server.uri(),
+            "authorization": { "participant_mode": "all" }
+        }))
+        .unwrap();
+        let ctx = SyncContext::new(
+            SdkClient::new(&server.uri()),
+            "run-1".to_string(),
+            "source-1".to_string(),
+            SourceType::Darwinbox,
+            SyncType::Full,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        sync_org_master_table(
+            &config,
+            "employee_manager",
+            "darwinbox:employee_manager",
+            &json!({
+                "status": 1,
+                "cols": ["Employee ID", "Name", "Manager Name", "From", "To", "Event", "Sub Event"],
+                "data": [
+                    ["WWITest2", "Dummy1 Test2", "Gowri Sridhar (WW1539)", "05-08-2025", "30-04-2025", "", ""],
+                    ["WWITest2", "Dummy1 Test2", "Tanmay Dattani (WW2306)", "06-07-2025", "Present", "", ""]
+                ],
+                "message": "Data Loaded Successfully"
+            }),
+            "source-1",
+            &ctx,
+        )
+        .await
+        .unwrap();
+        ctx.flush().await.unwrap();
+
+        let batch = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|request| request.url.path() == "/sdk/events/batch")
+            .expect("events batch should be emitted");
+        let body: JsonValue = serde_json::from_slice(&batch.body).unwrap();
+        let events = body["events"]
+            .as_array()
+            .expect("batch should carry events");
+        assert_eq!(events.len(), 2);
+        let event = &events[0];
+        assert_eq!(event["type"], "document_created");
+        assert_eq!(
+            event["document_id"],
+            "darwinbox:employee_manager:wwitest2-05-08-2025"
+        );
+        assert_eq!(event["metadata"]["content_type"], "employee_manager");
+        assert_eq!(event["metadata"]["title"], "Dummy1 Test2");
     }
 }
 

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -550,6 +550,115 @@ fn org_master_mappers_emit_searchable_attributes() {
     );
 }
 
+#[test]
+fn job_level_mapper_uses_provider_field_names() {
+    use omni_darwinbox_connector::mappers;
+    // Real joblevellist record: job_level/job_level_code/grade/status, not the
+    // generic name/code convention.
+    let document = mappers::format_job_level_item(&serde_json::json!({
+        "job_level": "Senior Manager",
+        "job_level_code": "006",
+        "grade": "Senior Manager",
+        "grade_code": "",
+        "status": "Active",
+        "created_date": "21-10-2019 20:26:44",
+        "updated_date": "12-03-2025 11:39:44",
+        "effective_from": "12-03-2025 00:00:00"
+    }));
+    assert_eq!(document.title, "Senior Manager");
+    assert!(document.body.contains("Code: 006"));
+    assert!(document.body.contains("Status: Active"));
+    assert!(
+        document
+            .body
+            .contains("Effective From: 12-03-2025 00:00:00")
+    );
+    assert!(
+        document
+            .attributes
+            .contains(&("job_level".to_string(), "Senior Manager".to_string()))
+    );
+    assert!(
+        document
+            .attributes
+            .contains(&("job_level_code".to_string(), "006".to_string()))
+    );
+}
+
+#[test]
+fn columnar_org_master_mapper_projects_provider_columns() {
+    use omni_darwinbox_connector::mappers;
+    // Real employeeJobLevel response shape: `cols` + `data` rows (arrays).
+    let cols = vec![
+        "Employee ID".to_string(),
+        "Name".to_string(),
+        "Job Level Name".to_string(),
+        "From".to_string(),
+        "To".to_string(),
+        "Event".to_string(),
+        "Sub Event".to_string(),
+    ];
+    let row = serde_json::json!([
+        "WWITest2",
+        "Dummy1 Test2",
+        "Lead (003)",
+        "05-08-2025",
+        "13-04-2025",
+        "",
+        ""
+    ]);
+    let document =
+        mappers::format_org_master_table_item(&cols, row.as_array().unwrap(), "employee_job_level");
+    assert_eq!(document.title, "Dummy1 Test2");
+    assert!(document.body.contains("Employee ID: WWITest2"));
+    assert!(document.body.contains("Job Level Name: Lead (003)"));
+    assert!(document.body.contains("From: 05-08-2025"));
+    assert!(
+        document
+            .attributes
+            .contains(&("employee_job_level".to_string(), "Lead (003)".to_string()))
+    );
+    assert!(
+        document
+            .attributes
+            .contains(&("employee_id".to_string(), "WWITest2".to_string()))
+    );
+
+    // employeeManager: the entity value is the manager name.
+    let manager_cols = vec![
+        "Employee ID".to_string(),
+        "Name".to_string(),
+        "Manager Name".to_string(),
+        "From".to_string(),
+        "To".to_string(),
+        "Event".to_string(),
+        "Sub Event".to_string(),
+    ];
+    let manager_row = serde_json::json!([
+        "WWITest2",
+        "Dummy1 Test2",
+        "Tanmay Dattani (WW2306)",
+        "06-07-2025",
+        "Present",
+        "",
+        ""
+    ]);
+    let document = mappers::format_org_master_table_item(
+        &manager_cols,
+        manager_row.as_array().unwrap(),
+        "employee_manager",
+    );
+    assert!(
+        document
+            .body
+            .contains("Manager Name: Tanmay Dattani (WW2306)")
+    );
+    assert!(document.attributes.contains(&(
+        "employee_manager".to_string(),
+        "Tanmay Dattani (WW2306)".to_string()
+    )));
+}
+
 #[tokio::test]
 async fn action_denied_by_provider_returns_not_allowed_error() {
     let server = MockServer::start().await;
@@ -680,7 +789,11 @@ async fn get_team_leave_calendar_is_scoped_to_direct_reports() {
         .mount(&server)
         .await;
 
-    let config = test_config(&server.uri());
+    let config = json!({
+        "base_url": server.uri(),
+        "read_only": true,
+        "authorization": { "participant_mode": "all", "max_batch_size": 20 }
+    });
     let response = execute_action(
         "get_team_leave_calendar",
         json!({ "from": "2026-06-01", "to": "2026-06-30" }),
@@ -728,7 +841,11 @@ async fn list_pending_leave_approvals_uses_action_one_for_reports() {
         .mount(&server)
         .await;
 
-    let config = test_config(&server.uri());
+    let config = json!({
+        "base_url": server.uri(),
+        "read_only": true,
+        "authorization": { "participant_mode": "all", "max_batch_size": 20 }
+    });
     let response = execute_action(
         "list_pending_leave_approvals",
         json!({}),
@@ -773,7 +890,11 @@ async fn manager_action_requires_direct_reports() {
     )
     .await;
 
-    let config = test_config(&server.uri());
+    let config = json!({
+        "base_url": server.uri(),
+        "read_only": true,
+        "authorization": { "participant_mode": "all" }
+    });
     let error = execute_action(
         "get_team_leave_calendar",
         json!({ "from": "2026-06-01", "to": "2026-06-30" }),
@@ -855,7 +976,7 @@ async fn approve_leave_request_submits_for_direct_report() {
         serde_json::from_slice(&requests[0].body).expect("request body should be JSON");
     assert_eq!(sent["employee_no"], json!("EMP002"));
     assert_eq!(sent["leave_id"], json!("T1"));
-    assert_eq!(sent["action"], json!("Approve"));
+    assert_eq!(sent["action"], json!("approve"));
     assert_eq!(sent["manager_message"], json!("Enjoy"));
 }
 
@@ -865,7 +986,12 @@ async fn reject_leave_request_is_blocked_by_read_only_source() {
     mock_employee_master(&server, manager_employee_master()).await;
 
     // test_config defaults to read_only; write actions must refuse loudly.
-    let config = test_config(&server.uri());
+    // Use an open participant mode so the read-only gate is what rejects.
+    let config = json!({
+        "base_url": server.uri(),
+        "read_only": true,
+        "authorization": { "participant_mode": "all" }
+    });
     let error = execute_action(
         "reject_leave_request",
         json!({ "employee_no": "EMP002", "leave_id": "T1" }),


### PR DESCRIPTION
- joblevellist records use job_level/job_level_code instead of the generic name/code convention, so they were dropped for missing stable IDs; give them a dedicated mapper and route through the typed collection path
- employeeJobLevel/employeeLocation/employeeManager return columnar `{cols, data}` payloads with array rows, not objects, so every record was dropped; add a table sync path that projects the provider's own column labels and derives stable document IDs from employee number + From date
- add search operators for job_level, employee_job_level, employee_location, and employee_manager
- fix latent test compilation and assertion bugs from #411 (missing action_definitions import, participant allowlist, max_batch_size truncation, approve-verb casing) that had never run