### PR TITLE
feat(people): make people search answer org, contact and title questions

### DIFF
--- a/connectors/darwinbox/src/models.rs
+++ b/connectors/darwinbox/src/models.rs
@@ -85,7 +85,9 @@ pub struct EmployeeWireRecord {
     pub company_email_id: Option<String>,
     #[serde(default)]
     pub department_name: Option<String>,
-    #[serde(default)]
+    // The live tenant sends `job_title_name`; older tenants may still send
+    // `designation_name`. Accept both so job titles never silently drop.
+    #[serde(default, alias = "job_title_name")]
     pub designation_name: Option<String>,
     #[serde(default)]
     pub office_area: Option<String>,
@@ -676,6 +678,42 @@ mod tests {
         assert_eq!(
             response.employee_data[0].personal_mobile_no.as_deref(),
             Some("9876543210")
+        );
+    }
+
+    #[test]
+    fn employee_wire_record_accepts_job_title_name() {
+        // The live tenant sends `job_title_name` (not `designation_name`); the
+        // alias keeps job titles from silently dropping.
+        let response: EmployeeDataResponse = serde_json::from_value(serde_json::json!({
+            "status": 1,
+            "employee_data": [{
+                "employee_id": "E-1",
+                "company_email_id": "ada@example.com",
+                "job_title_name": "Lead, People Operations"
+            }]
+        }))
+        .unwrap();
+        assert_eq!(
+            response.employee_data[0].designation_name.as_deref(),
+            Some("Lead, People Operations")
+        );
+    }
+
+    #[test]
+    fn employee_wire_record_keeps_designation_name_fallback() {
+        let response: EmployeeDataResponse = serde_json::from_value(serde_json::json!({
+            "status": 1,
+            "employee_data": [{
+                "employee_id": "E-1",
+                "company_email_id": "ada@example.com",
+                "designation_name": "Designer"
+            }]
+        }))
+        .unwrap();
+        assert_eq!(
+            response.employee_data[0].designation_name.as_deref(),
+            Some("Designer")
         );
     }
 

--- a/services/ai/tools/people_handler.py
+++ b/services/ai/tools/people_handler.py
@@ -58,6 +58,14 @@ class PeopleSearchHandler:
                             "type": "string",
                             "description": "Filter results to this employee type, e.g. 'Full Time'.",
                         },
+                        "manager": {
+                            "type": "string",
+                            "description": "Filter results to the direct reports of this manager (by name or employee id), e.g. 'Priya Sharma'. Use to find who reports to someone.",
+                        },
+                        "job_title": {
+                            "type": "string",
+                            "description": "Filter results to this job title, e.g. 'Community Manager'.",
+                        },
                     },
                     "required": ["query"],
                 },
@@ -88,6 +96,8 @@ class PeopleSearchHandler:
             office_location=tool_input.get("office_location"),
             work_country=tool_input.get("work_country"),
             employee_type=tool_input.get("employee_type"),
+            manager=tool_input.get("manager"),
+            job_title=tool_input.get("job_title"),
         )
 
         try:
@@ -125,6 +135,12 @@ class PeopleSearchHandler:
                 parts.append(f"Work Country: {person.work_country}")
             if person.employee_id:
                 parts.append(f"Employee ID: {person.employee_id}")
+            if person.manager_name:
+                parts.append(f"Manager: {person.manager_name}")
+            if person.phone:
+                parts.append(f"Phone: {person.phone}")
+            if person.top_department:
+                parts.append(f"Top Department: {person.top_department}")
             lines.append("\n".join(parts))
 
         text = "\n\n".join(lines)

--- a/services/ai/tools/searcher_client.py
+++ b/services/ai/tools/searcher_client.py
@@ -73,6 +73,8 @@ class PeopleSearchRequest(BaseModel):
     office_location: str | None = None
     work_country: str | None = None
     employee_type: str | None = None
+    manager: str | None = None
+    job_title: str | None = None
 
 
 class PersonResult(BaseModel):
@@ -96,6 +98,11 @@ class PersonResult(BaseModel):
     confirmation_status: str | None = None
     employment_start_date: str | None = None
     employment_end_date: str | None = None
+    manager_id: str | None = None
+    manager_name: str | None = None
+    phone: str | None = None
+    avatar_url: str | None = None
+    top_department: str | None = None
     score: float
 
 
@@ -221,6 +228,8 @@ class SearcherClient:
                 "office_location",
                 "work_country",
                 "employee_type",
+                "manager",
+                "job_title",
             ):
                 value = getattr(request, field)
                 if value:
