### PR TITLE
fix(darwinbox): map real org-master fields and keep holiday names

### DIFF
--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -969,6 +969,13 @@ fn sanitize_action_response(action: &str, value: JsonValue, is_write: bool) -> J
         "attendance_status",
         "holiday_name",
         "holiday_date",
+        // Real holidaylist item fields. The provider sends `name` (not
+        // `holiday_name`) plus these flag keys; without them the sanitizer
+        // would strip every holiday's name and flags.
+        "name",
+        "holiday_repeats",
+        "is_optional",
+        "is_national",
         "display_name",
         "company_email_id",
         "department_name",
@@ -1674,6 +1681,40 @@ mod tests {
         assert_eq!(item["action_by"], json!("Mgr (EMP001)"));
         assert_eq!(item["applied_leave_id"], json!("AL1"));
         assert!(!projected.to_string().contains("SECRET"));
+    }
+
+    #[test]
+    fn response_projection_keeps_holiday_names() {
+        // Real holidaylist item shape: name/date/year plus flag keys. The
+        // sanitizer must keep the holiday name so get_holiday_calendar can
+        // report what the holiday actually is.
+        let projected = sanitize_action_response(
+            "get_holiday_calendar",
+            json!({
+                "status": 1,
+                "message": "Successfully Loaded All Holidays",
+                "holidays": [
+                    {
+                        "id": "a68f996eb7bec5",
+                        "name": "New Year's Holiday",
+                        "date": "2026-01-01",
+                        "year": "2026",
+                        "holiday_repeats": "No",
+                        "is_optional": "No",
+                        "is_national": "No",
+                        "salary": "SECRET-SALARY"
+                    }
+                ]
+            }),
+            false,
+        );
+        let item = &projected["holidays"][0];
+        assert_eq!(item["name"], json!("New Year's Holiday"));
+        assert_eq!(item["date"], json!("2026-01-01"));
+        assert_eq!(item["year"], json!("2026"));
+        assert_eq!(item["holiday_repeats"], json!("No"));
+        assert_eq!(item["is_national"], json!("No"));
+        assert!(item.get("salary").is_none());
     }
 
     #[test]

--- a/connectors/darwinbox/src/mappers.rs
+++ b/connectors/darwinbox/src/mappers.rs
@@ -63,6 +63,123 @@ pub fn format_org_master_item(item: &JsonValue, attr_key: &'static str) -> SafeD
     }
 }
 
+/// Safely format a department master record. The departmentlist endpoint uses
+/// `department_name`/`department_code` rather than the generic org-master
+/// `name`/`code` convention, so departments get a dedicated mapper.
+pub fn format_department_item(item: &JsonValue) -> SafeDocument {
+    let title = item
+        .get("department_name")
+        .and_then(JsonValue::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            item.get("name")
+                .and_then(JsonValue::as_str)
+                .filter(|s| !s.trim().is_empty())
+        })
+        .unwrap_or("Department")
+        .to_string();
+    let code = item
+        .get("department_code")
+        .and_then(JsonValue::as_str)
+        .filter(|s| !s.trim().is_empty())
+        .or_else(|| {
+            item.get("code")
+                .and_then(JsonValue::as_str)
+                .filter(|s| !s.trim().is_empty())
+        })
+        .unwrap_or_default();
+
+    let mut body = format!("# {title}\n\n- Code: {code}");
+    for (label, key) in [
+        ("Parent Department Code", "parent_department_code"),
+        ("Top Department", "top_department"),
+        ("Business Unit", "business_unit"),
+        ("Cost Center", "cost_center"),
+        ("Department HOD", "departments_hod"),
+        ("Status", "status"),
+        ("Effective From", "effective_from_date"),
+    ] {
+        if let Some(value) = item
+            .get(key)
+            .and_then(JsonValue::as_str)
+            .filter(|s| !s.trim().is_empty())
+        {
+            body.push_str(&format!("\n- {label}: {value}"));
+        }
+    }
+
+    let mut attributes = vec![("department".to_string(), title.clone())];
+    if !code.is_empty() {
+        attributes.push(("department_code".to_string(), code.to_string()));
+    }
+    SafeDocument {
+        title,
+        body,
+        attributes,
+    }
+}
+
+/// Safely format an office location master record. The officelocationlist
+/// endpoint returns `work_area`/`loc_type_id`/`city`-style fields rather than
+/// the generic org-master `name`/`code` convention, so office locations get a
+/// dedicated mapper.
+pub fn format_office_location_item(item: &JsonValue) -> SafeDocument {
+    let work_area = item
+        .get("work_area")
+        .and_then(JsonValue::as_str)
+        .filter(|s| !s.trim().is_empty());
+    let city = item
+        .get("city")
+        .and_then(JsonValue::as_str)
+        .filter(|s| !s.trim().is_empty());
+    let title = match (work_area, city) {
+        (Some(work_area), Some(city)) => format!("{work_area} — {city}"),
+        (Some(work_area), None) => work_area.to_string(),
+        (None, Some(city)) => city.to_string(),
+        (None, None) => item
+            .get("company_name")
+            .and_then(JsonValue::as_str)
+            .filter(|s| !s.trim().is_empty())
+            .unwrap_or("Office Location")
+            .to_string(),
+    };
+    let code = item
+        .get("loc_type_id")
+        .and_then(JsonValue::as_str)
+        .unwrap_or_default();
+
+    let mut body = format!("# {title}");
+    for (label, key) in [
+        ("Work Area", "work_area"),
+        ("Company", "company_name"),
+        ("Address", "address"),
+        ("City", "city"),
+        ("State", "state"),
+        ("Country", "country"),
+        ("Pin Code", "pin_code"),
+        ("Location Head", "location_head"),
+        ("Status", "status"),
+    ] {
+        if let Some(value) = item
+            .get(key)
+            .and_then(JsonValue::as_str)
+            .filter(|s| !s.trim().is_empty())
+        {
+            body.push_str(&format!("\n- {label}: {value}"));
+        }
+    }
+
+    let mut attributes = vec![("office_location".to_string(), title.clone())];
+    if !code.is_empty() {
+        attributes.push(("office_location_code".to_string(), code.to_string()));
+    }
+    SafeDocument {
+        title,
+        body,
+        attributes,
+    }
+}
+
 /// Read a string field from a provider item, preferring `key` and falling
 /// back to `alias` so both Darwinbox response key variants are accepted.
 pub fn field_with_alias<'a>(item: &'a JsonValue, key: &'a str, alias: &'a str) -> Option<&'a str> {
