### PR TITLE
feat(darwinbox): add get_my_pending_tasks action

### DIFF
--- a/connectors/darwinbox/src/actions.rs
+++ b/connectors/darwinbox/src/actions.rs
@@ -37,6 +37,7 @@ pub fn action_endpoints(action: &str) -> &'static [&'static str] {
             "/masterapi/employee",
             "/leavesactionapi/leaveActionTakenLeaves",
         ],
+        "get_my_pending_tasks" => &["/masterapi/employee", "/orgmasterapi/getTasks"],
         "get_my_attendance" => &["/masterapi/employee", "/AttendanceDataApi/monthly"],
         "get_my_timesheet" => &[
             "/masterapi/employee",
@@ -86,6 +87,14 @@ pub fn action_policies() -> &'static [ActionPolicy] {
         },
         ActionPolicy {
             name: "get_my_leave_requests",
+            module: "employee_self_service",
+            mode: ActionMode::Read,
+            audience: "self",
+            is_write: false,
+            available: true,
+        },
+        ActionPolicy {
+            name: "get_my_pending_tasks",
             module: "employee_self_service",
             mode: ActionMode::Read,
             audience: "self",
@@ -396,6 +405,12 @@ pub fn action_definitions() -> Vec<ActionDefinition> {
                 json!({ "type": "object", "properties": { "from": { "type": "string" }, "to": { "type": "string" }, "action": { "type": "string" } }, "required": ["from", "to"], "additionalProperties": false }),
                 &source_types,
             ),
+            "get_my_pending_tasks" => read(
+                "get_my_pending_tasks",
+                "Get pending tasks (e.g. policy sign-offs, approvals) for the calling employee.",
+                json!({ "type": "object", "properties": {}, "additionalProperties": false }),
+                &source_types,
+            ),
             "get_my_attendance" => read(
                 "get_my_attendance",
                 "Get attendance for the calling employee.",
@@ -631,6 +646,11 @@ pub async fn execute_action(
                     action: optional_str(&params, "action").unwrap_or("0").to_string(),
                 })
                 .await?
+        }
+        "get_my_pending_tasks" => {
+            let employee = calling_employee.as_ref().expect("self action resolved caller");
+            let employee_no = employee_id(employee)?;
+            client.fetch_pending_tasks(employee_no).await?
         }
         "get_my_attendance" => {
             let employee = calling_employee.as_ref().expect("self action resolved caller");
@@ -983,6 +1003,24 @@ fn sanitize_action_response(action: &str, value: JsonValue, is_write: bool) -> J
         "office_area",
         "direct_manager_employee_id",
         "employee_type",
+        // getTasks envelope scalars: the aggregate counts at the top plus the
+        // per-task item fields (the caller sees only their own tasks).
+        "total_count",
+        "count",
+        "category_header",
+        "sub_category",
+        "user_id",
+        "policy_id",
+        "mobile_allowed",
+        "category",
+        "reportee_task",
+        "title",
+        "redirect_url",
+        "phase_id",
+        "actionid",
+        "approval_flow_set_id",
+        "separation_flow_id",
+        "created_on_timestamp",
     ];
     const SAFE_CONTAINER_KEYS: &[&str] = &[
         "employees",
@@ -995,6 +1033,16 @@ fn sanitize_action_response(action: &str, value: JsonValue, is_write: bool) -> J
         "timesheet",
         "attendance",
     ];
