### PR TITLE
feat(google): mirror Google's effective permission model in SA-direct mode

### DIFF
--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -37,10 +37,10 @@ const DEFAULT_GOOGLE_DRIVE_MAX_DOWNLOAD_BYTES: usize = 50 * 1024 * 1024;
 
 /// `fields` projection for file listings — includes `driveId` so shared-drive
 /// files can be attributed to their drive (observability + SA-direct metadata).
-const FILES_FIELDS: &str = "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,driveId,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))";
+const FILES_FIELDS: &str = "nextPageToken,files(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,driveId,inheritedPermissionsDisabled,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress))";
 
 /// `fields` projection for changes listings — mirrors `FILES_FIELDS`.
-const CHANGES_FIELDS: &str = "nextPageToken,newStartPageToken,changes(changeType,removed,file(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,trashed,driveId,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress)),fileId,time)";
+const CHANGES_FIELDS: &str = "nextPageToken,newStartPageToken,changes(changeType,removed,file(id,name,mimeType,webViewLink,createdTime,modifiedTime,size,parents,shared,trashed,driveId,inheritedPermissionsDisabled,permissions(id,type,emailAddress,domain,role,allowFileDiscovery,permissionDetails),owners(emailAddress)),fileId,time)";
 
 fn build_files_query(activity_after: Option<&str>) -> String {
     let mut query_parts = vec!["trashed=false".to_string()];
@@ -1384,6 +1384,75 @@ impl DriveClient {
         .await
     }
 
+    pub async fn list_folders_in_drive(
+        &self,
+        auth: &GoogleAuth,
+        user_email: &str,
+        drive_id: &str,
+        page_token: Option<&str>,
+    ) -> Result<FilesListResponse> {
+        let drive_id_owned = drive_id.to_string();
+        let page_token = page_token.map(|s| s.to_string());
+
+        execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
+            let drive_id = drive_id_owned.clone();
+            let page_token = page_token.clone();
+            async move {
+                let url = format!("{}/files", drive_api_base().as_str());
+                // Folders are always fetched in full (no cutoff): their
+                // access metadata (limited-access flag + direct ACL) defines
+                // the effective permissions of every descendant file.
+                let query =
+                    "trashed=false and mimeType='application/vnd.google-apps.folder'".to_string();
+
+                let mut params: Vec<(&str, &str)> = vec![
+                    ("pageSize", "100"),
+                    ("fields", FILES_FIELDS),
+                    ("q", query.as_str()),
+                    ("supportsAllDrives", "true"),
+                    ("includeItemsFromAllDrives", "true"),
+                    ("corpora", "drive"),
+                    ("driveId", &drive_id),
+                ];
+                if let Some(ref pt) = page_token {
+                    params.push(("pageToken", pt));
+                }
+
+                debug!(
+                    "[GOOGLE API CALL] list_folders_in_drive drive={}, page_token={:?}",
+                    drive_id, page_token
+                );
+                let response = self
+                    .client
+                    .get(&url)
+                    .bearer_auth(&token)
+                    .query(&params)
+                    .send()
+                    .await
+                    .with_context(|| format!("Failed to list folders in drive {}", drive_id))?;
+
+                let status = response.status();
+                if !status.is_success() {
+                    return classify_google_api_error(response, "Failed to list folders in drive")
+                        .await;
+                }
+
+                let response_text = response.text().await?;
+                let parsed: FilesListResponse =
+                    serde_json::from_str(&response_text).map_err(|e| {
+                        anyhow!(
+                            "Failed to parse drive-scoped folder list response: {}. Raw: {}",
+                            e,
+                            response_text
+                        )
+                    })?;
+
+                Ok(ApiResult::Success(parsed))
+            }
+        })
+        .await
+    }
+
     /// List a drive's trashed files (`files.list` with `trashed=true`),
     /// paginated fully. Used by the SA-direct full-traversal path to reconcile
     /// documents that were trashed before their trash event was observed by an