@@ -284,6 +401,103 @@ pub fn format_ats_job_item(item: &JsonValue) -> SafeDocument {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn department_mapper_formats_real_api_shape() {
+        // Real departmentlist record: department_name/department_code, not the
+        // generic name/code convention.
+        let document = format_department_item(&serde_json::json!({
+            "parent_company_id": "Example Corp",
+            "department_name": "ARCHIVED--New Member Development",
+            "department_code": "WWS_NMD",
+            "parent_department_code": "SALES",
+            "top_department": "Sales",
+            "cost_center": "",
+            "departments_hod": "Santosh Martin (WW1600)",
+            "status": "Active",
+            "effective_from_date": "05-07-2023"
+        }));
+        assert_eq!(document.title, "ARCHIVED--New Member Development");
+        assert!(document.body.contains("- Code: WWS_NMD"));
+        assert!(document.body.contains("- Parent Department Code: SALES"));
+        assert!(document.body.contains("- Top Department: Sales"));
+        assert!(
+            document
+                .body
+                .contains("- Department HOD: Santosh Martin (WW1600)")
+        );
+        assert!(document.body.contains("- Status: Active"));
+        assert!(document.body.contains("- Effective From: 05-07-2023"));
+        assert!(document.attributes.contains(&(
+            "department".to_string(),
+            "ARCHIVED--New Member Development".to_string()
+        )));
+        assert!(
+            document
+                .attributes
+                .contains(&("department_code".to_string(), "WWS_NMD".to_string()))
+        );
+        assert!(!document.title.contains("unknown"));
+    }
+
+    #[test]
+    fn department_mapper_falls_back_to_generic_keys() {
+        let document = format_department_item(&serde_json::json!({
+            "name": "Corporate",
+            "code": "CORP",
+            "status": "active"
+        }));
+        assert_eq!(document.title, "Corporate");
+        assert!(document.body.contains("- Code: CORP"));
+    }
+
+    #[test]
+    fn office_location_mapper_formats_real_api_shape() {
+        // Real officelocationlist record: work_area/loc_type_id/city fields,
+        // none of which matched the generic org-master convention.
+        let document = format_office_location_item(&serde_json::json!({
+            "company_name": "Temporary Employees",
+            "address": "Prestige Central Ground Floor, 36, Infantry Rd, Bengaluru, Karnataka 560001",
+            "pin_code": " 560001",
+            "city": "Bengaluru",
+            "state": "Karnataka",
+            "country": "India",
+            "location_head": "",
+            "work_area": "BLR01",
+            "status": "Active",
+            "loc_type_id": "5db93215ece4c"
+        }));
+        assert_eq!(document.title, "BLR01 — Bengaluru");
+        assert!(document.body.contains("- Work Area: BLR01"));
+        assert!(document.body.contains("- Company: Temporary Employees"));
+        assert!(document.body.contains("- City: Bengaluru"));
+        assert!(document.body.contains("- State: Karnataka"));
+        assert!(document.body.contains("- Country: India"));
+        assert!(document.body.contains("- Status: Active"));
+        assert!(document.attributes.contains(&(
+            "office_location".to_string(),
+            "BLR01 — Bengaluru".to_string()
+        )));
+        assert!(document.attributes.contains(&(
+            "office_location_code".to_string(),
+            "5db93215ece4c".to_string()
+        )));
+        assert!(!document.title.contains("unknown"));
+    }
+
+    #[test]
+    fn office_location_mapper_falls_back_to_company_name() {
+        let document = format_office_location_item(&serde_json::json!({
+            "company_name": "Example Corp",
+            "loc_type_id": "abc123"
+        }));
+        assert_eq!(document.title, "Example Corp");
+        assert!(
+            document
+                .attributes
+                .contains(&("office_location_code".to_string(), "abc123".to_string()))
+        );
+    }
 
     #[test]
     fn holiday_mapper_formats_typed_item() {

--- a/connectors/darwinbox/src/sync.rs
+++ b/connectors/darwinbox/src/sync.rs
@@ -418,8 +418,11 @@ async fn sync_org_master(
             );
             continue;
         };
-        let document =
-            mappers::format_org_master_item(item, content_type_to_attribute_key(content_type));
+        let document = match content_type {
+            "department" => mappers::format_department_item(item),
+            "office_location" => mappers::format_office_location_item(item),
+            _ => mappers::format_org_master_item(item, content_type_to_attribute_key(content_type)),
+        };
         let content_id = ctx.store_content(&document.body).await?;
 
         let document_id = format!("{external_prefix}:{id}");
@@ -673,6 +676,10 @@ fn extract_stable_id(value: &JsonValue) -> Option<String> {
         "department_code",
         "designation_code",
         "work_area_code",
+        "loc_type_id",
+        "work_area",
+        "city_code",
+        "city_id",
         "job_level",
         "job_level_code",
         "name",
@@ -951,6 +958,218 @@ mod tests {
         );
         assert_eq!(event["metadata"]["content_type"], "employee_manager");
         assert_eq!(event["metadata"]["title"], "Dummy1 Test2");
+    }
+
+    #[tokio::test]
+    async fn department_sync_emits_documents_from_real_api_field_names() {
+        // Real departmentlist records use department_name/department_code.
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/orgmasterapi/departmentlist"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "status": 1,
+                "message": "Data Loaded Successfully",
+                "data": [{
+                    "parent_company_id": "Example Corp",
+                    "department_name": "ARCHIVED--New Member Development",
+                    "department_code": "WWS_NMD",
+                    "parent_department_code": "SALES",
+                    "top_department": "Sales",
+                    "departments_hod": "Santosh Martin (WW1600)",
+                    "status": "Active",
+                    "effective_from_date": "05-07-2023"
+                }]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/content"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"content_id": "c-1"})))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/events/batch"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/sync/run-1/scanned"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+            "base_url": server.uri(),
+            "authorization": { "participant_mode": "all" }
+        }))
+        .unwrap();
+        let credentials = crate::credentials::DarwinboxCredentials::Basic {
+            username: "api-user".to_string(),
+            password: "secret".to_string(),
+            api_key: "api-key".to_string(),
+            dataset_key: "dataset-key".to_string(),
+        };
+        let client = DarwinboxClient::new(&config, credentials).unwrap();
+        let ctx = SyncContext::new(
+            SdkClient::new(&server.uri()),
+            "run-1".to_string(),
+            "source-1".to_string(),
+            SourceType::Darwinbox,
+            SyncType::Full,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        let response = client
+            .fetch_org_master("/orgmasterapi/departmentlist")
+            .await
+            .unwrap();
+        sync_org_master(
+            &config,
+            "department",
+            "darwinbox:department",
+            &response,
+            "source-1",
+            &ctx,
+        )
+        .await
+        .unwrap();
+        ctx.flush().await.unwrap();
+
+        let batch = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|request| request.url.path() == "/sdk/events/batch")
+            .expect("events batch should be emitted");
+        let body: JsonValue = serde_json::from_slice(&batch.body).unwrap();
+        let events = body["events"]
+            .as_array()
+            .expect("batch should carry events");
+        assert_eq!(events.len(), 1);
+        let event = &events[0];
+        assert_eq!(event["type"], "document_created");
+        assert_eq!(event["document_id"], "darwinbox:department:wws-nmd");
+        assert_eq!(event["metadata"]["content_type"], "department");
+        assert_eq!(
+            event["metadata"]["title"],
+            "ARCHIVED--New Member Development"
+        );
+    }
+
+    #[tokio::test]
+    async fn office_location_sync_emits_documents_with_loc_type_stable_id() {
+        // Real officelocationlist records: no id/code; the stable key is
+        // loc_type_id. Every record must produce a document (previously all
+        // were skipped for lacking a stable ID).
+        let server = MockServer::start().await;
+        Mock::given(method("POST"))
+            .and(path("/orgmasterapi/officelocationlist"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+                "status": 1,
+                "message": "Data Loaded Successfully",
+                "data": [
+                    {
+                        "company_name": "Temporary Employees",
+                        "address": "Prestige Central Ground Floor, Bengaluru",
+                        "pin_code": " 560001",
+                        "city": "Bengaluru",
+                        "state": "Karnataka",
+                        "country": "India",
+                        "work_area": "BLR01",
+                        "status": "Active",
+                        "loc_type_id": "5db93215ece4c"
+                    },
+                    {
+                        "company_name": "Temporary Employees",
+                        "address": "Raheja Platinum, Mumbai",
+                        "pin_code": "400059",
+                        "city": "Mumbai",
+                        "state": "Maharashtra",
+                        "country": "India",
+                        "work_area": "WEST",
+                        "status": "Active",
+                        "loc_type_id": "5db9321cf1fd0"
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/content"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(json!({"content_id": "c-1"})))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/events/batch"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/sdk/sync/run-1/scanned"))
+            .respond_with(ResponseTemplate::new(200))
+            .mount(&server)
+            .await;
+
+        let config: DarwinboxSourceConfig = serde_json::from_value(json!({
+            "base_url": server.uri(),
+            "authorization": { "participant_mode": "all" }
+        }))
+        .unwrap();
+        let credentials = crate::credentials::DarwinboxCredentials::Basic {
+            username: "api-user".to_string(),
+            password: "secret".to_string(),
+            api_key: "api-key".to_string(),
+            dataset_key: "dataset-key".to_string(),
+        };
+        let client = DarwinboxClient::new(&config, credentials).unwrap();
+        let ctx = SyncContext::new(
+            SdkClient::new(&server.uri()),
+            "run-1".to_string(),
+            "source-1".to_string(),
+            SourceType::Darwinbox,
+            SyncType::Full,
+            Arc::new(AtomicBool::new(false)),
+        );
+
+        let response = client
+            .fetch_org_master("/orgmasterapi/officelocationlist")
+            .await
+            .unwrap();
+        sync_org_master(
+            &config,
+            "office_location",
+            "darwinbox:office_location",
+            &response,
+            "source-1",
+            &ctx,
+        )
+        .await
+        .unwrap();
+        ctx.flush().await.unwrap();
+
+        let batch = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|request| request.url.path() == "/sdk/events/batch")
+            .expect("events batch should be emitted");
+        let body: JsonValue = serde_json::from_slice(&batch.body).unwrap();
+        let events = body["events"]
+            .as_array()
+            .expect("batch should carry events");
+        assert_eq!(events.len(), 2);
+        assert_eq!(
+            events[0]["document_id"],
+            "darwinbox:office_location:5db93215ece4c"
+        );
+        assert_eq!(events[0]["metadata"]["title"], "BLR01 — Bengaluru");
+        assert_eq!(
+            events[1]["document_id"],
+            "darwinbox:office_location:5db9321cf1fd0"
+        );
+        assert_eq!(events[1]["metadata"]["title"], "WEST — Mumbai");
     }
 }
 


### PR DESCRIPTION
- Map real departmentlist field names (`department_name`/`department_code` plus parent dept, top department, HOD, status, effective date) so department documents get proper titles instead of `unknown`.
- Give officelocationlist records a stable ID and mapper: the endpoint returns only `loc_type_id`/`work_area`/`city`-style fields, so all 107 records were previously skipped for lacking an ID and zero office-location documents were produced.
- Add `name`/`holiday_repeats`/`is_optional`/`is_national` to the action response sanitizer allowlist; holidaylist items send `name` (not `holiday_name`), so `get_holiday_calendar` was stripping every holiday's name.
- Cover all three paths with mapper unit tests and sync integration tests asserting the real provider fields survive.