### PR TITLE
fix(darwinbox): hide inactive org-master records from search

### DIFF
--- a/connectors/darwinbox/src/mappers.rs
+++ b/connectors/darwinbox/src/mappers.rs
@@ -188,6 +188,16 @@ pub fn field_with_alias<'a>(item: &'a JsonValue, key: &'a str, alias: &'a str) -
         .or_else(|| item.get(alias).and_then(JsonValue::as_str))
 }
 
+/// True when an org-master record is currently active. Records whose status is
+/// anything other than `Active` (e.g. `Inactive`, `Archived`) stay indexed but
+/// are hidden from search via private permissions.
+pub fn record_is_active(item: &JsonValue) -> bool {
+    item.get("status")
+        .and_then(JsonValue::as_str)
+        .map(|status| status.trim().eq_ignore_ascii_case("active"))
+        .unwrap_or(true)
+}
+
 /// Format a holiday document from the typed holiday-list item.
 pub fn format_holiday_item(item: &models::HolidayItem) -> SafeDocument {
     let mut lines = vec![format!("# {}", item.name), format!("- Date: {}", item.date)];
@@ -497,6 +507,20 @@ mod tests {
                 .attributes
                 .contains(&("office_location_code".to_string(), "abc123".to_string()))
         );
+    }
+
+    #[test]
+    fn record_is_active_treats_only_active_as_active() {
+        assert!(record_is_active(&serde_json::json!({"status": "Active"})));
+        assert!(record_is_active(&serde_json::json!({"status": " active "})));
+        assert!(!record_is_active(
+            &serde_json::json!({"status": "Inactive"})
+        ));
+        assert!(!record_is_active(
+            &serde_json::json!({"status": "Archived"})
+        ));
+        // No status field: treated as active (employee-scoped tables etc.).
+        assert!(record_is_active(&serde_json::json!({"name": "X"})));
     }
 
     #[test]

--- a/connectors/darwinbox/src/sync.rs
+++ b/connectors/darwinbox/src/sync.rs
@@ -2,7 +2,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 
 use anyhow::{Result, bail};
 use chrono::Utc;
-use omni_connector_sdk::{ConnectorEvent, DocumentMetadata, SyncContext};
+use omni_connector_sdk::{ConnectorEvent, DocumentMetadata, DocumentPermissions, SyncContext};
 use serde_json::{Value as JsonValue, json};
 use tracing::{info, warn};
 
@@ -13,6 +13,15 @@ use crate::models::{DarwinboxCheckpoint, DarwinboxSyncModuleKey, ModuleCheckpoin
 
 /// Schema version for per-person events and successfully synced email state.
 const CURRENT_CHECKPOINT_SCHEMA: u16 = 4;
+
+/// Permissions for records that must stay indexed but hidden from every
+/// search: they match no clause of the searcher's permission filter
+/// (public:true OR users:... OR groups:...).
+const PRIVATE_PERMISSIONS: DocumentPermissions = DocumentPermissions {
+    public: false,
+    users: Vec::new(),
+    groups: Vec::new(),
+};
 
 /// (content_type, external prefix, API path) for each org master entity.
 const ORG_MASTERS: &[(&str, &str, &str)] = &[
@@ -426,6 +435,11 @@ async fn sync_org_master(
         let content_id = ctx.store_content(&document.body).await?;
 
         let document_id = format!("{external_prefix}:{id}");
+        let doc_permissions = if mappers::record_is_active(item) {
+            &permissions
+        } else {
+            &PRIVATE_PERMISSIONS
+        };
         emit_document(
             ctx,
             content_type,
@@ -433,7 +447,7 @@ async fn sync_org_master(
             &document_id,
             content_id,
             &document,
-            &permissions,
+            doc_permissions,
         )
         .await?;
         count += 1;
@@ -601,6 +615,11 @@ where
         let content_id = ctx.store_content(&document.body).await?;
 
         let document_id = format!("{external_prefix}:{stable_id}");
+        let doc_permissions = if mappers::record_is_active(item) {
+            &permissions
+        } else {
+            &PRIVATE_PERMISSIONS
+        };
         emit_document(
             ctx,
             content_type,
@@ -608,7 +627,7 @@ where
             &document_id,
             content_id,
             &document,
-            &permissions,
+            doc_permissions,
         )
         .await?;
         count += 1;
@@ -978,6 +997,11 @@ mod tests {
                     "departments_hod": "Santosh Martin (WW1600)",
                     "status": "Active",
                     "effective_from_date": "05-07-2023"
+                }, {
+                    "department_name": "Growth Marketing & Partnerships",
+                    "department_code": "WWS_GMP",
+                    "top_department": "Brand & Marketing",
+                    "status": "Inactive"
                 }]
             })))
             .mount(&server)
@@ -1046,7 +1070,7 @@ mod tests {
         let events = body["events"]
             .as_array()
             .expect("batch should carry events");
-        assert_eq!(events.len(), 1);
+        assert_eq!(events.len(), 2);
         let event = &events[0];
         assert_eq!(event["type"], "document_created");
         assert_eq!(event["document_id"], "darwinbox:department:wws-nmd");
@@ -1055,6 +1079,13 @@ mod tests {
             event["metadata"]["title"],
             "ARCHIVED--New Member Development"
         );
+        assert_eq!(event["permissions"]["public"], json!(true));
+        // Inactive records stay indexed but are hidden from search.
+        let inactive = &events[1];
+        assert_eq!(inactive["document_id"], "darwinbox:department:wws-gmp");
+        assert_eq!(inactive["permissions"]["public"], json!(false));
+        assert_eq!(inactive["permissions"]["users"], json!([]));
+        assert_eq!(inactive["permissions"]["groups"], json!([]));
     }
 
     #[tokio::test]


### PR DESCRIPTION
- Org-master records with a status other than `Active` (Inactive/Archived) stayed fully public, so archived departments, inactive offices, and archived job levels surfaced in every search.
- Keep them indexed but make them invisible to search by emitting them with empty permissions (`public: false`, no users/groups), which matches no clause of the searcher's permission filter.
- Active records and records without a status field (e.g. employee-scoped tables) are unchanged.