### PR TITLE
feat(ai): rename search_documents tool to search and broaden its scope

### DIFF
--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -47,7 +47,7 @@ Current date and time: {current_datetime}
 Connected apps: {connected_apps}
 {toolsets_section}
 # Searching
-- The `search_documents` tool is the primary tool to query the Omni unified index that syncs data from all of the above connected apps.
+- The `search` tool is the primary tool to query the Omni unified index that syncs data from all of the above connected apps (documents, emails, messages, pages, and anything else connectors sync). For people-directory lookups (a person's title, manager, email or office), use `search_people` instead.
 {web_tool_lines}
 - Search results include relevant content snippets (highlights) extracted from the indexed documents. For most factual questions, these snippets already contain the answer — use them directly without calling `read_document`.
 - Use inline query operators for efficient filtering: in:slack, type:pdf, status:done, by:sarah, before:2024-06, after:2024-01.
@@ -67,7 +67,7 @@ Connected apps: {connected_apps}
 - Always search for **what the user is looking for** (facts, dates, decisions), not for document names or filenames. For example: instead of "termination_letter_employee_2026.pdf", search for "employee termination date last working day".
 - Never copy-paste a filename into the search query. The index contains the full document text — search for words that would appear inside the document.
 - Never re-search for a document you already found. If a search returned a document that seems relevant but the highlights don't have enough detail, use `read_document` with the `[_ref:ULID]` value from the result, not a new search with the filename.
-- If you find a document but need its full content, pass `document_id` to `search_documents` to search within that specific document: `{{"query": "letzter Arbeitstag", "document_id": "_ref:ULID"}}`. This returns all matching chunks from that single document.
+- If you find a document but need its full content, pass `document_id` to `search` to search within that specific document: `{{"query": "letzter Arbeitstag", "document_id": "_ref:ULID"}}`. This returns all matching chunks from that single document.
 
 # Taking actions
 - Before executing a write action, state exactly what you will do and why in one sentence. The user will be prompted to approve or deny.
@@ -119,7 +119,7 @@ Current date and time: {current_datetime}
 Connected apps: {connected_apps}
 {toolsets_section}
 # Searching
-- Use `search_documents` for internal workplace information from connected apps.
+- Use `search` for internal workplace information from connected apps.
 {web_tool_lines}
 - Use inline query operators for efficient filtering: in:slack, type:pdf, status:done, by:sarah, before:2024-06, after:2024-01.
 - Use `resource_search`/`load_resource` for connector-exposed MCP reference resources; read large resources in line-number chunks.
@@ -155,7 +155,7 @@ Connected apps: {connected_apps}
 - This is a read-only session. No write actions are available.
 
 # Searching
-- Use `search_documents` for internal workplace information from connected apps.
+- Use `search` for internal workplace information from connected apps.
 {web_tool_lines}
 - Use inline query operators for efficient filtering: in:slack, type:pdf, status:done, by:sarah, before:2024-06, after:2024-01.
 - Use `resource_search`/`load_resource` for connector-exposed MCP reference resources; read large resources in line-number chunks.
@@ -471,7 +471,9 @@ def _format_execution_log(execution_log: list[dict], max_chars: int = 5000) -> s
 
 
 def format_run_history(
-    runs: list, max_detailed: int = 3, user_configuration: UserConfiguration | None = None
+    runs: list,
+    max_detailed: int = 3,
+    user_configuration: UserConfiguration | None = None,
 ) -> str:
     """Format agent run history for injection into the system prompt.
 
@@ -492,9 +494,15 @@ def format_run_history(
     sections.append(f"## Agent Run History ({len(runs)} most recent runs)\n")
 
     for i, run in enumerate(runs):
-        started = format_datetime(run.started_at, user_configuration) if run.started_at else "N/A"
+        started = (
+            format_datetime(run.started_at, user_configuration)
+            if run.started_at
+            else "N/A"
+        )
         completed = (
-            format_datetime(run.completed_at, user_configuration) if run.completed_at else "N/A"
+            format_datetime(run.completed_at, user_configuration)
+            if run.completed_at
+            else "N/A"
         )
 
         header = f"### Run {i+1} — {started}"
@@ -544,7 +552,9 @@ def build_agent_chat_system_prompt(
 
     connected_apps = ", ".join(display_names) if display_names else "None"
     user_line = _format_user_line(user_name, user_email)
-    run_history_section = format_run_history(runs, user_configuration=user_configuration)
+    run_history_section = format_run_history(
+        runs, user_configuration=user_configuration
+    )
 
     prompt = AGENT_CHAT_SYSTEM_PROMPT_TEMPLATE.format(
         agent_name=agent.name,

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -176,7 +176,7 @@ def message_start_event():
 
 def tool_call_events(
     tool_call_json: dict[str, Any],
-    tool_name: str = "search_documents",
+    tool_name: str = "search",
     tool_id: str = "toolu_test",
 ):
     """Yield Anthropic SDK events simulating a tool_use content block."""
@@ -210,7 +210,7 @@ def tool_call_events(
 
 def thinking_tool_call_events(
     tool_call_json: dict[str, Any],
-    tool_name: str = "search_documents",
+    tool_name: str = "search",
     tool_id: str = "toolu_think",
 ):
     """Yield Anthropic SDK events simulating a tool_use turn on a model that
@@ -342,7 +342,7 @@ def empty_text_response_events():
 def create_mock_llm(
     tool_call_json: dict[str, Any],
     response_text: str = "Here are the results.",
-    tool_name: str = "search_documents",
+    tool_name: str = "search",
 ):
     """Return a mock LLMProvider: call 1 = tool call, call 2+ = text response."""
     call_count = 0
@@ -605,7 +605,7 @@ class GatedRecordingLLM:
         elif kind == "tool_call":
             for event in tool_call_events(
                 payload["input"],
-                tool_name=payload.get("name", "search_documents"),
+                tool_name=payload.get("name", "search"),
                 tool_id=payload.get("id", f"toolu_{call_idx}"),
             ):
                 yield event
@@ -614,7 +614,7 @@ class GatedRecordingLLM:
         elif kind == "thinking_tool_call":
             for event in thinking_tool_call_events(
                 payload["input"],
-                tool_name=payload.get("name", "search_documents"),
+                tool_name=payload.get("name", "search"),
                 tool_id=payload.get("id", f"toolu_{call_idx}"),
             ):
                 yield event

--- a/services/ai/tests/integration/test_agent_run_queue.py
+++ b/services/ai/tests/integration/test_agent_run_queue.py
@@ -11,7 +11,11 @@ from anthropic.types import MessageParam, ToolUseBlockParam
 from ulid import ULID
 
 import db.connection
-from agents.models import AgentRunAlreadyActive, AgentRunRetryPolicy, AgentRunTriggerType
+from agents.models import (
+    AgentRunAlreadyActive,
+    AgentRunRetryPolicy,
+    AgentRunTriggerType,
+)
 from agents.queue_worker import _execute_claimed_run
 from agents.repository import AgentRepository, AgentRunRepository
 from agents.scheduler import materialize_due_agent_runs
@@ -51,22 +55,38 @@ async def _create_agent(db_pool, user_id: str) -> str:
 def _policy(max_attempts: int = 3) -> AgentRunRetryPolicy:
     return AgentRunRetryPolicy(
         max_attempts=max_attempts,
-        backoff_delays=(timedelta(seconds=0), timedelta(seconds=0), timedelta(seconds=0)),
+        backoff_delays=(
+            timedelta(seconds=0),
+            timedelta(seconds=0),
+            timedelta(seconds=0),
+        ),
     )
 
 
 def _app_state_with_llm(mock_llm) -> AppState:
     app_state = AppState()
     from provider_cache import ResolvedModel
+
     async def _resolve_for_model(model_id: str):
-        return ResolvedModel(provider=mock_llm, model_record_id=model_id, model_name="mock-model")
+        return ResolvedModel(
+            provider=mock_llm, model_record_id=model_id, model_name="mock-model"
+        )
+
     async def _resolve_default():
-        return ResolvedModel(provider=mock_llm, model_record_id="mock-model", model_name="mock-model")
+        return ResolvedModel(
+            provider=mock_llm, model_record_id="mock-model", model_name="mock-model"
+        )
+
     async def _resolve_secondary_or_default():
-        return ResolvedModel(provider=mock_llm, model_record_id="mock-model", model_name="mock-model")
+        return ResolvedModel(
+            provider=mock_llm, model_record_id="mock-model", model_name="mock-model"
+        )
+
     app_state.provider_cache.resolve_for_model = _resolve_for_model
     app_state.provider_cache.resolve_default = _resolve_default
-    app_state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
+    app_state.provider_cache.resolve_secondary_or_default = (
+        _resolve_secondary_or_default
+    )
     app_state.searcher_tool = AsyncMock()
     app_state.content_storage = AsyncMock()
     app_state.redis_client = None
@@ -74,7 +94,9 @@ def _app_state_with_llm(mock_llm) -> AppState:
 
 
 @pytest.mark.asyncio
-async def test_create_run_if_idle_returns_conflict_for_active_run(db_pool, _patch_db_pool):
+async def test_create_run_if_idle_returns_conflict_for_active_run(
+    db_pool, _patch_db_pool
+):
     user_id, _ = await create_test_user(db_pool)
     agent_id = await _create_agent(db_pool, user_id)
     repo = AgentRunRepository(pool=db_pool)
@@ -122,7 +144,9 @@ async def test_cluster_concurrency_cap_blocks_claims(db_pool, _patch_db_pool):
 
 
 @pytest.mark.asyncio
-async def test_heartbeat_and_completion_are_fenced_by_claim_token(db_pool, _patch_db_pool):
+async def test_heartbeat_and_completion_are_fenced_by_claim_token(
+    db_pool, _patch_db_pool
+):
     user_id, _ = await create_test_user(db_pool)
     agent_id = await _create_agent(db_pool, user_id)
     repo = AgentRunRepository(pool=db_pool)
@@ -131,7 +155,9 @@ async def test_heartbeat_and_completion_are_fenced_by_claim_token(db_pool, _patc
     assert claim is not None
 
     assert not await repo.heartbeat_run(claim.run.id, "0" * 26, timedelta(minutes=5))
-    assert await repo.heartbeat_run(claim.run.id, claim.claim_token, timedelta(minutes=5))
+    assert await repo.heartbeat_run(
+        claim.run.id, claim.claim_token, timedelta(minutes=5)
+    )
 
     assert await repo.complete_run(claim.run.id, "0" * 26, "bad") is None
     completed = await repo.complete_run(claim.run.id, claim.claim_token, "done")
@@ -140,7 +166,9 @@ async def test_heartbeat_and_completion_are_fenced_by_claim_token(db_pool, _patc
 
 
 @pytest.mark.asyncio
-async def test_stale_lease_recovery_and_old_token_cannot_complete(db_pool, _patch_db_pool):
+async def test_stale_lease_recovery_and_old_token_cannot_complete(
+    db_pool, _patch_db_pool
+):
     user_id, _ = await create_test_user(db_pool)
     agent_id = await _create_agent(db_pool, user_id)
     repo = AgentRunRepository(pool=db_pool)
@@ -177,10 +205,14 @@ async def test_run_logs_are_fenced_and_ordered(db_pool, _patch_db_pool):
 
     tool_use = MessageParam(
         role="assistant",
-        content=[ToolUseBlockParam(type="tool_use", id="toolu_1", name="search", input={})],
+        content=[
+            ToolUseBlockParam(type="tool_use", id="toolu_1", name="search", input={})
+        ],
     )
     assert await repo.append_run_log_messages(claim.run.id, "0" * 26, [tool_use]) == []
-    rows = await repo.append_run_log_messages(claim.run.id, claim.claim_token, [tool_use])
+    rows = await repo.append_run_log_messages(
+        claim.run.id, claim.claim_token, [tool_use]
+    )
     assert len(rows) == 1
     assert rows[0].message_seq_num == 0
 
@@ -190,7 +222,9 @@ async def test_run_logs_are_fenced_and_ordered(db_pool, _patch_db_pool):
 
 
 @pytest.mark.asyncio
-async def test_scheduler_materializes_due_run_without_duplicate(db_pool, _patch_db_pool):
+async def test_scheduler_materializes_due_run_without_duplicate(
+    db_pool, _patch_db_pool
+):
     user_id, _ = await create_test_user(db_pool)
     agent_id = await _create_agent(db_pool, user_id)
     agent_repo = AgentRepository(pool=db_pool)
@@ -217,7 +251,9 @@ async def test_scheduler_materializes_due_run_without_duplicate(db_pool, _patch_
 
 
 @pytest.mark.asyncio
-async def test_queue_worker_executes_claimed_run_through_executor(db_pool, _patch_db_pool):
+async def test_queue_worker_executes_claimed_run_through_executor(
+    db_pool, _patch_db_pool
+):
     user_id, _ = await create_test_user(db_pool)
     agent_id = await _create_agent(db_pool, user_id)
     run_repo = AgentRunRepository(pool=db_pool)
@@ -225,10 +261,12 @@ async def test_queue_worker_executes_claimed_run_through_executor(db_pool, _patc
     claim = await run_repo.claim_next_run(10, timedelta(minutes=5), _policy())
     assert claim is not None
 
-    mock_llm = create_mock_llm_multi([
-        ("text", "The queued agent run completed."),
-        ("text", "Queued run summary."),
-    ])
+    mock_llm = create_mock_llm_multi(
+        [
+            ("text", "The queued agent run completed."),
+            ("text", "Queued run summary."),
+        ]
+    )
     await _execute_claimed_run(_app_state_with_llm(mock_llm), claim, _policy())
 
     completed = await run_repo.get_run(claim.run.id)
@@ -240,7 +278,9 @@ async def test_queue_worker_executes_claimed_run_through_executor(db_pool, _patc
 
 
 @pytest.mark.asyncio
-async def test_executor_recovers_interrupted_tool_call_from_run_logs(db_pool, _patch_db_pool):
+async def test_executor_recovers_interrupted_tool_call_from_run_logs(
+    db_pool, _patch_db_pool
+):
     user_id, _ = await create_test_user(db_pool)
     agent_id = await _create_agent(db_pool, user_id)
     run_repo = AgentRunRepository(pool=db_pool)
@@ -255,7 +295,7 @@ async def test_executor_recovers_interrupted_tool_call_from_run_logs(db_pool, _p
             ToolUseBlockParam(
                 type="tool_use",
                 id="toolu_interrupted",
-                name="search_documents",
+                name="search",
                 input={"query": "quarterly report"},
             )
         ],
@@ -264,13 +304,17 @@ async def test_executor_recovers_interrupted_tool_call_from_run_logs(db_pool, _p
         claim.run.id, claim.claim_token, [initial, interrupted_tool_use]
     )
 
-    mock_llm = create_mock_llm_multi([
-        ("text", "I saw the interrupted tool call and reconciled it."),
-        ("text", "Recovered interrupted run."),
-    ])
+    mock_llm = create_mock_llm_multi(
+        [
+            ("text", "I saw the interrupted tool call and reconciled it."),
+            ("text", "Recovered interrupted run."),
+        ]
+    )
     await _execute_claimed_run(_app_state_with_llm(mock_llm), claim, _policy())
 
     logs = await run_repo.list_run_logs(claim.run.id)
     log_text = str([log.message for log in logs])
     assert "previous attempt was interrupted" in log_text
-    assert (await run_repo.get_run(claim.run.id)).summary == "Recovered interrupted run."
+    assert (
+        await run_repo.get_run(claim.run.id)
+    ).summary == "Recovered interrupted run."

--- a/services/ai/tests/integration/test_chat_attribute_search.py
+++ b/services/ai/tests/integration/test_chat_attribute_search.py
@@ -1,4 +1,4 @@
-"""Integration tests for search_documents tool calls flowing through the chat SSE stream.
+"""Integration tests for search tool calls flowing through the chat SSE stream.
 
 Validates that the chat handler correctly maps LLM tool calls to SearchRequest
 and passes them to the searcher. Filters are now expressed via inline query
@@ -96,7 +96,7 @@ def create_mock_llm_with_invalid_tool_json(raw_json: str, response_text: str):
                 content_block=ToolUseBlock(
                     type="tool_use",
                     id="toolu_invalid_json",
-                    name="search_documents",
+                    name="search",
                     input={},
                 ),
             )
@@ -222,15 +222,25 @@ def _build_app(llm_provider, searcher_tool, model_id: str) -> FastAPI:
     app = FastAPI()
     app.state = AppState()
     from provider_cache import ResolvedModel
+
     async def _resolve_for_model(mid: str):
         return ResolvedModel(provider=llm_provider, model_record_id=mid, model_name=mid)
+
     async def _resolve_default():
-        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+        return ResolvedModel(
+            provider=llm_provider, model_record_id=model_id, model_name=model_id
+        )
+
     async def _resolve_secondary_or_default():
-        return ResolvedModel(provider=llm_provider, model_record_id=model_id, model_name=model_id)
+        return ResolvedModel(
+            provider=llm_provider, model_record_id=model_id, model_name=model_id
+        )
+
     app.state.provider_cache.resolve_for_model = _resolve_for_model
     app.state.provider_cache.resolve_default = _resolve_default
-    app.state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
+    app.state.provider_cache.resolve_secondary_or_default = (
+        _resolve_secondary_or_default
+    )
     app.state.searcher_tool = searcher_tool
     app.include_router(chat_router)
     return app

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -1058,7 +1058,7 @@ class TestStreamErrorPersistence:
                 (
                     "tool_call",
                     {
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "multi-turn"},
                         "id": "toolu_mt",
                     },
@@ -1139,7 +1139,7 @@ class TestStreamErrorPersistence:
                 (
                     "tool_call",
                     {
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "boom"},
                         "id": "toolu_boom",
                     },
@@ -1255,7 +1255,7 @@ class TestStreamStatusPending:
                     {
                         "type": "tool_use",
                         "id": tool_use_id,
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "test"},
                     }
                 ],
@@ -1268,7 +1268,7 @@ class TestStreamStatusPending:
         await approvals_repo.create_pending(
             chat_id=chat_id,
             user_id=_user_id,
-            tool_name="search_documents",
+            tool_name="search",
             tool_input={"query": "test"},
             tool_call_id=tool_use_id,
             approval_type=ToolApprovalType.APPROVAL,
@@ -1471,7 +1471,7 @@ class TestReconnectActive:
                 (
                     "tool_call",
                     {
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "test"},
                         "id": "toolu_b2_active",
                     },
@@ -1538,7 +1538,7 @@ class TestCancelEarly:
                 (
                     "tool_call",
                     {
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "cancel me"},
                         "id": "toolu_c2",
                     },
@@ -1662,7 +1662,7 @@ class TestCancelMidToolCall:
                 (
                     "tool_call",
                     {
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "test"},
                         "id": "toolu_mt_cancel",
                     },
@@ -1890,7 +1890,7 @@ class TestInterruptedToolCall:
                     {
                         "type": "tool_use",
                         "id": tool_use_id,
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "interrupted"},
                     }
                 ],
@@ -1946,7 +1946,7 @@ class TestMultiTurn:
                 (
                     "tool_call",
                     {
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "multi-turn"},
                         "id": "toolu_mt",
                     },
@@ -2020,7 +2020,7 @@ class TestMultiTurn:
                 (
                     "thinking_tool_call",
                     {
-                        "name": "search_documents",
+                        "name": "search",
                         "input": {"query": "leave balance"},
                         "id": "toolu_think123",
                     },

--- a/services/ai/tests/integration/test_dynamic_sources.py
+++ b/services/ai/tests/integration/test_dynamic_sources.py
@@ -508,7 +508,7 @@ async def test_build_registry_search_tool_has_dynamic_sources(
 
         # Verify search tool has query with operator syntax
         search_tools = result.registry.get_all_tools()
-        search_tool = next(t for t in search_tools if t["name"] == "search_documents")
+        search_tool = next(t for t in search_tools if t["name"] == "search")
         query_desc = search_tool["input_schema"]["properties"]["query"]["description"]
         assert "in:<source>" in query_desc
 
@@ -891,7 +891,7 @@ async def test_build_registry_no_sources_generic_description(
     result = await _build_registry(request, chat, is_admin=False, loaded_toolsets=set())
 
     search_tools = result.registry.get_all_tools()
-    search_tool = next(t for t in search_tools if t["name"] == "search_documents")
+    search_tool = next(t for t in search_tools if t["name"] == "search")
     query_desc = search_tool["input_schema"]["properties"]["query"]["description"]
     assert "in:<source>" in query_desc
 
@@ -944,7 +944,7 @@ async def test_build_registry_deleted_sources_excluded(
         )
 
         search_tools = result.registry.get_all_tools()
-        search_tool = next(t for t in search_tools if t["name"] == "search_documents")
+        search_tool = next(t for t in search_tools if t["name"] == "search")
         query_desc = search_tool["input_schema"]["properties"]["query"]["description"]
         assert "in:<source>" in query_desc
 

--- a/services/ai/tests/integration/test_model_prompt_and_tools.py
+++ b/services/ai/tests/integration/test_model_prompt_and_tools.py
@@ -64,8 +64,8 @@ class _RecordingSearcherClient:
         self.search_responses.append(response)
         return response
 
-    async def search_documents(self, request):
-        return await self.inner.search_documents(request)
+    async def search(self, request):
+        return await self.inner.search(request)
 
 
 class _RecordingLLM:
@@ -209,15 +209,25 @@ def _build_app(llm: _RecordingLLM, model_id: str) -> FastAPI:
     app = FastAPI()
     app.state = AppState()
     from provider_cache import ResolvedModel
+
     async def _resolve_for_model(mid: str):
         return ResolvedModel(provider=llm, model_record_id=mid, model_name=mid)
+
     async def _resolve_default():
-        return ResolvedModel(provider=llm, model_record_id=model_id, model_name=model_id)
+        return ResolvedModel(
+            provider=llm, model_record_id=model_id, model_name=model_id
+        )
+
     async def _resolve_secondary_or_default():
-        return ResolvedModel(provider=llm, model_record_id=model_id, model_name=model_id)
+        return ResolvedModel(
+            provider=llm, model_record_id=model_id, model_name=model_id
+        )
+
     app.state.provider_cache.resolve_for_model = _resolve_for_model
     app.state.provider_cache.resolve_default = _resolve_default
-    app.state.provider_cache.resolve_secondary_or_default = _resolve_secondary_or_default
+    app.state.provider_cache.resolve_secondary_or_default = (
+        _resolve_secondary_or_default
+    )
     searcher_tool = SearcherTool()
     recording_client = _RecordingSearcherClient(searcher_tool.client)
     searcher_tool.client = recording_client
@@ -274,7 +284,7 @@ async def test_initial_chat_turn_sends_loadable_toolsets_but_no_connector_tools(
     assert len(llm.calls) == 1
     names = _tool_names(llm.calls[0])
     assert {"tool_search", "load_tool", "load_tool_set"} <= names
-    assert "search_documents" in names
+    assert "search" in names
     assert "gmail__send_email" not in names
     assert "gmail__list_threads" not in names
 

--- a/services/ai/tests/unit/test_chat.py
+++ b/services/ai/tests/unit/test_chat.py
@@ -287,7 +287,7 @@ async def test_citation_stream_processor():
             content_block=ToolUseBlock(
                 type="tool_use",
                 id="toolu_test",
-                name="search_documents",
+                name="search",
                 input={},
             ),
         )
@@ -389,8 +389,14 @@ async def test_citation_stream_processor():
     tool_events = [
         event
         for event in with_tool
-        if (event.type == "content_block_start" and event.content_block.type == "tool_use")
-        or (event.type == "content_block_delta" and event.delta.type == "input_json_delta")
+        if (
+            event.type == "content_block_start"
+            and event.content_block.type == "tool_use"
+        )
+        or (
+            event.type == "content_block_delta"
+            and event.delta.type == "input_json_delta"
+        )
     ]
     assert [event.index for event in tool_events] == [2, 2]
     assert with_tool[-1].type == "content_block_stop"

--- a/services/ai/tests/unit/test_gemini_provider.py
+++ b/services/ai/tests/unit/test_gemini_provider.py
@@ -49,7 +49,7 @@ def test_convert_messages_does_not_forward_search_result_extras():
 def _darwinbox_style_tools() -> list[dict]:
     return [
         {
-            "name": "search_documents",
+            "name": "search",
             "description": "Search the Omni index",
             "input_schema": {
                 "type": "object",
@@ -96,7 +96,7 @@ def test_convert_tools_strips_schema_keys_gemini_cannot_round_trip():
     converted = _convert_tools_to_gemini(_darwinbox_style_tools())
     declarations = converted[0].function_declarations
     assert [d.name for d in declarations] == [
-        "search_documents",
+        "search",
         "darwinbox__attendance",
         "darwinbox__apply_leave",
     ]

--- a/services/ai/tests/unit/test_openai_compatible_provider.py
+++ b/services/ai/tests/unit/test_openai_compatible_provider.py
@@ -49,7 +49,7 @@ def test_convert_messages_preserves_deepseek_reasoning_content_with_tool_calls()
                 {
                     "type": "tool_use",
                     "id": "call_1",
-                    "name": "search_documents",
+                    "name": "search",
                     "input": {"query": "omni"},
                 },
                 {
@@ -129,7 +129,7 @@ def _assistant_with_tool_calls(tool_call_ids: list[str]) -> dict:
             {
                 "type": "tool_use",
                 "id": tool_id,
-                "name": "search_documents",
+                "name": "search",
                 "input": {},
             }
             for tool_id in tool_call_ids
@@ -155,7 +155,7 @@ def _openai_assistant_with_tool_calls(tool_call_ids: list[str]) -> dict:
             {
                 "id": tool_id,
                 "type": "function",
-                "function": {"name": "search_documents", "arguments": "{}"},
+                "function": {"name": "search", "arguments": "{}"},
             }
             for tool_id in tool_call_ids
         ],

--- a/services/ai/tests/unit/test_stream_persist.py
+++ b/services/ai/tests/unit/test_stream_persist.py
@@ -31,7 +31,7 @@ def test_valid_json_input_is_parsed():
     tool_call = ToolUseBlockParam(
         type="tool_use",
         id="toolu_json",
-        name="search_documents",
+        name="search",
         input='{"query": "leave balance"}',
     )
     errors = parse_tool_call_inputs([tool_call])
@@ -42,7 +42,7 @@ def test_valid_json_input_is_parsed():
 
 def test_invalid_json_input_yields_parse_error():
     tool_call = ToolUseBlockParam(
-        type="tool_use", id="toolu_bad", name="search_documents", input="{nope"
+        type="tool_use", id="toolu_bad", name="search", input="{nope"
     )
     errors = parse_tool_call_inputs([tool_call])
 

--- a/services/ai/tests/unit/test_tool_call_repair.py
+++ b/services/ai/tests/unit/test_tool_call_repair.py
@@ -12,7 +12,7 @@ from streaming.generate import (
 )
 
 
-def _tool_use(tool_id: str, name: str = "search_documents") -> dict:
+def _tool_use(tool_id: str, name: str = "search") -> dict:
     return {"type": "tool_use", "id": tool_id, "name": name, "input": {}}
 
 
@@ -32,7 +32,7 @@ def _interrupted_placeholder(tool_id: str) -> dict:
         "content": [
             {
                 "type": "text",
-                "text": f"Tool call search_documents {_INTERRUPTED_TOOL_RESULT_MARKER}. "
+                "text": f"Tool call search {_INTERRUPTED_TOOL_RESULT_MARKER}. "
                 "Treat this tool call as failed and retry it if the result is still needed.",
             }
         ],

--- a/services/ai/tools/document_handler.py
+++ b/services/ai/tools/document_handler.py
@@ -104,7 +104,7 @@ DOCUMENT_TOOL = {
     "description": (
         "Read a document's full content. For text documents, returns content directly or saves to sandbox if large. "
         "For binary files (spreadsheets, PDFs, etc.), fetches the actual file from the source and saves to sandbox workspace. "
-        "Use the [_ref:ULID] value from search_documents results as the 'id' argument."
+        "Use the [_ref:ULID] value from search results as the 'id' argument."
     ),
     "input_schema": {
         "type": "object",

--- a/services/ai/tools/search_handler.py
+++ b/services/ai/tools/search_handler.py
@@ -30,7 +30,7 @@ from tools.registry import ToolContext, ToolResult
 
 logger = logging.getLogger(__name__)
 
-_TOOL_NAMES = {"search_documents"}
+_TOOL_NAMES = {"search"}
 
 # Operators already documented as universal — exclude from connector-specific lists
 _UNIVERSAL_OPERATORS = {"by", "in", "from", "type", "before", "after"}
@@ -194,8 +194,8 @@ def _build_search_tools(
 
     return [
         {
-            "name": "search_documents",
-            "description": "Search the Omni index for data across all connected apps using hybrid text and semantic search. Use this when you need to find information to answer user questions. Use inline query operators (in:, by:, type:, status:, etc.) for filtering.",
+            "name": "search",
+            "description": "Search the Omni unified index across all connected apps using hybrid text and semantic search — documents, emails, messages, pages, and any other content your connectors sync. This is the primary tool for finding workplace information to answer user questions. Use inline query operators (in:, by:, type:, status:, etc.) for filtering. For people-directory lookups (a person's title, manager, email or office), use search_people instead.",
             "input_schema": {
                 "type": "object",
                 "properties": {
@@ -247,7 +247,7 @@ class SearchToolHandler:
     async def execute(
         self, tool_name: str, tool_input: dict, context: ToolContext
     ) -> ToolResult:
-        if tool_name == "search_documents":
+        if tool_name == "search":
             return await self._execute_search(tool_input, context)
         return ToolResult(
             content=[{"type": "text", "text": f"Unknown search tool: {tool_name}"}],
@@ -260,7 +260,7 @@ class SearchToolHandler:
         try:
             params = SearchToolParams.model_validate(tool_input)
         except ValidationError as e:
-            logger.error(f"Invalid search_documents input: {e}")
+            logger.error(f"Invalid search input: {e}")
             return ToolResult(
                 content=[{"type": "text", "text": f"Invalid parameters: {e}"}],
                 is_error=True,
@@ -268,10 +268,10 @@ class SearchToolHandler:
 
         # Strip the _ref: prefix if the LLM passes the internal reference token as document_id
         if params.document_id and params.document_id.startswith("_ref:"):
-            params.document_id = params.document_id[len("_ref:"):]
+            params.document_id = params.document_id[len("_ref:") :]
 
         logger.info(
-            f"Executing search_documents with query: {params.query}, document_id: {params.document_id}, context: {context}"
+            f"Executing search with query: {params.query}, document_id: {params.document_id}, context: {context}"
         )
         search_user_id = None if context.skip_permission_check else context.user_id
         search_user_email = (
@@ -406,7 +406,7 @@ async def _execute_search_tool(
     original_user_query: str | None = None,
     user_configuration: UserConfiguration | None = None,
 ) -> list[SearchResult]:
-    """Execute search_documents tool by calling omni-searcher."""
+    """Execute search tool by calling omni-searcher."""
     search_request = SearchRequest(
         query=tool_input.query,
         document_id=tool_input.document_id,

--- a/services/ai/tools/searcher_client.py
+++ b/services/ai/tools/searcher_client.py
@@ -185,7 +185,7 @@ class SearcherClient:
         self.searcher_url = searcher_url.rstrip("/")
         self.client = httpx.AsyncClient(timeout=30.0)
 
-    async def search_documents(self, request: SearchRequest) -> SearchResponse:
+    async def search(self, request: SearchRequest) -> SearchResponse:
         """
         Search documents using omni-searcher service
 

--- a/services/ai/tools/searcher_tool.py
+++ b/services/ai/tools/searcher_tool.py
@@ -11,4 +11,4 @@ class SearcherTool(BaseToolHandler):
 
     async def handle(self, request: SearchRequest) -> SearchResponse:
         """Handle the tool call and return a response."""
-        return await self.client.search_documents(request)
+        return await self.client.search(request)

--- a/web/e2e/chat-stream.spec.ts
+++ b/web/e2e/chat-stream.spec.ts
@@ -19,7 +19,7 @@ const capturedSeedChatPath = process.env.OMNI_CAPTURE_SEED_CHAT_PATH
 const capturedExpectedText = process.env.OMNI_CAPTURE_EXPECT_TEXT
 const capturedSubmitText = process.env.OMNI_CAPTURE_SUBMIT_TEXT
 
-const streamedMarkdown = `Here are the tools I have available to call right now:\n\n### Search & Retrieval\n- **\`search_documents(query, limit, document_id?)\`** — Search indexed documents\n- **\`read_document(document_id)\`** — Read a document`
+const streamedMarkdown = `Here are the tools I have available to call right now:\n\n### Search & Retrieval\n- **\`search(query, limit, document_id?)\`** — Search indexed documents\n- **\`read_document(document_id)\`** — Read a document`
 const branchedTemplateFixture = new URL(
     './fixtures/chat-01KT1M7YAYQBDP6Z46FAY7G42H.json',
     import.meta.url,
@@ -106,7 +106,7 @@ function assistantSearchToolEvents(index: number, toolUseId: string, query: stri
             content_block: {
                 type: 'tool_use',
                 id: toolUseId,
-                name: 'search_documents',
+                name: 'search',
                 input: {},
             },
         }),
@@ -351,7 +351,7 @@ async function seedInterruptedToolCallChat(): Promise<
                     {
                         type: 'tool_use',
                         id: toolUseId,
-                        name: 'search_documents',
+                        name: 'search',
                         input: { query: 'interrupted tool call', limit: 10 },
                     },
                 ],
@@ -549,7 +549,7 @@ test('chat page renders streamed assistant markdown from the SSE stream endpoint
             page.getByText('Here are the tools I have available to call right now:'),
         ).toBeVisible()
         await expect(page.getByRole('heading', { name: 'Search & Retrieval' })).toBeVisible()
-        await expect(page.getByText('search_documents(query, limit, document_id?)')).toBeVisible()
+        await expect(page.getByText('search(query, limit, document_id?)')).toBeVisible()
         await expect(page.getByText('Read a document')).toBeVisible()
     } finally {
         await cleanupChat(seeded)

--- a/web/e2e/fixtures/branched-chat-stream.sse
+++ b/web/e2e/fixtures/branched-chat-stream.sse
@@ -14,7 +14,7 @@ event: message
 data: {"index":0,"type":"content_block_stop"}
 
 event: message
-data: {"content_block":{"id":"toolu_01FK1YdwtRAfb8y3Cn136HFB","caller":{"type":"direct"},"input":{},"name":"search_documents","type":"tool_use"},"index":1,"type":"content_block_start"}
+data: {"content_block":{"id":"toolu_01FK1YdwtRAfb8y3Cn136HFB","caller":{"type":"direct"},"input":{},"name":"search","type":"tool_use"},"index":1,"type":"content_block_start"}
 
 event: message
 data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":1,"type":"content_block_delta"}
@@ -47,7 +47,7 @@ event: message
 data: {"index":1,"type":"content_block_stop"}
 
 event: message
-data: {"content_block":{"id":"toolu_01KUUvEettAFPx5VjWsF9BMn","caller":{"type":"direct"},"input":{},"name":"search_documents","type":"tool_use"},"index":2,"type":"content_block_start"}
+data: {"content_block":{"id":"toolu_01KUUvEettAFPx5VjWsF9BMn","caller":{"type":"direct"},"input":{},"name":"search","type":"tool_use"},"index":2,"type":"content_block_start"}
 
 event: message
 data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":2,"type":"content_block_delta"}
@@ -80,7 +80,7 @@ event: message
 data: {"index":2,"type":"content_block_stop"}
 
 event: message
-data: {"content_block":{"id":"toolu_01LYN35t3eSswU9jxuZ2KT9S","caller":{"type":"direct"},"input":{},"name":"search_documents","type":"tool_use"},"index":3,"type":"content_block_start"}
+data: {"content_block":{"id":"toolu_01LYN35t3eSswU9jxuZ2KT9S","caller":{"type":"direct"},"input":{},"name":"search","type":"tool_use"},"index":3,"type":"content_block_start"}
 
 event: message
 data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":3,"type":"content_block_delta"}

--- a/web/e2e/fixtures/captured-searches-stream.sse
+++ b/web/e2e/fixtures/captured-searches-stream.sse
@@ -2,7 +2,7 @@ event: message
 data: {"message":{"id":"msg_bdrk_01YS372VPHyjdf47UZNQhEDv","content":[],"model":"claude-sonnet-4-5-20250929","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":11990,"output_tokens":5}},"type":"message_start"}
 
 event: message
-data: {"content_block":{"id":"toolu_bdrk_01L5f8soX2KKwkWKrMUNj7cK","input":{},"name":"search_documents","type":"tool_use"},"index":0,"type":"content_block_start"}
+data: {"content_block":{"id":"toolu_bdrk_01L5f8soX2KKwkWKrMUNj7cK","input":{},"name":"search","type":"tool_use"},"index":0,"type":"content_block_start"}
 
 event: message
 data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":0,"type":"content_block_delta"}
@@ -80,7 +80,7 @@ event: message
 data: {"message":{"id":"msg_bdrk_01Jzo6KPHjMHjPhZSeWWufyZ","content":[],"model":"claude-sonnet-4-5-20250929","role":"assistant","stop_reason":null,"stop_sequence":null,"type":"message","usage":{"cache_creation":{"ephemeral_1h_input_tokens":0,"ephemeral_5m_input_tokens":0},"cache_creation_input_tokens":0,"cache_read_input_tokens":0,"input_tokens":16602,"output_tokens":27}},"type":"message_start"}
 
 event: message
-data: {"content_block":{"id":"toolu_bdrk_01T5YmwHqCHKq237uxjo58qh","input":{},"name":"search_documents","type":"tool_use"},"index":0,"type":"content_block_start"}
+data: {"content_block":{"id":"toolu_bdrk_01T5YmwHqCHKq237uxjo58qh","input":{},"name":"search","type":"tool_use"},"index":0,"type":"content_block_start"}
 
 event: message
 data: {"delta":{"partial_json":"","type":"input_json_delta"},"index":0,"type":"content_block_delta"}

--- a/web/e2e/fixtures/chat-01KT1M7YAYQBDP6Z46FAY7G42H.json
+++ b/web/e2e/fixtures/chat-01KT1M7YAYQBDP6Z46FAY7G42H.json
@@ -21,7 +21,7 @@
                 },
                 {
                     "id": "toolu_01QyzVfjTLcmeE8M9a73Poh8",
-                    "name": "search_documents",
+                    "name": "search",
                     "type": "tool_use",
                     "input": {
                         "query": "NEPA Nepanagar origin name"
@@ -882,7 +882,7 @@
                 },
                 {
                     "id": "toolu_01FK1YdwtRAfb8y3Cn136HFB",
-                    "name": "search_documents",
+                    "name": "search",
                     "type": "tool_use",
                     "input": {
                         "limit": 20,
@@ -891,7 +891,7 @@
                 },
                 {
                     "id": "toolu_01KUUvEettAFPx5VjWsF9BMn",
-                    "name": "search_documents",
+                    "name": "search",
                     "type": "tool_use",
                     "input": {
                         "limit": 20,
@@ -900,7 +900,7 @@
                 },
                 {
                     "id": "toolu_01LYN35t3eSswU9jxuZ2KT9S",
-                    "name": "search_documents",
+                    "name": "search",
                     "type": "tool_use",
                     "input": {
                         "limit": 20,

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -35,7 +35,7 @@
     }
 
     const ToolIndicators: Record<string, { loading: string; loaded: string }> = {
-        search_documents: {
+        search: {
             loading: 'searching',
             loaded: 'searched',
         },
@@ -102,7 +102,7 @@
     }
 
     const ToolInputKey: Record<string, string> = {
-        search_documents: 'query',
+        search: 'query',
         web_search: 'query',
         fetch_web_page: 'url',
         read_document: 'name',
@@ -398,7 +398,7 @@
             {/if}
         </div>
     </div>
-{:else if toolName === 'search_documents' || toolName === 'web_search'}
+{:else if toolName === 'search' || toolName === 'web_search'}
     <Accordion.Root type="single" bind:value={selectedItem}>
         <Accordion.Item value={message.toolUse.id}>
             <Accordion.Trigger

--- a/web/src/lib/types/message.ts
+++ b/web/src/lib/types/message.ts
@@ -109,7 +109,7 @@ export type OAuthRequiredEvent = OAuthRequiredAIEvent & {
     provider_configured: boolean
 }
 
-export type ToolName = 'search_documents' | 'read_document' | string
+export type ToolName = 'search' | 'read_document' | string
 
 export type UploadMessageContent = {
     id: number

--- a/web/src/routes/(app)/agents/[agentId]/runs/[runId]/+page.svelte
+++ b/web/src/routes/(app)/agents/[agentId]/runs/[runId]/+page.svelte
@@ -74,7 +74,10 @@
                         const searchResults = resultContent.filter(
                             (b: any) => b.type === 'search_result',
                         )
-                        if (toolMsg.toolUse.name === 'search_documents' || toolMsg.toolUse.name === 'web_search') {
+                        if (
+                            toolMsg.toolUse.name === 'search' ||
+                            toolMsg.toolUse.name === 'web_search'
+                        ) {
                             toolMsg.toolResult = {
                                 toolUseId,
                                 content: searchResults.map((r: any) => ({

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -275,7 +275,7 @@
     ]
 
     const toolVerbMap: Record<string, string[]> = {
-        search_documents: ['Searching', 'Looking it up', 'Digging through results'],
+        search: ['Searching', 'Looking it up', 'Digging through results'],
         web_search: ['Searching the web', 'Checking public sources'],
         fetch_web_page: ['Fetching web page', 'Reading web page'],
         read_document: ['Reading document', 'Reviewing document'],
@@ -935,7 +935,7 @@
         // pulled from `search_result` content blocks). Search tools render that
         // shape; everything else surfaces output via actionResult / oauthRequired
         // and should stay as a compact status row.
-        const SEARCH_TOOLS = new Set(['search_documents', 'web_search'])
+        const SEARCH_TOOLS = new Set(['search', 'web_search'])
         const updateToolBlock = (
             toolUseId: string,
             updateBlock: (block: ToolMessageContent) => ToolMessageContent,


### PR DESCRIPTION
- The `search_documents` tool name steered the model away from the unified index for org-master questions (departments, office locations, job levels, holidays), making it dead-end on connector actions or people search before finding the answer.
- Rename the LLM-facing tool to `search` and describe it as the primary do-it-all search across all connected apps, with people-directory lookups pointed at `search_people`.
- Update system prompts, internal client method, web tool rendering (chat page, tool-message, agent runs), and all tests/fixtures; no `search_documents` references remain in the codebase.