@@ -1473,7 +1542,8 @@ impl DriveClient {
     ///
     /// Paginates fully (pageSize=100) and returns the complete member list.
     /// Requires a caller-provided bearer token (SA self-token or impersonated
-    /// DWD token).
+    /// DWD token). Works for any fileId — used for drive ACLs and, in the
+    /// SA-direct effective-permission model, for folder ACLs.
     pub async fn list_drive_permissions(
         &self,
         token: &str,

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -319,7 +319,46 @@ pub struct GoogleSyncCheckpoint {
     /// so previously indexed unchanged documents get the new ACLs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub drive_acl_fingerprints: Option<HashMap<String, String>>,
+    /// Per-folder access state for the SA-direct effective-permission model.
+    /// Only folders that are limited-access or carry direct grants are
+    /// recorded; incremental syncs re-fetch their ACLs to detect changes that
+    /// `changes.list` does not deliver for descendants.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub folder_access: Option<HashMap<String, FolderAccessInfo>>,
+    /// Bumped whenever the SA-direct permission model changes so a deploy
+    /// forces one uncut full re-traversal, re-emitting every document with
+    /// corrected ACLs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub permission_model_version: Option<String>,
     pub chat: Option<GoogleChatCheckpoint>,
+}
+
+/// Bumped whenever the SA-direct permission model changes; see
+/// `GoogleSyncCheckpoint::permission_model_version`.
+pub const SA_DIRECT_PERMISSION_MODEL_VERSION: &str = "effective-acl-v1";
+
+/// Run-local access metadata for a folder during an SA-direct sync. Folders
+/// are discovered from the drive listing (parents + limited-access flag) and
+/// their directly-assigned ACLs are fetched lazily via `permissions.list`.
+#[derive(Debug, Clone, Default)]
+pub struct FolderAccessEntry {
+    pub parents: Vec<String>,
+    pub inherited_permissions_disabled: bool,
+    /// Directly-assigned ACL entries (inherited entries filtered out), `None`
+    /// until fetched.
+    pub acl: Option<Vec<GoogleDrivePermission>>,
+}
+
+/// Persisted per-folder access state in the sync checkpoint (see
+/// `GoogleSyncCheckpoint::folder_access`).
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct FolderAccessInfo {
+    pub drive_id: String,
+    pub parents: Vec<String>,
+    pub inherited_permissions_disabled: bool,
+    /// Fingerprint over the directly-assigned ACL entries, mirroring
+    /// `drive_acl_fingerprint`.
+    pub acl_fingerprint: String,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -391,6 +430,12 @@ pub struct GoogleDriveFile {
     pub trashed: Option<bool>,
     #[serde(rename = "driveId")]
     pub drive_id: Option<String>,
+    /// Folders only: `true` when the folder has limited access
+    /// (`inheritedPermissionsDisabled`), meaning inherited drive/parent
+    /// permissions do not apply to its contents. Files in shared drives do not
+    /// populate this field.
+    #[serde(rename = "inheritedPermissionsDisabled")]
+    pub inherited_permissions_disabled: Option<bool>,
     pub permissions: Option<Vec<GoogleDrivePermission>>,
     pub owners: Option<Vec<Owner>>,
 }
@@ -417,6 +462,22 @@ pub struct GoogleDrivePermission {
     pub allow_file_discovery: Option<bool>,
     #[serde(rename = "permissionDetails")]
     pub permission_details: Option<Vec<serde_json::Value>>,
+}
+
+impl GoogleDrivePermission {
+    /// Whether this permission entry is purely inherited from the drive or a
+    /// parent folder (per `permissionDetails[].inherited`). Entries without
+    /// `permissionDetails` are treated as directly assigned.
+    pub fn is_inherited_only(&self) -> bool {
+        match &self.permission_details {
+            None => false,
+            Some(details) => details.iter().all(|d| {
+                d.get("inherited")
+                    .and_then(|v| v.as_bool())
+                    .unwrap_or(false)
+            }),
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -572,6 +633,124 @@ pub fn drive_acl_fingerprint(permissions: &[GoogleDrivePermission]) -> String {
         ));
     }
     entries.into_iter().collect::<Vec<_>>().join(";")
+}
+
+/// Filter a folder/file permission list down to directly-assigned entries,
+/// dropping entries inherited from the drive or a parent folder (per
+/// `permissionDetails[].inherited`). Entries without `permissionDetails` are
+/// treated as direct. Inherited entries are already represented by the drive
+/// baseline / parent-folder effective ACL, so including them would double-count
+/// (and, for limited-access folders, would wrongly restore drive-wide access).
+pub fn filter_direct_permissions(
+    permissions: &[GoogleDrivePermission],
+) -> Vec<GoogleDrivePermission> {
+    permissions
+        .iter()
+        .filter(|perm| !perm.is_inherited_only())
+        .cloned()
+        .collect()
+}
+
+/// Union `from` into `into` (expansive-access merge): users/groups dedupe,
+/// `public` ORs. Direct grants add access; they never remove it.
+pub fn merge_document_permissions(into: &mut DocumentPermissions, from: &DocumentPermissions) {
+    if from.public {
+        into.public = true;
+    }
+    for user in &from.users {
+        if !into.users.contains(user) {
+            into.users.push(user.clone());
+        }
+    }
+    for group in &from.groups {
+        if !into.groups.contains(group) {
+            into.groups.push(group.clone());
+        }
+    }
+}
+
+/// The subset of a drive ACL that always retains access to limited-access
+/// folders: entries with role `organizer`. Per Google's limited-access model,
+/// only the `owner` role, the `organizer` role, and directly-granted principals
+/// keep access when `inheritedPermissionsDisabled` is set; shared-drive items
+/// have no owners, so organizers are the always-access set.
+pub fn organizer_permissions(
+    acl: &[GoogleDrivePermission],
+    exclude_email: Option<&str>,
+) -> DocumentPermissions {
+    let organizers: Vec<GoogleDrivePermission> = acl
+        .iter()
+        .filter(|perm| perm.role == "organizer")
+        .cloned()
+        .collect();
+    map_drive_permissions(&organizers, exclude_email)
+}
+
+/// Compute the effective permission set for a file in a shared drive,
+/// mirroring Google's model:
+///
+/// - Baseline is the drive ACL (membership is the floor).
+/// - Each ancestor folder's directly-assigned grants are unioned in
+///   (expansive access).
+/// - A limited-access ancestor folder (`inheritedPermissionsDisabled`) is a
+///   boundary: inherited drive membership stops there, and the effective ACL
+///   becomes drive organizers + that folder's direct grants. With nested
+///   boundaries the deepest one governs.
+/// - The file's own direct grants (shared-drive files do not carry permissions
+///   in list responses, but be correct if present) are unioned in.
+///
+/// `folder_access` must be populated for every ancestor folder of `file` (see
+/// `FolderAccessEntry`); ancestors absent from the map are treated as
+/// contributing nothing (no direct grants, not limited-access).
+pub fn compute_effective_permissions(
+    file: &GoogleDriveFile,
+    drive_id: &str,
+    baseline: &DocumentPermissions,
+    drive_acl_raw: &[GoogleDrivePermission],
+    folder_access: &HashMap<String, FolderAccessEntry>,
+    exclude_email: Option<&str>,
+) -> DocumentPermissions {
+    // Collect the ancestor chain file-adjacent -> root-most, stopping at the
+    // drive root or at a folder outside the access map (contributes nothing).
+    let mut chain: Vec<&FolderAccessEntry> = Vec::new();
+    let mut parent = file.parents.as_ref().and_then(|p| p.first()).cloned();
+    while let Some(parent_id) = parent {
+        if parent_id == drive_id {
+            break;
+        }
+        match folder_access.get(&parent_id) {
+            Some(entry) => {
+                chain.push(entry);
+                parent = entry.parents.first().cloned();
+            }
+            None => break,
+        }
+    }
+
+    let mut effective = baseline.clone();
+    // Process root-most -> file-adjacent so nested boundaries resolve to the
+    // deepest boundary (later replacements win).
+    for entry in chain.iter().rev() {
+        if entry.inherited_permissions_disabled {
+            effective = organizer_permissions(drive_acl_raw, exclude_email);
+            if let Some(acl) = &entry.acl {
+                let folder_permissions = map_drive_permissions(acl, exclude_email);
+                merge_document_permissions(&mut effective, &folder_permissions);
+            }
+        } else if let Some(acl) = &entry.acl {
+            let folder_permissions = map_drive_permissions(acl, exclude_email);
+            merge_document_permissions(&mut effective, &folder_permissions);
+        }
+    }
+
+    // The file's own direct grants.
+    if let Some(permissions) = &file.permissions {
+        let direct = filter_direct_permissions(permissions);
+        let file_permissions = map_drive_permissions(&direct, exclude_email);
+        merge_document_permissions(&mut effective, &file_permissions);
+    }
+
+    effective
 }
 
 /// Validate that a service account can read ACLs for a shared drive.
@@ -1346,6 +1525,7 @@ mod tests {
             shared: Some(true),
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),
                 permission_type: "user".to_string(),
@@ -1501,6 +1681,7 @@ mod tests {
             shared: None,
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: None,
             owners: None,
         };
@@ -1553,6 +1734,7 @@ mod tests {
             shared: None,
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: None,
             owners: None,
         };
@@ -1583,6 +1765,7 @@ mod tests {
             shared: Some(true),
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: Some(vec![
                 GoogleDrivePermission {
                     id: "perm1".to_string(),
@@ -1652,6 +1835,7 @@ mod tests {
             shared: None,
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: None,
             owners: None,
         };
@@ -1689,6 +1873,7 @@ mod tests {
             shared: Some(true),
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: Some(vec![
                 GoogleDrivePermission {
                     id: "perm_anyone_link".to_string(),
@@ -1732,6 +1917,7 @@ mod tests {
             shared: Some(true),
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm_domain".to_string(),
                 permission_type: "domain".to_string(),
@@ -1764,6 +1950,7 @@ mod tests {
             shared: None,
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: Some(vec![]),
             owners: Some(vec![Owner {
                 id: None,
@@ -1798,6 +1985,7 @@ mod tests {
             shared: Some(true),
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: Some(vec![]),
             owners: Some(vec![Owner {
                 id: None,
@@ -1843,6 +2031,7 @@ mod tests {
             shared: None,
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: Some(vec![GoogleDrivePermission {
                 id: "perm1".to_string(),
                 permission_type: "user".to_string(),
@@ -2468,5 +2657,301 @@ mod tests {
             fp1, fp3,
             "identical ACLs must produce identical fingerprints"
         );
+    }
+
+    #[test]
+    fn test_filter_direct_permissions_keeps_only_direct_entries() {
+        let inherited = GoogleDrivePermission {
+            id: "p1".to_string(),
+            permission_type: "user".to_string(),
+            email_address: Some("member@example.com".to_string()),
+            domain: None,
+            role: "reader".to_string(),
+            allow_file_discovery: None,
+            permission_details: Some(vec![json!({
+                "permissionType": "sharedDrive",
+                "role": "reader",
+                "inherited": true,
+                "inheritedFrom": "drive-1"
+            })]),
+        };
+        let direct = GoogleDrivePermission {
+            id: "p2".to_string(),
+            permission_type: "user".to_string(),
+            email_address: Some("guest@external.com".to_string()),
+            domain: None,
+            role: "writer".to_string(),
+            allow_file_discovery: None,
+            permission_details: Some(vec![json!({
+                "permissionType": "file",
+                "role": "writer",
+                "inherited": false
+            })]),
+        };
+        let no_details = GoogleDrivePermission {
+            id: "p3".to_string(),
+            permission_type: "domain".to_string(),
+            email_address: None,
+            domain: Some("example.com".to_string()),
+            role: "reader".to_string(),
+            allow_file_discovery: Some(true),
+            permission_details: None,
+        };
+
+        let filtered = filter_direct_permissions(&[inherited, direct, no_details]);
+        assert_eq!(filtered.len(), 2, "inherited-only entries must be dropped");
+        assert_eq!(filtered[0].id, "p2");
+        assert_eq!(filtered[1].id, "p3");
+    }
+
+    fn perm(id: &str, perm_type: &str, email: Option<&str>, role: &str) -> GoogleDrivePermission {
+        GoogleDrivePermission {
+            id: id.to_string(),
+            permission_type: perm_type.to_string(),
+            email_address: email.map(|e| e.to_string()),
+            domain: None,
+            role: role.to_string(),
+            allow_file_discovery: None,
+            permission_details: None,
+        }
+    }
+
+    fn folder_entry(
+        parents: Vec<&str>,
+        limited: bool,
+        acl: Vec<GoogleDrivePermission>,
+    ) -> FolderAccessEntry {
+        FolderAccessEntry {
+            parents: parents.into_iter().map(|s| s.to_string()).collect(),
+            inherited_permissions_disabled: limited,
+            acl: Some(acl),
+        }
+    }
+
+    fn drive_file(parent: Option<&str>) -> GoogleDriveFile {
+        GoogleDriveFile {
+            id: "file-1".to_string(),
+            name: "Doc.txt".to_string(),
+            mime_type: "text/plain".to_string(),
+            web_view_link: None,
+            created_time: None,
+            modified_time: None,
+            size: None,
+            parents: parent.map(|p| vec![p.to_string()]),
+            shared: None,
+            trashed: None,
+            drive_id: Some("drive-1".to_string()),
+            inherited_permissions_disabled: None,
+            permissions: None,
+            owners: None,
+        }
+    }
+
+    #[test]
+    fn test_effective_permissions_baseline_only() {
+        // Drive ACL: SA (organizer, excluded) + alice (writer). No folders.
+        let drive_acl = vec![
+            perm(
+                "p1",
+                "user",
+                Some("sa@test.iam.gserviceaccount.com"),
+                "organizer",
+            ),
+            perm("p2", "user", Some("alice@example.com"), "writer"),
+        ];
+        let baseline = map_drive_permissions(&drive_acl, Some("sa@test.iam.gserviceaccount.com"));
+        let effective = compute_effective_permissions(
+            &drive_file(None),
+            "drive-1",
+            &baseline,
+            &drive_acl,
+            &HashMap::new(),
+            Some("sa@test.iam.gserviceaccount.com"),
+        );
+        assert!(!effective.public);
+        assert_eq!(effective.users, vec!["alice@example.com"]);
+        assert!(effective.groups.is_empty());
+    }
+
+    #[test]
+    fn test_effective_permissions_expansive_union_on_normal_folder() {
+        // Folder "folder-1" directly grants an external user: union.
+        let drive_acl = vec![perm("p1", "user", Some("alice@example.com"), "writer")];
+        let baseline = map_drive_permissions(&drive_acl, None);
+        let mut folder_access = HashMap::new();
+        folder_access.insert(
+            "folder-1".to_string(),
+            folder_entry(
+                vec!["drive-1"],
+                false,
+                vec![perm("p2", "user", Some("guest@external.com"), "reader")],
+            ),
+        );
+        let effective = compute_effective_permissions(
+            &drive_file(Some("folder-1")),
+            "drive-1",
+            &baseline,
+            &drive_acl,
+            &folder_access,
+            None,
+        );
+        assert_eq!(effective.users.len(), 2);
+        assert!(effective.users.contains(&"alice@example.com".to_string()));
+        assert!(effective.users.contains(&"guest@external.com".to_string()));
+    }
+
+    #[test]
+    fn test_effective_permissions_limited_access_boundary() {
+        // Drive members: SA (organizer, excluded) + bob (reader). The folder is
+        // limited-access and grants only carol. Bob must lose access;
+        // organizers (minus the SA) always retain it.
+        let drive_acl = vec![
+            perm(
+                "p1",
+                "user",
+                Some("sa@test.iam.gserviceaccount.com"),
+                "organizer",
+            ),
+            perm("p2", "user", Some("bob@example.com"), "reader"),
+        ];
+        let baseline = map_drive_permissions(&drive_acl, Some("sa@test.iam.gserviceaccount.com"));
+        let mut folder_access = HashMap::new();
+        folder_access.insert(
+            "secret-1".to_string(),
+            folder_entry(
+                vec!["drive-1"],
+                true,
+                vec![perm("p3", "user", Some("carol@example.com"), "writer")],
+            ),
+        );
+        let effective = compute_effective_permissions(
+            &drive_file(Some("secret-1")),
+            "drive-1",
+            &baseline,
+            &drive_acl,
+            &folder_access,
+            Some("sa@test.iam.gserviceaccount.com"),
+        );
+        assert_eq!(
+            effective.users,
+            vec!["carol@example.com"],
+            "boundary must drop non-organizer drive members"
+        );
+    }
+
+    #[test]
+    fn test_effective_permissions_organizer_retains_access_at_boundary() {
+        // A different organizer (dave) keeps access inside the limited folder.
+        let drive_acl = vec![perm("p1", "user", Some("dave@example.com"), "organizer")];
+        let baseline = map_drive_permissions(&drive_acl, None);
+        let mut folder_access = HashMap::new();
+        folder_access.insert(
+            "secret-1".to_string(),
+            folder_entry(
+                vec!["drive-1"],
+                true,
+                vec![perm("p2", "user", Some("carol@example.com"), "writer")],
+            ),
+        );
+        let effective = compute_effective_permissions(
+            &drive_file(Some("secret-1")),
+            "drive-1",
+            &baseline,
+            &drive_acl,
+            &folder_access,
+            None,
+        );
+        assert!(effective.users.contains(&"dave@example.com".to_string()));
+        assert!(effective.users.contains(&"carol@example.com".to_string()));
+    }
+
+    #[test]
+    fn test_effective_permissions_nested_boundary_deepest_wins() {
+        // outer (normal, grants eve) -> inner (limited, grants frank).
+        // Eve must NOT appear: the inner boundary replaces everything above it.
+        let drive_acl = vec![perm("p1", "user", Some("alice@example.com"), "writer")];
+        let baseline = map_drive_permissions(&drive_acl, None);
+        let mut folder_access = HashMap::new();
+        folder_access.insert(
+            "outer-1".to_string(),
+            folder_entry(
+                vec!["drive-1"],
+                false,
+                vec![perm("p2", "user", Some("eve@example.com"), "reader")],
+            ),
+        );
+        folder_access.insert(
+            "inner-1".to_string(),
+            folder_entry(
+                vec!["outer-1"],
+                true,
+                vec![perm("p3", "user", Some("frank@example.com"), "writer")],
+            ),
+        );
+        let file = GoogleDriveFile {
+            parents: Some(vec!["inner-1".to_string()]),
+            ..drive_file(None)
+        };
+        let effective = compute_effective_permissions(
+            &file,
+            "drive-1",
+            &baseline,
+            &drive_acl,
+            &folder_access,
+            None,
+        );
+        assert_eq!(
+            effective.users,
+            vec!["frank@example.com"],
+            "deepest boundary governs"
+        );
+        assert!(!effective.users.contains(&"eve@example.com".to_string()));
+        assert!(!effective.users.contains(&"alice@example.com".to_string()));
+    }
+
+    #[test]
+    fn test_effective_permissions_group_and_domain_entries_survive() {
+        let drive_acl = vec![perm("p1", "domain", None, "reader")];
+        let mut drive_acl = drive_acl;
+        drive_acl[0].domain = Some("example.com".to_string());
+        drive_acl[0].allow_file_discovery = Some(true);
+        let baseline = map_drive_permissions(&drive_acl, None);
+        let mut folder_access = HashMap::new();
+        folder_access.insert(
+            "folder-1".to_string(),
+            folder_entry(
+                vec!["drive-1"],
+                false,
+                vec![perm("p2", "group", Some("hr@example.com"), "reader")],
+            ),
+        );
+        let effective = compute_effective_permissions(
+            &drive_file(Some("folder-1")),
+            "drive-1",
+            &baseline,
+            &drive_acl,
+            &folder_access,
+            None,
+        );
+        assert!(effective.groups.contains(&"example.com".to_string()));
+        assert!(effective.groups.contains(&"hr@example.com".to_string()));
+    }
+
+    #[test]
+    fn test_merge_document_permissions_dedupes() {
+        let mut into = DocumentPermissions {
+            public: false,
+            users: vec!["a@example.com".to_string()],
+            groups: vec!["g1@example.com".to_string()],
+        };
+        let from = DocumentPermissions {
+            public: true,
+            users: vec!["a@example.com".to_string(), "b@example.com".to_string()],
+            groups: vec!["g2@example.com".to_string()],
+        };
+        merge_document_permissions(&mut into, &from);
+        assert!(into.public);
+        assert_eq!(into.users.len(), 2);
+        assert_eq!(into.groups.len(), 2);
     }
 }

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -20,6 +20,13 @@ const GOOGLE_MAX_BUFFERED_BYTES: usize = 512 * 1024 * 1024;
 const GOOGLE_BUFFER_PERMIT_UNIT: usize = 64 * 1024;
 const GOOGLE_BUFFER_PERMITS: usize = GOOGLE_MAX_BUFFERED_BYTES / GOOGLE_BUFFER_PERMIT_UNIT;
 
+/// Batch size for SA-direct file emission (SA-direct path only).
+const SA_DIRECT_BATCH_SIZE: usize = 200;
+
+/// `application/vnd.google-apps.folder` — folders carry access metadata but are
+/// never indexed as documents.
+const FOLDER_MIME_TYPE: &str = "application/vnd.google-apps.folder";
+
 pub(crate) fn permits_for_bytes(bytes: usize) -> u32 {
     if bytes == 0 {
         return 0;
@@ -323,8 +330,8 @@ use crate::drive::{DriveClient, FileContent};
 use crate::gmail::{BatchThreadResult, ExtractedAttachment, GmailClient, MessageFormat};
 use crate::models::{
     AttachmentPointer, GmailThread, GoogleChatSegmentCheckpoint, GoogleChatSpaceCheckpoint,
-    GoogleConnectorState, GoogleDriveFile, GoogleSyncCheckpoint, UserFile, WebhookChannel,
-    WebhookChannelResponse, WebhookNotification, mime_type_to_content_type,
+    GoogleConnectorState, GoogleDriveFile, GoogleDrivePermission, GoogleSyncCheckpoint, UserFile,
+    WebhookChannel, WebhookChannelResponse, WebhookNotification, mime_type_to_content_type,
 };
 use omni_connector_sdk::RateLimiter;
 use omni_connector_sdk::SdkClient;
@@ -1032,10 +1039,13 @@ impl SyncManager {
             crate::models::GoogleAuthMode::ServiceAccountDirect
         );
 
-        // SA-direct sources never have Admin SDK access — skip group sync.
+        // SA-direct sources have no Admin SDK access via impersonation, but the
+        // SA itself may hold a customer-level admin role (the DWD-free path
+        // Google supports); attempt a best-effort group sync with the SA's own
+        // identity and degrade gracefully when Directory access is absent.
         let known_groups = if is_sa_direct {
-            debug!("Skipping group sync for SA-direct source {}", source.id);
-            HashSet::new()
+            self.maybe_sync_groups_sa_direct(source, service_creds, ctx)
+                .await
         } else {
             self.maybe_sync_groups(source, service_creds, ctx).await
         };
@@ -1878,6 +1888,7 @@ impl SyncManager {
             drive_scope_fingerprint,
             drive_acl_fingerprints: existing.drive_acl_fingerprints.clone(),
             chat: existing.chat.clone(),
+            ..Default::default()
         }
     }
 
@@ -2443,6 +2454,9 @@ impl SyncManager {
         let mut new_acl_fingerprints: HashMap<String, String> = HashMap::new();
         let mut drive_acl_overrides: HashMap<String, DocumentPermissions> = HashMap::new();
         let mut drive_acl_changed: HashMap<String, bool> = HashMap::new();
+        // Raw (unmapped) drive ACLs, needed to compute the always-access
+        // organizer set at limited-access folder boundaries.
+        let mut drive_acl_raw: HashMap<String, Vec<GoogleDrivePermission>> = HashMap::new();
 
         for drive_group in &drives {
             let drive_id = &drive_group.drive_id;
@@ -2466,6 +2480,19 @@ impl SyncManager {
             new_acl_fingerprints.insert(drive_id.clone(), fingerprint);
             drive_acl_overrides.insert(drive_id.clone(), permissions);
             drive_acl_changed.insert(drive_id.clone(), changed);
+            drive_acl_raw.insert(drive_id.clone(), drive_acl);
+
+            if drive_acl_raw
+                .get(drive_id)
+                .is_some_and(|acl| acl.iter().any(|p| p.permission_type == "group"))
+            {
+                warn!(
+                    "Drive {} ACL includes group grants. Group-granted documents are visible \
+                     only to users whose group memberships are synced into Omni by some source;\
+                     this source may not be able to sync them.",
+                    drive_id
+                );
+            }
         }
 
         let content_cache = Arc::new(DriveContentCache::default());
@@ -2476,7 +2503,33 @@ impl SyncManager {
             .drive_change_tokens
             .clone()
             .unwrap_or_default();
-        const BATCH_SIZE: usize = 200;
+
+        // Folder access metadata for the effective-permission model. In
+        // incremental mode, seed from the checkpoint (fingerprinted folders
+        // only: limited-access or directly-granted); full traversals rebuild
+        // the map from the drive listing.
+        let stored_folder_access = existing_state.folder_access.clone().unwrap_or_default();
+        let mut folder_access: HashMap<String, crate::models::FolderAccessEntry> =
+            if sync_type == SyncType::Incremental {
+                stored_folder_access
+                    .iter()
+                    .map(|(id, info)| {
+                        (
+                            id.clone(),
+                            crate::models::FolderAccessEntry {
+                                parents: info.parents.clone(),
+                                inherited_permissions_disabled: info.inherited_permissions_disabled,
+                                acl: None,
+                            },
+                        )
+                    })
+                    .collect()
+            } else {
+                HashMap::new()
+            };
+        // Drives that ran a full traversal this run (their folder-access state
+        // replaces the checkpoint's for those folders).
+        let mut full_drives: HashSet<String> = HashSet::new();
 
         for drive_group in &drives {
             if ctx.is_cancelled() {
@@ -2491,13 +2544,65 @@ impl SyncManager {
                 .expect("drive ACL resolved in preflight");
             let acl_changed = drive_acl_changed.get(drive_id).copied().unwrap_or(true);
 
-            // ACL change forces an uncut full traversal (no date cutoff) so every
-            // previously indexed unchanged document is re-emitted with new ACLs.
+            // Folder-level ACL preflight (incremental only): re-fetch ACLs for
+            // fingerprinted folders (limited-access or directly-granted) to
+            // detect changes that `changes.list` does not deliver for
+            // descendants. A mismatch forces an uncut full re-traversal so
+            // every descendant is re-emitted with the corrected ACL.
+            let mut folder_acl_changed = false;
+            if sync_type == SyncType::Incremental && !scope_changed {
+                for (folder_id, info) in stored_folder_access.iter() {
+                    if info.drive_id != *drive_id {
+                        continue;
+                    }
+                    let raw = match self
+                        .drive_client
+                        .list_drive_permissions(&access_token, folder_id)
+                        .await
+                    {
+                        Ok(raw) => raw,
+                        // The folder was deleted or the SA lost access to it;
+                        // its descendants are gone too, so force a full
+                        // re-traversal (which prunes the stale fingerprint).
+                        Err(e) => {
+                            warn!(
+                                "Folder {} ACL fetch failed ({}); forcing full re-traversal of drive {}",
+                                folder_id, e, drive_id
+                            );
+                            folder_acl_changed = true;
+                            break;
+                        }
+                    };
+                    let direct = crate::models::filter_direct_permissions(&raw);
+                    let fingerprint = crate::models::drive_acl_fingerprint(&direct);
+                    if fingerprint != info.acl_fingerprint {
+                        info!(
+                            "ACL fingerprint changed for folder {} — forcing full re-traversal of drive {}",
+                            folder_id, drive_id
+                        );
+                        folder_acl_changed = true;
+                        break;
+                    }
+                }
+            }
+
+            // Bumped when the SA-direct permission model changes so a deploy
+            // forces one uncut full re-traversal (documents re-emitted with
+            // corrected ACLs).
+            let model_mismatch = existing_state.permission_model_version.as_deref()
+                != Some(crate::models::SA_DIRECT_PERMISSION_MODEL_VERSION);
+
+            // ACL/scope/model changes force an uncut full traversal (no date
+            // cutoff) so every previously indexed unchanged document is
+            // re-emitted with new ACLs.
             let use_incremental = sync_type == SyncType::Incremental
                 && !scope_changed
                 && !acl_changed
+                && !folder_acl_changed
+                && !model_mismatch
                 && old_change_tokens.get(drive_id).is_some();
 
+            let mut force_full = false;
             if use_incremental {
                 let start_token = old_change_tokens.get(drive_id).unwrap().clone();
                 let mut current_token = start_token.clone();
@@ -2534,13 +2639,43 @@ impl SyncManager {
                         }
 
                         if let Some(file) = &change.file {
+                            if file.mime_type == FOLDER_MIME_TYPE {
+                                // Folders are not indexed, but they carry access
+                                // metadata. Track them and detect boundary
+                                // transitions that would leave descendants with
+                                // stale ACLs.
+                                self.handle_folder_change(
+                                    file,
+                                    &stored_folder_access,
+                                    &mut folder_access,
+                                    &mut force_full,
+                                );
+                                continue;
+                            }
                             if self.should_index_file(file) {
+                                self.ensure_folder_acl_chain(
+                                    &access_token,
+                                    file,
+                                    drive_id,
+                                    &mut folder_access,
+                                )
+                                .await?;
+                                let effective = crate::models::compute_effective_permissions(
+                                    file,
+                                    drive_id,
+                                    &drive_permissions,
+                                    drive_acl_raw
+                                        .get(drive_id)
+                                        .expect("drive ACL resolved in preflight"),
+                                    &folder_access,
+                                    Some(&sa_email),
+                                );
                                 file_batch.push(UserFile {
                                     user_email: Arc::new(sa_email.clone()),
                                     file: file.clone(),
-                                    permissions_override: Some(drive_permissions.clone()),
+                                    permissions_override: Some(effective),
                                 });
-                                if file_batch.len() >= BATCH_SIZE {
+                                if file_batch.len() >= SA_DIRECT_BATCH_SIZE {
                                     self.flush_batch(
                                         &mut file_batch,
                                         &source.id,
@@ -2573,13 +2708,45 @@ impl SyncManager {
                         new_change_tokens.insert(drive_id.clone(), new_token.clone());
                     }
 
+                    if force_full {
+                        break;
+                    }
+
                     match response.next_page_token {
                         Some(token) => current_token = token,
                         None => break,
                     }
                 }
 
-                if !new_change_tokens.contains_key(drive_id) {
+                if force_full {
+                    // A folder crossed into/out of the limited-access model
+                    // mid-feed; discard incremental progress and re-traverse
+                    // fully so descendants get correct ACLs. Always uncut:
+                    // affected descendants can be of any age.
+                    new_change_tokens.remove(drive_id);
+                    self.sa_direct_full_traverse_drive(
+                        source,
+                        &sync_run_id,
+                        ctx,
+                        &service_auth,
+                        &sa_email,
+                        &access_token,
+                        drive_id,
+                        &drive_permissions,
+                        drive_acl_raw
+                            .get(drive_id)
+                            .expect("drive ACL resolved in preflight"),
+                        &drive_cutoff_date,
+                        true,
+                        &content_cache,
+                        &mut folder_access,
+                        &mut total_scanned,
+                        &mut total_updated,
+                        &mut new_change_tokens,
+                    )
+                    .await?;
+                    full_drives.insert(drive_id.clone());
+                } else if !new_change_tokens.contains_key(drive_id) {
                     match self
                         .drive_client
                         .get_start_page_token_for_drive(&access_token, drive_id)
@@ -2597,107 +2764,28 @@ impl SyncManager {
                     }
                 }
             } else {
-                let next_change_token = match self
-                    .drive_client
-                    .get_start_page_token_for_drive(&access_token, drive_id)
-                    .await
-                {
-                    Ok(token) => Some(token),
-                    Err(error) => {
-                        warn!(
-                            "Failed to get start page token for drive {}: {}",
-                            drive_id, error
-                        );
-                        None
-                    }
-                };
-
-                let mut file_batch: Vec<UserFile> = Vec::new();
-                let mut page_token: Option<String> = None;
-                loop {
-                    // Full traversal: when the ACL changed, pass no cutoff so
-                    // every document (even unchanged old ones) is re-emitted;
-                    // otherwise apply the normal date cutoff.
-                    let modified_after: Option<&str> = if acl_changed {
-                        None
-                    } else {
-                        Some(&drive_cutoff_date)
-                    };
-                    let response = self
-                        .drive_client
-                        .list_files_in_drive(
-                            &service_auth,
-                            &sa_email,
-                            drive_id,
-                            page_token.as_deref(),
-                            modified_after,
-                        )
-                        .await?;
-
-                    for file in response.files {
-                        if self.should_index_file(&file) {
-                            file_batch.push(UserFile {
-                                user_email: Arc::new(sa_email.clone()),
-                                file,
-                                permissions_override: Some(drive_permissions.clone()),
-                            });
-                            if file_batch.len() >= BATCH_SIZE {
-                                self.flush_batch(
-                                    &mut file_batch,
-                                    &source.id,
-                                    &sync_run_id,
-                                    ctx,
-                                    service_auth.clone(),
-                                    content_cache.clone(),
-                                    &mut total_scanned,
-                                    &mut total_updated,
-                                )
-                                .await?;
-                            }
-                        }
-                    }
-
-                    if ctx.is_cancelled() {
-                        break;
-                    }
-
-                    page_token = response.next_page_token;
-                    if page_token.is_none() {
-                        break;
-                    }
-                }
-
-                self.flush_batch(
-                    &mut file_batch,
-                    &source.id,
+                self.sa_direct_full_traverse_drive(
+                    source,
                     &sync_run_id,
                     ctx,
-                    service_auth.clone(),
-                    content_cache.clone(),
+                    &service_auth,
+                    &sa_email,
+                    &access_token,
+                    drive_id,
+                    &drive_permissions,
+                    drive_acl_raw
+                        .get(drive_id)
+                        .expect("drive ACL resolved in preflight"),
+                    &drive_cutoff_date,
+                    acl_changed || model_mismatch || folder_acl_changed,
+                    &content_cache,
+                    &mut folder_access,
                     &mut total_scanned,
                     &mut total_updated,
+                    &mut new_change_tokens,
                 )
                 .await?;
-
-                // Reconcile trashed files: incremental changes.list only
-                // reports a trash transition once, so files trashed before we
-                // observed the event (or trashed while incremental was
-                // unavailable) would otherwise stay in the index forever. A
-                // full traversal is the safe point to list trashed=true and
-                // publish deletions.
-                let trashed_files = self
-                    .drive_client
-                    .list_trashed_files_in_drive(&service_auth, &sa_email, drive_id)
-                    .await?;
-                self.publish_trashed_deletions(ctx, trashed_files).await?;
-
-                if ctx.is_cancelled() {
-                    break;
-                }
-
-                if let Some(token) = next_change_token {
-                    new_change_tokens.insert(drive_id.clone(), token);
-                }
+                full_drives.insert(drive_id.clone());
             }
         }
 
@@ -2708,14 +2796,336 @@ impl SyncManager {
 
         self.folder_cache.clear();
 
+        // Persist folder access state: rebuilt from the run-local map for
+        // drives that were fully traversed; existing entries kept for drives
+        // that only ran incrementally.
+        let mut new_folder_access = stored_folder_access;
+        for drive_group in &drives {
+            if !full_drives.contains(&drive_group.drive_id) {
+                continue;
+            }
+            let drive_id = &drive_group.drive_id;
+            new_folder_access.retain(|_, info| info.drive_id != *drive_id);
+            for (folder_id, entry) in folder_access.iter() {
+                let Some(acl) = &entry.acl else {
+                    continue;
+                };
+                if !entry.inherited_permissions_disabled && acl.is_empty() {
+                    continue;
+                }
+                new_folder_access.insert(
+                    folder_id.clone(),
+                    crate::models::FolderAccessInfo {
+                        drive_id: drive_id.clone(),
+                        parents: entry.parents.clone(),
+                        inherited_permissions_disabled: entry.inherited_permissions_disabled,
+                        acl_fingerprint: crate::models::drive_acl_fingerprint(acl),
+                    },
+                );
+            }
+        }
+
         Ok(GoogleSyncCheckpoint {
             gmail_history_ids: existing_state.gmail_history_ids.clone(),
             drive_page_tokens: None,
             drive_change_tokens: Some(new_change_tokens),
             drive_scope_fingerprint: Some(current_fingerprint),
             drive_acl_fingerprints: Some(new_acl_fingerprints),
+            folder_access: Some(new_folder_access),
+            permission_model_version: Some(
+                crate::models::SA_DIRECT_PERMISSION_MODEL_VERSION.to_string(),
+            ),
             chat: existing_state.chat.clone(),
         })
+    }
+
+    /// Full (cutoff or uncut) traversal of one shared drive in SA-direct mode.
+    /// Builds the complete folder access index first (folders-only listing, no
+    /// cutoff), then streams indexable files computing per-file effective
+    /// permissions from drive + folder ACLs. Also reconciles pre-trashed files.
+    #[allow(clippy::too_many_arguments)]
+    async fn sa_direct_full_traverse_drive(
+        &self,
+        source: &Source,
+        sync_run_id: &str,
+        ctx: &SyncContext,
+        service_auth: &Arc<GoogleAuth>,
+        sa_email: &str,
+        access_token: &str,
+        drive_id: &str,
+        drive_permissions: &DocumentPermissions,
+        drive_acl_raw: &[GoogleDrivePermission],
+        drive_cutoff_date: &str,
+        uncut: bool,
+        content_cache: &Arc<DriveContentCache>,
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+        total_scanned: &mut usize,
+        total_updated: &mut usize,
+        new_change_tokens: &mut HashMap<String, String>,
+    ) -> Result<()> {
+        // Folders-first pass: the complete folder index must be in place before
+        // computing effective permissions for any file (listing order is
+        // arbitrary, so a file's ancestors may appear on later pages).
+        let mut folder_page: Option<String> = None;
+        loop {
+            let response = self
+                .drive_client
+                .list_folders_in_drive(service_auth, sa_email, drive_id, folder_page.as_deref())
+                .await?;
+            for folder in response.files {
+                let entry = folder_access.entry(folder.id.clone()).or_default();
+                entry.parents = folder.parents.clone().unwrap_or_default();
+                entry.inherited_permissions_disabled =
+                    folder.inherited_permissions_disabled.unwrap_or(false);
+            }
+            match response.next_page_token {
+                Some(token) => folder_page = Some(token),
+                None => break,
+            }
+        }
+
+        // Fetch directly-assigned ACLs for every folder with bounded
+        // concurrency. Needed for complete fingerprint coverage: a grant change
+        // on any granted folder must be detectable on future incremental runs
+        // even when its descendants were not re-walked this run.
+        let pending: Vec<String> = folder_access
+            .iter()
+            .filter(|(_, entry)| entry.acl.is_none())
+            .map(|(id, _)| id.clone())
+            .collect();
+        let client = self.drive_client.clone();
+        let token = access_token.to_string();
+        let semaphore = Arc::new(Semaphore::new(GOOGLE_FILE_CONCURRENCY));
+        let mut tasks = tokio::task::JoinSet::new();
+        for folder_id in pending {
+            let client = client.clone();
+            let token = token.clone();
+            let permit = semaphore.clone();
+            tasks.spawn(async move {
+                let _guard = permit.acquire_owned().await;
+                let result = client.list_drive_permissions(&token, &folder_id).await;
+                (folder_id, result)
+            });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            let (folder_id, result) =
+                joined.map_err(|e| anyhow!("Folder ACL fetch task failed: {}", e))?;
+            match result {
+                Ok(raw) => {
+                    if let Some(entry) = folder_access.get_mut(&folder_id) {
+                        entry.acl = Some(crate::models::filter_direct_permissions(&raw));
+                    }
+                }
+                Err(e) => {
+                    warn!("Failed to read ACLs for folder {}: {}", folder_id, e);
+                }
+            }
+        }
+
+        let next_change_token = match self
+            .drive_client
+            .get_start_page_token_for_drive(access_token, drive_id)
+            .await
+        {
+            Ok(token) => Some(token),
+            Err(error) => {
+                warn!(
+                    "Failed to get start page token for drive {}: {}",
+                    drive_id, error
+                );
+                None
+            }
+        };
+
+        let mut file_batch: Vec<UserFile> = Vec::new();
+        let mut page_token: Option<String> = None;
+        loop {
+            // Full traversal: when the ACL/scope/model changed, pass no cutoff
+            // so every document (even unchanged old ones) is re-emitted;
+            // otherwise apply the normal date cutoff.
+            let modified_after: Option<&str> = if uncut { None } else { Some(drive_cutoff_date) };
+            let response = self
+                .drive_client
+                .list_files_in_drive(
+                    service_auth,
+                    sa_email,
+                    drive_id,
+                    page_token.as_deref(),
+                    modified_after,
+                )
+                .await?;
+
+            for file in response.files {
+                if self.should_index_file(&file) {
+                    self.ensure_folder_acl_chain(access_token, &file, drive_id, folder_access)
+                        .await?;
+                    let effective = crate::models::compute_effective_permissions(
+                        &file,
+                        drive_id,
+                        drive_permissions,
+                        drive_acl_raw,
+                        folder_access,
+                        Some(sa_email),
+                    );
+                    file_batch.push(UserFile {
+                        user_email: Arc::new(sa_email.to_string()),
+                        file,
+                        permissions_override: Some(effective),
+                    });
+                    if file_batch.len() >= SA_DIRECT_BATCH_SIZE {
+                        self.flush_batch(
+                            &mut file_batch,
+                            &source.id,
+                            sync_run_id,
+                            ctx,
+                            service_auth.clone(),
+                            content_cache.clone(),
+                            total_scanned,
+                            total_updated,
+                        )
+                        .await?;
+                    }
+                }
+            }
+
+            if ctx.is_cancelled() {
+                break;
+            }
+
+            page_token = response.next_page_token;
+            if page_token.is_none() {
+                break;
+            }
+        }
+
+        self.flush_batch(
+            &mut file_batch,
+            &source.id,
+            sync_run_id,
+            ctx,
+            service_auth.clone(),
+            content_cache.clone(),
+            total_scanned,
+            total_updated,
+        )
+        .await?;
+
+        // Reconcile trashed files: incremental changes.list only reports a
+        // trash transition once, so files trashed before we observed the event
+        // (or trashed while incremental was unavailable) would otherwise stay
+        // in the index forever. A full traversal is the safe point to list
+        // trashed=true and publish deletions.
+        let trashed_files = self
+            .drive_client
+            .list_trashed_files_in_drive(service_auth, sa_email, drive_id)
+            .await?;
+        self.publish_trashed_deletions(ctx, trashed_files).await?;
+
+        if let Some(token) = next_change_token {
+            new_change_tokens.insert(drive_id.to_string(), token);
+        }
+
+        Ok(())
+    }
+
+    /// Ensure the directly-assigned ACL is fetched (and cached in
+    /// `folder_access`) for every ancestor folder of `file` that the effective
+    /// permission computation needs. Folders absent from the map contribute
+    /// nothing (no direct grants, not limited-access) and are skipped.
+    async fn ensure_folder_acl_chain(
+        &self,
+        access_token: &str,
+        file: &GoogleDriveFile,
+        drive_id: &str,
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+    ) -> Result<()> {
+        let mut parent = file.parents.as_ref().and_then(|p| p.first()).cloned();
+        while let Some(parent_id) = parent {
+            if parent_id == drive_id {
+                break;
+            }
+            let needs_fetch = match folder_access.get(&parent_id) {
+                Some(entry) => entry.acl.is_none(),
+                None => break,
+            };
+            if needs_fetch {
+                let raw = match self
+                    .drive_client
+                    .list_drive_permissions(access_token, &parent_id)
+                    .await
+                {
+                    Ok(raw) => raw,
+                    // Folder vanished mid-sync (its files are being deleted
+                    // too); an empty direct ACL keeps the computation
+                    // conservative without failing the run.
+                    Err(e) => {
+                        debug!(
+                            "Folder {} ACL fetch failed mid-sync ({}); treating as no direct grants",
+                            parent_id, e
+                        );
+                        if let Some(entry) = folder_access.get_mut(&parent_id) {
+                            entry.acl = Some(Vec::new());
+                        }
+                        break;
+                    }
+                };
+                if let Some(entry) = folder_access.get_mut(&parent_id) {
+                    entry.acl = Some(crate::models::filter_direct_permissions(&raw));
+                }
+            }
+            parent = folder_access
+                .get(&parent_id)
+                .and_then(|entry| entry.parents.first())
+                .cloned();
+        }
+        Ok(())
+    }
+
+    /// Track a folder change entry from the incremental changes feed. Updates
+    /// the run-local access map and detects boundary transitions that would
+    /// leave descendants with stale ACLs (a folder becoming limited-access, or
+    /// a fingerprinted folder flipping its flag) — those force a full
+    /// re-traversal.
+    fn handle_folder_change(
+        &self,
+        file: &GoogleDriveFile,
+        stored: &HashMap<String, crate::models::FolderAccessInfo>,
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+        force_full: &mut bool,
+    ) {
+        let folder_id = file.id.clone();
+        let limited = file.inherited_permissions_disabled.unwrap_or(false);
+        let stored_flag = stored
+            .get(&folder_id)
+            .map(|i| i.inherited_permissions_disabled);
+        match (limited, stored_flag) {
+            (true, None) => {
+                // Limited-access but never fingerprinted (created limited, or
+                // made limited after its last full traversal) — descendants
+                // may carry stale drive-wide ACLs.
+                info!(
+                    "Folder {} is limited-access without a recorded fingerprint — forcing full re-traversal",
+                    folder_id
+                );
+                *force_full = true;
+            }
+            (flag, Some(stored_flag)) if flag != stored_flag => {
+                info!(
+                    "Folder {} flipped limited-access {} -> {} — forcing full re-traversal",
+                    folder_id, stored_flag, flag
+                );
+                *force_full = true;
+            }
+            _ => {}
+        }
+        folder_access.insert(
+            folder_id,
+            crate::models::FolderAccessEntry {
+                parents: file.parents.clone().unwrap_or_default(),
+                inherited_permissions_disabled: limited,
+                acl: None,
+            },
+        );
     }
 
     async fn sync_drive_source_internal(
@@ -3002,6 +3412,7 @@ impl SyncManager {
                         drive_scope_fingerprint: Some(current_fingerprint.clone()),
                         drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
                         chat: chat_checkpoint.clone(),
+                        ..Default::default()
                     };
                     ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
                         .await
@@ -3060,6 +3471,7 @@ impl SyncManager {
             drive_scope_fingerprint: Some(current_fingerprint),
             drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
             chat: chat_checkpoint,
+            ..Default::default()
         })
     }
 
@@ -3269,6 +3681,7 @@ impl SyncManager {
                             drive_scope_fingerprint: existing_state.drive_scope_fingerprint.clone(),
                             drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
                             chat: chat_checkpoint.clone(),
+                            ..Default::default()
                         };
                         ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
                             .await
@@ -3320,6 +3733,7 @@ impl SyncManager {
             drive_scope_fingerprint: existing_state.drive_scope_fingerprint.clone(),
             drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
             chat: chat_checkpoint,
+            ..Default::default()
         })
     }
 
@@ -3478,6 +3892,7 @@ impl SyncManager {
                 drive_scope_fingerprint: existing_state.drive_scope_fingerprint.clone(),
                 drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
                 chat: Some(chat_checkpoint.clone()),
+                ..Default::default()
             };
             ctx.save_checkpoint(serde_json::to_value(&checkpoint_state)?)
                 .await?;
@@ -3490,6 +3905,7 @@ impl SyncManager {
             drive_scope_fingerprint: existing_state.drive_scope_fingerprint,
             drive_acl_fingerprints: existing_state.drive_acl_fingerprints,
             chat: Some(chat_checkpoint),
+            ..Default::default()
         })
     }
 
@@ -5459,6 +5875,72 @@ impl SyncManager {
         }
     }
 
+    /// Best-effort group membership sync for SA-direct sources. Works only when
+    /// the service account itself holds a customer-level admin role granting
+    /// Directory API access (no domain-wide delegation / impersonation
+    /// involved). Failures (403, missing scopes) are logged and the sync
+    /// continues without group data — group-granted documents then stay visible
+    /// only through group memberships synced by other sources.
+    async fn maybe_sync_groups_sa_direct(
+        &self,
+        source: &Source,
+        service_creds: &ServiceCredential,
+        ctx: &SyncContext,
+    ) -> HashSet<String> {
+        let native_source_type = match SourceType::try_from(source.source_type.as_str()) {
+            Ok(source_type) => source_type,
+            Err(e) => {
+                warn!(
+                    "Skipping SA-direct group sync for unsupported source type: {}",
+                    e
+                );
+                return HashSet::new();
+            }
+        };
+        let service_auth = match self.create_auth(service_creds, native_source_type).await {
+            Ok(auth) => auth,
+            Err(e) => {
+                warn!("Failed to create auth for SA-direct group sync: {}", e);
+                return HashSet::new();
+            }
+        };
+        if service_auth.is_oauth() {
+            debug!(
+                "Skipping SA-direct group sync for OAuth source {}",
+                source.id
+            );
+            return HashSet::new();
+        }
+        let domain = match crate::auth::get_domain_from_credentials(service_creds) {
+            Ok(d) => d,
+            Err(e) => {
+                warn!("Failed to get domain for SA-direct group sync: {}", e);
+                return HashSet::new();
+            }
+        };
+        let access_token = match service_auth.get_self_access_token().await {
+            Ok(token) => token,
+            Err(e) => {
+                warn!("Failed to get SA token for group sync: {}", e);
+                return HashSet::new();
+            }
+        };
+        match self
+            .sync_groups(&source.id, ctx.sync_run_id(), &domain, &access_token)
+            .await
+        {
+            Ok(group_emails) => group_emails,
+            Err(e) => {
+                warn!(
+                    "SA-direct group sync unavailable ({}). Group-granted documents will be \
+                     visible only through group memberships synced by other sources.",
+                    e
+                );
+                HashSet::new()
+            }
+        }
+    }
+
     async fn sync_groups(
         &self,
         source_id: &str,
@@ -5618,6 +6100,7 @@ mod tests {
             shared: None,
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: None,
             owners: None,
         };
@@ -5644,6 +6127,7 @@ mod tests {
             shared: None,
             trashed: None,
             drive_id: None,
+            inherited_permissions_disabled: None,
             permissions: None,
             owners: None,
         };
@@ -5860,6 +6344,7 @@ mod tests {
                 shared: None,
                 trashed: None,
                 drive_id: None,
+                inherited_permissions_disabled: None,
                 permissions: None,
                 owners: None,
             }

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -571,6 +571,8 @@ mod sa_direct_tests {
     struct SaMockState {
         /// The ACL member list served for every drive (overridable per test).
         permissions: Arc<Mutex<Option<JsonValue>>>,
+        /// Per-folder ACLs keyed by folder id (SA-direct folder ACL fetches).
+        folder_permissions: Arc<Mutex<HashMap<String, JsonValue>>>,
         /// Whether the permissions endpoint returns 403 (e.g. Viewer role).
         permissions_forbidden: Arc<AtomicBool>,
         /// Files served by list_files_in_drive (corpora=drive).
@@ -588,6 +590,12 @@ mod sa_direct_tests {
     impl SaMockState {
         fn set_permissions(&self, perms: JsonValue) {
             *self.permissions.lock().unwrap() = Some(perms);
+        }
+        fn set_folder_permissions(&self, folder_id: &str, perms: JsonValue) {
+            self.folder_permissions
+                .lock()
+                .unwrap()
+                .insert(folder_id.to_string(), perms);
         }
         fn set_permissions_forbidden(&self, forbidden: bool) {
             self.permissions_forbidden
@@ -695,12 +703,23 @@ mod sa_direct_tests {
 
     async fn list_permissions_mock(
         State(state): State<SaMockState>,
-        Path(_drive_id): Path<String>,
+        Path(file_id): Path<String>,
     ) -> Json<JsonValue> {
         if state.permissions_forbidden.load(Ordering::SeqCst) {
             return Json(json!({
                 "error": { "code": 403, "message": "Forbidden", "status": "PERMISSION_DENIED" }
             }));
+        }
+        // Folder ACLs (SA-direct effective-permission model) are keyed by id;
+        // the drive ACL is the shared default.
+        if let Some(perms) = state
+            .folder_permissions
+            .lock()
+            .unwrap()
+            .get(&file_id)
+            .cloned()
+        {
+            return Json(json!({ "permissions": perms }));
         }
         let perms = state.permissions.lock().unwrap().clone();
         match perms {
@@ -724,6 +743,20 @@ mod sa_direct_tests {
             state.trashed_files.lock().unwrap().clone()
         } else {
             state.files.lock().unwrap().clone()
+        };
+        // Mirror the API's server-side filtering so the folders-only pass only
+        // receives folders.
+        let is_folder_query = query
+            .get("q")
+            .map(|q| q.contains("mimeType='application/vnd.google-apps.folder'"))
+            .unwrap_or(false);
+        let files: Vec<JsonValue> = if is_folder_query {
+            files
+                .into_iter()
+                .filter(|f| f["mimeType"].as_str() == Some("application/vnd.google-apps.folder"))
+                .collect()
+        } else {
+            files
         };
         // If a modifiedTime cutoff is present, filter the mocked files so we
         // can distinguish a cutoff crawl from an uncut full traversal.
@@ -1206,6 +1239,9 @@ mod sa_direct_tests {
                     .to_string(),
             )])),
             drive_change_tokens: Some(HashMap::from([("drive-1".to_string(), "start-1".to_string())])),
+            permission_model_version: Some(
+                omni_google_connector::models::SA_DIRECT_PERMISSION_MODEL_VERSION.to_string(),
+            ),
             ..Default::default()
         };
 
@@ -1357,6 +1393,219 @@ mod sa_direct_tests {
         assert!(
             created >= 1,
             "expected the live file to be re-indexed during full traversal"
+        );
+
+        Ok(())
+    }
+
+    /// Collect document_created event permissions (users) keyed by document id.
+    fn created_users_by_doc(bodies: &[JsonValue]) -> HashMap<String, Vec<String>> {
+        let mut perms_by_doc: HashMap<String, Vec<String>> = HashMap::new();
+        for body in bodies {
+            if let Some(events) = body.get("events").and_then(|e| e.as_array()) {
+                for event in events {
+                    if event.get("type").and_then(|t| t.as_str()) != Some("document_created") {
+                        continue;
+                    }
+                    let doc_id = event
+                        .get("document_id")
+                        .and_then(|v| v.as_str())
+                        .unwrap_or("")
+                        .to_string();
+                    let users = event
+                        .get("permissions")
+                        .and_then(|p| p.get("users"))
+                        .and_then(|u| u.as_array())
+                        .map(|a| {
+                            a.iter()
+                                .filter_map(|v| v.as_str().map(|s| s.to_string()))
+                                .collect()
+                        })
+                        .unwrap_or_default();
+                    perms_by_doc.insert(doc_id, users);
+                }
+            }
+        }
+        perms_by_doc
+    }
+
+    /// Files inside a limited-access folder must be indexed with organizers +
+    /// the folder's direct grants, NOT the drive-wide ACL. Files in a normal
+    /// folder union in its direct grants (expansive access) and keep inherited
+    /// entries filtered out.
+    #[tokio::test]
+    async fn sa_direct_full_sync_applies_limited_access_folder_boundary() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        // Drive members: SA (organizer, excluded) + alice (writer) + bob (reader).
+        state.set_permissions(json!([
+            { "id": "p1", "type": "user", "emailAddress": SA_CLIENT_EMAIL, "domain": null, "role": "organizer", "allowFileDiscovery": null, "permissionDetails": null },
+            { "id": "p2", "type": "user", "emailAddress": "alice@example.com", "domain": null, "role": "writer", "allowFileDiscovery": null, "permissionDetails": null },
+            { "id": "p3", "type": "user", "emailAddress": "bob@example.com", "domain": null, "role": "reader", "allowFileDiscovery": null, "permissionDetails": null }
+        ]));
+
+        // secret-1 is limited-access and grants only carol.
+        state.set_folder_permissions(
+            "secret-1",
+            json!([
+                { "id": "p4", "type": "user", "emailAddress": "carol@example.com", "domain": null, "role": "writer", "allowFileDiscovery": null, "permissionDetails": null }
+            ]),
+        );
+        // folder-1 is a normal folder with a direct external grant + inherited
+        // drive entries (which must be filtered out of the direct ACL).
+        state.set_folder_permissions(
+            "folder-1",
+            json!([
+                { "id": "p5", "type": "user", "emailAddress": "alice@example.com", "domain": null, "role": "writer", "allowFileDiscovery": null, "permissionDetails": [
+                    { "permissionType": "sharedDrive", "role": "writer", "inherited": true, "inheritedFrom": "drive-1" }
+                ] },
+                { "id": "p6", "type": "user", "emailAddress": "guest@external.com", "domain": null, "role": "reader", "allowFileDiscovery": null, "permissionDetails": null }
+            ]),
+        );
+
+        state.set_files(vec![
+            json!({ "id": "doc-outside", "name": "Outside.txt", "mimeType": "text/plain", "size": "10", "webViewLink": "https://example.test/outside", "createdTime": "2024-01-01T00:00:00Z", "modifiedTime": "2024-01-02T00:00:00Z", "driveId": "drive-1", "permissions": [], "owners": [] }),
+            json!({ "id": "folder-1", "name": "Shared", "mimeType": "application/vnd.google-apps.folder", "size": null, "webViewLink": null, "createdTime": "2024-01-01T00:00:00Z", "modifiedTime": "2024-01-02T00:00:00Z", "driveId": "drive-1", "parents": [], "inheritedPermissionsDisabled": false, "permissions": [], "owners": [] }),
+            json!({ "id": "doc-in-folder", "name": "Inside shared.txt", "mimeType": "text/plain", "size": "10", "webViewLink": "https://example.test/infolder", "createdTime": "2024-01-01T00:00:00Z", "modifiedTime": "2024-01-02T00:00:00Z", "driveId": "drive-1", "parents": ["folder-1"], "permissions": [], "owners": [] }),
+            json!({ "id": "secret-1", "name": "Confidential", "mimeType": "application/vnd.google-apps.folder", "size": null, "webViewLink": null, "createdTime": "2024-01-01T00:00:00Z", "modifiedTime": "2024-01-02T00:00:00Z", "driveId": "drive-1", "parents": [], "inheritedPermissionsDisabled": true, "permissions": [], "owners": [] }),
+            json!({ "id": "doc-in-secret", "name": "Secret.txt", "mimeType": "text/plain", "size": "10", "webViewLink": "https://example.test/secret", "createdTime": "2024-01-01T00:00:00Z", "modifiedTime": "2024-01-02T00:00:00Z", "driveId": "drive-1", "parents": ["secret-1"], "permissions": [], "owners": [] }),
+        ]);
+
+        let sync_result = run_sa_sync(
+            &mock_base,
+            sa_source(),
+            sa_credentials(&mock_base),
+            SyncType::Full,
+        )
+        .await;
+
+        if let Some(value) = previous_drive_base {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        sync_result?;
+
+        let perms_by_doc = created_users_by_doc(&state.event_bodies());
+
+        let outside = perms_by_doc
+            .get("doc-outside")
+            .expect("doc-outside indexed");
+        assert!(outside.contains(&"alice@example.com".to_string()));
+        assert!(outside.contains(&"bob@example.com".to_string()));
+        assert!(
+            !outside.contains(&"carol@example.com".to_string()),
+            "drive-wide ACL must not leak into the limited folder"
+        );
+
+        let in_folder = perms_by_doc
+            .get("doc-in-folder")
+            .expect("doc-in-folder indexed");
+        assert!(in_folder.contains(&"alice@example.com".to_string()));
+        assert!(in_folder.contains(&"bob@example.com".to_string()));
+        assert!(
+            in_folder.contains(&"guest@external.com".to_string()),
+            "normal folder direct grants must union in (expansive access)"
+        );
+
+        let in_secret = perms_by_doc
+            .get("doc-in-secret")
+            .expect("doc-in-secret indexed");
+        assert_eq!(
+            in_secret,
+            &vec!["carol@example.com".to_string()],
+            "limited-access boundary must drop non-organizer drive members"
+        );
+
+        Ok(())
+    }
+
+    /// A folder-ACL fingerprint change (grant added/removed on a fingerprinted
+    /// folder) must force a full re-traversal on the next incremental run so
+    /// descendants are re-emitted with corrected ACLs.
+    #[tokio::test]
+    async fn sa_direct_incremental_folder_acl_change_forces_full_traversal() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        let drive_acl = json!([
+            { "id": "p1", "type": "user", "emailAddress": SA_CLIENT_EMAIL, "domain": null, "role": "organizer", "allowFileDiscovery": null, "permissionDetails": null },
+            { "id": "p2", "type": "user", "emailAddress": "alice@example.com", "domain": null, "role": "writer", "allowFileDiscovery": null, "permissionDetails": null }
+        ]);
+        state.set_permissions(drive_acl.clone());
+
+        // Live ACL for secret-1 differs from the stale checkpoint fingerprint.
+        state.set_folder_permissions(
+            "secret-1",
+            json!([
+                { "id": "p4", "type": "user", "emailAddress": "carol@example.com", "domain": null, "role": "writer", "allowFileDiscovery": null, "permissionDetails": null },
+                { "id": "p5", "type": "user", "emailAddress": "dave@example.com", "domain": null, "role": "reader", "allowFileDiscovery": null, "permissionDetails": null }
+            ]),
+        );
+
+        let drive_acl_typed: Vec<omni_google_connector::models::GoogleDrivePermission> =
+            serde_json::from_value(drive_acl)?;
+        let drive_fp = omni_google_connector::models::drive_acl_fingerprint(&drive_acl_typed);
+        let config: omni_google_connector::models::GoogleSourceConfig =
+            serde_json::from_value(sa_source().config)?;
+        let scope_fp = format!(
+            "sa-direct:{}",
+            omni_google_connector::models::compute_scope_fingerprint(Some(
+                &config.folder_path_filters
+            ))
+        );
+
+        let checkpoint = GoogleSyncCheckpoint {
+            drive_change_tokens: Some(HashMap::from([("drive-1".to_string(), "tok1".to_string())])),
+            drive_scope_fingerprint: Some(scope_fp),
+            drive_acl_fingerprints: Some(HashMap::from([("drive-1".to_string(), drive_fp)])),
+            folder_access: Some(HashMap::from([(
+                "secret-1".to_string(),
+                omni_google_connector::models::FolderAccessInfo {
+                    drive_id: "drive-1".to_string(),
+                    parents: vec![],
+                    inherited_permissions_disabled: true,
+                    acl_fingerprint: "stale-fingerprint".to_string(),
+                },
+            )])),
+            permission_model_version: Some(
+                omni_google_connector::models::SA_DIRECT_PERMISSION_MODEL_VERSION.to_string(),
+            ),
+            ..Default::default()
+        };
+
+        let sync_result = run_sa_sync_with_checkpoint(
+            &mock_base,
+            sa_source(),
+            sa_credentials(&mock_base),
+            SyncType::Incremental,
+            checkpoint,
+        )
+        .await;
+
+        if let Some(value) = previous_drive_base {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        sync_result?;
+
+        assert!(
+            state.file_list_calls() >= 1,
+            "folder ACL fingerprint change must trigger a full re-traversal"
         );
 
         Ok(())


### PR DESCRIPTION
- Limited-access folders (inheritedPermissionsDisabled) now act as permission boundaries: files inside are indexed for drive organizers + the folder's direct grants instead of the full drive ACL, closing an over-exposure leak.
- Effective per-file ACLs computed per Google's model: drive ACL baseline, expansive union of normal-folder direct grants, inherited entries filtered via permissionDetails, deepest limited-access boundary wins.
- Folder access fingerprints persisted in the checkpoint; incremental syncs detect folder-ACL changes and force an uncut full re-traversal so descendants get corrected ACLs.
- Permission-model version bump forces one full uncut re-traversal on first run after deploy, re-emitting existing documents with corrected ACLs.
- Replaced the hard SA-direct group-sync skip with a best-effort Admin SDK sync using the service account's own token; 403/absence degrades to warn + continue, so group-granted documents are matchable when the SA holds a customer-level admin role.