@@ -278,9 +287,7 @@ class SearcherClient:
         )
         if response.status_code == 200:
             return CapabilitiesSyncResponse.model_validate(response.json())
-        logger.error(
-            f"Capability sync error: {response.status_code} - {response.text}"
-        )
+        logger.error(f"Capability sync error: {response.status_code} - {response.text}")
         raise SearcherError(
             message=f"Capability sync failed: {response.status_code} {response.text}",
             request=response.request,

--- a/services/searcher/src/handlers.rs
+++ b/services/searcher/src/handlers.rs
@@ -463,6 +463,8 @@ pub struct PeopleSearchQuery {
     pub office_location: Option<String>,
     pub work_country: Option<String>,
     pub employee_type: Option<String>,
+    pub manager: Option<String>,
+    pub job_title: Option<String>,
 }
 
 pub async fn people_search(
@@ -477,6 +479,8 @@ pub async fn people_search(
         office_location: non_empty(&query.office_location),
         work_country: non_empty(&query.work_country),
         employee_type: non_empty(&query.employee_type),
+        manager: non_empty(&query.manager),
+        job_title: non_empty(&query.job_title),
     };
 
     let results = person_repo
@@ -507,6 +511,11 @@ pub async fn people_search(
             confirmation_status: p.confirmation_status,
             employment_start_date: p.employment_start_date,
             employment_end_date: p.employment_end_date,
+            manager_id: p.manager_id,
+            manager_name: p.manager_name,
+            phone: p.phone,
+            avatar_url: p.avatar_url,
+            top_department: p.top_department,
             score: p.score,
         })
         .collect();

--- a/services/searcher/src/models.rs
+++ b/services/searcher/src/models.rs
@@ -206,6 +206,16 @@ pub struct PersonResult {
     pub employment_start_date: Option<chrono::NaiveDate>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub employment_end_date: Option<chrono::NaiveDate>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manager_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub manager_name: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub phone: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub avatar_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub top_department: Option<String>,
     pub score: f32,
 }
 

--- a/services/searcher/tests/integration_tests.rs
+++ b/services/searcher/tests/integration_tests.rs
@@ -1812,6 +1812,118 @@ async fn test_person_search_structured_filters_and_rich_fields() -> Result<()> {
     Ok(())
 }
 
+#[tokio::test]
+async fn test_people_search_manager_filter_and_manager_name() -> Result<()> {
+    let fixture = SearcherTestFixture::new().await?;
+    let pool = fixture.test_env.db_pool.pool();
+    let person_repo = PersonRepository::new(pool);
+
+    // Insert a manager and two reportees; reportees reference the manager id.
+    sqlx::query(
+        r#"
+        INSERT INTO people (
+            id, email, display_name, job_title, department, office_location,
+            employee_id, manager_id, is_active, source_data
+        ) VALUES (
+            'mgr-id-000000001', 'mgr@example.com', 'Maya Rao',
+            'Director', 'Marketing', 'Paris', 'EMP-1', NULL, true, '{}'
+        )
+        ON CONFLICT (id) DO NOTHING
+        "#,
+    )
+    .execute(pool)
+    .await?;
+    sqlx::query(
+        r#"
+        INSERT INTO people (
+            id, email, display_name, job_title, department, office_location,
+            employee_id, manager_id, is_active, source_data
+        ) VALUES
+        (
+            'rep1-id-000000001', 'r1@example.com', 'Riya One',
+            'Associate', 'Marketing', 'Paris', 'EMP-2',
+            'mgr-id-000000001', true, '{}'
+        ),
+        (
+            'rep2-id-000000001', 'r2@example.com', 'Rahul Two',
+            'Associate', 'Engineering', 'Bengaluru', 'EMP-3',
+            'mgr-id-000000001', true, '{}'
+        ),
+        (
+            'zoe-id-000000001', 'zoe@example.com', 'Zoe Three',
+            'Associate', 'Engineering', 'Bengaluru', 'EMP-4', NULL, true, '{}'
+        )
+        ON CONFLICT (id) DO NOTHING
+        "#,
+    )
+    .execute(pool)
+    .await?;
+
+    // manager filter by manager display name -> exactly the two reportees.
+    let results = person_repo
+        .search_people(
+            "example.com",
+            10,
+            &PersonSearchFilter {
+                manager: Some("Maya Rao".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    let emails: Vec<&str> = results.iter().map(|r| r.email.as_str()).collect();
+    assert!(
+        emails.contains(&"r1@example.com") && emails.contains(&"r2@example.com"),
+        "expected both reportees under Maya, got {emails:?}"
+    );
+    assert!(
+        !emails.contains(&"mgr@example.com") && !emails.contains(&"zoe@example.com"),
+        "manager and unrelated people must not appear, got {emails:?}"
+    );
+
+    // manager filter by employee id works too.
+    let results = person_repo
+        .search_people(
+            "example.com",
+            10,
+            &PersonSearchFilter {
+                manager: Some("EMP-1".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert_eq!(results.len(), 2);
+
+    // manager_name is resolved from the manager_id self-join.
+    let results = person_repo
+        .search_people("riya", 10, &PersonSearchFilter::default())
+        .await?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].manager_name.as_deref(), Some("Maya Rao"));
+    assert_eq!(results[0].manager_id.as_deref(), Some("mgr-id-000000001"));
+
+    // A person without a manager reports no manager_name.
+    let results = person_repo
+        .search_people("zoe", 10, &PersonSearchFilter::default())
+        .await?;
+    assert_eq!(results[0].manager_name, None);
+
+    // job_title filter narrows to a title.
+    let results = person_repo
+        .search_people(
+            "example.com",
+            10,
+            &PersonSearchFilter {
+                job_title: Some("Director".to_string()),
+                ..Default::default()
+            },
+        )
+        .await?;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].email, "mgr@example.com");
+
+    Ok(())
+}
+
 // ============================================================================
 // Special Character / Tantivy Escaping Tests
 // ============================================================================

--- a/shared/src/db/repositories/person.rs
+++ b/shared/src/db/repositories/person.rs
@@ -32,6 +32,8 @@ pub struct PersonSearchFilter {
     pub office_location: Option<String>,
     pub work_country: Option<String>,
     pub employee_type: Option<String>,
+    pub manager: Option<String>,
+    pub job_title: Option<String>,
 }
 
 #[derive(Debug, Clone, sqlx::FromRow)]
@@ -56,6 +58,11 @@ pub struct PersonSearchResult {
     pub confirmation_status: Option<String>,
     pub employment_start_date: Option<chrono::NaiveDate>,
     pub employment_end_date: Option<chrono::NaiveDate>,
+    pub manager_id: Option<String>,
+    pub manager_name: Option<String>,
+    pub phone: Option<String>,
+    pub avatar_url: Option<String>,
+    pub top_department: Option<String>,
     pub score: f32,
 }
 
@@ -129,15 +136,21 @@ impl PersonRepository {
                    p.office_location, p.work_country, p.employee_id, p.employee_type,
                    p.cost_center, p.grade, p.band, p.confirmation_status,
                    p.employment_start_date, p.employment_end_date,
+                   p.manager_id, m.display_name AS manager_name,
+                   p.phone, p.avatar_url, p.top_department,
                    pdb.score(p.id) AS score
             FROM people p
+            LEFT JOIN people m ON m.id = p.manager_id
             WHERE p.is_active = true
               AND p.id @@@ pdb.parse(query_string => $1, lenient => true)
               AND ($2::text IS NULL OR p.department @@@ $2)
               AND ($3::text IS NULL OR p.office_location @@@ $3)
               AND ($4::text IS NULL OR p.work_country @@@ $4)
               AND ($5::text IS NULL OR p.employee_type @@@ $5)
-            ORDER BY score DESC LIMIT $6
+              AND ($6::text IS NULL OR m.display_name @@@ $6
+                    OR m.employee_id = $6)
+              AND ($7::text IS NULL OR p.job_title @@@ $7)
+            ORDER BY score DESC LIMIT $8
             "#,
         )
         .bind(query)
@@ -145,6 +158,8 @@ impl PersonRepository {
         .bind(filter.office_location.as_deref())
         .bind(filter.work_country.as_deref())
         .bind(filter.employee_type.as_deref())
+        .bind(filter.manager.as_deref())
+        .bind(filter.job_title.as_deref())
         .bind(limit)
         .fetch_all(&self.pool)
         .await?)


### PR DESCRIPTION
- Resolve `manager_name` in people search results via a self-join on `people.manager_id`, and surface `manager_id`, `phone`, `avatar_url`, and `top_department` so the agent can answer "who is my manager / manager of X" from the directory.
- Add `manager` and `job_title` filters to `search_people` (manager matches by display name or employee id) so "who are my reportees / reportees of X" and "everyone with title T" are single-call queries; expose both in the agent tool schema.
- Accept `job_title_name` from the Darwinbox employee API (the live tenant sends it instead of `designation_name`), so `people.job_title` stops being empty and title-based questions like "community manager for location X" work.
- Manager relationships were already synced (`people.manager_id` from `direct_manager_employee_id`) but never surfaced; phone remains NULL until the provider returns it, with the existing alias picking it up automatically if it ever does.