+    // Maps whose keys are provider-defined (getTasks groups tasks under
+    // dynamic category names and indexes items numerically). The keys cannot
+    // be allowlisted, so the whole map is kept but every value is still
+    // projected through the scalar/container allowlists.
+    const SAFE_MAP_CONTAINER_KEYS: &[&str] = &["tasks_data", "details"];
+    // Structured payloads with provider-defined keys whose values are plain
+    // scalar metadata (policy names/dates, action button labels, per-category
+    // counts) — no nested objects that could carry unknown fields. Kept
+    // verbatim because the keys are arbitrary labels.
+    const SAFE_RAW_KEYS: &[&str] = &["headers_data", "action_buttons", "category_wise_count"];
 
     fn project_object(value: JsonValue) -> JsonValue {
         let JsonValue::Object(object) = value else {
@@ -1004,7 +1052,31 @@ fn sanitize_action_response(action: &str, value: JsonValue, is_write: bool) -> J
             object
                 .into_iter()
                 .filter_map(|(key, value)| {
-                    if SAFE_SCALAR_KEYS.contains(&key.as_str())
+                    if SAFE_RAW_KEYS.contains(&key.as_str()) {
+                        // Verbatim passthrough for provider-defined maps.
+                        Some((key, value))
+                    } else if SAFE_MAP_CONTAINER_KEYS.contains(&key.as_str()) {
+                        // Dynamic-key map: keep the map but project every
+                        // value through the allowlists (e.g. getTasks' task
+                        // items indexed numerically under each category).
+                        let projected = match value {
+                            JsonValue::Object(items) => JsonValue::Object(
+                                items
+                                    .into_iter()
+                                    .map(|(item_key, item)| (item_key, project_object(item)))
+                                    .collect(),
+                            ),
+                            JsonValue::Array(items) => JsonValue::Array(
+                                items
+                                    .into_iter()
+                                    .filter(|item| item.is_object())
+                                    .map(project_object)
+                                    .collect(),
+                            ),
+                            _ => JsonValue::Null,
+                        };
+                        Some((key, projected))
+                    } else if SAFE_SCALAR_KEYS.contains(&key.as_str())
                         && !value.is_array()
                         && !value.is_object()
                     {
@@ -1718,6 +1790,68 @@ mod tests {
     }
 
     #[test]
+    fn response_projection_keeps_pending_task_payload() {
+        // Real getTasks response: category-keyed task groups with
+        // provider-defined header maps. The sanitizer must keep the task
+        // structure (headers_data etc.) while still stripping unknown keys.
+        let projected = sanitize_action_response(
+            "get_my_pending_tasks",
+            json!({
+                "status": 1,
+                "message": "success",
+                "data": {
+                    "total_count": 2,
+                    "category_wise_count": { "policy_sign_off": 2 },
+                    "tasks_data": {
+                        "policy_sign_off": {
+                            "count": 2,
+                            "category_header": "HR Policy Sign Off",
+                            "details": {
+                                "1": {
+                                    "id": "a69f91200353d3949170430",
+                                    "sub_category": null,
+                                    "meta": [],
+                                    "user_id": "226875",
+                                    "headers_data": {
+                                        "Policy Name": "Code Of Conduct - Section 8",
+                                        "Trigger Date with time zone": "05-May-2026",
+                                        "Is Overdue": false
+                                    },
+                                    "policy_id": "a69f8465f34acd",
+                                    "action_buttons": { "1": "ACT" },
+                                    "mobile_allowed": true,
+                                    "category": "policy_sign_off",
+                                    "reportee_task": false,
+                                    "title": "Please sign-off the policy by clicking on ACT button.",
+                                    "salary": "SECRET-SALARY"
+                                }
+                            }
+                        }
+                    }
+                }
+            }),
+            false,
+        );
+        let task = &projected["data"]["tasks_data"]["policy_sign_off"]["details"]["1"];
+        assert_eq!(task["id"], json!("a69f91200353d3949170430"));
+        assert_eq!(
+            task["title"],
+            json!("Please sign-off the policy by clicking on ACT button.")
+        );
+        assert_eq!(
+            task["headers_data"]["Policy Name"],
+            json!("Code Of Conduct - Section 8")
+        );
+        assert_eq!(task["action_buttons"]["1"], json!("ACT"));
+        assert_eq!(projected["data"]["total_count"], json!(2));
+        assert_eq!(
+            projected["data"]["category_wise_count"]["policy_sign_off"],
+            json!(2)
+        );
+        assert!(task.get("salary").is_none());
+    }
+
+    #[test]
     fn action_definitions_expose_leave_actions() {
         let definitions = action_definitions();
         let names = definitions
@@ -1729,6 +1863,7 @@ mod tests {
             "get_team_leave_calendar",
             "approve_leave_request",
             "reject_leave_request",
+            "get_my_pending_tasks",
         ] {
             assert!(names.contains(&name), "{name} should be exposed");
         }

--- a/connectors/darwinbox/src/client.rs
+++ b/connectors/darwinbox/src/client.rs
@@ -287,6 +287,18 @@ impl DarwinboxClient {
             .await
     }
 
+    pub async fn fetch_pending_tasks(
+        &self,
+        employee_id: &str,
+    ) -> std::result::Result<JsonValue, DarwinboxApiError> {
+        self.post_json(
+            "/orgmasterapi/getTasks",
+            json!({ "employee_id": employee_id }),
+            false,
+        )
+        .await
+    }
+
     pub async fn take_leave_decision(
         &self,
         request: LeaveDecisionRequest,
@@ -471,6 +483,7 @@ fn capability_for_endpoint(path: &str) -> &'static str {
         "/leavesactionapi/leavebalance" => "leave balance",
         "/leavesactionapi/holidaylist" => "holiday calendar",
         "/leavesactionapi/leaveActionTakenLeaves" => "leave requests",
+        "/orgmasterapi/getTasks" => "pending tasks",
         "/AttendanceDataApi/monthly" => "attendance",
         "/attendanceDataApi/timesheetdatewise" => "timesheet",
         "/leavesactionapi/importleave" => "leave changes",

--- a/connectors/darwinbox/tests/integration_test.rs
+++ b/connectors/darwinbox/tests/integration_test.rs
@@ -1003,3 +1003,107 @@ async fn reject_leave_request_is_blocked_by_read_only_source() {
     .unwrap_err();
     assert!(error.to_string().contains("read-only"));
 }
+
+#[tokio::test]
+async fn get_my_pending_tasks_resolves_caller_and_returns_task_payload() {
+    let server = MockServer::start().await;
+    mock_employee_master(&server, manager_employee_master()).await;
+    Mock::given(method("POST"))
+        .and(path("/orgmasterapi/getTasks"))
+        .respond_with(ResponseTemplate::new(200).set_body_json(json!({
+            "status": 1,
+            "message": "success",
+            "data": {
+                "total_count": 2,
+                "category_wise_count": { "policy_sign_off": 2 },
+                "tasks_data": {
+                    "policy_sign_off": {
+                        "count": 2,
+                        "category_header": "HR Policy Sign Off",
+                        "details": {
+                            "1": {
+                                "id": "task-1",
+                                "title": "Please sign-off the policy by clicking on ACT button.",
+                                "category": "policy_sign_off",
+                                "headers_data": {
+                                    "Policy Name": "Code Of Conduct - Section 8",
+                                    "Trigger Date with time zone": "05-May-2026",
+                                    "Is Overdue": false
+                                },
+                                "action_buttons": { "1": "ACT" },
+                                "user_id": "226875",
+                                "mobile_allowed": true,
+                                "reportee_task": false,
+                                "salary": "SECRET-SALARY"
+                            }
+                        }
+                    }
+                }
+            }
+        })))
+        .mount(&server)
+        .await;
+
+    let config = json!({
+        "base_url": server.uri(),
+        "read_only": true,
+        "authorization": { "participant_mode": "all" }
+    });
+    let response = execute_action(
+        "get_my_pending_tasks",
+        json!({}),
+        Some(test_credential()),
+        Some(test_source(config)),
+        test_actor("mgr@example.com"),
+    )
+    .await
+    .unwrap();
+    let body = response_body(response).await;
+    assert_eq!(body["status"], json!("success"));
+    let task = &body["result"]["data"]["tasks_data"]["policy_sign_off"]["details"]["1"];
+    assert_eq!(
+        task["title"],
+        json!("Please sign-off the policy by clicking on ACT button.")
+    );
+    assert_eq!(
+        task["headers_data"]["Policy Name"],
+        json!("Code Of Conduct - Section 8")
+    );
+    assert_eq!(body["result"]["data"]["total_count"], json!(2));
+    assert!(body.to_string().contains("SECRET") == false);
+
+    // The provider request must carry exactly the caller's employee id.
+    let requests = server
+        .received_requests()
+        .await
+        .expect("mock server should record requests")
+        .into_iter()
+        .filter(|request| request.url.path() == "/orgmasterapi/getTasks")
+        .collect::<Vec<_>>();
+    assert_eq!(requests.len(), 1);
+    let sent: serde_json::Value =
+        serde_json::from_slice(&requests[0].body).expect("request body should be JSON");
+    assert_eq!(sent["employee_id"], json!("EMP001"));
+}
+
+#[tokio::test]
+async fn get_my_pending_tasks_rejects_identity_spoofing() {
+    let server = MockServer::start().await;
+    mock_employee_master(&server, manager_employee_master()).await;
+
+    let config = json!({
+        "base_url": server.uri(),
+        "read_only": true,
+        "authorization": { "participant_mode": "all" }
+    });
+    let error = execute_action(
+        "get_my_pending_tasks",
+        json!({ "employee_id": "EMP999" }),
+        Some(test_credential()),
+        Some(test_source(config)),
+        test_actor("mgr@example.com"),
+    )
+    .await
+    .unwrap_err();
+    assert!(error.to_string().contains("employee_id"));
+}


### PR DESCRIPTION
- Add a self-service read action backed by `/orgmasterapi/getTasks` so employees can see pending tasks (policy sign-offs, approvals); the employer enables this API per-tenant and it currently goes unused.
- Derive the target from the caller's own email-resolved employee record, so users can only fetch their own tasks; caller-supplied identity fields stay rejected.
- Extend the response sanitizer with map-container and raw-passthrough key handling, since getTasks groups tasks under provider-defined category keys and label-keyed metadata maps that a fixed-key allowlist cannot enumerate.
- Follows the existing self-service pattern (`get_my_leave_balance` / `get_my_leave_requests`); no sync module since tasks are personal and transient.