### PR TITLE
feat(google): add personal Drive folder filtering

### DIFF
--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -53,3 +53,9 @@ The setup dialog has two tabs (DWD | Shared drive no-DWD); SA-direct is
 Drive-only and validates the SA's role on every selected drive before the
 source is created. The drive settings page repeats that validation before
 Save.
+
+Personal Google OAuth connections are configured from **My Integrations**.
+The owner must choose either the whole Drive or one or more accessible folders
+before indexing starts. Folder selections are stored in
+`sources.config.folder_path_filters` and enforced during OAuth sync; Google
+still grants the connector its normal read-only Drive OAuth scope.

--- a/connectors/google/README.md
+++ b/connectors/google/README.md
@@ -17,8 +17,10 @@ and Chat sync.
 
 ### Service account direct (shared drives, no DWD)
 
-A plain service account (no DWD, no Admin SDK scopes, no `sub` impersonation)
-syncs selected shared drives with their inherited ACLs.
+A plain service account (no DWD and no `sub` impersonation) syncs selected
+shared drives with their inherited ACLs. Group membership sync uses the service
+account's own identity with the Admin Directory group-read scope and Workspace
+domain.
 
 Google-side setup:
 
@@ -34,25 +36,25 @@ Google-side setup:
 
 Behavior:
 
-- Only `drive.readonly` scope; source config selects the mode with
-  `auth_mode: "service_account_direct"` and one or more
+- Uses `drive.readonly` and
+  `admin.directory.group.readonly`; source config selects the mode with
+  `auth_mode: "service_account_direct"`, a Workspace `domain`, and one or more
   `folder_path_filters` entries of kind `shared_drive_root`.
 - Documents carry the drive-level member list as permissions
   (`public`/`users`/`groups`); the SA's own email is excluded.
 - ACLs are fingerprinted each run; a membership change triggers a full drive
   re-traversal so existing documents get the new ACLs.
 - Polling only — no webhook registration. Google Groups on the drive map to
-  `groups` but group members are undergranted in v1 (group membership comes
-  from Admin SDK sync, unavailable here). Prefer drives with direct
-  user/domain/anyone members.
+  `groups`; group membership is validated during setup and emitted through
+  Admin SDK group-membership events during sync.
 - Per-file overrides outside the drive are not resolved; drive-level ACLs
   apply. Switching an existing DWD source to SA-direct is not supported —
   create a new source.
 
 The setup dialog has two tabs (DWD | Shared drive no-DWD); SA-direct is
-Drive-only and validates the SA's role on every selected drive before the
-source is created. The drive settings page repeats that validation before
-Save.
+Drive-only and validates both Workspace group access and the SA's role on every
+selected drive before the source is created. The drive settings page preserves
+the domain and required scopes when saving.
 
 Personal Google OAuth connections are configured from **My Integrations**.
 The owner must choose either the whole Drive or one or more accessible folders

--- a/connectors/google/src/auth.rs
+++ b/connectors/google/src/auth.rs
@@ -12,6 +12,42 @@ use std::time::Duration as StdDuration;
 use tokio::sync::RwLock;
 use tracing::{debug, info, warn};
 
+pub const GOOGLE_DRIVE_READ_SCOPE: &str = "https://www.googleapis.com/auth/drive.readonly";
+pub const GOOGLE_DRIVE_WRITE_SCOPE: &str = "https://www.googleapis.com/auth/drive.file";
+pub const GOOGLE_DOCS_SCOPE: &str = "https://www.googleapis.com/auth/documents";
+pub const GOOGLE_SHEETS_SCOPE: &str = "https://www.googleapis.com/auth/spreadsheets";
+pub const GOOGLE_SLIDES_SCOPE: &str = "https://www.googleapis.com/auth/presentations";
+pub const GMAIL_READ_SCOPE: &str = "https://www.googleapis.com/auth/gmail.readonly";
+pub const GMAIL_SEND_SCOPE: &str = "https://www.googleapis.com/auth/gmail.send";
+pub const GMAIL_MODIFY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.modify";
+pub const GOOGLE_CHAT_SPACES_READ_SCOPE: &str =
+    "https://www.googleapis.com/auth/chat.spaces.readonly";
+pub const GOOGLE_CHAT_MEMBERSHIPS_READ_SCOPE: &str =
+    "https://www.googleapis.com/auth/chat.memberships.readonly";
+pub const GOOGLE_CHAT_ADMIN_MEMBERSHIPS_READ_SCOPE: &str =
+    "https://www.googleapis.com/auth/chat.admin.memberships.readonly";
+pub const GOOGLE_CHAT_MESSAGES_READ_SCOPE: &str =
+    "https://www.googleapis.com/auth/chat.messages.readonly";
+pub const GOOGLE_ADMIN_DIRECTORY_USER_READ_SCOPE: &str =
+    "https://www.googleapis.com/auth/admin.directory.user.readonly";
+pub const GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE: &str =
+    "https://www.googleapis.com/auth/admin.directory.group.readonly";
+
+/// Scopes used by the Google Workspace CLI bridge when a JWT credential does
+/// not carry an explicit scope override.
+pub const GOOGLE_WORKSPACE_SCOPES: &[&str] = &[
+    GOOGLE_ADMIN_DIRECTORY_USER_READ_SCOPE,
+    GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE,
+    GOOGLE_DRIVE_READ_SCOPE,
+    GOOGLE_DRIVE_WRITE_SCOPE,
+    GOOGLE_DOCS_SCOPE,
+    GOOGLE_SHEETS_SCOPE,
+    GOOGLE_SLIDES_SCOPE,
+    GMAIL_READ_SCOPE,
+    GMAIL_SEND_SCOPE,
+    GMAIL_MODIFY_SCOPE,
+];
+
 #[derive(Debug, Clone, Deserialize)]
 pub struct GoogleServiceAccountCredentials {
     pub service_account_key: String,
@@ -437,28 +473,26 @@ impl GoogleAuth {
 pub fn get_scopes_for_source_type(source_type: SourceType) -> Vec<String> {
     let mut scopes = vec![
         // Admin scopes needed to list users and groups
-        "https://www.googleapis.com/auth/admin.directory.user.readonly".to_string(),
-        "https://www.googleapis.com/auth/admin.directory.group.readonly".to_string(),
+        GOOGLE_ADMIN_DIRECTORY_USER_READ_SCOPE.to_string(),
+        GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE.to_string(),
     ];
 
     match source_type {
         SourceType::GoogleDrive => {
-            scopes.push("https://www.googleapis.com/auth/drive.readonly".to_string());
+            scopes.push(GOOGLE_DRIVE_READ_SCOPE.to_string());
         }
         SourceType::Gmail => {
-            scopes.push("https://www.googleapis.com/auth/gmail.readonly".to_string());
+            scopes.push(GMAIL_READ_SCOPE.to_string());
         }
         SourceType::GoogleChat => {
-            scopes.push("https://www.googleapis.com/auth/chat.spaces.readonly".to_string());
-            scopes.push("https://www.googleapis.com/auth/chat.memberships.readonly".to_string());
-            scopes.push(
-                "https://www.googleapis.com/auth/chat.admin.memberships.readonly".to_string(),
-            );
-            scopes.push("https://www.googleapis.com/auth/chat.messages.readonly".to_string());
+            scopes.push(GOOGLE_CHAT_SPACES_READ_SCOPE.to_string());
+            scopes.push(GOOGLE_CHAT_MEMBERSHIPS_READ_SCOPE.to_string());
+            scopes.push(GOOGLE_CHAT_ADMIN_MEMBERSHIPS_READ_SCOPE.to_string());
+            scopes.push(GOOGLE_CHAT_MESSAGES_READ_SCOPE.to_string());
         }
         _ => {
-            scopes.push("https://www.googleapis.com/auth/drive.readonly".to_string());
-            scopes.push("https://www.googleapis.com/auth/gmail.readonly".to_string());
+            scopes.push(GOOGLE_DRIVE_READ_SCOPE.to_string());
+            scopes.push(GMAIL_READ_SCOPE.to_string());
         }
     }
 
@@ -468,26 +502,38 @@ pub fn get_scopes_for_source_type(source_type: SourceType) -> Vec<String> {
 /// Determine the required OAuth scopes for a source type (no admin directory scope)
 pub fn get_oauth_scopes_for_source_type(source_type: SourceType) -> Vec<String> {
     match source_type {
-        SourceType::GoogleDrive => {
-            vec!["https://www.googleapis.com/auth/drive.readonly".to_string()]
-        }
-        SourceType::Gmail => {
-            vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()]
-        }
-        SourceType::GoogleChat => {
-            vec![
-                "https://www.googleapis.com/auth/chat.spaces.readonly".to_string(),
-                "https://www.googleapis.com/auth/chat.memberships.readonly".to_string(),
-                "https://www.googleapis.com/auth/chat.messages.readonly".to_string(),
-            ]
-        }
-        _ => {
-            vec![
-                "https://www.googleapis.com/auth/drive.readonly".to_string(),
-                "https://www.googleapis.com/auth/gmail.readonly".to_string(),
-            ]
-        }
+        SourceType::GoogleDrive => vec![GOOGLE_DRIVE_READ_SCOPE.to_string()],
+        SourceType::Gmail => vec![GMAIL_READ_SCOPE.to_string()],
+        SourceType::GoogleChat => vec![
+            GOOGLE_CHAT_SPACES_READ_SCOPE.to_string(),
+            GOOGLE_CHAT_MEMBERSHIPS_READ_SCOPE.to_string(),
+            GOOGLE_CHAT_MESSAGES_READ_SCOPE.to_string(),
+        ],
+        _ => vec![
+            GOOGLE_DRIVE_READ_SCOPE.to_string(),
+            GMAIL_READ_SCOPE.to_string(),
+        ],
     }
+}
+
+/// Return whether a service-account credential explicitly or implicitly carries a scope.
+pub fn has_service_account_scope(
+    creds: &ServiceCredential,
+    source_type: SourceType,
+    required_scope: &str,
+) -> bool {
+    let scopes = creds
+        .config
+        .get("scopes")
+        .and_then(|v| v.as_array())
+        .map(|arr| {
+            arr.iter()
+                .filter_map(|v| v.as_str().map(String::from))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_else(|| get_scopes_for_source_type(source_type));
+
+    scopes.iter().any(|scope| scope.as_str() == required_scope)
 }
 
 /// Build a `ServiceAccountAuth` from a `ServiceCredential` JWT row. Honors a
@@ -691,11 +737,9 @@ mod tests {
     fn test_get_scopes_for_google_drive() {
         let scopes = get_scopes_for_source_type(SourceType::GoogleDrive);
 
-        assert!(scopes.contains(
-            &"https://www.googleapis.com/auth/admin.directory.user.readonly".to_string()
-        ));
-        assert!(scopes.contains(&"https://www.googleapis.com/auth/drive.readonly".to_string()));
-        assert!(!scopes.contains(&"https://www.googleapis.com/auth/gmail.readonly".to_string()));
+        assert!(scopes.contains(&GOOGLE_ADMIN_DIRECTORY_USER_READ_SCOPE.to_string()));
+        assert!(scopes.contains(&GOOGLE_DRIVE_READ_SCOPE.to_string()));
+        assert!(!scopes.contains(&GMAIL_READ_SCOPE.to_string()));
         assert_eq!(scopes.len(), 3);
     }
 
@@ -703,14 +747,10 @@ mod tests {
     fn test_get_scopes_for_gmail() {
         let scopes = get_scopes_for_source_type(SourceType::Gmail);
 
-        assert!(scopes.contains(
-            &"https://www.googleapis.com/auth/admin.directory.user.readonly".to_string()
-        ));
-        assert!(scopes.contains(
-            &"https://www.googleapis.com/auth/admin.directory.group.readonly".to_string()
-        ));
-        assert!(scopes.contains(&"https://www.googleapis.com/auth/gmail.readonly".to_string()));
-        assert!(!scopes.contains(&"https://www.googleapis.com/auth/drive.readonly".to_string()));
+        assert!(scopes.contains(&GOOGLE_ADMIN_DIRECTORY_USER_READ_SCOPE.to_string()));
+        assert!(scopes.contains(&GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE.to_string()));
+        assert!(scopes.contains(&GMAIL_READ_SCOPE.to_string()));
+        assert!(!scopes.contains(&GOOGLE_DRIVE_READ_SCOPE.to_string()));
         assert_eq!(scopes.len(), 3);
     }
 
@@ -719,14 +759,10 @@ mod tests {
         let scopes = get_scopes_for_source_type(SourceType::LocalFiles);
 
         // For other source types, should include both drive and gmail scopes
-        assert!(scopes.contains(
-            &"https://www.googleapis.com/auth/admin.directory.user.readonly".to_string()
-        ));
-        assert!(scopes.contains(
-            &"https://www.googleapis.com/auth/admin.directory.group.readonly".to_string()
-        ));
-        assert!(scopes.contains(&"https://www.googleapis.com/auth/drive.readonly".to_string()));
-        assert!(scopes.contains(&"https://www.googleapis.com/auth/gmail.readonly".to_string()));
+        assert!(scopes.contains(&GOOGLE_ADMIN_DIRECTORY_USER_READ_SCOPE.to_string()));
+        assert!(scopes.contains(&GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE.to_string()));
+        assert!(scopes.contains(&GOOGLE_DRIVE_READ_SCOPE.to_string()));
+        assert!(scopes.contains(&GMAIL_READ_SCOPE.to_string()));
         assert_eq!(scopes.len(), 4);
     }
 
@@ -795,7 +831,7 @@ mod tests {
         let claims = GoogleJwtClaims {
             iss: "sa@project.iam.gserviceaccount.com".to_string(),
             sub: None,
-            scope: "https://www.googleapis.com/auth/drive.readonly".to_string(),
+            scope: GOOGLE_DRIVE_READ_SCOPE.to_string(),
             aud: "https://oauth2.googleapis.com/token".to_string(),
             exp: 1_700_000_000,
             iat: 1_699_999_400,
@@ -813,7 +849,7 @@ mod tests {
         let claims = GoogleJwtClaims {
             iss: "sa@project.iam.gserviceaccount.com".to_string(),
             sub: Some("admin@example.com".to_string()),
-            scope: "https://www.googleapis.com/auth/drive.readonly".to_string(),
+            scope: GOOGLE_DRIVE_READ_SCOPE.to_string(),
             aud: "https://oauth2.googleapis.com/token".to_string(),
             exp: 1_700_000_000,
             iat: 1_699_999_400,

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -3,15 +3,18 @@ use std::time::{Duration, Instant};
 
 use crate::admin::AdminClient;
 use crate::auth::{
+    GMAIL_MODIFY_SCOPE, GMAIL_READ_SCOPE, GMAIL_SEND_SCOPE,
+    GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE, GOOGLE_DOCS_SCOPE, GOOGLE_DRIVE_READ_SCOPE,
+    GOOGLE_DRIVE_WRITE_SCOPE, GOOGLE_SHEETS_SCOPE, GOOGLE_SLIDES_SCOPE, GOOGLE_WORKSPACE_SCOPES,
     GoogleCredentialPayload, GoogleOAuthCredentials, create_service_auth,
-    get_domain_from_credentials,
+    get_domain_from_credentials, has_service_account_scope,
 };
 use crate::drive::DriveClient;
 use crate::gmail::{MessageFormat, MessagePart};
 use crate::models::{
     DriveFolderDiscoveryEntry, DriveFolderDiscoveryResponse, GoogleAuthMode, GoogleDirectoryUser,
-    GoogleSourceConfig, GoogleSyncCheckpoint, SearchUsersResponse, SharedDriveAccessResponse,
-    SharedDriveAccessResult,
+    GoogleSourceConfig, GoogleSyncCheckpoint, SaDirectGroupAccessResponse, SearchUsersResponse,
+    SharedDriveAccessResponse, SharedDriveAccessResult,
 };
 use crate::sync::SyncManager;
 use anyhow::{Context, Result, anyhow};
@@ -39,26 +42,6 @@ const FOLDER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
 const GWS_SCHEMA_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const GWS_SCHEMA_CACHE_MAX_ENTRIES: usize = 256;
 const GOOGLE_WORKSPACE_CLI_TOKEN: &str = "GOOGLE_WORKSPACE_CLI_TOKEN";
-const GOOGLE_DRIVE_READ_SCOPE: &str = "https://www.googleapis.com/auth/drive.readonly";
-const GOOGLE_DRIVE_WRITE_SCOPE: &str = "https://www.googleapis.com/auth/drive.file";
-const GOOGLE_DOCS_SCOPE: &str = "https://www.googleapis.com/auth/documents";
-const GOOGLE_SHEETS_SCOPE: &str = "https://www.googleapis.com/auth/spreadsheets";
-const GOOGLE_SLIDES_SCOPE: &str = "https://www.googleapis.com/auth/presentations";
-const GMAIL_READ_SCOPE: &str = "https://www.googleapis.com/auth/gmail.readonly";
-const GMAIL_SEND_SCOPE: &str = "https://www.googleapis.com/auth/gmail.send";
-const GMAIL_MODIFY_SCOPE: &str = "https://www.googleapis.com/auth/gmail.modify";
-const GOOGLE_WORKSPACE_SCOPES: &[&str] = &[
-    "https://www.googleapis.com/auth/admin.directory.user.readonly",
-    "https://www.googleapis.com/auth/admin.directory.group.readonly",
-    GOOGLE_DRIVE_READ_SCOPE,
-    GOOGLE_DRIVE_WRITE_SCOPE,
-    GOOGLE_DOCS_SCOPE,
-    GOOGLE_SHEETS_SCOPE,
-    GOOGLE_SLIDES_SCOPE,
-    GMAIL_READ_SCOPE,
-    GMAIL_SEND_SCOPE,
-    GMAIL_MODIFY_SCOPE,
-];
 
 #[derive(Debug, Deserialize)]
 struct GwsSchemaRequest {
@@ -174,6 +157,14 @@ struct ValidateSharedDriveAccessParams {
     auth_mode: Option<GoogleAuthMode>,
     #[serde(default)]
     drive_ids: Vec<String>,
+}
+
+/// Params for the `validate_sa_direct_group_access` connector action.
+#[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ValidateSaDirectGroupAccessParams {
+    #[serde(default)]
+    auth_mode: Option<GoogleAuthMode>,
 }
 
 fn parse_attachment_doc_id(composite: &str) -> Result<ParsedAttachmentDocId> {
@@ -1129,6 +1120,112 @@ impl GoogleConnector {
         let response = SharedDriveAccessResponse { drives: results };
         Ok(ActionResponse::success(serde_json::to_value(response)?).into_response())
     }
+
+    /// Validate that an SA-direct credential can enumerate Workspace groups and
+    /// their members before the source is created. Group membership events are
+    /// required for group-granted shared-drive documents to remain searchable.
+    async fn execute_validate_sa_direct_group_access(
+        &self,
+        params: JsonValue,
+        creds: &ServiceCredential,
+    ) -> Result<axum::response::Response> {
+        if creds.auth_type != AuthType::Jwt {
+            return Ok(ActionResponse::failure(
+                "validate_sa_direct_group_access requires JWT credentials".to_string(),
+            )
+            .into_response());
+        }
+
+        let params: ValidateSaDirectGroupAccessParams = serde_json::from_value(params)?;
+        if params.auth_mode != Some(GoogleAuthMode::ServiceAccountDirect) {
+            return Ok(ActionResponse::failure(
+                "validate_sa_direct_group_access requires auth_mode=service_account_direct"
+                    .to_string(),
+            )
+            .into_response());
+        }
+
+        let domain = match get_domain_from_credentials(creds) {
+            Ok(domain) if !domain.trim().is_empty() => domain.trim().to_string(),
+            Ok(_) | Err(_) => {
+                return Ok(ActionResponse::failure(
+                    "SA-direct group membership validation requires an organization domain"
+                        .to_string(),
+                )
+                .into_response());
+            }
+        };
+
+        if !has_service_account_scope(
+            creds,
+            SourceType::GoogleDrive,
+            GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE,
+        ) {
+            return Ok(ActionResponse::failure(format!(
+                "The service-account credential must include the {} scope to sync Google Workspace group memberships",
+                GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE
+            ))
+            .into_response());
+        }
+
+        let auth = match create_service_auth(creds, SourceType::GoogleDrive) {
+            Ok(auth) => auth,
+            Err(e) => {
+                return Ok(ActionResponse::failure(format!(
+                    "Invalid Google service-account credentials: {e}"
+                ))
+                .into_response());
+            }
+        };
+        let access_token = match auth.get_self_access_token().await {
+            Ok(token) => token,
+            Err(e) => {
+                return Ok(ActionResponse::failure(format!(
+                    "The service account could not obtain a token for Google Workspace group access: {e}"
+                ))
+                .into_response());
+            }
+        };
+
+        let groups = match self
+            .admin_client
+            .list_all_groups(&access_token, &domain)
+            .await
+        {
+            Ok(groups) => groups,
+            Err(e) => {
+                return Ok(ActionResponse::failure(format!(
+                    "The service account cannot list Google Workspace groups for {domain}: {e}"
+                ))
+                .into_response());
+            }
+        };
+
+        let mut memberships = 0;
+        for group in &groups {
+            match self
+                .admin_client
+                .list_all_group_members(&access_token, &group.email)
+                .await
+            {
+                Ok(members) => memberships += members.len(),
+                Err(e) => {
+                    return Ok(ActionResponse::failure(format!(
+                        "The service account cannot list members of Google Workspace group {}: {}",
+                        group.email, e
+                    ))
+                    .into_response());
+                }
+            }
+        }
+
+        let response = SaDirectGroupAccessResponse {
+            domain,
+            groups: groups.len(),
+            memberships,
+        };
+        Ok(ActionResponse::success(serde_json::to_value(response)?).into_response())
+    }
 }
 
 #[async_trait]
@@ -1310,6 +1407,27 @@ impl Connector for GoogleConnector {
                 hidden: true,
             },
             ActionDefinition {
+                name: "validate_sa_direct_group_access".to_string(),
+                description:
+                    "Validate that an SA-direct credential can enumerate Workspace groups and group members before setup."
+                        .to_string(),
+                mode: omni_connector_sdk::ActionMode::Read,
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "auth_mode": {
+                            "type": "string",
+                            "enum": ["service_account_direct"]
+                        }
+                    },
+                    "required": ["auth_mode"]
+                }),
+                required_scopes: None,
+                source_types: vec![SourceType::GoogleDrive],
+                admin_only: true,
+                hidden: true,
+            },
+            ActionDefinition {
                 name: "google_workspace_call".to_string(),
                 description: "Call a Google Workspace API through the installed gws CLI"
                     .to_string(),
@@ -1424,7 +1542,7 @@ impl Connector for GoogleConnector {
         scopes.insert(
             "google_drive".to_string(),
             OAuthScopeSet {
-                read: vec!["https://www.googleapis.com/auth/drive.readonly".to_string()],
+                read: vec![GOOGLE_DRIVE_READ_SCOPE.to_string()],
                 // drive.file scopes the grant to files the app creates/opens,
                 // which is the safe default for Drive write tools. Docs,
                 // Sheets, and Slides need their API-specific scopes for
@@ -1440,11 +1558,8 @@ impl Connector for GoogleConnector {
         scopes.insert(
             "gmail".to_string(),
             OAuthScopeSet {
-                read: vec!["https://www.googleapis.com/auth/gmail.readonly".to_string()],
-                write: vec![
-                    "https://www.googleapis.com/auth/gmail.send".to_string(),
-                    "https://www.googleapis.com/auth/gmail.modify".to_string(),
-                ],
+                read: vec![GMAIL_READ_SCOPE.to_string()],
+                write: vec![GMAIL_SEND_SCOPE.to_string(), GMAIL_MODIFY_SCOPE.to_string()],
             },
         );
 
@@ -1545,6 +1660,29 @@ impl Connector for GoogleConnector {
                             e
                         ))
                     })?;
+                } else {
+                    create_service_auth(creds, native_source_type).map_err(|e| {
+                        SyncRequestValidationError::BadRequest(format!(
+                            "Invalid Google service-account credentials: {}",
+                            e
+                        ))
+                    })?;
+                    get_domain_from_credentials(creds).map_err(|e| {
+                        SyncRequestValidationError::BadRequest(format!(
+                            "Invalid SA-direct service-account config: {}",
+                            e
+                        ))
+                    })?;
+                    if !has_service_account_scope(
+                        creds,
+                        native_source_type,
+                        GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE,
+                    ) {
+                        return Err(SyncRequestValidationError::BadRequest(format!(
+                            "SA-direct credentials must include the {} scope for group membership sync",
+                            GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE
+                        )));
+                    }
                 }
             }
         }
@@ -1589,6 +1727,10 @@ impl Connector for GoogleConnector {
             }
             "validate_shared_drive_access" => {
                 self.execute_validate_shared_drive_access(params, &creds)
+                    .await
+            }
+            "validate_sa_direct_group_access" => {
+                self.execute_validate_sa_direct_group_access(params, &creds)
                     .await
             }
             "google_workspace_schema" => self.execute_gws_schema(params).await,
@@ -1761,16 +1903,8 @@ mod tests {
 
         assert_eq!(creds.auth_type, AuthType::Jwt);
         let scopes = creds.config["scopes"].as_array().expect("scopes");
-        assert!(
-            scopes
-                .iter()
-                .any(|s| s == "https://www.googleapis.com/auth/drive.readonly")
-        );
-        assert!(
-            scopes
-                .iter()
-                .any(|s| s == "https://www.googleapis.com/auth/gmail.readonly")
-        );
+        assert!(scopes.iter().any(|s| s == GOOGLE_DRIVE_READ_SCOPE));
+        assert!(scopes.iter().any(|s| s == GMAIL_READ_SCOPE));
         assert!(scopes.iter().any(|s| s == GOOGLE_DOCS_SCOPE));
         assert!(scopes.iter().any(|s| s == GOOGLE_SHEETS_SCOPE));
         assert!(scopes.iter().any(|s| s == GOOGLE_SLIDES_SCOPE));

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -36,7 +36,6 @@ const GWS_TIMEOUT: Duration = Duration::from_secs(60);
 const MAX_FOLDER_DISCOVERY_RESULTS: usize = 500;
 const MIN_FOLDER_DISCOVERY_QUERY_CHARS: usize = 2;
 const FOLDER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
-const MAX_INITIAL_DRIVE_ROOTS: usize = 100;
 const GWS_SCHEMA_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const GWS_SCHEMA_CACHE_MAX_ENTRIES: usize = 256;
 const GOOGLE_WORKSPACE_CLI_TOKEN: &str = "GOOGLE_WORKSPACE_CLI_TOKEN";
@@ -888,20 +887,22 @@ impl GoogleConnector {
         // Fail loudly on malformed params rather than guessing.
         let params: DiscoverFoldersParams = serde_json::from_value(params)?;
         let is_sa_direct = params.auth_mode == Some(GoogleAuthMode::ServiceAccountDirect);
-        let search_query = params
-            .query
-            .as_deref()
-            .map(str::trim)
-            .filter(|query| !query.is_empty());
-        if search_query.is_some_and(|query| query.chars().count() > 200) {
+        let search_query = match params.query.as_deref().map(str::trim) {
+            Some(query) if !query.is_empty() => query,
+            _ => {
+                return Ok(ActionResponse::failure(
+                    "folder discovery query is required".to_string(),
+                )
+                .into_response());
+            }
+        };
+        if search_query.chars().count() > 200 {
             return Ok(ActionResponse::failure(
                 "folder discovery query must be 200 characters or fewer".to_string(),
             )
             .into_response());
         }
-        if search_query
-            .is_some_and(|query| query.chars().count() < MIN_FOLDER_DISCOVERY_QUERY_CHARS)
-        {
+        if search_query.chars().count() < MIN_FOLDER_DISCOVERY_QUERY_CHARS {
             return Ok(ActionResponse::failure(
                 "folder discovery query must contain at least 2 characters".to_string(),
             )
@@ -950,26 +951,21 @@ impl GoogleConnector {
             }
         };
 
-        let discovery_limit = if search_query.is_some() {
-            MAX_FOLDER_DISCOVERY_RESULTS
-        } else {
-            MAX_INITIAL_DRIVE_ROOTS
-        };
+        let discovery_limit = MAX_FOLDER_DISCOVERY_RESULTS;
         let include_my_drive = creds.auth_type == AuthType::OAuth;
-        let include_folder_results = !is_sa_direct && (include_my_drive || search_query.is_some());
+        let include_folder_results = !is_sa_direct;
         let drive_client = self.sync_manager.drive_client().clone();
         let folder_drive_client = drive_client.clone();
         let drives_auth = google_auth.clone();
         let drives_user_email = user_email.clone();
         let folders_auth = google_auth.clone();
         let folders_user_email = user_email.clone();
-        let search_query_owned = search_query.map(str::to_owned);
-        let drives_search_query = search_query_owned.clone();
-        let folders_search_query = search_query_owned;
+        let drives_search_query = search_query.to_owned();
+        let folders_search_query = drives_search_query.clone();
         let drives_future = drive_client.list_drives(
             &drives_auth,
             &drives_user_email,
-            drives_search_query.as_deref(),
+            Some(&drives_search_query),
             discovery_limit,
         );
         let folders_future = async move {
@@ -978,7 +974,7 @@ impl GoogleConnector {
                     .list_accessible_folders(
                         &folders_auth,
                         &folders_user_email,
-                        folders_search_query.as_deref(),
+                        Some(&folders_search_query),
                         include_my_drive,
                         discovery_limit,
                     )
@@ -1002,13 +998,8 @@ impl GoogleConnector {
 
         // Shared-drive roots are valid selections for DWD, OAuth, and
         // SA-direct. SA-direct intentionally does not expose folder children.
-        // Search results may use the full combined result cap for roots, while
-        // initial discovery intentionally shows only a bounded root sample.
-        let root_limit = if search_query.is_some() {
-            MAX_FOLDER_DISCOVERY_RESULTS
-        } else {
-            MAX_INITIAL_DRIVE_ROOTS
-        };
+        // Search results use a bounded combined result cap for roots and folders.
+        let root_limit = MAX_FOLDER_DISCOVERY_RESULTS;
         for drive in &shared_drives {
             item_ids.insert(drive.id.clone());
         }
@@ -1044,11 +1035,7 @@ impl GoogleConnector {
                 items.push(DriveFolderDiscoveryEntry {
                     id: folder.id.clone(),
                     name: folder.name.clone(),
-                    path: build_discovery_folder_path(
-                        &folder,
-                        &shared_drive_names,
-                        search_query.is_some(),
-                    ),
+                    path: build_discovery_folder_path(&folder, &shared_drive_names, true),
                     drive_id,
                     kind: "folder".to_string(),
                 });
@@ -1264,10 +1251,10 @@ impl Connector for GoogleConnector {
                             "type": "string",
                             "minLength": 2,
                             "maxLength": 200,
-                            "description": "Optional folder or shared-drive name prefix search."
+                            "description": "Folder or shared-drive name prefix search."
                         }
                     },
-                    "required": []
+                    "required": ["query"]
                 }),
                 required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive],
@@ -1287,10 +1274,10 @@ impl Connector for GoogleConnector {
                             "type": "string",
                             "minLength": 2,
                             "maxLength": 200,
-                            "description": "Optional folder or shared-drive name prefix search."
+                            "description": "Folder or shared-drive name prefix search."
                         }
                     },
-                    "required": []
+                    "required": ["query"]
                 }),
                 required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive],
@@ -1677,6 +1664,26 @@ mod tests {
     fn google_connector_does_not_use_mcp_server() {
         let connector = test_connector();
         assert!(connector.mcp_server().is_none());
+    }
+
+    #[tokio::test]
+    async fn folder_discovery_requires_a_search_query() -> anyhow::Result<()> {
+        let connector = test_connector();
+        let response = connector
+            .execute_action(
+                "discover_folders",
+                json!({ "auth_mode": "service_account_direct" }),
+                Some(test_service_credential(AuthType::Jwt, json!({}))),
+                None,
+                None,
+            )
+            .await?;
+        let body: serde_json::Value =
+            serde_json::from_slice(&axum::body::to_bytes(response.into_body(), usize::MAX).await?)?;
+
+        assert_eq!(body["status"], "error");
+        assert_eq!(body["error"], "folder discovery query is required");
+        Ok(())
     }
 
     #[test]

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -156,7 +156,7 @@ fn build_discovery_folder_path(
             shared_drive_names
                 .get(drive_id)
                 .map(|name| format!("{} (Shared Drive)", name))
-                .unwrap_or_else(|| format!("Shared Drive {}", drive_id))
+                .unwrap_or_else(|| "Shared Drive".to_string())
         })
         .unwrap_or_else(|| "My Drive".to_string());
     if partial {
@@ -1616,16 +1616,16 @@ mod tests {
     use serde_json::json;
 
     use crate::admin::AdminClient;
-    use crate::models::GoogleAuthMode;
+    use crate::models::{GoogleAuthMode, GoogleDriveFile};
     use crate::sync::SyncManager;
 
     use super::{
         DiscoverFoldersParams, GMAIL_MODIFY_SCOPE, GMAIL_READ_SCOPE, GMAIL_SEND_SCOPE,
         GOOGLE_DOCS_SCOPE, GOOGLE_DRIVE_READ_SCOPE, GOOGLE_DRIVE_WRITE_SCOPE, GOOGLE_SHEETS_SCOPE,
         GOOGLE_SLIDES_SCOPE, GoogleConnector, GwsCallRequest, GwsSchemaRequest,
-        build_attachment_doc_id, build_gws_call_args, build_gws_schema_args,
-        file_name_with_extension, gws_action_response, gws_required_action_scopes,
-        missing_gws_call_scopes, parse_attachment_doc_id,
+        build_attachment_doc_id, build_discovery_folder_path, build_gws_call_args,
+        build_gws_schema_args, file_name_with_extension, gws_action_response,
+        gws_required_action_scopes, missing_gws_call_scopes, parse_attachment_doc_id,
     };
 
     fn test_connector() -> GoogleConnector {
@@ -1684,6 +1684,31 @@ mod tests {
         assert_eq!(body["status"], "error");
         assert_eq!(body["error"], "folder discovery query is required");
         Ok(())
+    }
+
+    #[test]
+    fn discovery_folder_path_does_not_expose_unknown_drive_id() {
+        let folder = GoogleDriveFile {
+            id: "folder-id".to_string(),
+            name: "Roadmap".to_string(),
+            mime_type: "application/vnd.google-apps.folder".to_string(),
+            web_view_link: None,
+            created_time: None,
+            modified_time: None,
+            size: None,
+            parents: None,
+            shared: None,
+            trashed: None,
+            drive_id: Some("drive-id".to_string()),
+            inherited_permissions_disabled: None,
+            permissions: None,
+            owners: None,
+        };
+
+        let path = build_discovery_folder_path(&folder, &std::collections::HashMap::new(), true);
+
+        assert_eq!(path, "/Shared Drive/…/Roadmap");
+        assert!(!path.contains("drive-id"));
     }
 
     #[test]

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -25,14 +25,18 @@ use omni_connector_sdk::{
 };
 use serde::Deserialize;
 use serde_json::{Value as JsonValue, json};
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 use tokio::process::Command;
 use tokio::sync::RwLock;
 use tokio::time::timeout;
-use tracing::debug;
+use tracing::{debug, warn};
 
 const GWS_COMMAND: &str = "gws";
 const GWS_TIMEOUT: Duration = Duration::from_secs(60);
+const MAX_FOLDER_DISCOVERY_RESULTS: usize = 500;
+const MIN_FOLDER_DISCOVERY_QUERY_CHARS: usize = 2;
+const FOLDER_DISCOVERY_TIMEOUT: Duration = Duration::from_secs(20);
+const MAX_INITIAL_DRIVE_ROOTS: usize = 100;
 const GWS_SCHEMA_CACHE_TTL: Duration = Duration::from_secs(60 * 60);
 const GWS_SCHEMA_CACHE_MAX_ENTRIES: usize = 256;
 const GOOGLE_WORKSPACE_CLI_TOKEN: &str = "GOOGLE_WORKSPACE_CLI_TOKEN";
@@ -137,10 +141,35 @@ pub struct ParsedAttachmentDocId {
 struct DiscoverFoldersParams {
     #[serde(default)]
     auth_mode: Option<GoogleAuthMode>,
+    #[serde(default)]
+    query: Option<String>,
+}
+
+fn build_discovery_folder_path(
+    folder: &crate::models::GoogleDriveFile,
+    shared_drive_names: &HashMap<String, String>,
+    partial: bool,
+) -> String {
+    let location = folder
+        .drive_id
+        .as_deref()
+        .map(|drive_id| {
+            shared_drive_names
+                .get(drive_id)
+                .map(|name| format!("{} (Shared Drive)", name))
+                .unwrap_or_else(|| format!("Shared Drive {}", drive_id))
+        })
+        .unwrap_or_else(|| "My Drive".to_string());
+    if partial {
+        format!("/{}/…/{}", location, folder.name)
+    } else {
+        format!("/{}/{}", location, folder.name)
+    }
 }
 
 /// Params for the `validate_shared_drive_access` connector action.
 #[derive(Debug, Default, Deserialize)]
+#[serde(deny_unknown_fields)]
 struct ValidateSharedDriveAccessParams {
     #[serde(default)]
     auth_mode: Option<GoogleAuthMode>,
@@ -834,47 +863,157 @@ impl GoogleConnector {
         params: JsonValue,
         creds: &ServiceCredential,
     ) -> Result<axum::response::Response> {
-        // Only JWT secrets are supported for shared-drive discovery.
-        if creds.auth_type != AuthType::Jwt {
+        match timeout(
+            FOLDER_DISCOVERY_TIMEOUT,
+            self.execute_discover_folders_inner(params, creds),
+        )
+        .await
+        {
+            Ok(result) => result,
+            Err(_) => {
+                warn!("Google Drive folder discovery exceeded its time budget");
+                Ok(ActionResponse::failure(
+                    "Drive folder discovery took too long. Refine your search and try again.",
+                )
+                .into_response())
+            }
+        }
+    }
+
+    async fn execute_discover_folders_inner(
+        &self,
+        params: JsonValue,
+        creds: &ServiceCredential,
+    ) -> Result<axum::response::Response> {
+        // Fail loudly on malformed params rather than guessing.
+        let params: DiscoverFoldersParams = serde_json::from_value(params)?;
+        let is_sa_direct = params.auth_mode == Some(GoogleAuthMode::ServiceAccountDirect);
+        let search_query = params
+            .query
+            .as_deref()
+            .map(str::trim)
+            .filter(|query| !query.is_empty());
+        if search_query.is_some_and(|query| query.chars().count() > 200) {
             return Ok(ActionResponse::failure(
-                "discover_folders requires JWT credentials".to_string(),
+                "folder discovery query must be 200 characters or fewer".to_string(),
+            )
+            .into_response());
+        }
+        if search_query
+            .is_some_and(|query| query.chars().count() < MIN_FOLDER_DISCOVERY_QUERY_CHARS)
+        {
+            return Ok(ActionResponse::failure(
+                "folder discovery query must contain at least 2 characters".to_string(),
             )
             .into_response());
         }
 
-        // Fail loudly on malformed params rather than guessing.
-        let params: DiscoverFoldersParams = serde_json::from_value(params)?;
-        let is_sa_direct = params.auth_mode == Some(GoogleAuthMode::ServiceAccountDirect);
-
-        let auth = crate::auth::create_service_auth(creds, SourceType::GoogleDrive)?;
-        let google_auth = crate::auth::GoogleAuth::ServiceAccount(auth);
-
-        // SA-direct discovery uses the SA self-token (no impersonation); DWD
-        // discovery impersonates the configured principal email.
-        let user_email = if is_sa_direct {
-            match &google_auth {
-                crate::auth::GoogleAuth::ServiceAccount(sa) => sa.client_email().to_string(),
-                crate::auth::GoogleAuth::OAuth(_) => unreachable!(),
+        // SA-direct discovery uses the service account itself. DWD uses the
+        // configured delegated principal, while OAuth uses the authenticated
+        // user's identity. The latter is used by personal Drive settings.
+        let (google_auth, user_email) = match creds.auth_type {
+            AuthType::OAuth => {
+                if is_sa_direct {
+                    return Ok(ActionResponse::failure(
+                        "service_account_direct requires JWT credentials".to_string(),
+                    )
+                    .into_response());
+                }
+                let auth = self
+                    .sync_manager
+                    .create_auth(creds, SourceType::GoogleDrive)
+                    .await?;
+                let email = auth
+                    .oauth_user_email()
+                    .ok_or_else(|| anyhow!("OAuth credentials are missing the user email"))?
+                    .to_string();
+                (auth, email)
             }
-        } else {
-            creds
-                .principal_email
-                .as_deref()
-                .ok_or_else(|| anyhow!("Missing principal_email in credentials"))?
-                .to_string()
+            _ => {
+                let auth = crate::auth::create_service_auth(creds, SourceType::GoogleDrive)?;
+                let google_auth = crate::auth::GoogleAuth::ServiceAccount(auth);
+                let email = if is_sa_direct {
+                    match &google_auth {
+                        crate::auth::GoogleAuth::ServiceAccount(sa) => {
+                            sa.client_email().to_string()
+                        }
+                        crate::auth::GoogleAuth::OAuth(_) => unreachable!(),
+                    }
+                } else {
+                    creds
+                        .principal_email
+                        .as_deref()
+                        .ok_or_else(|| anyhow!("Missing principal_email in credentials"))?
+                        .to_string()
+                };
+                (google_auth, email)
+            }
         };
 
-        // 1. List all shared drives
-        let drives_response = self
-            .sync_manager
-            .drive_client()
-            .list_drives(&google_auth, &user_email)
-            .await?;
-
+        let discovery_limit = if search_query.is_some() {
+            MAX_FOLDER_DISCOVERY_RESULTS
+        } else {
+            MAX_INITIAL_DRIVE_ROOTS
+        };
+        let include_my_drive = creds.auth_type == AuthType::OAuth;
+        let include_folder_results = !is_sa_direct && (include_my_drive || search_query.is_some());
+        let drive_client = self.sync_manager.drive_client().clone();
+        let folder_drive_client = drive_client.clone();
+        let drives_auth = google_auth.clone();
+        let drives_user_email = user_email.clone();
+        let folders_auth = google_auth.clone();
+        let folders_user_email = user_email.clone();
+        let search_query_owned = search_query.map(str::to_owned);
+        let drives_search_query = search_query_owned.clone();
+        let folders_search_query = search_query_owned;
+        let drives_future = drive_client.list_drives(
+            &drives_auth,
+            &drives_user_email,
+            drives_search_query.as_deref(),
+            discovery_limit,
+        );
+        let folders_future = async move {
+            if include_folder_results {
+                folder_drive_client
+                    .list_accessible_folders(
+                        &folders_auth,
+                        &folders_user_email,
+                        folders_search_query.as_deref(),
+                        include_my_drive,
+                        discovery_limit,
+                    )
+                    .await
+                    .map(Some)
+            } else {
+                Ok(None)
+            }
+        };
+        let (drives_result, folders_result) = tokio::join!(drives_future, folders_future);
+        let shared_drive_response = drives_result?;
+        let folders = folders_result?;
+        let shared_drives = shared_drive_response.drives;
+        let shared_drive_names: HashMap<String, String> = shared_drives
+            .iter()
+            .map(|drive| (drive.id.clone(), drive.name.clone()))
+            .collect();
+        let mut truncated = shared_drive_response.next_page_token.is_some();
         let mut items: Vec<DriveFolderDiscoveryEntry> = Vec::new();
+        let mut item_ids = HashSet::new();
 
-        // 2. Add each shared drive as a selectable root
-        for drive in &drives_response.drives {
+        // Shared-drive roots are valid selections for DWD, OAuth, and
+        // SA-direct. SA-direct intentionally does not expose folder children.
+        // Search results may use the full combined result cap for roots, while
+        // initial discovery intentionally shows only a bounded root sample.
+        let root_limit = if search_query.is_some() {
+            MAX_FOLDER_DISCOVERY_RESULTS
+        } else {
+            MAX_INITIAL_DRIVE_ROOTS
+        };
+        for drive in &shared_drives {
+            item_ids.insert(drive.id.clone());
+        }
+        for drive in shared_drives.iter().take(root_limit) {
+            item_ids.insert(drive.id.clone());
             items.push(DriveFolderDiscoveryEntry {
                 id: drive.id.clone(),
                 name: drive.name.clone(),
@@ -883,36 +1022,45 @@ impl GoogleConnector {
                 kind: "shared_drive_root".to_string(),
             });
         }
+        if shared_drives.len() > root_limit {
+            truncated = true;
+        }
 
-        // 3. For each shared drive, list top-level folder children (DWD only).
-        // SA-direct v1 selects whole drives only — no top-level folder listing.
-        if !is_sa_direct {
-            for drive in &drives_response.drives {
-                let folders = self
-                    .sync_manager
-                    .drive_client()
-                    .list_folder_children(&google_auth, &user_email, &drive.id, &drive.id)
-                    .await
-                    .with_context(|| {
-                        format!(
-                            "Failed to list folder children for shared drive '{}' ({})",
-                            drive.name, drive.id
-                        )
-                    })?;
-
-                for folder in &folders.files {
-                    items.push(DriveFolderDiscoveryEntry {
-                        id: folder.id.clone(),
-                        name: folder.name.clone(),
-                        path: format!("/{}/{}", drive.name, folder.name),
-                        drive_id: drive.id.clone(),
-                        kind: "folder".to_string(),
-                    });
+        if let Some(folders) = folders {
+            truncated |= folders.next_page_token.is_some();
+            let folder_files = folders.files;
+            for folder in folder_files {
+                if items.len() >= MAX_FOLDER_DISCOVERY_RESULTS {
+                    truncated = true;
+                    break;
                 }
+                if !item_ids.insert(folder.id.clone()) {
+                    continue;
+                }
+                let drive_id = folder
+                    .drive_id
+                    .clone()
+                    .unwrap_or_else(|| "my_drive".to_string());
+                items.push(DriveFolderDiscoveryEntry {
+                    id: folder.id.clone(),
+                    name: folder.name.clone(),
+                    path: build_discovery_folder_path(
+                        &folder,
+                        &shared_drive_names,
+                        search_query.is_some(),
+                    ),
+                    drive_id,
+                    kind: "folder".to_string(),
+                });
             }
         }
 
-        let result = DriveFolderDiscoveryResponse { items };
+        if items.len() > MAX_FOLDER_DISCOVERY_RESULTS {
+            items.truncate(MAX_FOLDER_DISCOVERY_RESULTS);
+            truncated = true;
+        }
+
+        let result = DriveFolderDiscoveryResponse { items, truncated };
 
         Ok(ActionResponse::success(serde_json::to_value(result)?).into_response())
     }
@@ -1096,10 +1244,12 @@ impl Connector for GoogleConnector {
                 admin_only: false,
                 hidden: false,
             },
+            // Keep these discovery actions separate: Connector Manager uses
+            // admin_only for both authorization and credential selection.
             ActionDefinition {
                 name: "discover_folders".to_string(),
                 description:
-                    "List accessible shared drives and their top-level folders for folder-path filter selection."
+                    "List accessible shared drives and shared-drive folders for folder-path filter selection."
                         .to_string(),
                 mode: omni_connector_sdk::ActionMode::Read,
                 input_schema: json!({
@@ -1109,6 +1259,12 @@ impl Connector for GoogleConnector {
                             "type": "string",
                             "enum": ["domain_wide_delegation", "service_account_direct"],
                             "description": "Auth mode. SA-direct returns shared-drive roots only."
+                        },
+                        "query": {
+                            "type": "string",
+                            "minLength": 2,
+                            "maxLength": 200,
+                            "description": "Optional folder or shared-drive name prefix search."
                         }
                     },
                     "required": []
@@ -1116,6 +1272,29 @@ impl Connector for GoogleConnector {
                 required_scopes: None,
                 source_types: vec![SourceType::GoogleDrive],
                 admin_only: true,
+                hidden: true,
+            },
+            ActionDefinition {
+                name: "discover_personal_folders".to_string(),
+                description:
+                    "List folders visible to the owner of a personal Google Drive source."
+                        .to_string(),
+                mode: omni_connector_sdk::ActionMode::Read,
+                input_schema: json!({
+                    "type": "object",
+                    "properties": {
+                        "query": {
+                            "type": "string",
+                            "minLength": 2,
+                            "maxLength": 200,
+                            "description": "Optional folder or shared-drive name prefix search."
+                        }
+                    },
+                    "required": []
+                }),
+                required_scopes: None,
+                source_types: vec![SourceType::GoogleDrive],
+                admin_only: false,
                 hidden: true,
             },
             ActionDefinition {
@@ -1333,6 +1512,10 @@ impl Connector for GoogleConnector {
         let native_source_type = SourceType::try_from(source.source_type.as_str())
             .map_err(SyncRequestValidationError::BadRequest)?;
 
+        config
+            .validate(native_source_type, creds.auth_type)
+            .map_err(SyncRequestValidationError::BadRequest)?;
+
         match creds.auth_type {
             omni_connector_sdk::AuthType::OAuth => {
                 if config.auth_mode == GoogleAuthMode::ServiceAccountDirect {
@@ -1361,12 +1544,6 @@ impl Connector for GoogleConnector {
                 }
             }
             _ => {
-                // Cross-field validation (SA-direct rules, Drive-only, root-only
-                // filters, JWT requirement).
-                config
-                    .validate(native_source_type, creds.auth_type)
-                    .map_err(SyncRequestValidationError::BadRequest)?;
-
                 if config.auth_mode == GoogleAuthMode::DomainWideDelegation {
                     // DWD still requires domain + valid service-account creds.
                     create_service_auth(creds, native_source_type).map_err(|e| {
@@ -1420,7 +1597,9 @@ impl Connector for GoogleConnector {
         match action {
             "fetch_file" => self.execute_fetch_file(params, &creds).await,
             "search_users" => self.execute_search_users(params, &creds).await,
-            "discover_folders" => self.execute_discover_folders(params, &creds).await,
+            "discover_folders" | "discover_personal_folders" => {
+                self.execute_discover_folders(params, &creds).await
+            }
             "validate_shared_drive_access" => {
                 self.execute_validate_shared_drive_access(params, &creds)
                     .await
@@ -1450,11 +1629,12 @@ mod tests {
     use serde_json::json;
 
     use crate::admin::AdminClient;
+    use crate::models::GoogleAuthMode;
     use crate::sync::SyncManager;
 
     use super::{
-        GMAIL_MODIFY_SCOPE, GMAIL_READ_SCOPE, GMAIL_SEND_SCOPE, GOOGLE_DOCS_SCOPE,
-        GOOGLE_DRIVE_READ_SCOPE, GOOGLE_DRIVE_WRITE_SCOPE, GOOGLE_SHEETS_SCOPE,
+        DiscoverFoldersParams, GMAIL_MODIFY_SCOPE, GMAIL_READ_SCOPE, GMAIL_SEND_SCOPE,
+        GOOGLE_DOCS_SCOPE, GOOGLE_DRIVE_READ_SCOPE, GOOGLE_DRIVE_WRITE_SCOPE, GOOGLE_SHEETS_SCOPE,
         GOOGLE_SLIDES_SCOPE, GoogleConnector, GwsCallRequest, GwsSchemaRequest,
         build_attachment_doc_id, build_gws_call_args, build_gws_schema_args,
         file_name_with_extension, gws_action_response, gws_required_action_scopes,
@@ -1505,6 +1685,21 @@ mod tests {
         let actions = connector.actions();
         assert!(actions.iter().any(|a| a.name == "google_workspace_schema"));
         assert!(actions.iter().any(|a| a.name == "google_workspace_call"));
+    }
+
+    #[test]
+    fn personal_discovery_params_allow_merged_source_config() {
+        let params: DiscoverFoldersParams = serde_json::from_value(json!({
+            "auth_mode": "domain_wide_delegation",
+            "query": "roadmap",
+            "index_scope": "pending",
+            "folder_path_filters": [],
+            "domain": "example.com"
+        }))
+        .expect("persisted source config should not break discovery params");
+
+        assert_eq!(params.auth_mode, Some(GoogleAuthMode::DomainWideDelegation));
+        assert_eq!(params.query.as_deref(), Some("roadmap"));
     }
 
     #[test]

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -144,6 +144,26 @@ pub struct DriveClient {
     user_sheets_rate_limiters: Arc<RwLock<HashMap<String, Arc<RateLimiter>>>>,
 }
 
+#[derive(Clone, Debug)]
+enum FilesListCorpus {
+    Default,
+    User,
+    AllDrives,
+    Drive(String),
+}
+
+#[derive(Clone)]
+struct FilesListRequest {
+    query: String,
+    fields: &'static str,
+    order_by: Option<&'static str>,
+    corpus: FilesListCorpus,
+    spaces: Option<&'static str>,
+    page_token: Option<String>,
+    operation: String,
+    parse_errors_retryable: bool,
+}
+
 impl DriveClient {
     pub fn new() -> Self {
         let client = Client::builder()
@@ -185,6 +205,106 @@ impl DriveClient {
         }
     }
 
+    async fn list_files_page(
+        &self,
+        auth: &GoogleAuth,
+        user_email: &str,
+        request: FilesListRequest,
+    ) -> Result<FilesListResponse> {
+        let user_email_owned = user_email.to_string();
+        let client = self.client.clone();
+        let rate_limiter = self.rate_limiter.clone();
+
+        execute_with_auth_retry(auth, &user_email_owned, rate_limiter, |token| {
+            let client = client.clone();
+            let request = request.clone();
+            async move {
+                let url = format!("{}/files", drive_api_base().as_str());
+                let mut params: Vec<(&str, &str)> = vec![
+                    ("pageSize", "100"),
+                    ("fields", request.fields),
+                    ("q", request.query.as_str()),
+                    ("supportsAllDrives", "true"),
+                    ("includeItemsFromAllDrives", "true"),
+                ];
+                if let Some(order_by) = request.order_by {
+                    params.push(("orderBy", order_by));
+                }
+                match &request.corpus {
+                    FilesListCorpus::Default => {}
+                    FilesListCorpus::User => params.push(("corpora", "user")),
+                    FilesListCorpus::AllDrives => params.push(("corpora", "allDrives")),
+                    FilesListCorpus::Drive(drive_id) => {
+                        params.push(("corpora", "drive"));
+                        params.push(("driveId", drive_id));
+                    }
+                }
+                if let Some(spaces) = request.spaces {
+                    params.push(("spaces", spaces));
+                }
+                if let Some(ref page_token) = request.page_token {
+                    params.push(("pageToken", page_token));
+                }
+
+                debug!(
+                    "[GOOGLE API CALL] {} corpus={:?} page_token={:?}",
+                    request.operation, request.corpus, request.page_token
+                );
+                let response = client
+                    .get(&url)
+                    .bearer_auth(&token)
+                    .query(&params)
+                    .send()
+                    .await
+                    .with_context(|| format!("Failed to {}", request.operation))?;
+
+                if !response.status().is_success() {
+                    return classify_google_api_error(
+                        response,
+                        format!("Failed to {}", request.operation),
+                    )
+                    .await;
+                }
+
+                let response_text = response.text().await?;
+                let parsed = serde_json::from_str(&response_text).map_err(|e| {
+                    anyhow!(
+                        "Failed to parse {} response: {}. Raw response: {}",
+                        request.operation,
+                        e,
+                        response_text
+                    )
+                });
+                match parsed {
+                    Ok(parsed) => Ok(ApiResult::Success(parsed)),
+                    Err(error) if request.parse_errors_retryable => Err(error),
+                    Err(error) => Ok(ApiResult::OtherError(error)),
+                }
+            }
+        })
+        .await
+    }
+
+    async fn list_all_files(
+        &self,
+        auth: &GoogleAuth,
+        user_email: &str,
+        mut request: FilesListRequest,
+    ) -> Result<Vec<GoogleDriveFile>> {
+        let mut all_files = Vec::new();
+        loop {
+            let page = self
+                .list_files_page(auth, user_email, request.clone())
+                .await?;
+            all_files.extend(page.files);
+            request.page_token = page.next_page_token;
+            if request.page_token.is_none() {
+                break;
+            }
+        }
+        Ok(all_files)
+    }
+
     pub async fn list_files(
         &self,
         auth: &GoogleAuth,
@@ -192,69 +312,20 @@ impl DriveClient {
         page_token: Option<&str>,
         modified_after: Option<&str>,
     ) -> Result<FilesListResponse> {
-        let page_token = page_token.map(|s| s.to_string());
-        let modified_after = modified_after.map(|s| s.to_string());
-
-        execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
-            let page_token = page_token.clone();
-            let modified_after = modified_after.clone();
-            async move {
-                let url = format!("{}/files", drive_api_base().as_str());
-
-                let query = build_files_query(modified_after.as_deref());
-
-                let mut params = vec![
-                    ("pageSize", "100"),
-                    ("fields", FILES_FIELDS),
-                    ("q", query.as_str()),
-                    ("orderBy", "modifiedTime desc"),
-                    ("includeItemsFromAllDrives", "true"),
-                    ("supportsAllDrives", "true"),
-                ];
-
-                if let Some(ref page_token) = page_token {
-                    params.push(("pageToken", page_token));
-                }
-
-                debug!(
-                    "[GOOGLE API CALL] list_files for user {}, page_token {:?}",
-                    user_email, page_token
-                );
-                let response = self
-                    .client
-                    .get(&url)
-                    .bearer_auth(&token)
-                    .query(&params)
-                    .send()
-                    .await
-                    .with_context(|| {
-                        format!("Failed to send list_files request for user {}", user_email)
-                    })?;
-
-                let status = response.status();
-                debug!("Drive list_files response status: {}", status);
-
-                if !status.is_success() {
-                    return classify_google_api_error(response, "Failed to list files").await;
-                }
-
-                let response_text = response.text().await?;
-                debug!("Drive API raw response: {}", response_text);
-
-                let parsed_response = match serde_json::from_str(&response_text) {
-                    Ok(parsed_response) => parsed_response,
-                    Err(e) => {
-                        return Ok(ApiResult::OtherError(anyhow!(
-                            "Failed to parse Drive API response: {}. Raw response: {}",
-                            e,
-                            response_text
-                        )));
-                    }
-                };
-
-                Ok(ApiResult::Success(parsed_response))
-            }
-        })
+        self.list_files_page(
+            auth,
+            user_email,
+            FilesListRequest {
+                query: build_files_query(modified_after),
+                fields: FILES_FIELDS,
+                order_by: Some("modifiedTime desc"),
+                corpus: FilesListCorpus::Default,
+                spaces: None,
+                page_token: page_token.map(str::to_string),
+                operation: format!("list Drive files for user {user_email}"),
+                parse_errors_retryable: false,
+            },
+        )
         .await
     }
 
@@ -267,71 +338,18 @@ impl DriveClient {
         auth: &GoogleAuth,
         user_email: &str,
     ) -> Result<Vec<GoogleDriveFile>> {
-        execute_with_auth_retry(
+        self.list_all_files(
             auth,
             user_email,
-            self.rate_limiter.clone(),
-            |token| async move {
-                let url = format!("{}/files", drive_api_base().as_str());
-                let query = "trashed=true".to_string();
-
-                let mut all_files: Vec<GoogleDriveFile> = Vec::new();
-                let mut page_token: Option<String> = None;
-
-                loop {
-                    let mut params: Vec<(&str, &str)> = vec![
-                        ("pageSize", "100"),
-                        ("fields", FILES_FIELDS),
-                        ("q", query.as_str()),
-                        ("includeItemsFromAllDrives", "true"),
-                        ("supportsAllDrives", "true"),
-                    ];
-                    if let Some(ref pt) = page_token {
-                        params.push(("pageToken", pt));
-                    }
-
-                    debug!(
-                        "[GOOGLE API CALL] list_trashed_files_for_user user={}, page_token={:?}",
-                        user_email, page_token
-                    );
-                    let response = self
-                        .client
-                        .get(&url)
-                        .bearer_auth(&token)
-                        .query(&params)
-                        .send()
-                        .await
-                        .with_context(|| {
-                            format!("Failed to list trashed files for user {}", user_email)
-                        })?;
-
-                    let status = response.status();
-                    if !status.is_success() {
-                        return classify_google_api_error(
-                            response,
-                            "Failed to list trashed files for user",
-                        )
-                        .await;
-                    }
-
-                    let response_text = response.text().await?;
-                    let parsed: FilesListResponse =
-                        serde_json::from_str(&response_text).map_err(|e| {
-                            anyhow!(
-                                "Failed to parse user trashed file list response: {}. Raw: {}",
-                                e,
-                                response_text
-                            )
-                        })?;
-
-                    all_files.extend(parsed.files);
-                    page_token = parsed.next_page_token;
-                    if page_token.is_none() {
-                        break;
-                    }
-                }
-
-                Ok(ApiResult::Success(all_files))
+            FilesListRequest {
+                query: "trashed=true".to_string(),
+                fields: FILES_FIELDS,
+                order_by: None,
+                corpus: FilesListCorpus::Default,
+                spaces: None,
+                page_token: None,
+                operation: format!("list trashed Drive files for user {user_email}"),
+                parse_errors_retryable: true,
             },
         )
         .await
@@ -1243,86 +1261,70 @@ impl DriveClient {
         include_my_drive: bool,
         max_results: usize,
     ) -> Result<FilesListResponse> {
-        execute_with_auth_retry(
-            auth,
-            user_email,
-            self.rate_limiter.clone(),
-            |token| async move {
-                let url = format!("{}/files", drive_api_base().as_str());
-                let query = if let Some(search) = search {
-                    let escaped = search.trim().replace('\\', "\\\\").replace('\'', "\\'");
-                    format!(
-                        "trashed=false and mimeType='application/vnd.google-apps.folder' and name contains '{}'",
-                        escaped
-                    )
-                } else {
-                    "trashed=false and mimeType='application/vnd.google-apps.folder' and 'root' in parents".to_string()
-                };
-                let corpora = if search.is_some() { "allDrives" } else { "user" };
-                let max_results = max_results.max(1);
-                let mut all_files = Vec::new();
-                let mut page_token: Option<String> = None;
-                let mut incomplete_search = false;
+        let query = if let Some(search) = search {
+            let escaped = search.trim().replace('\\', "\\\\").replace('\'', "\\'");
+            format!(
+                "trashed=false and mimeType='application/vnd.google-apps.folder' and name contains '{}'",
+                escaped
+            )
+        } else {
+            "trashed=false and mimeType='application/vnd.google-apps.folder' and 'root' in parents"
+                .to_string()
+        };
+        let corpus = if search.is_some() {
+            FilesListCorpus::AllDrives
+        } else {
+            FilesListCorpus::User
+        };
+        let max_results = max_results.max(1);
+        let mut all_files = Vec::new();
+        let mut page_token: Option<String> = None;
+        let mut incomplete_search = false;
 
-                let truncated = loop {
-                    let mut params = vec![
-                        ("pageSize", "100"),
-                        ("fields", FOLDER_DISCOVERY_FIELDS),
-                        ("q", query.as_str()),
-                        ("orderBy", "name"),
-                        ("includeItemsFromAllDrives", "true"),
-                        ("supportsAllDrives", "true"),
-                        ("corpora", corpora),
-                        ("spaces", "drive"),
-                    ];
-                    if let Some(ref page_token) = page_token {
-                        params.push(("pageToken", page_token));
-                    }
+        let truncated = loop {
+            let parsed = self
+                .list_files_page(
+                    auth,
+                    user_email,
+                    FilesListRequest {
+                        query: query.clone(),
+                        fields: FOLDER_DISCOVERY_FIELDS,
+                        order_by: Some("name"),
+                        corpus: corpus.clone(),
+                        spaces: Some("drive"),
+                        page_token: page_token.clone(),
+                        operation: "list accessible Drive folders".to_string(),
+                        parse_errors_retryable: true,
+                    },
+                )
+                .await?;
+            let next_page = parsed.next_page_token;
+            incomplete_search |= parsed.incomplete_search;
+            let mut page_files = parsed.files;
+            if !include_my_drive {
+                page_files.retain(|file| file.drive_id.is_some());
+            }
+            all_files.extend(page_files);
 
-                    let response = self
-                        .client
-                        .get(&url)
-                        .bearer_auth(&token)
-                        .query(&params)
-                        .send()
-                        .await
-                        .context("Failed to list accessible Drive folders")?;
-                    if !response.status().is_success() {
-                        return classify_google_api_error(
-                            response,
-                            "Failed to list accessible Drive folders",
-                        )
-                        .await;
-                    }
-                    let parsed: FilesListResponse = response.json().await?;
-                    let next_page = parsed.next_page_token;
-                    incomplete_search |= parsed.incomplete_search;
-                    let mut page_files = parsed.files;
-                    if !include_my_drive {
-                        page_files.retain(|file| file.drive_id.is_some());
-                    }
-                    all_files.extend(page_files);
-                    if all_files.len() >= max_results {
-                        let exceeded_limit = all_files.len() > max_results;
-                        all_files.truncate(max_results);
-                        break incomplete_search || next_page.is_some() || exceeded_limit;
-                    }
-                    page_token = next_page;
-                    if page_token.is_none() {
-                        break incomplete_search;
-                    }
-                };
+            if all_files.len() >= max_results {
+                let truncated =
+                    incomplete_search || next_page.is_some() || all_files.len() > max_results;
+                all_files.truncate(max_results);
+                break truncated;
+            }
+            page_token = next_page;
+            if page_token.is_none() {
+                break incomplete_search;
+            }
+        };
 
-                Ok(ApiResult::Success(FilesListResponse {
-                    files: all_files,
-                    incomplete_search,
-                    // The caller only uses this as a bounded-result marker;
-                    // it must not attempt to continue this discovery request.
-                    next_page_token: truncated.then(|| "discovery-truncated".to_string()),
-                }))
-            },
-        )
-        .await
+        Ok(FilesListResponse {
+            files: all_files,
+            incomplete_search,
+            // The caller only uses this as a bounded-result marker; it must not
+            // attempt to continue this discovery request.
+            next_page_token: truncated.then(|| "discovery-truncated".to_string()),
+        })
     }
 
     /// List shared drives visible to the delegated principal's credentials.
@@ -1439,64 +1441,20 @@ impl DriveClient {
         page_token: Option<&str>,
         modified_after: Option<&str>,
     ) -> Result<FilesListResponse> {
-        let drive_id_owned = drive_id.to_string();
-        let page_token = page_token.map(|s| s.to_string());
-        let modified_after = modified_after.map(|s| s.to_string());
-
-        execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
-            let drive_id = drive_id_owned.clone();
-            let page_token = page_token.clone();
-            let modified_after = modified_after.clone();
-            async move {
-                let url = format!("{}/files", drive_api_base().as_str());
-                let query = build_files_query(modified_after.as_deref());
-
-                let mut params: Vec<(&str, &str)> = vec![
-                    ("pageSize", "100"),
-                    ("fields", FILES_FIELDS),
-                    ("q", query.as_str()),
-                    ("orderBy", "modifiedTime desc"),
-                    ("supportsAllDrives", "true"),
-                    ("includeItemsFromAllDrives", "true"),
-                    ("corpora", "drive"),
-                    ("driveId", &drive_id),
-                ];
-                if let Some(ref pt) = page_token {
-                    params.push(("pageToken", pt));
-                }
-
-                debug!(
-                    "[GOOGLE API CALL] list_files_in_drive drive={}, page_token={:?}",
-                    drive_id, page_token
-                );
-                let response = self
-                    .client
-                    .get(&url)
-                    .bearer_auth(&token)
-                    .query(&params)
-                    .send()
-                    .await
-                    .with_context(|| format!("Failed to list files in drive {}", drive_id))?;
-
-                let status = response.status();
-                if !status.is_success() {
-                    return classify_google_api_error(response, "Failed to list files in drive")
-                        .await;
-                }
-
-                let response_text = response.text().await?;
-                let parsed: FilesListResponse =
-                    serde_json::from_str(&response_text).map_err(|e| {
-                        anyhow!(
-                            "Failed to parse drive-scoped file list response: {}. Raw: {}",
-                            e,
-                            response_text
-                        )
-                    })?;
-
-                Ok(ApiResult::Success(parsed))
-            }
-        })
+        self.list_files_page(
+            auth,
+            user_email,
+            FilesListRequest {
+                query: build_files_query(modified_after),
+                fields: FILES_FIELDS,
+                order_by: Some("modifiedTime desc"),
+                corpus: FilesListCorpus::Drive(drive_id.to_string()),
+                spaces: None,
+                page_token: page_token.map(str::to_string),
+                operation: format!("list files in Drive {drive_id}"),
+                parse_errors_retryable: true,
+            },
+        )
         .await
     }
 
@@ -1507,65 +1465,23 @@ impl DriveClient {
         drive_id: &str,
         page_token: Option<&str>,
     ) -> Result<FilesListResponse> {
-        let drive_id_owned = drive_id.to_string();
-        let page_token = page_token.map(|s| s.to_string());
-
-        execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
-            let drive_id = drive_id_owned.clone();
-            let page_token = page_token.clone();
-            async move {
-                let url = format!("{}/files", drive_api_base().as_str());
-                // Folders are always fetched in full (no cutoff): their
-                // access metadata (limited-access flag + direct ACL) defines
-                // the effective permissions of every descendant file.
-                let query =
-                    "trashed=false and mimeType='application/vnd.google-apps.folder'".to_string();
-
-                let mut params: Vec<(&str, &str)> = vec![
-                    ("pageSize", "100"),
-                    ("fields", FILES_FIELDS),
-                    ("q", query.as_str()),
-                    ("supportsAllDrives", "true"),
-                    ("includeItemsFromAllDrives", "true"),
-                    ("corpora", "drive"),
-                    ("driveId", &drive_id),
-                ];
-                if let Some(ref pt) = page_token {
-                    params.push(("pageToken", pt));
-                }
-
-                debug!(
-                    "[GOOGLE API CALL] list_folders_in_drive drive={}, page_token={:?}",
-                    drive_id, page_token
-                );
-                let response = self
-                    .client
-                    .get(&url)
-                    .bearer_auth(&token)
-                    .query(&params)
-                    .send()
-                    .await
-                    .with_context(|| format!("Failed to list folders in drive {}", drive_id))?;
-
-                let status = response.status();
-                if !status.is_success() {
-                    return classify_google_api_error(response, "Failed to list folders in drive")
-                        .await;
-                }
-
-                let response_text = response.text().await?;
-                let parsed: FilesListResponse =
-                    serde_json::from_str(&response_text).map_err(|e| {
-                        anyhow!(
-                            "Failed to parse drive-scoped folder list response: {}. Raw: {}",
-                            e,
-                            response_text
-                        )
-                    })?;
-
-                Ok(ApiResult::Success(parsed))
-            }
-        })
+        // Folders are always fetched in full (no cutoff): their access metadata
+        // defines the effective permissions of every descendant file.
+        self.list_files_page(
+            auth,
+            user_email,
+            FilesListRequest {
+                query: "trashed=false and mimeType='application/vnd.google-apps.folder'"
+                    .to_string(),
+                fields: FILES_FIELDS,
+                order_by: None,
+                corpus: FilesListCorpus::Drive(drive_id.to_string()),
+                spaces: None,
+                page_token: page_token.map(str::to_string),
+                operation: format!("list folders in Drive {drive_id}"),
+                parse_errors_retryable: true,
+            },
+        )
         .await
     }
 
@@ -1581,74 +1497,20 @@ impl DriveClient {
         user_email: &str,
         drive_id: &str,
     ) -> Result<Vec<GoogleDriveFile>> {
-        let drive_id_owned = drive_id.to_string();
-        execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
-            let drive_id = drive_id_owned.clone();
-            async move {
-                let url = format!("{}/files", drive_api_base().as_str());
-                let query = "trashed=true".to_string();
-
-                let mut all_files: Vec<GoogleDriveFile> = Vec::new();
-                let mut page_token: Option<String> = None;
-
-                loop {
-                    let mut params: Vec<(&str, &str)> = vec![
-                        ("pageSize", "100"),
-                        ("fields", FILES_FIELDS),
-                        ("q", query.as_str()),
-                        ("supportsAllDrives", "true"),
-                        ("includeItemsFromAllDrives", "true"),
-                        ("corpora", "drive"),
-                        ("driveId", &drive_id),
-                    ];
-                    if let Some(ref pt) = page_token {
-                        params.push(("pageToken", pt));
-                    }
-
-                    debug!(
-                        "[GOOGLE API CALL] list_trashed_files_in_drive drive={}, page_token={:?}",
-                        drive_id, page_token
-                    );
-                    let response = self
-                        .client
-                        .get(&url)
-                        .bearer_auth(&token)
-                        .query(&params)
-                        .send()
-                        .await
-                        .with_context(|| {
-                            format!("Failed to list trashed files in drive {}", drive_id)
-                        })?;
-
-                    let status = response.status();
-                    if !status.is_success() {
-                        return classify_google_api_error(
-                            response,
-                            "Failed to list trashed files in drive",
-                        )
-                        .await;
-                    }
-
-                    let response_text = response.text().await?;
-                    let parsed: FilesListResponse =
-                        serde_json::from_str(&response_text).map_err(|e| {
-                            anyhow!(
-                                "Failed to parse drive-scoped trashed file list response: {}. Raw: {}",
-                                e,
-                                response_text
-                            )
-                        })?;
-
-                    all_files.extend(parsed.files);
-                    page_token = parsed.next_page_token;
-                    if page_token.is_none() {
-                        break;
-                    }
-                }
-
-                Ok(ApiResult::Success(all_files))
-            }
-        })
+        self.list_all_files(
+            auth,
+            user_email,
+            FilesListRequest {
+                query: "trashed=true".to_string(),
+                fields: FILES_FIELDS,
+                order_by: None,
+                corpus: FilesListCorpus::Drive(drive_id.to_string()),
+                spaces: None,
+                page_token: None,
+                operation: format!("list trashed files in Drive {drive_id}"),
+                parse_errors_retryable: true,
+            },
+        )
         .await
     }
 
@@ -1751,61 +1613,22 @@ impl DriveClient {
         drive_id: Option<&str>,
         page_token: Option<&str>,
     ) -> Result<FilesListResponse> {
-        let parent_id_owned = parent_id.to_string();
-        let drive_id_owned = drive_id.map(str::to_string);
-        let page_token = page_token.map(str::to_string);
-
-        execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
-            let parent_id = parent_id_owned.clone();
-            let drive_id = drive_id_owned.clone();
-            let page_token = page_token.clone();
-            async move {
-                let url = format!("{}/files", drive_api_base().as_str());
-                let query = format!("trashed=false and '{}' in parents", parent_id);
-                let mut params: Vec<(&str, &str)> = vec![
-                    ("pageSize", "100"),
-                    ("fields", FILES_FIELDS),
-                    ("q", query.as_str()),
-                    ("supportsAllDrives", "true"),
-                    ("includeItemsFromAllDrives", "true"),
-                ];
-                if let Some(ref drive_id) = drive_id {
-                    params.push(("corpora", "drive"));
-                    params.push(("driveId", drive_id));
-                }
-                if let Some(ref page_token) = page_token {
-                    params.push(("pageToken", page_token));
-                }
-
-                debug!(
-                    "[GOOGLE API CALL] list_files_in_parent parent={}, drive={:?}, page_token={:?}",
-                    parent_id, drive_id, page_token
-                );
-                let response = self
-                    .client
-                    .get(&url)
-                    .bearer_auth(&token)
-                    .query(&params)
-                    .send()
-                    .await
-                    .with_context(|| format!("Failed to list files in folder {}", parent_id))?;
-                if !response.status().is_success() {
-                    return classify_google_api_error(response, "Failed to list files in folder")
-                        .await;
-                }
-
-                let response_text = response.text().await?;
-                let parsed: FilesListResponse =
-                    serde_json::from_str(&response_text).map_err(|e| {
-                        anyhow!(
-                            "Failed to parse folder-scoped file list response: {}. Raw: {}",
-                            e,
-                            response_text
-                        )
-                    })?;
-                Ok(ApiResult::Success(parsed))
-            }
-        })
+        self.list_files_page(
+            auth,
+            user_email,
+            FilesListRequest {
+                query: format!("trashed=false and '{}' in parents", parent_id),
+                fields: FILES_FIELDS,
+                order_by: None,
+                corpus: drive_id
+                    .map(|drive_id| FilesListCorpus::Drive(drive_id.to_string()))
+                    .unwrap_or(FilesListCorpus::Default),
+                spaces: None,
+                page_token: page_token.map(str::to_string),
+                operation: format!("list files in folder {parent_id}"),
+                parse_errors_retryable: true,
+            },
+        )
         .await
     }
 

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -34,6 +34,8 @@ const SHEETS_API_BASE: &str = "https://sheets.googleapis.com/v4";
 const SLIDES_API_BASE: &str = "https://slides.googleapis.com/v1";
 const DEFAULT_GOOGLE_SHEETS_MAX_INDEXED_ROWS: usize = 1000;
 const DEFAULT_GOOGLE_DRIVE_MAX_DOWNLOAD_BYTES: usize = 50 * 1024 * 1024;
+const FOLDER_DISCOVERY_FIELDS: &str =
+    "nextPageToken,incompleteSearch,files(id,name,mimeType,parents,driveId)";
 
 /// `fields` projection for file listings — includes `driveId` so shared-drive
 /// files can be attributed to their drive (observability + SA-direct metadata).
@@ -1230,9 +1232,102 @@ impl DriveClient {
         })
     }
 
+    /// List root folders for initial discovery, or search all accessible
+    /// folders when `search` is provided. When `include_my_drive` is false,
+    /// shared-drive search results are filtered before applying `max_results`.
+    pub async fn list_accessible_folders(
+        &self,
+        auth: &GoogleAuth,
+        user_email: &str,
+        search: Option<&str>,
+        include_my_drive: bool,
+        max_results: usize,
+    ) -> Result<FilesListResponse> {
+        execute_with_auth_retry(
+            auth,
+            user_email,
+            self.rate_limiter.clone(),
+            |token| async move {
+                let url = format!("{}/files", drive_api_base().as_str());
+                let query = if let Some(search) = search {
+                    let escaped = search.trim().replace('\\', "\\\\").replace('\'', "\\'");
+                    format!(
+                        "trashed=false and mimeType='application/vnd.google-apps.folder' and name contains '{}'",
+                        escaped
+                    )
+                } else {
+                    "trashed=false and mimeType='application/vnd.google-apps.folder' and 'root' in parents".to_string()
+                };
+                let corpora = if search.is_some() { "allDrives" } else { "user" };
+                let max_results = max_results.max(1);
+                let mut all_files = Vec::new();
+                let mut page_token: Option<String> = None;
+                let mut incomplete_search = false;
+
+                let truncated = loop {
+                    let mut params = vec![
+                        ("pageSize", "100"),
+                        ("fields", FOLDER_DISCOVERY_FIELDS),
+                        ("q", query.as_str()),
+                        ("orderBy", "name"),
+                        ("includeItemsFromAllDrives", "true"),
+                        ("supportsAllDrives", "true"),
+                        ("corpora", corpora),
+                        ("spaces", "drive"),
+                    ];
+                    if let Some(ref page_token) = page_token {
+                        params.push(("pageToken", page_token));
+                    }
+
+                    let response = self
+                        .client
+                        .get(&url)
+                        .bearer_auth(&token)
+                        .query(&params)
+                        .send()
+                        .await
+                        .context("Failed to list accessible Drive folders")?;
+                    if !response.status().is_success() {
+                        return classify_google_api_error(
+                            response,
+                            "Failed to list accessible Drive folders",
+                        )
+                        .await;
+                    }
+                    let parsed: FilesListResponse = response.json().await?;
+                    let next_page = parsed.next_page_token;
+                    incomplete_search |= parsed.incomplete_search;
+                    let mut page_files = parsed.files;
+                    if !include_my_drive {
+                        page_files.retain(|file| file.drive_id.is_some());
+                    }
+                    all_files.extend(page_files);
+                    if all_files.len() >= max_results {
+                        let exceeded_limit = all_files.len() > max_results;
+                        all_files.truncate(max_results);
+                        break incomplete_search || next_page.is_some() || exceeded_limit;
+                    }
+                    page_token = next_page;
+                    if page_token.is_none() {
+                        break incomplete_search;
+                    }
+                };
+
+                Ok(ApiResult::Success(FilesListResponse {
+                    files: all_files,
+                    incomplete_search,
+                    // The caller only uses this as a bounded-result marker;
+                    // it must not attempt to continue this discovery request.
+                    next_page_token: truncated.then(|| "discovery-truncated".to_string()),
+                }))
+            },
+        )
+        .await
+    }
+
     /// List shared drives visible to the delegated principal's credentials.
     ///
-    /// Paginates through all pages and returns the full list, sorted by drive name.
+    /// Paginates through accessible drives up to `max_results`, sorted by name.
     /// Only shared drives that the authenticated principal can see are returned;
     /// does NOT use `useDomainAdminAccess` so drives the principal explicitly has
     /// access to (e.g. shared drives they are members of) are surfaced.
@@ -1240,18 +1335,27 @@ impl DriveClient {
         &self,
         auth: &GoogleAuth,
         user_email: &str,
+        search: Option<&str>,
+        max_results: usize,
     ) -> Result<DrivesListResponse> {
         let user_email_owned = user_email.to_string();
+        let search_query = search
+            .map(str::trim)
+            .filter(|search| !search.is_empty())
+            .map(|search| search.replace('\\', "\\\\").replace('\'', "\\'"));
+        let max_results = max_results.max(1);
         let rate_limiter = self.rate_limiter.clone();
         let client = self.client.clone();
 
         let mut all_drives: Vec<DriveMetadata> = Vec::new();
         let mut page_token: Option<String> = None;
+        let mut truncated = false;
 
         loop {
             let page: DrivesListResponse =
                 execute_with_auth_retry(auth, &user_email_owned, rate_limiter.clone(), |token| {
                     let page_token = page_token.clone();
+                    let search_query = search_query.clone();
                     let client = client.clone();
                     async move {
                         let url = format!("{}/drives", drive_api_base().as_str());
@@ -1259,6 +1363,12 @@ impl DriveClient {
                             ("pageSize", "100"),
                             ("fields", "nextPageToken,drives(id,name)"),
                         ];
+                        let search_clause = search_query
+                            .as_ref()
+                            .map(|search| format!("name contains '{}'", search));
+                        if let Some(ref search_clause) = search_clause {
+                            params.push(("q", search_clause.as_str()));
+                        }
                         if let Some(ref pt) = page_token {
                             params.push(("pageToken", pt));
                         }
@@ -1294,9 +1404,15 @@ impl DriveClient {
                 })
                 .await?;
 
+            let next_page = page.next_page_token;
             all_drives.extend(page.drives);
+            if all_drives.len() >= max_results {
+                truncated = next_page.is_some() || all_drives.len() > max_results;
+                all_drives.truncate(max_results);
+                break;
+            }
 
-            if let Some(next) = page.next_page_token {
+            if let Some(next) = next_page {
                 page_token = Some(next);
             } else {
                 break;
@@ -1308,7 +1424,7 @@ impl DriveClient {
 
         Ok(DrivesListResponse {
             drives: all_drives,
-            next_page_token: None,
+            next_page_token: truncated.then(|| "discovery-truncated".to_string()),
         })
     }
 
@@ -1623,52 +1739,47 @@ impl DriveClient {
         Ok(all_permissions)
     }
 
-    /// List all files under a given folder (non-recursive, paginated).
+    /// List all immediate children (files and sub-folders) under a parent.
     ///
-    /// Lists ALL immediate children (files and sub-folders) regardless of
-    /// modification time so that old folders containing new files are never
-    /// missed. Date-based filtering is applied client-side in the caller.
-    /// Used by folder-subtree traversal in scoped filtered sync.
-    pub async fn list_files_in_folder(
+    /// A shared-drive ID selects `corpora=drive`; `None` uses the caller's
+    /// normal Drive corpus for My Drive and avoids sending `driveId=root`.
+    pub async fn list_files_in_parent(
         &self,
         auth: &GoogleAuth,
         user_email: &str,
-        folder_id: &str,
-        drive_id: &str,
+        parent_id: &str,
+        drive_id: Option<&str>,
         page_token: Option<&str>,
     ) -> Result<FilesListResponse> {
-        let folder_id_owned = folder_id.to_string();
-        let drive_id_owned = drive_id.to_string();
-        let page_token = page_token.map(|s| s.to_string());
+        let parent_id_owned = parent_id.to_string();
+        let drive_id_owned = drive_id.map(str::to_string);
+        let page_token = page_token.map(str::to_string);
 
         execute_with_auth_retry(auth, user_email, self.rate_limiter.clone(), |token| {
-            let folder_id = folder_id_owned.clone();
+            let parent_id = parent_id_owned.clone();
             let drive_id = drive_id_owned.clone();
             let page_token = page_token.clone();
             async move {
                 let url = format!("{}/files", drive_api_base().as_str());
-
-                // No date-cutoff in the query — we must discover old folders
-                // that may contain new files. The caller applies the cutoff
-                // client-side to non-folder file types only.
-                let query = format!("trashed=false and '{}' in parents", folder_id);
-
+                let query = format!("trashed=false and '{}' in parents", parent_id);
                 let mut params: Vec<(&str, &str)> = vec![
                     ("pageSize", "100"),
                     ("fields", FILES_FIELDS),
                     ("q", query.as_str()),
                     ("supportsAllDrives", "true"),
                     ("includeItemsFromAllDrives", "true"),
-                    ("corpora", "drive"),
-                    ("driveId", &drive_id),
                 ];
-                if let Some(ref pt) = page_token {
-                    params.push(("pageToken", pt));
+                if let Some(ref drive_id) = drive_id {
+                    params.push(("corpora", "drive"));
+                    params.push(("driveId", drive_id));
+                }
+                if let Some(ref page_token) = page_token {
+                    params.push(("pageToken", page_token));
                 }
 
                 debug!(
-                    "[GOOGLE API CALL] list_files_in_folder folder={}, drive={}, page_token={:?}",
-                    folder_id, drive_id, page_token
+                    "[GOOGLE API CALL] list_files_in_parent parent={}, drive={:?}, page_token={:?}",
+                    parent_id, drive_id, page_token
                 );
                 let response = self
                     .client
@@ -1677,10 +1788,8 @@ impl DriveClient {
                     .query(&params)
                     .send()
                     .await
-                    .with_context(|| format!("Failed to list files in folder {}", folder_id))?;
-
-                let status = response.status();
-                if !status.is_success() {
+                    .with_context(|| format!("Failed to list files in folder {}", parent_id))?;
+                if !response.status().is_success() {
                     return classify_google_api_error(response, "Failed to list files in folder")
                         .await;
                 }
@@ -1694,112 +1803,23 @@ impl DriveClient {
                             response_text
                         )
                     })?;
-
                 Ok(ApiResult::Success(parsed))
             }
         })
         .await
     }
 
-    /// List immediate children (sub-folders only) of a given folder in any drive.
-    ///
-    /// Paginates through all pages and returns the full list, sorted by name.
-    /// Uses `corpora=drive` and `driveId` scoping for shared-drive children.
-    pub async fn list_folder_children(
+    /// List all files under a shared-drive folder (non-recursive, paginated).
+    pub async fn list_files_in_folder(
         &self,
         auth: &GoogleAuth,
         user_email: &str,
         folder_id: &str,
         drive_id: &str,
+        page_token: Option<&str>,
     ) -> Result<FilesListResponse> {
-        let folder_id_owned = folder_id.to_string();
-        let drive_id_owned = drive_id.to_string();
-        let user_email_owned = user_email.to_string();
-        let rate_limiter = self.rate_limiter.clone();
-        let client = self.client.clone();
-
-        let mut all_files: Vec<GoogleDriveFile> = Vec::new();
-        let mut page_token: Option<String> = None;
-
-        loop {
-            let page: FilesListResponse = execute_with_auth_retry(
-                auth,
-                &user_email_owned,
-                rate_limiter.clone(),
-                |token| {
-                    let folder_id = folder_id_owned.clone();
-                    let drive_id = drive_id_owned.clone();
-                    let page_token = page_token.clone();
-                    let client = client.clone();
-                    async move {
-                        let url = format!("{}/files", drive_api_base().as_str());
-
-                        let query = format!(
-                            "trashed=false and mimeType='application/vnd.google-apps.folder' and '{}' in parents",
-                            folder_id
-                        );
-
-                        let mut params: Vec<(&str, &str)> = vec![
-                            ("pageSize", "100"),
-                            ("fields", "nextPageToken,files(id,name,mimeType,parents,createdTime)"),
-                            ("q", query.as_str()),
-                            ("supportsAllDrives", "true"),
-                            ("includeItemsFromAllDrives", "true"),
-                            ("corpora", "drive"),
-                            ("driveId", &drive_id),
-                        ];
-                        if let Some(ref pt) = page_token {
-                            params.push(("pageToken", pt));
-                        }
-
-                        let response = client
-                            .get(&url)
-                            .bearer_auth(&token)
-                            .query(&params)
-                            .send()
-                            .await?;
-
-                        let status = response.status();
-                        if !status.is_success() {
-                            return classify_google_api_error(
-                                response,
-                                format!("Failed to list folder children for {folder_id}"),
-                            )
-                            .await;
-                        }
-
-                        let response_text = response.text().await?;
-                        let parsed: FilesListResponse =
-                            serde_json::from_str(&response_text).map_err(|e| {
-                                anyhow!(
-                                    "Failed to parse folder children response: {}. Raw: {}",
-                                    e,
-                                    response_text
-                                )
-                            })?;
-
-                        Ok(ApiResult::Success(parsed))
-                    }
-                },
-            )
-            .await?;
-
-            all_files.extend(page.files);
-
-            if let Some(next) = page.next_page_token {
-                page_token = Some(next);
-            } else {
-                break;
-            }
-        }
-
-        // Deterministic sort by name for stable UI ordering.
-        all_files.sort_by(|a, b| a.name.cmp(&b.name));
-
-        Ok(FilesListResponse {
-            files: all_files,
-            next_page_token: None,
-        })
+        self.list_files_in_parent(auth, user_email, folder_id, Some(drive_id), page_token)
+            .await
     }
 }
 
@@ -1822,6 +1842,8 @@ pub struct FilesListResponse {
     pub files: Vec<GoogleDriveFile>,
     #[serde(rename = "nextPageToken")]
     pub next_page_token: Option<String>,
+    #[serde(default, rename = "incompleteSearch")]
+    pub incomplete_search: bool,
 }
 
 #[derive(Debug, Deserialize)]

--- a/connectors/google/src/drive.rs
+++ b/connectors/google/src/drive.rs
@@ -1111,7 +1111,10 @@ impl DriveClient {
                 let url = format!("{}/files/{}", drive_api_base().as_str(), folder_id);
 
                 let params = vec![
-                    ("fields", "id,name,parents,mimeType"),
+                    (
+                        "fields",
+                        "id,name,parents,mimeType,driveId,inheritedPermissionsDisabled",
+                    ),
                     ("supportsAllDrives", "true"),
                 ];
 
@@ -1520,8 +1523,7 @@ impl DriveClient {
     ///
     /// Paginates fully (pageSize=100) and returns the complete member list.
     /// Requires a caller-provided bearer token (SA self-token or impersonated
-    /// DWD token). Works for any fileId — used for drive ACLs and, in the
-    /// SA-direct effective-permission model, for folder ACLs.
+    /// DWD token). Works for any fileId — used for drive ACLs and folder ACLs.
     pub async fn list_drive_permissions(
         &self,
         token: &str,

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -58,6 +58,17 @@ pub enum GoogleAuthMode {
     ServiceAccountDirect,
 }
 
+/// Controls whether a Drive source is ready to index and which files are in scope.
+/// Missing values are treated as `All` for backwards compatibility.
+#[derive(Debug, Clone, Copy, Default, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "snake_case")]
+pub enum GoogleIndexScope {
+    #[default]
+    All,
+    Selected,
+    Pending,
+}
+
 /// Typed view of a Google source's `sources.config` blob.
 ///
 /// Deserialized once at the sync/action boundary and validated via
@@ -67,11 +78,15 @@ pub enum GoogleAuthMode {
 pub struct GoogleSourceConfig {
     #[serde(default)]
     pub auth_mode: GoogleAuthMode,
+    /// Personal OAuth onboarding uses `pending` until the owner chooses a scope.
+    #[serde(default)]
+    pub index_scope: GoogleIndexScope,
     /// Retained for existing source-config compatibility (DWD).
     #[serde(default)]
     pub domain: Option<String>,
     /// Selected shared drives (kind `shared_drive_root`) and optional folder
-    /// subtrees (kind `folder`). Empty/missing => index everything (DWD).
+    /// subtrees (kind `folder`). Empty/missing means all files unless
+    /// `index_scope` is `selected`.
     #[serde(default)]
     pub folder_path_filters: Vec<FolderPathFilterEntry>,
     #[serde(default)]
@@ -87,6 +102,8 @@ impl GoogleSourceConfig {
     /// is the stored credential's auth type (OAuth vs service-account JWT).
     ///
     /// Rules:
+    /// - `Pending` is rejected so an OAuth source cannot sync before setup.
+    /// - `Selected` requires at least one folder filter.
     /// - `ServiceAccountDirect` requires JWT/service-account credentials and is
     ///   valid only for Google Drive.
     /// - `ServiceAccountDirect` requires a non-empty `folder_path_filters` list
@@ -97,8 +114,34 @@ impl GoogleSourceConfig {
         source_type: SourceType,
         credential_auth_type: AuthType,
     ) -> Result<(), String> {
+        match self.index_scope {
+            GoogleIndexScope::Pending => {
+                return Err("Google Drive source is waiting for an indexing scope".to_string());
+            }
+            GoogleIndexScope::Selected if self.folder_path_filters.is_empty() => {
+                return Err(
+                    "selected Drive scope requires at least one folder or shared drive".to_string(),
+                );
+            }
+            GoogleIndexScope::All | GoogleIndexScope::Selected => {}
+        }
+
         match self.auth_mode {
-            GoogleAuthMode::DomainWideDelegation => Ok(()),
+            GoogleAuthMode::DomainWideDelegation => {
+                if credential_auth_type != AuthType::OAuth
+                    && source_type == SourceType::GoogleDrive
+                    && self
+                        .folder_path_filters
+                        .iter()
+                        .any(|entry| entry.drive_id == "my_drive")
+                {
+                    return Err(
+                        "domain-wide Drive folder scopes must target shared drives; use personal OAuth for My Drive folders"
+                            .to_string(),
+                    );
+                }
+                Ok(())
+            }
             GoogleAuthMode::ServiceAccountDirect => {
                 if credential_auth_type == AuthType::OAuth {
                     return Err(
@@ -149,6 +192,7 @@ pub struct DriveFolderDiscoveryEntry {
 #[derive(Debug, Clone, Serialize)]
 pub struct DriveFolderDiscoveryResponse {
     pub items: Vec<DriveFolderDiscoveryEntry>,
+    pub truncated: bool,
 }
 
 /// Helper to parse folder_path_filters from a source config.
@@ -2446,6 +2490,38 @@ mod tests {
     }
 
     #[test]
+    fn test_personal_index_scope_validation() {
+        let pending: GoogleSourceConfig = serde_json::from_value(json!({
+            "index_scope": "pending"
+        }))
+        .unwrap();
+        assert!(
+            pending
+                .validate(SourceType::GoogleDrive, AuthType::OAuth)
+                .is_err()
+        );
+
+        let selected: GoogleSourceConfig = serde_json::from_value(json!({
+            "index_scope": "selected"
+        }))
+        .unwrap();
+        assert!(
+            selected
+                .validate(SourceType::GoogleDrive, AuthType::OAuth)
+                .is_err()
+        );
+
+        let all: GoogleSourceConfig = serde_json::from_value(json!({
+            "index_scope": "all"
+        }))
+        .unwrap();
+        assert!(
+            all.validate(SourceType::GoogleDrive, AuthType::OAuth)
+                .is_ok()
+        );
+    }
+
+    #[test]
     fn test_google_source_config_tolerates_unknown_top_level_keys() {
         // Legacy/unknown top-level config keys must not reject deserialization
         // (they could break every existing source at dispatch time).
@@ -2525,7 +2601,7 @@ mod tests {
                 .is_err()
         );
 
-        // DWD remains permissive regardless of filters.
+        // DWD remains permissive for non-Drive configurations.
         let dwd = GoogleSourceConfig {
             auth_mode: GoogleAuthMode::DomainWideDelegation,
             folder_path_filters: vec![],

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -81,7 +81,7 @@ pub struct GoogleSourceConfig {
     /// Personal OAuth onboarding uses `pending` until the owner chooses a scope.
     #[serde(default)]
     pub index_scope: GoogleIndexScope,
-    /// Retained for existing source-config compatibility (DWD).
+    /// Workspace domain used for DWD impersonation or SA-direct group sync.
     #[serde(default)]
     pub domain: Option<String>,
     /// Selected shared drives (kind `shared_drive_root`) and optional folder
@@ -106,8 +106,9 @@ impl GoogleSourceConfig {
     /// - `Selected` requires at least one folder filter.
     /// - `ServiceAccountDirect` requires JWT/service-account credentials and is
     ///   valid only for Google Drive.
-    /// - `ServiceAccountDirect` requires a non-empty `folder_path_filters` list
-    ///   whose entries are all `SharedDriveRoot` (whole drives only in v1).
+    /// - `ServiceAccountDirect` requires a non-empty domain and
+    ///   `folder_path_filters` list whose entries are all `SharedDriveRoot`
+    ///   (whole drives only in v1).
     /// - `DomainWideDelegation` keeps the existing permissive behavior.
     pub fn validate(
         &self,
@@ -158,6 +159,16 @@ impl GoogleSourceConfig {
                 if self.folder_path_filters.is_empty() {
                     return Err(
                         "service_account_direct requires at least one shared drive in folder_path_filters"
+                            .to_string(),
+                    );
+                }
+                if self
+                    .domain
+                    .as_deref()
+                    .is_none_or(|domain| domain.trim().is_empty())
+                {
+                    return Err(
+                        "service_account_direct requires an organization domain for group membership sync"
                             .to_string(),
                     );
                 }
@@ -298,6 +309,15 @@ pub struct SharedDriveAccessResult {
 #[derive(Debug, Clone, Serialize)]
 pub struct SharedDriveAccessResponse {
     pub drives: Vec<SharedDriveAccessResult>,
+}
+
+/// Result of validating SA-direct Google Workspace group membership access.
+/// Mirrors the web's `SaDirectGroupAccessResponse` type.
+#[derive(Debug, Clone, Serialize)]
+pub struct SaDirectGroupAccessResponse {
+    pub domain: String,
+    pub groups: usize,
+    pub memberships: usize,
 }
 
 #[derive(Debug, Clone, Default, Serialize, Deserialize)]
@@ -2546,6 +2566,7 @@ mod tests {
         // Valid SA-direct: JWT creds + Drive + root filter.
         let valid = GoogleSourceConfig {
             auth_mode: GoogleAuthMode::ServiceAccountDirect,
+            domain: Some("example.com".to_string()),
             folder_path_filters: vec![root.clone()],
             ..Default::default()
         };

--- a/connectors/google/src/models.rs
+++ b/connectors/google/src/models.rs
@@ -363,7 +363,7 @@ pub struct GoogleSyncCheckpoint {
     /// so previously indexed unchanged documents get the new ACLs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub drive_acl_fingerprints: Option<HashMap<String, String>>,
-    /// Per-folder access state for the SA-direct effective-permission model.
+    /// Per-folder access state for shared-drive effective-permission models.
     /// Only folders that are limited-access or carry direct grants are
     /// recorded; incremental syncs re-fetch their ACLs to detect changes that
     /// `changes.list` does not deliver for descendants.
@@ -381,7 +381,7 @@ pub struct GoogleSyncCheckpoint {
 /// `GoogleSyncCheckpoint::permission_model_version`.
 pub const SA_DIRECT_PERMISSION_MODEL_VERSION: &str = "effective-acl-v1";
 
-/// Run-local access metadata for a folder during an SA-direct sync. Folders
+/// Run-local access metadata for a folder during a shared-drive sync. Folders
 /// are discovered from the drive listing (parents + limited-access flag) and
 /// their directly-assigned ACLs are fetched lazily via `permissions.list`.
 #[derive(Debug, Clone, Default)]
@@ -450,9 +450,9 @@ pub struct GoogleChatSegmentCheckpoint {
 pub struct UserFile {
     pub user_email: Arc<String>,
     pub file: GoogleDriveFile,
-    /// Optional drive-level ACL override (SA-direct mode). When set, this is
-    /// used as the event's permissions instead of the file's own (empty for
-    /// shared-drive items) permission array.
+    /// Optional effective ACL override for shared-drive syncs. When set, this
+    /// is used as the event's permissions instead of the file's own (usually
+    /// empty for shared-drive items) permission array.
     pub permissions_override: Option<DocumentPermissions>,
 }
 

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -113,6 +113,14 @@ struct DriveGroup {
     folder_ids: Vec<String>,
 }
 
+#[derive(Debug, Default)]
+struct SharedDriveAclState {
+    drive_acl_fingerprints: HashMap<String, String>,
+    drive_acl_overrides: HashMap<String, DocumentPermissions>,
+    drive_acl_raw: HashMap<String, Vec<GoogleDrivePermission>>,
+    drive_acl_changed: HashMap<String, bool>,
+}
+
 struct DriveUserSyncResult {
     scanned: usize,
     updated: usize,
@@ -2001,25 +2009,109 @@ impl SyncManager {
         Ok(())
     }
 
+    /// Fetch and fingerprint the shared-drive ACLs used by both service-account
+    /// direct sync and impersonated DWD sync. The caller controls whether a
+    /// technical service-account member is excluded from the mapped document ACL.
+    async fn load_shared_drive_acl_state(
+        &self,
+        access_token: &str,
+        drives: &[DriveGroup],
+        old_acl_fingerprints: &HashMap<String, String>,
+        exclude_email: Option<&str>,
+    ) -> Result<SharedDriveAclState> {
+        let mut state = SharedDriveAclState::default();
+        for drive_group in drives {
+            let drive_id = &drive_group.drive_id;
+            let drive_acl = self
+                .drive_client
+                .list_drive_permissions(access_token, drive_id)
+                .await
+                .with_context(|| format!("Failed to read ACLs for drive {}", drive_id))?;
+
+            let fingerprint = crate::models::drive_acl_fingerprint(&drive_acl);
+            let changed = old_acl_fingerprints.get(drive_id) != Some(&fingerprint);
+            if changed {
+                info!(
+                    "ACL fingerprint changed for drive {} — forcing full re-traversal",
+                    drive_id
+                );
+            }
+            state
+                .drive_acl_fingerprints
+                .insert(drive_id.clone(), fingerprint);
+            state.drive_acl_overrides.insert(
+                drive_id.clone(),
+                crate::models::map_drive_permissions(&drive_acl, exclude_email),
+            );
+            state.drive_acl_raw.insert(drive_id.clone(), drive_acl);
+            state.drive_acl_changed.insert(drive_id.clone(), changed);
+        }
+        Ok(state)
+    }
+
+    fn record_folder_access(
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+        folder: &GoogleDriveFile,
+    ) {
+        let entry = folder_access.entry(folder.id.clone()).or_default();
+        entry.parents = folder.parents.clone().unwrap_or_default();
+        entry.inherited_permissions_disabled =
+            folder.inherited_permissions_disabled.unwrap_or(false);
+    }
+
+    /// Fetch directly-assigned ACLs for folders with bounded concurrency.
+    /// SA-direct preserves its historical best-effort behavior while scoped DWD
+    /// fails closed because it cannot safely model a selected subtree without
+    /// its folder ACLs.
+    async fn load_folder_acls(
+        &self,
+        access_token: &str,
+        folder_ids: Vec<String>,
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+        strict: bool,
+    ) -> Result<()> {
+        let client = self.drive_client.clone();
+        let token = access_token.to_string();
+        let semaphore = Arc::new(Semaphore::new(GOOGLE_FILE_CONCURRENCY));
+        let mut tasks = tokio::task::JoinSet::new();
+        for folder_id in folder_ids {
+            let client = client.clone();
+            let token = token.clone();
+            let permit = semaphore.clone();
+            tasks.spawn(async move {
+                let _guard = permit.acquire_owned().await;
+                let result = client.list_drive_permissions(&token, &folder_id).await;
+                (folder_id, result)
+            });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            let (folder_id, result) =
+                joined.map_err(|error| anyhow!("Folder ACL fetch task failed: {}", error))?;
+            match result {
+                Ok(raw) => {
+                    if let Some(entry) = folder_access.get_mut(&folder_id) {
+                        entry.acl = Some(crate::models::filter_direct_permissions(&raw));
+                    }
+                }
+                Err(error) if strict => {
+                    return Err(error)
+                        .with_context(|| format!("Failed to read ACL for folder {}", folder_id));
+                }
+                Err(error) => {
+                    warn!("Failed to read ACLs for folder {}: {}", folder_id, error);
+                }
+            }
+        }
+        Ok(())
+    }
+
     fn record_scoped_folder_access(
         folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
         folder_drive_ids: &mut HashMap<String, String>,
         folder: &GoogleDriveFile,
         drive_id: &str,
     ) {
-        let existing_acl = folder_access
-            .get(&folder.id)
-            .and_then(|entry| entry.acl.clone());
-        folder_access.insert(
-            folder.id.clone(),
-            crate::models::FolderAccessEntry {
-                parents: folder.parents.clone().unwrap_or_default(),
-                inherited_permissions_disabled: folder
-                    .inherited_permissions_disabled
-                    .unwrap_or(false),
-                acl: existing_acl,
-            },
-        );
+        Self::record_folder_access(folder_access, folder);
         folder_drive_ids.insert(folder.id.clone(), drive_id.to_string());
     }
 
@@ -2128,31 +2220,8 @@ impl SyncManager {
                     .then(|| folder_id.clone())
             })
             .collect();
-        let client = self.drive_client.clone();
-        let token = access_token.to_string();
-        let semaphore = Arc::new(Semaphore::new(GOOGLE_FILE_CONCURRENCY));
-        let mut tasks = tokio::task::JoinSet::new();
-        for folder_id in pending {
-            let client = client.clone();
-            let token = token.clone();
-            let permit = semaphore.clone();
-            tasks.spawn(async move {
-                let _guard = permit.acquire_owned().await;
-                let result = client.list_drive_permissions(&token, &folder_id).await;
-                (folder_id, result)
-            });
-        }
-        while let Some(joined) = tasks.join_next().await {
-            let (folder_id, result) =
-                joined.map_err(|error| anyhow!("Folder ACL fetch task failed: {}", error))?;
-            let raw =
-                result.with_context(|| format!("Failed to read ACL for folder {}", folder_id))?;
-            if let Some(entry) = folder_access.get_mut(&folder_id) {
-                entry.acl = Some(crate::models::filter_direct_permissions(&raw));
-            }
-        }
-
-        Ok(())
+        self.load_folder_acls(access_token, pending, folder_access, true)
+            .await
     }
 
     /// Scoped full sync: crawl selected shared drives and/or folder subtrees only,
@@ -2253,40 +2322,32 @@ impl SyncManager {
             .drive_acl_fingerprints
             .clone()
             .unwrap_or_default();
-        let mut new_acl_fingerprints: HashMap<String, String> = HashMap::new();
-        let mut drive_acl_overrides: HashMap<String, DocumentPermissions> = HashMap::new();
-        let mut drive_acl_raw: HashMap<String, Vec<GoogleDrivePermission>> = HashMap::new();
-        let mut drive_acl_changed: HashMap<String, bool> = HashMap::new();
-        for drive_group in &drives {
-            let drive_id = &drive_group.drive_id;
-            let drive_acl = self
-                .drive_client
-                .list_drive_permissions(&access_token, drive_id)
-                .await
-                .with_context(|| format!("Failed to read ACLs for drive {}", drive_id))?;
+        let service_account_email = match service_auth.as_ref() {
+            GoogleAuth::ServiceAccount(service_account) => Some(service_account.client_email()),
+            GoogleAuth::OAuth(_) => None,
+        };
+        let acl_state = self
+            .load_shared_drive_acl_state(
+                &access_token,
+                &drives,
+                &old_acl_fingerprints,
+                service_account_email,
+            )
+            .await?;
+        for (drive_id, drive_acl) in &acl_state.drive_acl_raw {
             if drive_acl.is_empty() {
                 return Err(anyhow!(
                     "Drive {} returned an empty permission list; refusing to index shared-drive documents without a complete ACL",
                     drive_id
                 ));
             }
-
-            let fingerprint = crate::models::drive_acl_fingerprint(&drive_acl);
-            let changed = old_acl_fingerprints.get(drive_id) != Some(&fingerprint);
-            if changed {
-                info!(
-                    "ACL fingerprint changed for drive {} — forcing full re-traversal",
-                    drive_id
-                );
-            }
-            new_acl_fingerprints.insert(drive_id.clone(), fingerprint);
-            drive_acl_overrides.insert(
-                drive_id.clone(),
-                crate::models::map_drive_permissions(&drive_acl, None),
-            );
-            drive_acl_raw.insert(drive_id.clone(), drive_acl);
-            drive_acl_changed.insert(drive_id.clone(), changed);
         }
+        let SharedDriveAclState {
+            drive_acl_fingerprints: new_acl_fingerprints,
+            drive_acl_overrides,
+            drive_acl_raw,
+            drive_acl_changed,
+        } = acl_state;
 
         let stored_folder_access = existing_state.folder_access.clone().unwrap_or_default();
         let mut folder_access: HashMap<String, crate::models::FolderAccessEntry> =
@@ -2939,40 +3000,19 @@ impl SyncManager {
             .drive_acl_fingerprints
             .clone()
             .unwrap_or_default();
-        let mut new_acl_fingerprints: HashMap<String, String> = HashMap::new();
-        let mut drive_acl_overrides: HashMap<String, DocumentPermissions> = HashMap::new();
-        let mut drive_acl_changed: HashMap<String, bool> = HashMap::new();
-        // Raw (unmapped) drive ACLs, needed to compute the always-access
-        // organizer set at limited-access folder boundaries.
-        let mut drive_acl_raw: HashMap<String, Vec<GoogleDrivePermission>> = HashMap::new();
-
-        for drive_group in &drives {
-            let drive_id = &drive_group.drive_id;
-            let drive_acl = self
-                .drive_client
-                .list_drive_permissions(&access_token, drive_id)
-                .await
-                .with_context(|| format!("Failed to read ACLs for drive {}", drive_id))?;
-
-            let _role = crate::models::validate_sa_drive_access(drive_id, &drive_acl, &sa_email)?;
-
-            let permissions = crate::models::map_drive_permissions(&drive_acl, Some(&sa_email));
-            let fingerprint = crate::models::drive_acl_fingerprint(&drive_acl);
-            let changed = old_acl_fingerprints.get(drive_id) != Some(&fingerprint);
-            if changed {
-                info!(
-                    "ACL fingerprint changed for drive {} — forcing full re-traversal",
-                    drive_id
-                );
-            }
-            new_acl_fingerprints.insert(drive_id.clone(), fingerprint);
-            drive_acl_overrides.insert(drive_id.clone(), permissions);
-            drive_acl_changed.insert(drive_id.clone(), changed);
-            drive_acl_raw.insert(drive_id.clone(), drive_acl);
-
-            if drive_acl_raw
-                .get(drive_id)
-                .is_some_and(|acl| acl.iter().any(|p| p.permission_type == "group"))
+        let acl_state = self
+            .load_shared_drive_acl_state(
+                &access_token,
+                &drives,
+                &old_acl_fingerprints,
+                Some(&sa_email),
+            )
+            .await?;
+        for (drive_id, drive_acl) in &acl_state.drive_acl_raw {
+            crate::models::validate_sa_drive_access(drive_id, drive_acl, &sa_email)?;
+            if drive_acl
+                .iter()
+                .any(|permission| permission.permission_type == "group")
             {
                 warn!(
                     "Drive {} ACL includes group grants. Group-granted documents are visible \
@@ -2982,6 +3022,12 @@ impl SyncManager {
                 );
             }
         }
+        let SharedDriveAclState {
+            drive_acl_fingerprints: new_acl_fingerprints,
+            drive_acl_overrides,
+            drive_acl_raw,
+            drive_acl_changed,
+        } = acl_state;
 
         let content_cache = Arc::new(DriveContentCache::default());
         let mut total_scanned = 0;
@@ -3367,10 +3413,7 @@ impl SyncManager {
                 .list_folders_in_drive(service_auth, sa_email, drive_id, folder_page.as_deref())
                 .await?;
             for folder in response.files {
-                let entry = folder_access.entry(folder.id.clone()).or_default();
-                entry.parents = folder.parents.clone().unwrap_or_default();
-                entry.inherited_permissions_disabled =
-                    folder.inherited_permissions_disabled.unwrap_or(false);
+                Self::record_folder_access(folder_access, &folder);
             }
             match response.next_page_token {
                 Some(token) => folder_page = Some(token),
@@ -3387,34 +3430,8 @@ impl SyncManager {
             .filter(|(_, entry)| entry.acl.is_none())
             .map(|(id, _)| id.clone())
             .collect();
-        let client = self.drive_client.clone();
-        let token = access_token.to_string();
-        let semaphore = Arc::new(Semaphore::new(GOOGLE_FILE_CONCURRENCY));
-        let mut tasks = tokio::task::JoinSet::new();
-        for folder_id in pending {
-            let client = client.clone();
-            let token = token.clone();
-            let permit = semaphore.clone();
-            tasks.spawn(async move {
-                let _guard = permit.acquire_owned().await;
-                let result = client.list_drive_permissions(&token, &folder_id).await;
-                (folder_id, result)
-            });
-        }
-        while let Some(joined) = tasks.join_next().await {
-            let (folder_id, result) =
-                joined.map_err(|e| anyhow!("Folder ACL fetch task failed: {}", e))?;
-            match result {
-                Ok(raw) => {
-                    if let Some(entry) = folder_access.get_mut(&folder_id) {
-                        entry.acl = Some(crate::models::filter_direct_permissions(&raw));
-                    }
-                }
-                Err(e) => {
-                    warn!("Failed to read ACLs for folder {}: {}", folder_id, e);
-                }
-            }
-        }
+        self.load_folder_acls(access_token, pending, folder_access, false)
+            .await?;
 
         let mut file_batch: Vec<UserFile> = Vec::new();
         let mut page_token: Option<String> = None;

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -20,8 +20,12 @@ const GOOGLE_MAX_BUFFERED_BYTES: usize = 512 * 1024 * 1024;
 const GOOGLE_BUFFER_PERMIT_UNIT: usize = 64 * 1024;
 const GOOGLE_BUFFER_PERMITS: usize = GOOGLE_MAX_BUFFERED_BYTES / GOOGLE_BUFFER_PERMIT_UNIT;
 
-/// Batch size for SA-direct file emission (SA-direct path only).
+/// Batch size for shared-drive ACL-aware file emission.
 const SA_DIRECT_BATCH_SIZE: usize = 200;
+
+/// Bump when scoped DWD permission derivation changes so existing documents
+/// are re-emitted with freshly computed shared-drive ACLs.
+const SCOPED_DWD_PERMISSION_MODEL_VERSION: &str = "scoped-dwd-effective-acl-v1";
 
 /// `application/vnd.google-apps.folder` — folders carry access metadata but are
 /// never indexed as documents.
@@ -1580,9 +1584,10 @@ impl SyncManager {
 
                 let file_lock = content_cache.lock_for_file(&user_file.file.id);
                 let _file_guard = file_lock.lock().await;
-                // SA-direct mode carries a drive-level ACL override; use it as-is
-                // (the file's own permissions array is empty for shared drives).
-                // Otherwise derive from the file + syncing user as before.
+                // Shared-drive syncs carry a computed effective ACL override;
+                // use it as-is because the file's own permissions array is
+                // empty for shared-drive items. Otherwise derive permissions
+                // from the file and syncing user as before.
                 let current_permissions = match &user_file.permissions_override {
                     Some(override_permissions) => override_permissions.clone(),
                     None => user_file
@@ -1930,15 +1935,19 @@ impl SyncManager {
         drive_page_tokens: Option<HashMap<String, String>>,
         drive_change_tokens: Option<HashMap<String, String>>,
         drive_scope_fingerprint: Option<String>,
+        drive_acl_fingerprints: Option<HashMap<String, String>>,
+        folder_access: Option<HashMap<String, crate::models::FolderAccessInfo>>,
+        permission_model_version: Option<String>,
     ) -> GoogleSyncCheckpoint {
         GoogleSyncCheckpoint {
             gmail_history_ids: existing.gmail_history_ids.clone(),
             drive_page_tokens,
             drive_change_tokens,
             drive_scope_fingerprint,
-            drive_acl_fingerprints: existing.drive_acl_fingerprints.clone(),
+            drive_acl_fingerprints,
+            folder_access,
+            permission_model_version,
             chat: existing.chat.clone(),
-            ..Default::default()
         }
     }
 
@@ -1989,6 +1998,160 @@ impl SyncManager {
             .await?;
         *total_scanned += s;
         *total_updated += u;
+        Ok(())
+    }
+
+    fn record_scoped_folder_access(
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+        folder_drive_ids: &mut HashMap<String, String>,
+        folder: &GoogleDriveFile,
+        drive_id: &str,
+    ) {
+        let existing_acl = folder_access
+            .get(&folder.id)
+            .and_then(|entry| entry.acl.clone());
+        folder_access.insert(
+            folder.id.clone(),
+            crate::models::FolderAccessEntry {
+                parents: folder.parents.clone().unwrap_or_default(),
+                inherited_permissions_disabled: folder
+                    .inherited_permissions_disabled
+                    .unwrap_or(false),
+                acl: existing_acl,
+            },
+        );
+        folder_drive_ids.insert(folder.id.clone(), drive_id.to_string());
+    }
+
+    /// Load metadata and directly assigned ACLs from `folder_id` up to the
+    /// shared-drive root. The scoped traversal needs this for a selected folder
+    /// itself and for changed files whose ordinary ancestors are intentionally
+    /// absent from the compact persisted ACL checkpoint.
+    async fn ensure_scoped_folder_acl_chain(
+        &self,
+        service_auth: &GoogleAuth,
+        principal_email: &str,
+        access_token: &str,
+        folder_id: Option<String>,
+        drive_id: &str,
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+        folder_drive_ids: &mut HashMap<String, String>,
+    ) -> Result<()> {
+        let mut current_id = folder_id;
+        while let Some(id) = current_id {
+            if id == drive_id {
+                break;
+            }
+
+            if !folder_access.contains_key(&id) {
+                let folder = self
+                    .drive_client
+                    .get_folder_metadata(service_auth, principal_email, &id)
+                    .await
+                    .with_context(|| format!("Failed to read metadata for folder {}", id))?;
+                Self::record_scoped_folder_access(
+                    folder_access,
+                    folder_drive_ids,
+                    &folder,
+                    drive_id,
+                );
+            }
+
+            let needs_acl = folder_access
+                .get(&id)
+                .is_some_and(|entry| entry.acl.is_none());
+            if needs_acl {
+                let raw = self
+                    .drive_client
+                    .list_drive_permissions(access_token, &id)
+                    .await
+                    .with_context(|| format!("Failed to read ACL for folder {}", id))?;
+                if let Some(entry) = folder_access.get_mut(&id) {
+                    entry.acl = Some(crate::models::filter_direct_permissions(&raw));
+                }
+            }
+
+            folder_drive_ids.insert(id.clone(), drive_id.to_string());
+            current_id = folder_access
+                .get(&id)
+                .and_then(|entry| entry.parents.first())
+                .cloned();
+        }
+        Ok(())
+    }
+
+    /// Populate the complete folder hierarchy and direct ACL map before files
+    /// from an entire shared drive are emitted. `files.list` ordering is
+    /// arbitrary, so files cannot safely be permissioned until their ancestor
+    /// metadata is available.
+    async fn load_scoped_drive_folder_access(
+        &self,
+        service_auth: &GoogleAuth,
+        principal_email: &str,
+        access_token: &str,
+        drive_id: &str,
+        folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
+        folder_drive_ids: &mut HashMap<String, String>,
+    ) -> Result<()> {
+        let mut page_token: Option<String> = None;
+        loop {
+            let response = self
+                .drive_client
+                .list_folders_in_drive(
+                    service_auth,
+                    principal_email,
+                    drive_id,
+                    page_token.as_deref(),
+                )
+                .await?;
+            for folder in response.files {
+                Self::record_scoped_folder_access(
+                    folder_access,
+                    folder_drive_ids,
+                    &folder,
+                    drive_id,
+                );
+            }
+            page_token = response.next_page_token;
+            if page_token.is_none() {
+                break;
+            }
+        }
+
+        let pending: Vec<String> = folder_drive_ids
+            .iter()
+            .filter(|(_, entry_drive_id)| entry_drive_id.as_str() == drive_id)
+            .filter_map(|(folder_id, _)| {
+                folder_access
+                    .get(folder_id)
+                    .is_some_and(|entry| entry.acl.is_none())
+                    .then(|| folder_id.clone())
+            })
+            .collect();
+        let client = self.drive_client.clone();
+        let token = access_token.to_string();
+        let semaphore = Arc::new(Semaphore::new(GOOGLE_FILE_CONCURRENCY));
+        let mut tasks = tokio::task::JoinSet::new();
+        for folder_id in pending {
+            let client = client.clone();
+            let token = token.clone();
+            let permit = semaphore.clone();
+            tasks.spawn(async move {
+                let _guard = permit.acquire_owned().await;
+                let result = client.list_drive_permissions(&token, &folder_id).await;
+                (folder_id, result)
+            });
+        }
+        while let Some(joined) = tasks.join_next().await {
+            let (folder_id, result) =
+                joined.map_err(|error| anyhow!("Folder ACL fetch task failed: {}", error))?;
+            let raw =
+                result.with_context(|| format!("Failed to read ACL for folder {}", folder_id))?;
+            if let Some(entry) = folder_access.get_mut(&folder_id) {
+                entry.acl = Some(crate::models::filter_direct_permissions(&raw));
+            }
+        }
+
         Ok(())
     }
 
@@ -2045,6 +2208,9 @@ impl SyncManager {
                 None,
                 None,
                 Some(current_fingerprint),
+                existing_state.drive_acl_fingerprints.clone(),
+                existing_state.folder_access.clone(),
+                existing_state.permission_model_version.clone(),
             ));
         }
 
@@ -2058,10 +2224,94 @@ impl SyncManager {
         // Shared-drive operations need a single access token (no impersonation per user).
         let access_token = service_auth.get_access_token(&principal_email).await?;
 
+        // Capture watermarks before ACL preflight. If a membership change
+        // forces a full traversal, changes made during that traversal must be
+        // replayed from a token that predates the preflight.
+        let mut full_traversal_start_tokens: HashMap<String, Option<String>> = HashMap::new();
+        for drive_group in &drives {
+            let token = match self
+                .drive_client
+                .get_start_page_token_for_drive(&access_token, &drive_group.drive_id)
+                .await
+            {
+                Ok(token) => Some(token),
+                Err(error) => {
+                    warn!(
+                        "Failed to get start page token for drive {}: {}",
+                        drive_group.drive_id, error
+                    );
+                    None
+                }
+            };
+            full_traversal_start_tokens.insert(drive_group.drive_id.clone(), token);
+        }
+
+        // Shared-drive file list responses do not contain their effective ACL.
+        // Resolve the drive member list explicitly and fingerprint it so a
+        // membership change re-emits unchanged documents with corrected ACLs.
+        let old_acl_fingerprints = existing_state
+            .drive_acl_fingerprints
+            .clone()
+            .unwrap_or_default();
+        let mut new_acl_fingerprints: HashMap<String, String> = HashMap::new();
+        let mut drive_acl_overrides: HashMap<String, DocumentPermissions> = HashMap::new();
+        let mut drive_acl_raw: HashMap<String, Vec<GoogleDrivePermission>> = HashMap::new();
+        let mut drive_acl_changed: HashMap<String, bool> = HashMap::new();
+        for drive_group in &drives {
+            let drive_id = &drive_group.drive_id;
+            let drive_acl = self
+                .drive_client
+                .list_drive_permissions(&access_token, drive_id)
+                .await
+                .with_context(|| format!("Failed to read ACLs for drive {}", drive_id))?;
+            if drive_acl.is_empty() {
+                return Err(anyhow!(
+                    "Drive {} returned an empty permission list; refusing to index shared-drive documents without a complete ACL",
+                    drive_id
+                ));
+            }
+
+            let fingerprint = crate::models::drive_acl_fingerprint(&drive_acl);
+            let changed = old_acl_fingerprints.get(drive_id) != Some(&fingerprint);
+            if changed {
+                info!(
+                    "ACL fingerprint changed for drive {} — forcing full re-traversal",
+                    drive_id
+                );
+            }
+            new_acl_fingerprints.insert(drive_id.clone(), fingerprint);
+            drive_acl_overrides.insert(
+                drive_id.clone(),
+                crate::models::map_drive_permissions(&drive_acl, None),
+            );
+            drive_acl_raw.insert(drive_id.clone(), drive_acl);
+            drive_acl_changed.insert(drive_id.clone(), changed);
+        }
+
+        let stored_folder_access = existing_state.folder_access.clone().unwrap_or_default();
+        let mut folder_access: HashMap<String, crate::models::FolderAccessEntry> =
+            stored_folder_access
+                .iter()
+                .map(|(folder_id, info)| {
+                    (
+                        folder_id.clone(),
+                        crate::models::FolderAccessEntry {
+                            parents: info.parents.clone(),
+                            inherited_permissions_disabled: info.inherited_permissions_disabled,
+                            acl: None,
+                        },
+                    )
+                })
+                .collect();
+        let mut folder_drive_ids: HashMap<String, String> = stored_folder_access
+            .iter()
+            .map(|(folder_id, info)| (folder_id.clone(), info.drive_id.clone()))
+            .collect();
+        let mut completed_drives: HashSet<String> = HashSet::new();
+
         let content_cache = Arc::new(DriveContentCache::default());
         let mut total_scanned = 0;
         let mut total_updated = 0;
-
         let mut new_change_tokens: HashMap<String, String> = HashMap::new();
         let old_change_tokens = existing_state
             .drive_change_tokens
@@ -2080,8 +2330,63 @@ impl SyncManager {
                 drive_group.drive_id, drive_group.entire_drive, drive_group.folder_ids
             );
 
-            let stored_token = old_change_tokens.get(&drive_group.drive_id);
-            let use_incremental = !effective_full && stored_token.is_some();
+            let drive_id = &drive_group.drive_id;
+            let drive_permissions = drive_acl_overrides
+                .get(drive_id)
+                .cloned()
+                .expect("drive ACL resolved in preflight");
+            let raw_drive_acl = drive_acl_raw
+                .get(drive_id)
+                .expect("drive ACL resolved in preflight");
+            let acl_changed = drive_acl_changed.get(drive_id).copied().unwrap_or(true);
+
+            // Permission changes on a folder do not update every descendant in
+            // changes.list. Re-check every persisted limited/direct-grant folder
+            // and force a complete selected-scope traversal if one changed.
+            let mut folder_acl_changed = false;
+            if sync_type == SyncType::Incremental && !scope_changed && !acl_changed {
+                for (folder_id, info) in &stored_folder_access {
+                    if info.drive_id != *drive_id {
+                        continue;
+                    }
+                    let raw = match self
+                        .drive_client
+                        .list_drive_permissions(&access_token, folder_id)
+                        .await
+                    {
+                        Ok(raw) => raw,
+                        Err(error) => {
+                            warn!(
+                                "Folder {} ACL fetch failed ({}); forcing full re-traversal of drive {}",
+                                folder_id, error, drive_id
+                            );
+                            folder_acl_changed = true;
+                            break;
+                        }
+                    };
+                    let direct = crate::models::filter_direct_permissions(&raw);
+                    if crate::models::drive_acl_fingerprint(&direct) != info.acl_fingerprint {
+                        info!(
+                            "ACL fingerprint changed for folder {} — forcing full re-traversal of drive {}",
+                            folder_id, drive_id
+                        );
+                        folder_acl_changed = true;
+                        break;
+                    }
+                    if let Some(entry) = folder_access.get_mut(folder_id) {
+                        entry.acl = Some(direct);
+                    }
+                }
+            }
+
+            let model_mismatch = existing_state.permission_model_version.as_deref()
+                != Some(SCOPED_DWD_PERMISSION_MODEL_VERSION);
+            let stored_token = old_change_tokens.get(drive_id);
+            let use_incremental = !effective_full
+                && !acl_changed
+                && !folder_acl_changed
+                && !model_mismatch
+                && stored_token.is_some();
 
             if use_incremental {
                 // Incremental per-drive changes path. Use newStartPageToken
@@ -2159,10 +2464,32 @@ impl SyncManager {
                                 }
                             }
 
+                            self.ensure_scoped_folder_acl_chain(
+                                service_auth.as_ref(),
+                                &principal_email,
+                                &access_token,
+                                file.parents
+                                    .as_ref()
+                                    .and_then(|parents| parents.first())
+                                    .cloned(),
+                                drive_id,
+                                &mut folder_access,
+                                &mut folder_drive_ids,
+                            )
+                            .await?;
+                            let effective_permissions =
+                                crate::models::compute_effective_permissions(
+                                    file,
+                                    drive_id,
+                                    &drive_permissions,
+                                    raw_drive_acl,
+                                    &folder_access,
+                                    None,
+                                );
                             file_batch.push(UserFile {
                                 user_email: Arc::new(principal_email.clone()),
                                 file: file.clone(),
-                                permissions_override: None,
+                                permissions_override: Some(effective_permissions),
                             });
 
                             if file_batch.len() >= BATCH_SIZE {
@@ -2214,27 +2541,38 @@ impl SyncManager {
                     }
                 }
             } else {
-                // Capture the drive-scoped token before the full crawl so changes
-                // made while pagination is in progress are replayed next time.
-                let next_change_token = match self
-                    .drive_client
-                    .get_start_page_token_for_drive(&access_token, &drive_group.drive_id)
-                    .await
-                {
-                    Ok(token) => Some(token),
-                    Err(error) => {
-                        warn!(
-                            "Failed to get start page token for drive {}: {}",
-                            drive_group.drive_id, error
-                        );
-                        None
-                    }
-                };
+                let next_change_token = full_traversal_start_tokens
+                    .get(drive_id)
+                    .cloned()
+                    .unwrap_or(None);
+
+                // Rebuild this drive's compact folder ACL state from the full
+                // selected-scope traversal, dropping entries for folders that
+                // no longer exist or are no longer selected.
+                let old_drive_folder_ids: Vec<String> = stored_folder_access
+                    .iter()
+                    .filter(|(_, info)| info.drive_id == *drive_id)
+                    .map(|(folder_id, _)| folder_id.clone())
+                    .collect();
+                for folder_id in old_drive_folder_ids {
+                    folder_access.remove(&folder_id);
+                    folder_drive_ids.remove(&folder_id);
+                }
 
                 // Full scoped sync for this drive. Stream directly into batches.
                 let mut file_batch: Vec<UserFile> = Vec::new();
 
                 if drive_group.entire_drive {
+                    self.load_scoped_drive_folder_access(
+                        service_auth.as_ref(),
+                        &principal_email,
+                        &access_token,
+                        drive_id,
+                        &mut folder_access,
+                        &mut folder_drive_ids,
+                    )
+                    .await?;
+
                     // Entire-drive selection: list all files with corpora=drive
                     let mut page_token: Option<String> = None;
                     loop {
@@ -2251,10 +2589,19 @@ impl SyncManager {
 
                         for file in response.files {
                             if self.should_index_file(&file) {
+                                let effective_permissions =
+                                    crate::models::compute_effective_permissions(
+                                        &file,
+                                        drive_id,
+                                        &drive_permissions,
+                                        raw_drive_acl,
+                                        &folder_access,
+                                        None,
+                                    );
                                 file_batch.push(UserFile {
                                     user_email: Arc::new(principal_email.clone()),
                                     file,
-                                    permissions_override: None,
+                                    permissions_override: Some(effective_permissions),
                                 });
                                 if file_batch.len() >= BATCH_SIZE {
                                     self.flush_batch(
@@ -2294,6 +2641,17 @@ impl SyncManager {
                             continue; // already traversed via overlapping selection
                         }
 
+                        self.ensure_scoped_folder_acl_chain(
+                            service_auth.as_ref(),
+                            &principal_email,
+                            &access_token,
+                            Some(folder_id.clone()),
+                            drive_id,
+                            &mut folder_access,
+                            &mut folder_drive_ids,
+                        )
+                        .await?;
+
                         let mut queue = VecDeque::from([folder_id.clone()]);
                         while let Some(current_folder_id) = queue.pop_front() {
                             if ctx.is_cancelled() {
@@ -2325,11 +2683,18 @@ impl SyncManager {
                                     }
                                     seen_file_ids.insert(file.id.clone());
 
-                                    // Folders are enqueued unconditionally.
-                                    if file.mime_type == "application/vnd.google-apps.folder"
-                                        && !visited_folders.contains(&file.id)
-                                    {
-                                        queue.push_back(file.id.clone());
+                                    // Folders are enqueued unconditionally and
+                                    // retained for descendant ACL computation.
+                                    if file.mime_type == FOLDER_MIME_TYPE {
+                                        Self::record_scoped_folder_access(
+                                            &mut folder_access,
+                                            &mut folder_drive_ids,
+                                            &file,
+                                            drive_id,
+                                        );
+                                        if !visited_folders.contains(&file.id) {
+                                            queue.push_back(file.id.clone());
+                                        }
                                     }
 
                                     // Non-folder files in a selected subtree are
@@ -2337,10 +2702,32 @@ impl SyncManager {
                                     if !self.should_index_file(&file) {
                                         continue;
                                     }
+                                    self.ensure_scoped_folder_acl_chain(
+                                        service_auth.as_ref(),
+                                        &principal_email,
+                                        &access_token,
+                                        file.parents
+                                            .as_ref()
+                                            .and_then(|parents| parents.first())
+                                            .cloned(),
+                                        drive_id,
+                                        &mut folder_access,
+                                        &mut folder_drive_ids,
+                                    )
+                                    .await?;
+                                    let effective_permissions =
+                                        crate::models::compute_effective_permissions(
+                                            &file,
+                                            drive_id,
+                                            &drive_permissions,
+                                            raw_drive_acl,
+                                            &folder_access,
+                                            None,
+                                        );
                                     file_batch.push(UserFile {
                                         user_email: Arc::new(principal_email.clone()),
                                         file,
-                                        permissions_override: None,
+                                        permissions_override: Some(effective_permissions),
                                     });
                                     if file_batch.len() >= BATCH_SIZE {
                                         self.flush_batch(
@@ -2403,6 +2790,40 @@ impl SyncManager {
                     new_change_tokens.insert(drive_group.drive_id.clone(), token);
                 }
             }
+
+            if ctx.is_cancelled() {
+                break;
+            }
+            completed_drives.insert(drive_id.clone());
+        }
+
+        let mut new_folder_access = stored_folder_access;
+        for drive_group in &drives {
+            let drive_id = &drive_group.drive_id;
+            if !completed_drives.contains(drive_id) {
+                continue;
+            }
+            new_folder_access.retain(|_, info| info.drive_id != *drive_id);
+            for (folder_id, entry) in &folder_access {
+                if folder_drive_ids.get(folder_id) != Some(drive_id) {
+                    continue;
+                }
+                let Some(acl) = &entry.acl else {
+                    continue;
+                };
+                if !entry.inherited_permissions_disabled && acl.is_empty() {
+                    continue;
+                }
+                new_folder_access.insert(
+                    folder_id.clone(),
+                    crate::models::FolderAccessInfo {
+                        drive_id: drive_id.clone(),
+                        parents: entry.parents.clone(),
+                        inherited_permissions_disabled: entry.inherited_permissions_disabled,
+                        acl_fingerprint: crate::models::drive_acl_fingerprint(acl),
+                    },
+                );
+            }
         }
 
         info!(
@@ -2417,6 +2838,9 @@ impl SyncManager {
             None, // No per-user page tokens in scoped mode.
             Some(new_change_tokens),
             Some(current_fingerprint),
+            Some(new_acl_fingerprints),
+            Some(new_folder_access),
+            Some(SCOPED_DWD_PERMISSION_MODEL_VERSION.to_string()),
         ))
     }
 

--- a/connectors/google/src/sync.rs
+++ b/connectors/google/src/sync.rs
@@ -109,6 +109,12 @@ struct DriveGroup {
     folder_ids: Vec<String>,
 }
 
+struct DriveUserSyncResult {
+    scanned: usize,
+    updated: usize,
+    next_page_token: Option<String>,
+}
+
 /// Build drive groups from folder-path filter entries. Multiple entries for the
 /// same drive merge; a `SharedDriveRoot` entry makes the whole drive selected
 /// and clears any folder IDs (entire-drive supersedes per-folder selection).
@@ -1137,11 +1143,8 @@ impl SyncManager {
         Ok((drive_format, gmail_format))
     }
 
-    // TODO: When folder-path filters are narrowed or changed, documents that were
-    // previously indexed but are no longer in scope are NOT automatically pruned from
-    // the search index. A future reconciliation step should delete documents whose
-    // parent ancestry no longer intersects the configured filter set.
-
+    // Narrowing or changing folder filters does not prune documents from prior
+    // runs; source-wide reconciliation is tracked separately in issue #422.
     /// Check whether a file should be included based on configured folder-path filters.
     /// Uses `self.folder_cache` (the same LRU cache used by `build_full_path`) for
     /// folder-metadata lookups during ancestry resolution.
@@ -1210,8 +1213,31 @@ impl SyncManager {
         created_after: Option<&str>,
         content_cache: Arc<DriveContentCache>,
         folder_filter_ids: Option<Arc<HashSet<String>>>,
-    ) -> Result<(usize, usize)> {
+        preserved_change_token: Option<String>,
+    ) -> Result<DriveUserSyncResult> {
         info!("Processing Drive files for user: {}", user_email);
+
+        // A token preserved from a preceding changes pass is intentionally kept
+        // instead of replacing it with a later token. Changes made during this
+        // crawl must be replayed on the next run.
+        let next_page_token = if preserved_change_token.is_some() {
+            preserved_change_token
+        } else {
+            match self
+                .drive_client
+                .get_start_page_token_for_user(service_auth.as_ref(), user_email)
+                .await
+            {
+                Ok(token) => Some(token),
+                Err(error) => {
+                    warn!(
+                        "Failed to capture Drive change token for user {} before full traversal: {}",
+                        user_email, error
+                    );
+                    None
+                }
+            }
+        };
 
         let mut total_scanned = 0;
         let mut total_updated = 0;
@@ -1263,10 +1289,7 @@ impl SyncManager {
                             )
                             .await?
                         {
-                            debug!(
-                                "Skipping file {} ({}) — outside configured folder scope",
-                                file.name, file.id
-                            );
+                            // Full traversals only index in-scope files.
                             continue;
                         }
                     }
@@ -1342,7 +1365,11 @@ impl SyncManager {
             "Completed processing user {}: {} scanned, {} updated",
             user_email, total_scanned, total_updated
         );
-        Ok((total_scanned, total_updated))
+        Ok(DriveUserSyncResult {
+            scanned: total_scanned,
+            updated: total_updated,
+            next_page_token,
+        })
     }
 
     async fn sync_drive_for_user_incremental(
@@ -1355,7 +1382,7 @@ impl SyncManager {
         start_page_token: &str,
         content_cache: Arc<DriveContentCache>,
         folder_filter_ids: Option<Arc<HashSet<String>>>,
-    ) -> Result<(usize, usize)> {
+    ) -> Result<DriveUserSyncResult> {
         info!(
             "Processing incremental Drive sync for user {} from pageToken {}",
             user_email, start_page_token
@@ -1364,6 +1391,7 @@ impl SyncManager {
         let access_token = service_auth.get_access_token(user_email).await?;
 
         let mut all_changes = Vec::new();
+        let mut next_page_token: Option<String> = None;
         let mut current_token = start_page_token.to_string();
 
         loop {
@@ -1373,6 +1401,9 @@ impl SyncManager {
                 .await?;
 
             all_changes.extend(response.changes);
+            if response.new_start_page_token.is_some() {
+                next_page_token = response.new_start_page_token;
+            }
 
             if ctx.is_cancelled() {
                 info!(
@@ -1424,6 +1455,12 @@ impl SyncManager {
             }
 
             if let Some(file) = change.file {
+                if file.mime_type == FOLDER_MIME_TYPE {
+                    // Drive does not reliably emit changes for every descendant
+                    // when a folder moves. Defer subtree pruning to source-wide
+                    // reconciliation rather than guessing from one folder event.
+                    continue;
+                }
                 if !self.should_index_file(&file) {
                     continue;
                 }
@@ -1436,9 +1473,10 @@ impl SyncManager {
                         .await?
                     {
                         debug!(
-                            "Skipping change for file {} ({}) — outside configured folder scope",
+                            "File {} ({}) moved outside configured folder scope; publishing deletion",
                             file.name, file.id
                         );
+                        self.publish_deletion_event(ctx, &file.id).await?;
                         continue;
                     }
                 }
@@ -1486,7 +1524,19 @@ impl SyncManager {
             "Completed incremental Drive sync for user {}: {} scanned, {} updated",
             user_email, total_scanned, total_updated
         );
-        Ok((total_scanned, total_updated))
+        let next_page_token = if ctx.is_cancelled() {
+            None
+        } else {
+            // If Google omitted newStartPageToken, retain the old watermark and
+            // replay the changes next run rather than taking a fresh token that
+            // could skip changes made while this run was processing.
+            Some(next_page_token.unwrap_or_else(|| start_page_token.to_string()))
+        };
+        Ok(DriveUserSyncResult {
+            scanned: total_scanned,
+            updated: total_updated,
+            next_page_token,
+        })
     }
 
     async fn process_file_batch(
@@ -1896,6 +1946,7 @@ impl SyncManager {
     /// Returns `true` if the file passes the cutoff (or no cutoff is set).
     /// Folders are never filtered by the cutoff — they must be discovered
     /// regardless of age so their contents can be indexed.
+    #[allow(dead_code)]
     fn pass_cutoff(file: &crate::models::GoogleDriveFile, cutoff: OffsetDateTime) -> bool {
         if file.mime_type == "application/vnd.google-apps.folder" {
             return true;
@@ -1955,9 +2006,6 @@ impl SyncManager {
         let native_source_type = SourceType::try_from(source.source_type.as_str())
             .map_err(|e| anyhow!("Unsupported source type: {}", e))?;
         let service_auth = Arc::new(self.create_auth(service_creds, native_source_type).await?);
-        let (drive_cutoff_date, _gmail_cutoff_date) = self.get_cutoff_date()?;
-        let drive_cutoff = parse_google_time(Some(&drive_cutoff_date))
-            .ok_or_else(|| anyhow!("Invalid Drive cutoff time: {}", drive_cutoff_date))?;
 
         // Parse filters; will error on malformed config.
         let filter_entries = match crate::models::parse_folder_path_filters(&source.config) {
@@ -2079,6 +2127,12 @@ impl SyncManager {
                         }
 
                         if let Some(file) = &change.file {
+                            if file.mime_type == FOLDER_MIME_TYPE {
+                                // Drive does not reliably emit changes for every
+                                // descendant when a folder moves. Defer subtree
+                                // pruning to source-wide reconciliation.
+                                continue;
+                            }
                             if !self.should_index_file(file) {
                                 continue;
                             }
@@ -2097,9 +2151,10 @@ impl SyncManager {
                                     .await?
                                 {
                                     debug!(
-                                        "Skipping changed file {} ({}) — outside folder scope",
+                                        "File {} ({}) moved outside configured folder scope; publishing deletion",
                                         file.name, file.id
                                     );
+                                    self.publish_deletion_event(ctx, &file.id).await?;
                                     continue;
                                 }
                             }
@@ -2150,22 +2205,12 @@ impl SyncManager {
                     }
                 }
 
-                // Fallback: if no newStartPageToken was received, fetch one.
+                // If Google omitted newStartPageToken, retain the old
+                // watermark and replay this page on the next run. Taking a
+                // fresh token here could skip changes made while processing.
                 if !new_change_tokens.contains_key(&drive_group.drive_id) {
-                    match self
-                        .drive_client
-                        .get_start_page_token_for_drive(&access_token, &drive_group.drive_id)
-                        .await
-                    {
-                        Ok(token) => {
-                            new_change_tokens.insert(drive_group.drive_id.clone(), token);
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to get start page token for drive {}: {}",
-                                drive_group.drive_id, e
-                            );
-                        }
+                    if let Some(token) = stored_token {
+                        new_change_tokens.insert(drive_group.drive_id.clone(), token.clone());
                     }
                 }
             } else {
@@ -2200,7 +2245,7 @@ impl SyncManager {
                                 &principal_email,
                                 &drive_group.drive_id,
                                 page_token.as_deref(),
-                                Some(&drive_cutoff_date),
+                                None,
                             )
                             .await?;
 
@@ -2287,14 +2332,11 @@ impl SyncManager {
                                         queue.push_back(file.id.clone());
                                     }
 
-                                    // Non-folder files: apply cutoff locally.
+                                    // Non-folder files in a selected subtree are
+                                    // part of the complete scope regardless of age.
                                     if !self.should_index_file(&file) {
                                         continue;
                                     }
-                                    if !Self::pass_cutoff(&file, drive_cutoff) {
-                                        continue;
-                                    }
-
                                     file_batch.push(UserFile {
                                         user_email: Arc::new(principal_email.clone()),
                                         file,
@@ -2421,6 +2463,12 @@ impl SyncManager {
 
         // Build drive groups from the typed config (already validated root-only).
         let filter_entries = &config.folder_path_filters;
+        let current_fingerprint = format!(
+            "sa-direct:{}",
+            crate::models::compute_scope_fingerprint(Some(filter_entries))
+        );
+        let stored_fingerprint = existing_state.drive_scope_fingerprint.as_deref();
+        let scope_changed = stored_fingerprint != Some(&current_fingerprint);
         let drives = build_drive_groups(filter_entries);
         if drives.is_empty() {
             return Err(anyhow!(
@@ -2428,15 +2476,31 @@ impl SyncManager {
             ));
         }
 
+        // Capture every drive watermark before ACL and folder preflight. A full
+        // traversal may be selected only after those checks, so the watermark
+        // must be established before them to avoid skipping intervening changes.
+        let mut full_traversal_start_tokens: HashMap<String, Option<String>> = HashMap::new();
+        for drive_group in &drives {
+            let token = match self
+                .drive_client
+                .get_start_page_token_for_drive(&access_token, &drive_group.drive_id)
+                .await
+            {
+                Ok(token) => Some(token),
+                Err(error) => {
+                    warn!(
+                        "Failed to get start page token for drive {}: {}",
+                        drive_group.drive_id, error
+                    );
+                    None
+                }
+            };
+            full_traversal_start_tokens.insert(drive_group.drive_id.clone(), token);
+        }
+
         // Scope fingerprint: include the auth mode so a DWD→SA-direct switch on
         // the same source forces a full resync (defensive; in-place conversion is
         // not a supported v1 path).
-        let current_fingerprint = format!(
-            "sa-direct:{}",
-            crate::models::compute_scope_fingerprint(Some(filter_entries))
-        );
-        let stored_fingerprint = existing_state.drive_scope_fingerprint.as_deref();
-        let scope_changed = stored_fingerprint != Some(&current_fingerprint);
         if scope_changed {
             info!(
                 "Drive scope transition detected: {:?} -> {} — forcing full sync",
@@ -2738,6 +2802,10 @@ impl SyncManager {
                             .expect("drive ACL resolved in preflight"),
                         &drive_cutoff_date,
                         true,
+                        full_traversal_start_tokens
+                            .get(drive_id)
+                            .cloned()
+                            .unwrap_or(None),
                         &content_cache,
                         &mut folder_access,
                         &mut total_scanned,
@@ -2747,20 +2815,10 @@ impl SyncManager {
                     .await?;
                     full_drives.insert(drive_id.clone());
                 } else if !new_change_tokens.contains_key(drive_id) {
-                    match self
-                        .drive_client
-                        .get_start_page_token_for_drive(&access_token, drive_id)
-                        .await
-                    {
-                        Ok(token) => {
-                            new_change_tokens.insert(drive_id.clone(), token);
-                        }
-                        Err(e) => {
-                            warn!(
-                                "Failed to get start page token for drive {}: {}",
-                                drive_id, e
-                            );
-                        }
+                    // Keep the old watermark when Google did not return a new
+                    // one; taking a fresh token here can skip in-flight changes.
+                    if let Some(token) = old_change_tokens.get(drive_id) {
+                        new_change_tokens.insert(drive_id.clone(), token.clone());
                     }
                 }
             } else {
@@ -2777,7 +2835,14 @@ impl SyncManager {
                         .get(drive_id)
                         .expect("drive ACL resolved in preflight"),
                     &drive_cutoff_date,
-                    acl_changed || model_mismatch || folder_acl_changed,
+                    sync_type != SyncType::Incremental
+                        || acl_changed
+                        || model_mismatch
+                        || folder_acl_changed,
+                    full_traversal_start_tokens
+                        .get(drive_id)
+                        .cloned()
+                        .unwrap_or(None),
                     &content_cache,
                     &mut folder_access,
                     &mut total_scanned,
@@ -2857,12 +2922,17 @@ impl SyncManager {
         drive_acl_raw: &[GoogleDrivePermission],
         drive_cutoff_date: &str,
         uncut: bool,
+        start_change_token: Option<String>,
         content_cache: &Arc<DriveContentCache>,
         folder_access: &mut HashMap<String, crate::models::FolderAccessEntry>,
         total_scanned: &mut usize,
         total_updated: &mut usize,
         new_change_tokens: &mut HashMap<String, String>,
     ) -> Result<()> {
+        // Changes made after this token and during the full pass are replayed
+        // on the next incremental run.
+        let next_change_token = start_change_token;
+
         // Folders-first pass: the complete folder index must be in place before
         // computing effective permissions for any file (listing order is
         // arbitrary, so a file's ancestors may appear on later pages).
@@ -2921,21 +2991,6 @@ impl SyncManager {
                 }
             }
         }
-
-        let next_change_token = match self
-            .drive_client
-            .get_start_page_token_for_drive(access_token, drive_id)
-            .await
-        {
-            Ok(token) => Some(token),
-            Err(error) => {
-                warn!(
-                    "Failed to get start page token for drive {}: {}",
-                    drive_id, error
-                );
-                None
-            }
-        };
 
         let mut file_batch: Vec<UserFile> = Vec::new();
         let mut page_token: Option<String> = None;
@@ -3138,6 +3193,10 @@ impl SyncManager {
         ctx: &SyncContext,
     ) -> Result<GoogleSyncCheckpoint> {
         let sync_run_id = ctx.sync_run_id();
+        // Folder ancestry metadata is only a run-local view. Discard entries
+        // left by an interrupted run so a move is evaluated against current
+        // Drive parents during scope evaluation.
+        self.folder_cache.clear();
 
         let native_source_type = SourceType::try_from(source.source_type.as_str())
             .map_err(|e| anyhow!("Unsupported source type: {}", e))?;
@@ -3169,24 +3228,22 @@ impl SyncManager {
             }
         };
 
-        // Scoped mode (filters present, non-OAuth): delegate to sync_drive_scoped.
+        // Scoped service-account mode uses the drive-corpora traversal. OAuth
+        // sources keep the per-user listing and apply ancestry filtering below.
         if parsed_filters.is_some() && !service_auth.is_oauth() {
             return self
                 .sync_drive_scoped(source, service_creds, sync_type, &existing_state, ctx)
                 .await;
         }
 
-        // === Unfiltered / OAuth path: existing all-user listing ===
+        // === OAuth or unfiltered DWD path: per-user listing ===
 
-        // Compute fingerprint. For OAuth sources, filters are ignored —
-        // folder filtering is DWD-only — so the fingerprint is always "all".
-        let current_fingerprint = if service_auth.is_oauth() {
-            "all".to_string()
-        } else {
-            match &parsed_filters {
-                Some(f) => crate::models::compute_scope_fingerprint(Some(f)),
-                None => "all".to_string(),
-            }
+        // Scope fingerprints are shared by OAuth and service-account sources.
+        // A changed personal scope forces a full traversal so files moved into
+        // the selected folders are discovered immediately.
+        let current_fingerprint = match &parsed_filters {
+            Some(f) => crate::models::compute_scope_fingerprint(Some(f)),
+            None => "all".to_string(),
         };
 
         // Detect scope transition and force full sync if needed.
@@ -3200,7 +3257,15 @@ impl SyncManager {
         }
 
         let (drive_cutoff_date, _gmail_cutoff_date) = self.get_cutoff_date()?;
-        info!("Using Drive cutoff date: {}", drive_cutoff_date);
+        // A selected Drive scope represents the user's complete folder
+        // selection, not only recently modified files. Full traversals must
+        // therefore include older files so they can be indexed.
+        let drive_created_after = if parsed_filters.is_some() {
+            None
+        } else {
+            Some(drive_cutoff_date.as_str())
+        };
+        info!("Using Drive cutoff date: {:?}", drive_created_after);
 
         // Build user list: single OAuth user or all domain users
         let user_emails: Vec<String> = if service_auth.is_oauth() {
@@ -3240,8 +3305,11 @@ impl SyncManager {
 
         let gmail_history_ids = existing_state.gmail_history_ids.clone();
         let chat_checkpoint = existing_state.chat.clone();
-        let old_page_tokens = existing_state.drive_page_tokens.unwrap_or_default();
+        let has_checkpoint = parsed_filters.is_some() && existing_state.drive_page_tokens.is_some();
+        let old_page_tokens = existing_state.drive_page_tokens.clone().unwrap_or_default();
         let can_resume_full = sync_type == SyncType::Full && ctx.is_resume() && !scope_changed;
+        let requires_complete_full_checkpoint =
+            parsed_filters.is_some() && !is_incremental && !can_resume_full;
         let mut new_page_tokens: HashMap<String, String> = if can_resume_full {
             old_page_tokens.clone()
         } else {
@@ -3259,13 +3327,12 @@ impl SyncManager {
         let mut successful_users = 0;
         let mut errors = 0;
         let mut last_error: Option<String> = None;
-        let folder_filter_ids: Option<Arc<HashSet<String>>> = if service_auth.is_oauth() {
-            None
-        } else {
-            parsed_filters
-                .as_ref()
-                .map(|filters| Arc::new(filters.iter().map(|filter| filter.id.clone()).collect()))
-        };
+        // OAuth sources use the same ancestry filter as DWD sources. Shared
+        // drive roots work because Drive file parents include the drive root id;
+        // My Drive folder selections are matched by walking parent metadata.
+        let folder_filter_ids: Option<Arc<HashSet<String>>> = parsed_filters
+            .as_ref()
+            .map(|filters| Arc::new(filters.iter().map(|filter| filter.id.clone()).collect()));
         let content_cache = Arc::new(DriveContentCache::default());
         let parallel_users = google_drive_parallel_users();
         info!("Processing Drive users with concurrency {}", parallel_users);
@@ -3274,7 +3341,6 @@ impl SyncManager {
             let service_auth = service_auth.clone();
             let source_id = source.id.clone();
             let sync_run_id = sync_run_id.to_string();
-            let drive_cutoff_date = drive_cutoff_date.clone();
             let ctx = ctx.clone();
             let content_cache = content_cache.clone();
             let stored_page_token = old_page_tokens.get(cur_user_email.as_str()).cloned();
@@ -3286,7 +3352,14 @@ impl SyncManager {
                         "Skipping Drive user {} already checkpointed for sync {}",
                         cur_user_email, sync_run_id
                     );
-                    return (cur_user_email, Ok((0, 0, None)));
+                    return (
+                        cur_user_email,
+                        Ok(DriveUserSyncResult {
+                            scanned: 0,
+                            updated: 0,
+                            next_page_token: None,
+                        }),
+                    );
                 }
 
                 if ctx.is_cancelled() {
@@ -3294,7 +3367,14 @@ impl SyncManager {
                         "Sync {} cancelled, skipping Drive sync for user {}",
                         sync_run_id, cur_user_email
                     );
-                    return (cur_user_email, Ok((0, 0, None)));
+                    return (
+                        cur_user_email,
+                        Ok(DriveUserSyncResult {
+                            scanned: 0,
+                            updated: 0,
+                            next_page_token: None,
+                        }),
+                    );
                 }
 
                 let _access_token = match service_auth.get_access_token(&cur_user_email).await {
@@ -3314,7 +3394,52 @@ impl SyncManager {
                 info!("Processing user: {}", cur_user_email);
 
                 let use_incremental = is_incremental && stored_page_token.is_some();
-                let result = if use_incremental {
+                let reconcile_changes_before_full =
+                    !is_incremental && has_checkpoint && stored_page_token.is_some();
+                let result = if reconcile_changes_before_full {
+                    let start_token = stored_page_token.as_deref().unwrap();
+                    // Consume the saved changes token before the full crawl so
+                    // removed or access-revoked files also leave the index.
+                    let pre_full_result = match self
+                        .sync_drive_for_user_incremental(
+                            &cur_user_email,
+                            service_auth.clone(),
+                            &source_id,
+                            &sync_run_id,
+                            &ctx,
+                            start_token,
+                            content_cache.clone(),
+                            folder_filter_ids.clone(),
+                        )
+                        .await
+                    {
+                        Ok(result) => result,
+                        Err(error) => {
+                            let user_email = cur_user_email.clone();
+                            return (
+                                cur_user_email,
+                                Err(error).with_context(|| {
+                                    format!(
+                                        "Pre-full-sync Drive changes reconciliation failed for {}",
+                                        user_email
+                                    )
+                                }),
+                            );
+                        }
+                    };
+                    self.sync_drive_for_user(
+                        &cur_user_email,
+                        service_auth.clone(),
+                        &source_id,
+                        &sync_run_id,
+                        &ctx,
+                        drive_created_after,
+                        content_cache.clone(),
+                        folder_filter_ids.clone(),
+                        pre_full_result.next_page_token,
+                    )
+                    .await
+                } else if use_incremental {
                     let start_token = stored_page_token.as_deref().unwrap();
                     info!(
                         "Using incremental Drive sync for user {} from pageToken {}",
@@ -3355,31 +3480,16 @@ impl SyncManager {
                         &source_id,
                         &sync_run_id,
                         &ctx,
-                        Some(&drive_cutoff_date),
+                        drive_created_after,
                         content_cache.clone(),
                         folder_filter_ids.clone(),
+                        None,
                     )
                     .await
                 };
 
                 match result {
-                    Ok((scanned, updated)) => {
-                        let page_token = match self
-                            .drive_client
-                            .get_start_page_token_for_user(service_auth.as_ref(), &cur_user_email)
-                            .await
-                        {
-                            Ok(token) => Some(token),
-                            Err(e) => {
-                                warn!(
-                                    "Failed to get start page token for user {}: {}",
-                                    cur_user_email, e
-                                );
-                                None
-                            }
-                        };
-                        (cur_user_email, Ok((scanned, updated, page_token)))
-                    }
+                    Ok(result) => (cur_user_email, Ok(result)),
                     Err(e) => (cur_user_email, Err(e)),
                 }
             }
@@ -3388,16 +3498,19 @@ impl SyncManager {
         let mut user_results = user_tasks.buffer_unordered(parallel_users);
         while let Some((cur_user_email, result)) = user_results.next().await {
             match result {
-                Ok((scanned, updated, page_token)) => {
+                Ok(result) => {
                     successful_users += 1;
-                    total_scanned += scanned;
-                    total_updated += updated;
+                    total_scanned += result.scanned;
+                    total_updated += result.updated;
                     info!(
                         "User {} Drive sync completed: {} scanned, {} updated",
-                        cur_user_email, scanned, updated
+                        cur_user_email, result.scanned, result.updated
                     );
 
-                    if let Some(token) = page_token {
+                    if let Some(token) = result
+                        .next_page_token
+                        .or_else(|| old_page_tokens.get(&cur_user_email).cloned())
+                    {
                         new_page_tokens.insert(cur_user_email.clone(), token);
                     }
 
@@ -3409,7 +3522,11 @@ impl SyncManager {
                             Some(new_page_tokens.clone())
                         },
                         drive_change_tokens: None,
-                        drive_scope_fingerprint: Some(current_fingerprint.clone()),
+                        drive_scope_fingerprint: if requires_complete_full_checkpoint {
+                            None
+                        } else {
+                            Some(current_fingerprint.clone())
+                        },
                         drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
                         chat: chat_checkpoint.clone(),
                         ..Default::default()
@@ -3450,6 +3567,9 @@ impl SyncManager {
             ));
         }
 
+        let full_scope_sync_completed =
+            !ctx.is_cancelled() && errors == 0 && successful_users == user_emails.len();
+
         info!(
             "Sync completed for source {}: {} scanned, {} updated",
             source.id, total_scanned, total_updated
@@ -3460,7 +3580,7 @@ impl SyncManager {
 
         info!("Completed sync for source: {}", source.id);
 
-        Ok(GoogleSyncCheckpoint {
+        let checkpoint = GoogleSyncCheckpoint {
             gmail_history_ids,
             drive_page_tokens: if new_page_tokens.is_empty() {
                 None
@@ -3468,11 +3588,23 @@ impl SyncManager {
                 Some(new_page_tokens)
             },
             drive_change_tokens: None,
-            drive_scope_fingerprint: Some(current_fingerprint),
+            drive_scope_fingerprint: if requires_complete_full_checkpoint
+                && !full_scope_sync_completed
+            {
+                None
+            } else {
+                Some(current_fingerprint)
+            },
             drive_acl_fingerprints: existing_state.drive_acl_fingerprints.clone(),
             chat: chat_checkpoint,
             ..Default::default()
-        })
+        };
+        if requires_complete_full_checkpoint {
+            ctx.save_checkpoint(serde_json::to_value(&checkpoint)?)
+                .await
+                .context("Failed to save Drive full-sync checkpoint")?;
+        }
+        Ok(checkpoint)
     }
 
     async fn sync_gmail_source_internal(
@@ -6053,6 +6185,11 @@ pub(crate) async fn check_ancestry_static(
         }
         if allowed_ids.contains(&cur) {
             return Ok(true);
+        }
+        // `root` is the My Drive root alias, not a regular folder resource.
+        // There is no need to fetch metadata once ancestry reaches it.
+        if cur == "root" {
+            continue;
         }
         let (_name, parent) = lookup(cur).await?;
         if let Some(p) = parent {

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -1338,6 +1338,48 @@ mod sa_direct_tests {
     }
 
     #[tokio::test]
+    async fn scoped_dwd_full_sync_applies_shared_drive_acl() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        state.set_permissions(json!([
+            { "id": "p1", "type": "user", "emailAddress": "praveen@example.com", "domain": null, "role": "organizer", "allowFileDiscovery": null, "permissionDetails": null },
+            { "id": "p2", "type": "user", "emailAddress": "sudhir@example.com", "domain": null, "role": "writer", "allowFileDiscovery": null, "permissionDetails": null },
+            { "id": "p3", "type": "user", "emailAddress": "shahid@example.com", "domain": null, "role": "reader", "allowFileDiscovery": null, "permissionDetails": null }
+        ]));
+
+        let mut source = sa_source();
+        source.config["auth_mode"] = json!("domain_wide_delegation");
+        let mut credentials = sa_credentials(&mock_base);
+        credentials.principal_email = Some("praveen@example.com".to_string());
+
+        let sync_result = run_sa_sync(&mock_base, source, credentials, SyncType::Full).await;
+
+        if let Some(value) = previous_drive_base {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        sync_result?;
+
+        let perms_by_doc = created_users_by_doc(&state.event_bodies());
+        assert!(!perms_by_doc.is_empty(), "expected indexed documents");
+        for users in perms_by_doc.values() {
+            assert!(users.contains(&"praveen@example.com".to_string()));
+            assert!(users.contains(&"sudhir@example.com".to_string()));
+            assert!(users.contains(&"shahid@example.com".to_string()));
+        }
+
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn sa_direct_full_sync_applies_drive_acl() -> Result<()> {
         let _guard = SA_ENV_LOCK.lock().await;
         let (mock_base, state) = spawn_sa_mock().await?;

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -1043,7 +1043,7 @@ mod sa_direct_tests {
         let response = connector
             .execute_action(
                 "discover_folders",
-                json!({ "auth_mode": "service_account_direct" }),
+                json!({ "auth_mode": "service_account_direct", "query": "policy" }),
                 Some(creds),
                 None,
                 None,

--- a/connectors/google/tests/integration_tests.rs
+++ b/connectors/google/tests/integration_tests.rs
@@ -585,6 +585,14 @@ mod sa_direct_tests {
         event_bodies: Arc<Mutex<Vec<JsonValue>>>,
         /// Count of /drive/v3/files list calls (to detect uncut full traversal).
         file_list_calls: Arc<AtomicUsize>,
+        /// Query parameters captured for folder-discovery assertions.
+        file_list_queries: Arc<Mutex<Vec<HashMap<String, String>>>>,
+        /// Whether folder discovery responses should report an incomplete corpus search.
+        incomplete_search: Arc<AtomicBool>,
+        /// Whether folder discovery responses should paginate in 100-item pages.
+        folder_discovery_pagination: Arc<AtomicBool>,
+        /// Count of file metadata requests, used to detect ancestor loading.
+        file_metadata_calls: Arc<AtomicUsize>,
     }
 
     impl SaMockState {
@@ -609,6 +617,19 @@ mod sa_direct_tests {
         }
         fn file_list_calls(&self) -> usize {
             self.file_list_calls.load(Ordering::SeqCst)
+        }
+        fn file_list_queries(&self) -> Vec<HashMap<String, String>> {
+            self.file_list_queries.lock().unwrap().clone()
+        }
+        fn set_incomplete_search(&self, incomplete: bool) {
+            self.incomplete_search.store(incomplete, Ordering::SeqCst);
+        }
+        fn set_folder_discovery_pagination(&self, enabled: bool) {
+            self.folder_discovery_pagination
+                .store(enabled, Ordering::SeqCst);
+        }
+        fn file_metadata_calls(&self) -> usize {
+            self.file_metadata_calls.load(Ordering::SeqCst)
         }
         fn event_bodies(&self) -> Vec<JsonValue> {
             self.event_bodies.lock().unwrap().clone()
@@ -685,7 +706,26 @@ mod sa_direct_tests {
         }))
     }
 
-    async fn list_drives_mock() -> Json<JsonValue> {
+    async fn list_drives_mock(Query(query): Query<HashMap<String, String>>) -> Json<JsonValue> {
+        if query
+            .get("q")
+            .map(|q| q.contains("name contains 'shared'"))
+            .unwrap_or(false)
+        {
+            let drives = (0..101)
+                .map(|index| {
+                    json!({
+                        "id": format!("drive-{index}"),
+                        "name": if index == 1 {
+                            "Shared Policy Docs".to_string()
+                        } else {
+                            format!("Shared Drive {index}")
+                        }
+                    })
+                })
+                .collect::<Vec<_>>();
+            return Json(json!({ "drives": drives }));
+        }
         Json(json!({
             "drives": [
                 { "id": "drive-1", "name": "Policy Docs" },
@@ -694,7 +734,11 @@ mod sa_direct_tests {
         }))
     }
 
-    async fn get_file_mock(Query(query): Query<HashMap<String, String>>) -> Json<JsonValue> {
+    async fn get_file_mock(
+        State(state): State<SaMockState>,
+        Query(query): Query<HashMap<String, String>>,
+    ) -> Json<JsonValue> {
+        state.file_metadata_calls.fetch_add(1, Ordering::SeqCst);
         if query.get("alt").map(String::as_str) == Some("media") {
             return Json(json!("content for file"));
         }
@@ -733,6 +777,7 @@ mod sa_direct_tests {
         Query(query): Query<HashMap<String, String>>,
     ) -> Json<JsonValue> {
         state.file_list_calls.fetch_add(1, Ordering::SeqCst);
+        state.file_list_queries.lock().unwrap().push(query.clone());
         // trashed=true queries serve the trashed-file set for full-traversal
         // reconciliation; everything else serves the live file set.
         let is_trashed_query = query
@@ -772,7 +817,53 @@ mod sa_direct_tests {
         } else {
             files
         };
-        Json(json!({ "files": files }))
+
+        let files: Vec<JsonValue> = if is_folder_query {
+            let prefix = query
+                .get("q")
+                .and_then(|q| q.split_once("name contains '").map(|(_, rest)| rest))
+                .and_then(|rest| rest.split_once('\'').map(|(prefix, _)| prefix))
+                .map(str::to_lowercase);
+            files
+                .into_iter()
+                .filter(|file| {
+                    prefix
+                        .as_ref()
+                        .map(|prefix| {
+                            file["name"]
+                                .as_str()
+                                .map(|name| name.to_lowercase().starts_with(prefix))
+                                .unwrap_or(false)
+                        })
+                        .unwrap_or(true)
+                })
+                .collect()
+        } else {
+            files
+        };
+
+        let page_start = query
+            .get("pageToken")
+            .and_then(|token| token.strip_prefix("folder-page-"))
+            .and_then(|offset| offset.parse::<usize>().ok())
+            .unwrap_or(0);
+        let paginate = is_folder_query && state.folder_discovery_pagination.load(Ordering::SeqCst);
+        let page_end = if paginate {
+            (page_start + 100).min(files.len())
+        } else {
+            files.len()
+        };
+        let page_files = files.get(page_start..page_end).unwrap_or_default().to_vec();
+        let next_page = (page_end < files.len()).then(|| format!("folder-page-{page_end}"));
+        let mut response = if state.incomplete_search.load(Ordering::SeqCst) && is_folder_query {
+            json!({ "files": page_files, "incompleteSearch": true })
+        } else {
+            json!({ "files": page_files })
+        };
+        if let Some(next_page) = next_page {
+            response["nextPageToken"] = json!(next_page);
+        }
+        Json(response)
     }
 
     async fn start_page_token_mock() -> Json<JsonValue> {
@@ -985,6 +1076,167 @@ mod sa_direct_tests {
                 body
             );
         }
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn dwd_folder_search_uses_all_drives_and_filters_before_limit() -> Result<()> {
+        let _guard = SA_ENV_LOCK.lock().await;
+        let (mock_base, state) = spawn_sa_mock().await?;
+        let previous_drive_base = std::env::var("GOOGLE_DRIVE_API_BASE").ok();
+        // TODO: Audit that the environment access only happens in single-threaded code.
+        unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", format!("{}/drive/v3", mock_base)) };
+
+        let mut folders: Vec<JsonValue> = (0..500)
+            .map(|index| {
+                json!({
+                    "id": format!("my-folder-{index}"),
+                    "name": format!("Shared Folder {index}"),
+                    "mimeType": "application/vnd.google-apps.folder"
+                })
+            })
+            .collect();
+        folders.insert(
+            0,
+            json!({
+                "id": "nested-folder",
+                "name": "Shared Nested Folder",
+                "mimeType": "application/vnd.google-apps.folder",
+                "driveId": "drive-1",
+                "parents": ["parent-folder"]
+            }),
+        );
+        folders.insert(
+            1,
+            json!({
+                "id": "drive-100",
+                "name": "Shared Drive 100",
+                "mimeType": "application/vnd.google-apps.folder",
+                "driveId": "drive-100"
+            }),
+        );
+        folders.push(json!({
+            "id": "shared-folder",
+            "name": "Shared Folder",
+            "mimeType": "application/vnd.google-apps.folder",
+            "driveId": "drive-1",
+            "parents": ["drive-1"]
+        }));
+        folders.push(json!({
+            "id": "drive-1",
+            "name": "Shared Drive",
+            "mimeType": "application/vnd.google-apps.folder",
+            "driveId": "drive-1"
+        }));
+        state.set_files(folders);
+        state.set_incomplete_search(true);
+        state.set_folder_discovery_pagination(true);
+
+        let connector = omni_google_connector::connector::GoogleConnector::new(
+            Arc::new(SyncManager::new(
+                Arc::new(AdminClient::new()),
+                SdkClient::new(&mock_base),
+                None,
+            )),
+            Arc::new(AdminClient::new()),
+        );
+
+        let mut creds = sa_credentials(&mock_base);
+        creds.principal_email = Some("user@example.com".to_string());
+        let response = connector
+            .execute_action(
+                "discover_folders",
+                json!({ "query": "shared" }),
+                Some(creds),
+                None,
+                None,
+            )
+            .await?;
+
+        if let Some(value) = previous_drive_base {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::set_var("GOOGLE_DRIVE_API_BASE", value) };
+        } else {
+            // TODO: Audit that the environment access only happens in single-threaded code.
+            unsafe { std::env::remove_var("GOOGLE_DRIVE_API_BASE") };
+        }
+
+        let status = response.status();
+        let body: JsonValue = axum::body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .map(|bytes| serde_json::from_slice(&bytes).unwrap_or(json!({})))?;
+        assert_eq!(status, 200, "discovery should succeed: {}", body);
+        assert_eq!(
+            body["result"]["truncated"], true,
+            "incomplete search: {}",
+            body
+        );
+        let items = body["result"]["items"]
+            .as_array()
+            .cloned()
+            .unwrap_or_default();
+        assert!(
+            items.iter().any(|item| item["id"] == "shared-folder"),
+            "shared-drive folders must survive My Drive filtering before the cap: {}",
+            body
+        );
+        assert!(
+            items.iter().any(|item| item["id"] == "nested-folder"),
+            "nested folders must remain selectable: {}",
+            body
+        );
+        let nested_path = items
+            .iter()
+            .find(|item| item["id"] == "nested-folder")
+            .and_then(|item| item["path"].as_str());
+        assert_eq!(
+            nested_path,
+            Some("/Shared Policy Docs (Shared Drive)/…/Shared Nested Folder"),
+            "searched nested folder paths must be visibly partial: {}",
+            body
+        );
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| item["kind"] == "shared_drive_root")
+                .count(),
+            101,
+            "search discovery should allow roots beyond the initial 100-root cap: {}",
+            body
+        );
+        let drive_100 = items.iter().find(|item| item["id"] == "drive-100");
+        assert_eq!(
+            drive_100.and_then(|item| item["kind"].as_str()),
+            Some("shared_drive_root"),
+            "search roots beyond the initial root sample must remain roots: {}",
+            body
+        );
+        assert_eq!(
+            items
+                .iter()
+                .filter(|item| item["id"] == "drive-100")
+                .count(),
+            1,
+            "search roots beyond the initial root sample must not reappear as folders: {}",
+            body
+        );
+        let file_queries = state.file_list_queries();
+        assert_eq!(
+            file_queries.len(),
+            6,
+            "search should paginate folders without per-drive child calls"
+        );
+        assert_eq!(
+            state.file_metadata_calls(),
+            0,
+            "search should not load folder ancestors"
+        );
+        assert!(
+            file_queries
+                .iter()
+                .all(|query| query.get("corpora").map(String::as_str) == Some("allDrives")),
+            "folder search must use the allDrives corpus"
+        );
         Ok(())
     }
 

--- a/setup/google-workspace/terraform/main.tf
+++ b/setup/google-workspace/terraform/main.tf
@@ -59,14 +59,14 @@ locals {
     "orgpolicy.googleapis.com"
   ]
 
-  oauth_scopes = var.include_gmail_scope ? [
-    "https://www.googleapis.com/auth/admin.directory.user.readonly",
-    "https://www.googleapis.com/auth/drive.readonly",
-    "https://www.googleapis.com/auth/gmail.readonly"
-    ] : [
-    "https://www.googleapis.com/auth/admin.directory.user.readonly",
-    "https://www.googleapis.com/auth/drive.readonly"
-  ]
+  oauth_scopes = concat(
+    [
+      "https://www.googleapis.com/auth/admin.directory.user.readonly",
+      "https://www.googleapis.com/auth/admin.directory.group.readonly",
+      "https://www.googleapis.com/auth/drive.readonly"
+    ],
+    var.include_gmail_scope ? ["https://www.googleapis.com/auth/gmail.readonly"] : []
+  )
 }
 
 # Create the project

--- a/web/src/lib/components/google-drive-folder-selector.svelte
+++ b/web/src/lib/components/google-drive-folder-selector.svelte
@@ -5,8 +5,8 @@
     import * as Alert from '$lib/components/ui/alert'
     import * as Popover from '$lib/components/ui/popover'
     import { onDestroy } from 'svelte'
-    import type { FolderPathFilter } from '$lib/types'
     import type { DriveFolderDiscoveryEntry, DriveFolderDiscoveryResponse } from '$lib/types/search'
+    import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
     import {
         GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS,
         googleDriveFolderSearchLength,
@@ -54,80 +54,11 @@
     let inputRef = $state<HTMLInputElement | null>(null)
     let dropdownAnchor = $state<HTMLElement | null>(null)
 
-    // Guard: preserve persisted selections on the initial mount. Discovery is
-    // search-driven and never runs automatically.
-    let hasInitialized = $state(false)
-
-    // Generation counter: bumped on every credential-context change.
-    // Each async operation captures the generation at start and verifies it
-    // before any state mutation after an await.
-    let generation = $state(0)
-
     // Request-level counter: only the request whose version matches
     // `currentRequestVersion` may mutate state after an await, preventing
-    // races between sequential searches with the same credential generation.
+    // races between sequential searches and remounted credential contexts.
     let currentRequestVersion = $state(0)
     let lastDiscoveryQuery = $state('')
-
-    // Build a credential-context token from all relevant inputs.
-    // Uses the raw values rather than a hash to guarantee no collisions,
-    // and includes sourceId as fallback for stored-credential mode.
-    // PrincipalEmail/domain changes count even when key is blank
-    // because they are part of the credential context.
-    let contextToken = $derived(
-        JSON.stringify({
-            sa: serviceAccountJson,
-            pe: principalEmail,
-            dm: domain,
-            am: authMode,
-            sid: sourceId,
-        }),
-    )
-
-    // Track the previous context token to detect changes.
-    let prevContextToken = $state('')
-
-    // Reactive effect: reset discovery state when the credential context changes.
-    $effect(() => {
-        // First evaluation: set up initial state without clearing selections.
-        if (!hasInitialized) {
-            hasInitialized = true
-            prevContextToken = contextToken
-            return
-        }
-
-        // Subsequent evaluations: detect actual changes.
-        if (contextToken === prevContextToken) return
-        prevContextToken = contextToken
-
-        // Bump generation to invalidate any in-flight responses.
-        generation += 1
-
-        // Cancel any in-flight request or pending search debounce.
-        pendingRequest?.abort()
-        pendingRequest = null
-        currentRequestVersion += 1
-        if (searchDebounce) clearTimeout(searchDebounce)
-        searchDebounce = undefined
-
-        // Clear selected items ONLY on an actual credential-context change
-        // after initialization. On initial mount, pre-loaded selected items
-        // from persisted config are preserved.
-        selected = []
-        onSelectedChange?.(selected)
-
-        // Reset discovery state.
-        searchQuery = ''
-        allItems = []
-        filteredItems = []
-        hasLoaded = false
-        errorMessage = ''
-        discoveryNotice = ''
-        lastDiscoveryQuery = ''
-
-        // Discovery starts only after the user enters a search prefix.
-    })
-
     let pendingRequest: AbortController | null = null
     let searchDebounce: GoogleDriveFolderSearchTimer | undefined
 
@@ -138,14 +69,14 @@
             searchDebounce,
             query,
             (normalizedQuery) => {
-                discoverFolders(generation, normalizedQuery)
+                discoverFolders(normalizedQuery)
                 searchDebounce = undefined
             },
         )
     }
 
     // Search accessible folders and drives for a user-entered prefix.
-    async function discoverFolders(gen: number, query: string) {
+    async function discoverFolders(query: string) {
         const normalizedQuery = query.trim()
         if (googleDriveFolderSearchLength(normalizedQuery) < GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS)
             return
@@ -219,15 +150,15 @@
                 return
             }
 
-            // RACE CHECK: if generation or request version has changed, discard.
-            if (gen !== generation || rv !== currentRequestVersion) return
+            // RACE CHECK: if the request version has changed, discard.
+            if (rv !== currentRequestVersion) return
 
             if (response.ok) {
                 const body: { status?: string; result?: DriveFolderDiscoveryResponse } =
                     await response.json()
 
                 // RACE CHECK
-                if (gen !== generation || rv !== currentRequestVersion) return
+                if (rv !== currentRequestVersion) return
 
                 const statusOk = body?.status === 'ok' || body?.status === 'success'
                 const items = body?.result?.items ?? []
@@ -252,23 +183,23 @@
                 let msg = 'Failed to discover folders'
                 try {
                     const errBody = await response.json()
-                    if (gen !== generation || rv !== currentRequestVersion) return
+                    if (rv !== currentRequestVersion) return
                     msg = errBody.error || errBody.message || msg
                 } catch {
-                    if (gen !== generation || rv !== currentRequestVersion) return
+                    if (rv !== currentRequestVersion) return
                     msg = (await response.text()) || msg
                 }
                 errorMessage = msg
             }
         } catch (err) {
-            if (gen !== generation || rv !== currentRequestVersion) return
+            if (rv !== currentRequestVersion) return
             if (err instanceof DOMException && err.name === 'AbortError') {
                 return
             }
             console.error('Error discovering folders:', err)
             errorMessage = 'Network error. Please check your connection and try again.'
         } finally {
-            if (gen === generation && rv === currentRequestVersion) {
+            if (rv === currentRequestVersion) {
                 isLoading = false
             }
         }
@@ -358,7 +289,7 @@
     }
 
     function handleRetry() {
-        // Reset state and trigger a fresh discovery with the current generation.
+        // Reset state and trigger a fresh discovery for the current query.
         allItems = []
         filteredItems = []
         hasLoaded = false
@@ -369,6 +300,7 @@
 
     // Clean up in-flight requests on destroy
     onDestroy(() => {
+        currentRequestVersion += 1
         pendingRequest?.abort()
         if (searchDebounce) clearTimeout(searchDebounce)
     })
@@ -394,7 +326,7 @@
 
 <div class="space-y-2">
     <Label class="text-sm font-medium">{label}</Label>
-    <p class="text-muted-foreground text-xs">{description} Search uses the beginning of a name.</p>
+    <p class="text-muted-foreground text-xs">{description}</p>
 
     <!-- Error state -->
     {#if errorMessage && !isLoading}

--- a/web/src/lib/components/google-drive-folder-selector.svelte
+++ b/web/src/lib/components/google-drive-folder-selector.svelte
@@ -17,8 +17,9 @@
         selected = $bindable([] as FolderPathFilter[]),
         disabled = false,
         label = 'Folders to index',
-        description = 'Select specific shared drives or top-level folders to index. Leave empty to index everything.',
+        description = 'Select specific My Drive folders, shared drives, or shared-drive folders. Leave empty to index everything.',
         onSelectedChange = undefined as ((selected: FolderPathFilter[]) => void) | undefined,
+        action = 'discover_folders',
     }: {
         sourceId?: string
         serviceAccountJson?: string
@@ -30,6 +31,7 @@
         label?: string
         description?: string
         onSelectedChange?: (selected: FolderPathFilter[]) => void
+        action?: 'discover_folders' | 'discover_personal_folders'
     } = $props()
 
     const isSaDirect = $derived(authMode === 'service_account_direct')
@@ -42,6 +44,7 @@
     let isLoading = $state(false)
     let hasLoaded = $state(false)
     let errorMessage = $state('')
+    let discoveryNotice = $state('')
     let inputRef = $state<HTMLInputElement | null>(null)
     let dropdownAnchor = $state<HTMLElement | null>(null)
 
@@ -60,6 +63,7 @@
     // mutate state after an await, preventing races between sequential calls
     // with the same credential generation.
     let currentRequestVersion = $state(0)
+    let lastDiscoveryQuery = $state('')
 
     // Build a credential-context token from all relevant inputs.
     // Uses the raw values rather than a hash to guarantee no collisions,
@@ -95,9 +99,11 @@
         // Bump generation to invalidate any in-flight responses.
         generation += 1
 
-        // Cancel any in-flight request.
+        // Cancel any in-flight request or pending search debounce.
         pendingRequest?.abort()
         pendingRequest = null
+        if (searchDebounce) clearTimeout(searchDebounce)
+        searchDebounce = undefined
 
         // Clear selected items ONLY on an actual credential-context change
         // after initialization. On initial mount, pre-loaded selected items
@@ -111,12 +117,19 @@
         filteredItems = []
         hasLoaded = false
         errorMessage = ''
+        discoveryNotice = ''
 
         // Automatically trigger discovery for the new context.
         discoverFolders(generation)
     })
 
     let pendingRequest: AbortController | null = null
+    let searchDebounce: ReturnType<typeof setTimeout> | undefined
+    const minRemoteSearchLength = 2
+
+    function queryLength(query: string): number {
+        return Array.from(query.trim()).length
+    }
 
     // Load folders when credentials are available.
     // Takes `gen` (credential generation) and `rv` (request version) captured
@@ -125,7 +138,8 @@
     // Every invocation gets a unique request version. Only the call whose
     // `rv` matches `currentRequestVersion` may mutate state after an await,
     // preventing races between sequential calls with the same credential gen.
-    async function discoverFolders(gen: number, rv?: number) {
+    async function discoverFolders(gen: number, rv?: number, query = '') {
+        lastDiscoveryQuery = query
         // Determine request version for this invocation.
         if (rv === undefined) {
             currentRequestVersion += 1
@@ -156,11 +170,17 @@
         allItems = []
         filteredItems = []
         hasLoaded = false
+        discoveryNotice = ''
 
         const signal = controller.signal
 
         try {
             let response: Response
+
+            const actionParams = {
+                ...(isSaDirect ? { auth_mode: 'service_account_direct' } : {}),
+                ...(query ? { query } : {}),
+            }
 
             if (serviceAccountJson && (isSaDirect || (principalEmail && domain))) {
                 // Invoke the connector directly with transient credentials.
@@ -168,8 +188,8 @@
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
                     body: JSON.stringify({
-                        action: 'discover_folders',
-                        params: isSaDirect ? { auth_mode: 'service_account_direct' } : {},
+                        action,
+                        params: actionParams,
                         serviceAccountJson,
                         principalEmail,
                         domain,
@@ -182,10 +202,7 @@
                 response = await fetch(`/api/sources/${sourceId}/action`, {
                     method: 'POST',
                     headers: { 'Content-Type': 'application/json' },
-                    body: JSON.stringify({
-                        action: 'discover_folders',
-                        params: isSaDirect ? { auth_mode: 'service_account_direct' } : {},
-                    }),
+                    body: JSON.stringify({ action, params: actionParams }),
                     signal,
                 })
             } else {
@@ -206,12 +223,16 @@
 
                 const statusOk = body?.status === 'ok' || body?.status === 'success'
                 const items = body?.result?.items ?? []
+                discoveryNotice = body.result?.truncated
+                    ? 'Results are limited. Refine your search to see more folders or drives.'
+                    : ''
                 if (statusOk && items.length > 0) {
                     allItems = items
                     filteredItems = items
                     hasLoaded = true
                     if (searchQuery.trim()) {
                         filterItems(searchQuery)
+                        showDropdown = filteredItems.length > 0
                     }
                 } else if (statusOk && items.length === 0) {
                     hasLoaded = true
@@ -257,20 +278,40 @@
             isSaDirect ? allItems.filter((item) => item.kind === 'shared_drive_root') : allItems
         ).filter(
             (item) =>
-                !selected.some((s) => s.id === item.id) &&
-                (item.name.toLowerCase().includes(q) ||
-                    item.path.toLowerCase().includes(q) ||
-                    item.driveId.toLowerCase().includes(q)),
+                !selected.some((s) => s.id === item.id) && item.name.toLowerCase().startsWith(q),
         )
     }
 
     function handleInput() {
+        const query = searchQuery.trim()
+        if (searchDebounce) clearTimeout(searchDebounce)
+        searchDebounce = undefined
+        if (
+            queryLength(query) < minRemoteSearchLength &&
+            queryLength(lastDiscoveryQuery) >= minRemoteSearchLength
+        ) {
+            // Restore the root-folder result set after leaving a remote search.
+            discoverFolders(generation)
+            showDropdown = false
+            return
+        }
+        if (queryLength(query) >= minRemoteSearchLength) {
+            // Search the full accessible hierarchy instead of limiting users to
+            // the initially discovered root folders. SA-direct searches drive
+            // names while DWD/OAuth searches folders and drives.
+            searchDebounce = setTimeout(() => {
+                discoverFolders(generation, undefined, query)
+                searchDebounce = undefined
+            }, 250)
+            showDropdown = false
+            return
+        }
         if (!hasLoaded && !isLoading && !errorMessage) {
             // Auto-discover on first input interaction
             discoverFolders(generation)
         }
         filterItems(searchQuery)
-        showDropdown = filteredItems.length > 0 && searchQuery.trim().length > 0
+        showDropdown = filteredItems.length > 0 && queryLength(query) > 0
     }
 
     function selectItem(item: DriveFolderDiscoveryEntry) {
@@ -305,12 +346,19 @@
         filteredItems = []
         hasLoaded = false
         errorMessage = ''
-        discoverFolders(generation)
+        discoveryNotice = ''
+        const query = searchQuery.trim()
+        discoverFolders(
+            generation,
+            undefined,
+            queryLength(query) >= minRemoteSearchLength ? query : '',
+        )
     }
 
     // Clean up in-flight requests on destroy
     onDestroy(() => {
         pendingRequest?.abort()
+        if (searchDebounce) clearTimeout(searchDebounce)
     })
 
     function handleBlur() {
@@ -337,13 +385,13 @@
 
 <div class="space-y-2">
     <Label class="text-sm font-medium">{label}</Label>
-    <p class="text-muted-foreground text-xs">{description}</p>
+    <p class="text-muted-foreground text-xs">{description} Search uses the beginning of a name.</p>
 
     <!-- Loading state -->
     {#if isLoading && !hasLoaded}
         <div class="text-muted-foreground flex items-center gap-2 py-2 text-sm">
             <Loader2 class="h-4 w-4 animate-spin" />
-            <span>Discovering shared drives and folders...</span>
+            <span>Discovering Drive folders...</span>
         </div>
     {/if}
 
@@ -365,11 +413,15 @@
         </Alert.Root>
     {/if}
 
+    {#if discoveryNotice && !isLoading}
+        <p class="text-muted-foreground py-1 text-xs">{discoveryNotice}</p>
+    {/if}
+
     <!-- Empty state (discovered but no items) -->
     {#if hasLoaded && allItems.length === 0 && !isLoading && !errorMessage}
         <p class="text-muted-foreground py-1 text-sm italic">
-            No shared drives found. Make sure the service account has access to shared drives in
-            this domain.
+            No folders or shared drives found. Make sure this account has access to the Drive
+            content you want to index.
         </p>
     {/if}
 
@@ -384,7 +436,7 @@
                 oninput={handleInput}
                 onfocus={handleFocus}
                 onblur={handleBlur}
-                placeholder="Search folders..."
+                placeholder="Search names (prefix)..."
                 class="px-10 py-1"
                 {disabled} />
             {#if isLoading}
@@ -410,6 +462,18 @@
                         <div class="min-w-0 flex-1">
                             <div class="truncate font-medium">{item.name}</div>
                             <div class="text-muted-foreground truncate text-xs">{item.path}</div>
+                            {#if item.kind === 'shared_drive_root'}
+                                <div class="text-muted-foreground truncate text-[10px]">
+                                    Drive ID: {item.driveId}
+                                </div>
+                            {:else}
+                                <div class="text-muted-foreground truncate text-[10px]">
+                                    Folder ID: {item.id}
+                                </div>
+                                <div class="text-muted-foreground truncate text-[10px]">
+                                    Drive ID: {item.driveId}
+                                </div>
+                            {/if}
                         </div>
                         <span
                             class="mt-0.5 shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600 uppercase dark:bg-slate-800 dark:text-slate-300">
@@ -428,6 +492,12 @@
                 <div
                     class="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors">
                     <span class="max-w-40 truncate" title={item.path}>{item.name}</span>
+                    <span
+                        class="text-muted-foreground max-w-32 truncate text-[10px]"
+                        title={item.kind === 'folder'
+                            ? `Folder ID: ${item.id}\nDrive ID: ${item.driveId}`
+                            : `Drive ID: ${item.driveId}`}
+                        >{item.kind === 'folder' ? item.id : item.driveId}</span>
                     {#if !disabled}
                         <button
                             type="button"

--- a/web/src/lib/components/google-drive-folder-selector.svelte
+++ b/web/src/lib/components/google-drive-folder-selector.svelte
@@ -7,6 +7,12 @@
     import { onDestroy } from 'svelte'
     import type { FolderPathFilter } from '$lib/types'
     import type { DriveFolderDiscoveryEntry, DriveFolderDiscoveryResponse } from '$lib/types/search'
+    import {
+        GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS,
+        googleDriveFolderSearchLength,
+        scheduleGoogleDriveFolderSearch,
+        type GoogleDriveFolderSearchTimer,
+    } from '$lib/utils/google-drive-folder-search'
 
     let {
         sourceId = '',
@@ -123,17 +129,26 @@
     })
 
     let pendingRequest: AbortController | null = null
-    let searchDebounce: ReturnType<typeof setTimeout> | undefined
-    const minRemoteSearchLength = 2
+    let searchDebounce: GoogleDriveFolderSearchTimer | undefined
 
-    function queryLength(query: string): number {
-        return Array.from(query.trim()).length
+    // Keep every discovery request behind this scheduler. In particular,
+    // lifecycle and focus handlers must never invoke discovery.
+    function scheduleDiscovery(query: string) {
+        searchDebounce = scheduleGoogleDriveFolderSearch(
+            searchDebounce,
+            query,
+            (normalizedQuery) => {
+                discoverFolders(generation, normalizedQuery)
+                searchDebounce = undefined
+            },
+        )
     }
 
     // Search accessible folders and drives for a user-entered prefix.
     async function discoverFolders(gen: number, query: string) {
         const normalizedQuery = query.trim()
-        if (queryLength(normalizedQuery) < minRemoteSearchLength) return
+        if (googleDriveFolderSearchLength(normalizedQuery) < GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS)
+            return
 
         lastDiscoveryQuery = normalizedQuery
         currentRequestVersion += 1
@@ -278,7 +293,7 @@
     function handleInput() {
         const query = searchQuery.trim()
         if (
-            queryLength(query) >= minRemoteSearchLength &&
+            googleDriveFolderSearchLength(query) >= GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS &&
             query === lastDiscoveryQuery &&
             (isLoading || hasLoaded)
         ) {
@@ -299,7 +314,7 @@
         discoveryNotice = ''
         showDropdown = false
 
-        if (queryLength(query) < minRemoteSearchLength) {
+        if (googleDriveFolderSearchLength(query) < GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS) {
             // Short or cleared input never triggers discovery.
             lastDiscoveryQuery = ''
             allItems = []
@@ -313,10 +328,7 @@
         hasLoaded = false
 
         // Search the full accessible hierarchy after the user pauses typing.
-        searchDebounce = setTimeout(() => {
-            discoverFolders(generation, query)
-            searchDebounce = undefined
-        }, 250)
+        scheduleDiscovery(query)
     }
 
     function selectItem(item: DriveFolderDiscoveryEntry) {
@@ -352,10 +364,7 @@
         hasLoaded = false
         errorMessage = ''
         discoveryNotice = ''
-        const query = searchQuery.trim()
-        if (queryLength(query) >= minRemoteSearchLength) {
-            discoverFolders(generation, query)
-        }
+        scheduleDiscovery(searchQuery)
     }
 
     // Clean up in-flight requests on destroy
@@ -374,7 +383,7 @@
     function handleFocus() {
         if (
             hasLoaded &&
-            queryLength(searchQuery) >= minRemoteSearchLength &&
+            googleDriveFolderSearchLength(searchQuery) >= GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS &&
             filteredItems.length > 0 &&
             !showDropdown
         ) {

--- a/web/src/lib/components/google-drive-folder-selector.svelte
+++ b/web/src/lib/components/google-drive-folder-selector.svelte
@@ -48,9 +48,8 @@
     let inputRef = $state<HTMLInputElement | null>(null)
     let dropdownAnchor = $state<HTMLElement | null>(null)
 
-    // Guard: only start auto-discovery after mount, and only when credential
-    // context actually changes (not on first mount where persisted selected
-    // items are already present).
+    // Guard: preserve persisted selections on the initial mount. Discovery is
+    // search-driven and never runs automatically.
     let hasInitialized = $state(false)
 
     // Generation counter: bumped on every credential-context change.
@@ -58,10 +57,9 @@
     // before any state mutation after an await.
     let generation = $state(0)
 
-    // Request-level counter: bumped on EVERY discoverFolders invocation.
-    // Only the request whose version matches `currentRequestVersion` may
-    // mutate state after an await, preventing races between sequential calls
-    // with the same credential generation.
+    // Request-level counter: only the request whose version matches
+    // `currentRequestVersion` may mutate state after an await, preventing
+    // races between sequential searches with the same credential generation.
     let currentRequestVersion = $state(0)
     let lastDiscoveryQuery = $state('')
 
@@ -83,7 +81,7 @@
     // Track the previous context token to detect changes.
     let prevContextToken = $state('')
 
-    // Reactive effect: detect credential-context change and re-discover.
+    // Reactive effect: reset discovery state when the credential context changes.
     $effect(() => {
         // First evaluation: set up initial state without clearing selections.
         if (!hasInitialized) {
@@ -102,6 +100,7 @@
         // Cancel any in-flight request or pending search debounce.
         pendingRequest?.abort()
         pendingRequest = null
+        currentRequestVersion += 1
         if (searchDebounce) clearTimeout(searchDebounce)
         searchDebounce = undefined
 
@@ -118,9 +117,9 @@
         hasLoaded = false
         errorMessage = ''
         discoveryNotice = ''
+        lastDiscoveryQuery = ''
 
-        // Automatically trigger discovery for the new context.
-        discoverFolders(generation)
+        // Discovery starts only after the user enters a search prefix.
     })
 
     let pendingRequest: AbortController | null = null
@@ -131,20 +130,14 @@
         return Array.from(query.trim()).length
     }
 
-    // Load folders when credentials are available.
-    // Takes `gen` (credential generation) and `rv` (request version) captured
-    // at call time for race-safe post-await checks.
-    //
-    // Every invocation gets a unique request version. Only the call whose
-    // `rv` matches `currentRequestVersion` may mutate state after an await,
-    // preventing races between sequential calls with the same credential gen.
-    async function discoverFolders(gen: number, rv?: number, query = '') {
-        lastDiscoveryQuery = query
-        // Determine request version for this invocation.
-        if (rv === undefined) {
-            currentRequestVersion += 1
-            rv = currentRequestVersion
-        }
+    // Search accessible folders and drives for a user-entered prefix.
+    async function discoverFolders(gen: number, query: string) {
+        const normalizedQuery = query.trim()
+        if (queryLength(normalizedQuery) < minRemoteSearchLength) return
+
+        lastDiscoveryQuery = normalizedQuery
+        currentRequestVersion += 1
+        const rv = currentRequestVersion
 
         if (!serviceAccountJson) {
             if (!sourceId) {
@@ -179,7 +172,7 @@
 
             const actionParams = {
                 ...(isSaDirect ? { auth_mode: 'service_account_direct' } : {}),
-                ...(query ? { query } : {}),
+                query: normalizedQuery,
             }
 
             if (serviceAccountJson && (isSaDirect || (principalEmail && domain))) {
@@ -284,34 +277,46 @@
 
     function handleInput() {
         const query = searchQuery.trim()
+        if (
+            queryLength(query) >= minRemoteSearchLength &&
+            query === lastDiscoveryQuery &&
+            (isLoading || hasLoaded)
+        ) {
+            if (hasLoaded) {
+                filterItems(query)
+                showDropdown = filteredItems.length > 0
+            }
+            return
+        }
+
         if (searchDebounce) clearTimeout(searchDebounce)
         searchDebounce = undefined
-        if (
-            queryLength(query) < minRemoteSearchLength &&
-            queryLength(lastDiscoveryQuery) >= minRemoteSearchLength
-        ) {
-            // Restore the root-folder result set after leaving a remote search.
-            discoverFolders(generation)
-            showDropdown = false
+        pendingRequest?.abort()
+        pendingRequest = null
+        currentRequestVersion += 1
+        isLoading = false
+        errorMessage = ''
+        discoveryNotice = ''
+        showDropdown = false
+
+        if (queryLength(query) < minRemoteSearchLength) {
+            // Short or cleared input never triggers discovery.
+            lastDiscoveryQuery = ''
+            allItems = []
+            filteredItems = []
+            hasLoaded = false
             return
         }
-        if (queryLength(query) >= minRemoteSearchLength) {
-            // Search the full accessible hierarchy instead of limiting users to
-            // the initially discovered root folders. SA-direct searches drive
-            // names while DWD/OAuth searches folders and drives.
-            searchDebounce = setTimeout(() => {
-                discoverFolders(generation, undefined, query)
-                searchDebounce = undefined
-            }, 250)
-            showDropdown = false
-            return
-        }
-        if (!hasLoaded && !isLoading && !errorMessage) {
-            // Auto-discover on first input interaction
-            discoverFolders(generation)
-        }
-        filterItems(searchQuery)
-        showDropdown = filteredItems.length > 0 && queryLength(query) > 0
+
+        allItems = []
+        filteredItems = []
+        hasLoaded = false
+
+        // Search the full accessible hierarchy after the user pauses typing.
+        searchDebounce = setTimeout(() => {
+            discoverFolders(generation, query)
+            searchDebounce = undefined
+        }, 250)
     }
 
     function selectItem(item: DriveFolderDiscoveryEntry) {
@@ -348,11 +353,9 @@
         errorMessage = ''
         discoveryNotice = ''
         const query = searchQuery.trim()
-        discoverFolders(
-            generation,
-            undefined,
-            queryLength(query) >= minRemoteSearchLength ? query : '',
-        )
+        if (queryLength(query) >= minRemoteSearchLength) {
+            discoverFolders(generation, query)
+        }
     }
 
     // Clean up in-flight requests on destroy
@@ -371,14 +374,11 @@
     function handleFocus() {
         if (
             hasLoaded &&
-            searchQuery.trim().length > 0 &&
+            queryLength(searchQuery) >= minRemoteSearchLength &&
             filteredItems.length > 0 &&
             !showDropdown
         ) {
             showDropdown = true
-        }
-        if (!hasLoaded && !isLoading && !errorMessage) {
-            discoverFolders(generation)
         }
     }
 </script>
@@ -386,14 +386,6 @@
 <div class="space-y-2">
     <Label class="text-sm font-medium">{label}</Label>
     <p class="text-muted-foreground text-xs">{description} Search uses the beginning of a name.</p>
-
-    <!-- Loading state -->
-    {#if isLoading && !hasLoaded}
-        <div class="text-muted-foreground flex items-center gap-2 py-2 text-sm">
-            <Loader2 class="h-4 w-4 animate-spin" />
-            <span>Discovering Drive folders...</span>
-        </div>
-    {/if}
 
     <!-- Error state -->
     {#if errorMessage && !isLoading}
@@ -436,7 +428,7 @@
                 oninput={handleInput}
                 onfocus={handleFocus}
                 onblur={handleBlur}
-                placeholder="Search names (prefix)..."
+                placeholder="Search drives and folders..."
                 class="px-10 py-1"
                 {disabled} />
             {#if isLoading}
@@ -462,18 +454,6 @@
                         <div class="min-w-0 flex-1">
                             <div class="truncate font-medium">{item.name}</div>
                             <div class="text-muted-foreground truncate text-xs">{item.path}</div>
-                            {#if item.kind === 'shared_drive_root'}
-                                <div class="text-muted-foreground truncate text-[10px]">
-                                    Drive ID: {item.driveId}
-                                </div>
-                            {:else}
-                                <div class="text-muted-foreground truncate text-[10px]">
-                                    Folder ID: {item.id}
-                                </div>
-                                <div class="text-muted-foreground truncate text-[10px]">
-                                    Drive ID: {item.driveId}
-                                </div>
-                            {/if}
                         </div>
                         <span
                             class="mt-0.5 shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-[10px] text-slate-600 uppercase dark:bg-slate-800 dark:text-slate-300">
@@ -492,12 +472,6 @@
                 <div
                     class="bg-secondary text-secondary-foreground hover:bg-secondary/80 inline-flex items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors">
                     <span class="max-w-40 truncate" title={item.path}>{item.name}</span>
-                    <span
-                        class="text-muted-foreground max-w-32 truncate text-[10px]"
-                        title={item.kind === 'folder'
-                            ? `Folder ID: ${item.id}\nDrive ID: ${item.driveId}`
-                            : `Drive ID: ${item.driveId}`}
-                        >{item.kind === 'folder' ? item.id : item.driveId}</span>
                     {#if !disabled}
                         <button
                             type="button"

--- a/web/src/lib/components/google-drive-folder-selector.types.ts
+++ b/web/src/lib/components/google-drive-folder-selector.types.ts
@@ -1,0 +1,7 @@
+export interface FolderPathFilter {
+    id: string
+    name: string
+    path: string
+    driveId: string
+    kind: 'shared_drive_root' | 'folder'
+}

--- a/web/src/lib/components/google-oauth-setup.svelte
+++ b/web/src/lib/components/google-oauth-setup.svelte
@@ -72,7 +72,8 @@
                         {/if}
                     </div>
                     <div class="text-muted-foreground text-sm">
-                        Index your Drive documents, spreadsheets, and presentations
+                        Index your Drive documents, spreadsheets, and presentations. You will choose
+                        the folders after connecting.
                     </div>
                 </div>
             </label>

--- a/web/src/lib/components/google-service-account-form.svelte
+++ b/web/src/lib/components/google-service-account-form.svelte
@@ -15,6 +15,10 @@
         // Hide the SA-direct explanation paragraph when the surrounding page
         // already explains the mode (e.g. a banner on the settings page).
         showSaDirectInfo?: boolean
+        onCredentialsChange?: () => void
+        onAccountDetailsChange?: () => void
+        onCredentialReplacementStart?: () => void
+        onCredentialReplacementCancel?: () => void
     }
 
     let {
@@ -25,6 +29,10 @@
         disabled = false,
         mode = 'dwd',
         showSaDirectInfo = true,
+        onCredentialsChange,
+        onAccountDetailsChange,
+        onCredentialReplacementStart,
+        onCredentialReplacementCancel,
     }: Props = $props()
 
     const isSaDirect = $derived(mode === 'sa-direct')
@@ -39,6 +47,9 @@
             hasStoredValue={hasStoredKey}
             multiline
             {disabled}
+            onValueChange={onCredentialsChange}
+            onReplacementStart={onCredentialReplacementStart}
+            onReplacementCancel={onCredentialReplacementCancel}
             placeholder="Paste your Google service account JSON key here..." />
         <p class="text-muted-foreground text-sm">
             Download this from the Google Cloud Console under "Service Accounts" > "Keys".
@@ -64,6 +75,7 @@
                 placeholder="admin@yourdomain.com"
                 type="email"
                 {disabled}
+                oninput={onAccountDetailsChange ?? onCredentialsChange}
                 required />
             <p class="text-muted-foreground text-sm">
                 The admin user the service account impersonates to access Google Workspace APIs.
@@ -79,6 +91,7 @@
                 placeholder="yourdomain.com"
                 type="text"
                 {disabled}
+                oninput={onAccountDetailsChange ?? onCredentialsChange}
                 required />
             <p class="text-muted-foreground text-sm">
                 Your Google Workspace domain (e.g., company.com).

--- a/web/src/lib/components/google-service-account-form.svelte
+++ b/web/src/lib/components/google-service-account-form.svelte
@@ -9,9 +9,12 @@
         domain?: string
         hasStoredKey?: boolean
         disabled?: boolean
-        // 'sa-direct' hides the admin-email/domain fields and shows
+        // 'sa-direct' hides the admin-email field and shows
         // non-impersonation guidance. Defaults to DWD behavior.
         mode?: 'dwd' | 'sa-direct'
+        // SA-direct group membership sync needs the Workspace domain but never
+        // impersonates an admin user.
+        showDomain?: boolean
         // Hide the SA-direct explanation paragraph when the surrounding page
         // already explains the mode (e.g. a banner on the settings page).
         showSaDirectInfo?: boolean
@@ -28,6 +31,7 @@
         hasStoredKey = false,
         disabled = false,
         mode = 'dwd',
+        showDomain = false,
         showSaDirectInfo = true,
         onCredentialsChange,
         onAccountDetailsChange,
@@ -64,6 +68,24 @@
                 <span class="font-medium">Content manager</span> or
                 <span class="font-medium">Manager</span>.
             </p>
+        {/if}
+        {#if showDomain}
+            <div class="space-y-2">
+                <Label for="sa-direct-domain">Organization Domain</Label>
+                <Input
+                    id="sa-direct-domain"
+                    name="domain"
+                    bind:value={domain}
+                    placeholder="yourdomain.com"
+                    type="text"
+                    {disabled}
+                    oninput={onAccountDetailsChange ?? onCredentialsChange}
+                    required />
+                <p class="text-muted-foreground text-sm">
+                    Used to validate and sync Google Workspace group memberships. This does not
+                    impersonate a Workspace user.
+                </p>
+            </div>
         {/if}
     {:else}
         <div class="space-y-2">

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -17,6 +17,7 @@
     import GoogleServiceAccountForm from '$lib/components/google-service-account-form.svelte'
     import GoogleDriveFolderSelector from '$lib/components/google-drive-folder-selector.svelte'
     import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
+    import { GOOGLE_SA_DIRECT_SCOPES } from '$lib/utils/google-scopes'
 
     interface Props {
         open: boolean
@@ -45,6 +46,20 @@
         drives: SharedDriveAccessResult[]
     }
 
+    interface SaDirectGroupAccessResponse {
+        domain: string
+        groups: number
+        memberships: number
+    }
+
+    interface GroupAccessStatus {
+        pending: boolean
+        ok: boolean
+        groups: number | null
+        memberships: number | null
+        error: string | null
+    }
+
     interface DriveAccessStatus {
         pending: boolean
         ok: boolean
@@ -69,6 +84,7 @@
 
     // SA-direct form state (kept separate so switching tabs preserves each)
     let saServiceAccountJson = $state('')
+    let saDomain = $state('')
     let saDriveFilters = $state<FolderPathFilter[]>([])
     let saSelectorRevision = $state(0)
     let saFiltersBeforeCredentialReplacement = $state<FolderPathFilter[] | null>(null)
@@ -77,6 +93,16 @@
     let isValidating = $state(false)
     let validationAbort: AbortController | null = null
     let validationGeneration = $state(0)
+    let groupAccessValidation = $state<GroupAccessStatus>({
+        pending: false,
+        ok: false,
+        groups: null,
+        memberships: null,
+        error: null,
+    })
+    let groupValidationAbort: AbortController | null = null
+    let groupValidationGeneration = $state(0)
+    let groupValidationTimer: ReturnType<typeof setTimeout> | undefined
 
     // Switch to SA-direct tab: force Drive-only. The tab value itself is
     // kept in sync by Tabs.Root's bind:value, so this only applies side
@@ -90,12 +116,30 @@
         }
     }
 
+    function invalidateGroupAccessValidation() {
+        groupValidationGeneration += 1
+        groupValidationAbort?.abort()
+        groupValidationAbort = null
+        if (groupValidationTimer) {
+            clearTimeout(groupValidationTimer)
+            groupValidationTimer = undefined
+        }
+        groupAccessValidation = {
+            pending: false,
+            ok: false,
+            groups: null,
+            memberships: null,
+            error: null,
+        }
+    }
+
     function invalidateSaValidation() {
         validationGeneration += 1
         validationAbort?.abort()
         validationAbort = null
         accessValidation = {}
         isValidating = false
+        invalidateGroupAccessValidation()
         isSubmitting = false
     }
 
@@ -138,6 +182,10 @@
         invalidateSaValidation()
     }
 
+    function handleSaAccountDetailsChange() {
+        scheduleGroupAccessValidation()
+    }
+
     // Event-driven SA-direct access validation. The drive selector reports
     // every selection change (add/remove) via onSelectedChange; validation
     // runs only when both a key and drives are present.
@@ -150,6 +198,102 @@
             validateAccess(saServiceAccountJson, filters)
         } else {
             invalidateSaValidation()
+        }
+        scheduleGroupAccessValidation()
+    }
+
+    function scheduleGroupAccessValidation() {
+        invalidateGroupAccessValidation()
+
+        if (!saServiceAccountJson.trim() || !saDomain.trim()) {
+            return
+        }
+
+        groupValidationTimer = setTimeout(() => {
+            groupValidationTimer = undefined
+            validateGroupAccess(saServiceAccountJson, saDomain)
+        }, 300)
+    }
+
+    async function validateGroupAccess(saJson: string, workspaceDomain: string) {
+        const generation = ++groupValidationGeneration
+        groupValidationAbort?.abort()
+        const controller = new AbortController()
+        groupValidationAbort = controller
+        groupAccessValidation = {
+            pending: true,
+            ok: false,
+            groups: null,
+            memberships: null,
+            error: null,
+        }
+
+        try {
+            const response = await fetch('/api/connectors/google_drive/action', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    action: 'validate_sa_direct_group_access',
+                    params: { auth_mode: 'service_account_direct' },
+                    serviceAccountJson: saJson,
+                    domain: workspaceDomain.trim(),
+                    authMode: 'service_account_direct',
+                }),
+                signal: controller.signal,
+            })
+            if (generation !== groupValidationGeneration) return
+
+            if (!response.ok) {
+                const errBody = (await response.json().catch(() => null)) as {
+                    error?: string
+                    message?: string
+                } | null
+                groupAccessValidation = {
+                    pending: false,
+                    ok: false,
+                    groups: null,
+                    memberships: null,
+                    error:
+                        errBody?.error ||
+                        errBody?.message ||
+                        'Failed to validate Workspace group access',
+                }
+                return
+            }
+
+            const body =
+                (await response.json()) as ConnectorActionResponse<SaDirectGroupAccessResponse>
+            if (body.status === 'success' && body.result) {
+                groupAccessValidation = {
+                    pending: false,
+                    ok: true,
+                    groups: body.result.groups,
+                    memberships: body.result.memberships,
+                    error: null,
+                }
+            } else {
+                groupAccessValidation = {
+                    pending: false,
+                    ok: false,
+                    groups: null,
+                    memberships: null,
+                    error: body.error || 'Workspace group access could not be verified',
+                }
+            }
+        } catch (err) {
+            if (generation !== groupValidationGeneration) return
+            if (err instanceof DOMException && err.name === 'AbortError') return
+            groupAccessValidation = {
+                pending: false,
+                ok: false,
+                groups: null,
+                memberships: null,
+                error: 'Network error while validating Workspace group access',
+            }
+        } finally {
+            if (generation === groupValidationGeneration) {
+                groupValidationAbort = null
+            }
         }
     }
 
@@ -253,6 +397,13 @@
             }),
     )
 
+    const groupAccessValidated = $derived(
+        saServiceAccountJson.trim().length > 0 &&
+            saDomain.trim().length > 0 &&
+            !groupAccessValidation.pending &&
+            groupAccessValidation.ok,
+    )
+
     const validationInProgress = $derived(
         saDriveFilters.some((f) => accessValidation[f.driveId]?.pending),
     )
@@ -281,6 +432,9 @@
         if (!saServiceAccountJson.trim()) {
             throw new Error('Service account JSON is required')
         }
+        if (!saDomain.trim()) {
+            throw new Error('Organization domain is required for group membership sync')
+        }
         try {
             JSON.parse(saServiceAccountJson)
         } catch {
@@ -294,9 +448,16 @@
                 'Wait for every selected shared drive to pass access validation (Content manager or Manager required)',
             )
         }
+        if (!groupAccessValidated) {
+            throw new Error(
+                groupAccessValidation.error ||
+                    'Wait for Workspace group membership access validation to pass',
+            )
+        }
 
         const driveConfig: GoogleSourceConfig = {
             auth_mode: 'service_account_direct',
+            domain: saDomain.trim(),
             folder_path_filters: saDriveFilters,
         }
 
@@ -320,7 +481,8 @@
         const driveSource = await driveSourceResponse.json()
 
         const credConfig: Record<string, unknown> = {
-            scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+            domain: saDomain.trim(),
+            scopes: GOOGLE_SA_DIRECT_SCOPES,
         }
         const credentialsResponse = await fetch('/api/service-credentials', {
             method: 'POST',
@@ -518,6 +680,7 @@
         driveSelectorRevision += 1
         driveFiltersBeforeCredentialReplacement = null
         saServiceAccountJson = ''
+        saDomain = ''
         saDriveFilters = []
         saSelectorRevision += 1
         saFiltersBeforeCredentialReplacement = null
@@ -617,10 +780,47 @@
             <Tabs.Content value="service_account_direct" class="space-y-4 pt-4">
                 <GoogleServiceAccountForm
                     bind:serviceAccountJson={saServiceAccountJson}
+                    bind:domain={saDomain}
                     mode="sa-direct"
+                    showDomain
                     onCredentialsChange={handleSaCredentialsChange}
+                    onAccountDetailsChange={handleSaAccountDetailsChange}
                     onCredentialReplacementStart={handleSaCredentialReplacementStart}
                     onCredentialReplacementCancel={handleSaCredentialReplacementCancel} />
+
+                {#if saServiceAccountJson.trim()}
+                    {#if groupAccessValidation.pending}
+                        <Alert.Root>
+                            <Loader2 class="h-4 w-4 animate-spin" />
+                            <Alert.Title>Checking Workspace group access</Alert.Title>
+                            <Alert.Description>
+                                Verifying that this service account can list groups and group
+                                members.
+                            </Alert.Description>
+                        </Alert.Root>
+                    {:else if groupAccessValidation.ok}
+                        <Alert.Root>
+                            <CheckCircle2 class="h-4 w-4 text-green-600" />
+                            <Alert.Title>Workspace group access verified</Alert.Title>
+                            <Alert.Description>
+                                Found {groupAccessValidation.groups} groups and
+                                {groupAccessValidation.memberships} active memberships. Group membership
+                                events will be emitted during sync.
+                            </Alert.Description>
+                        </Alert.Root>
+                    {:else}
+                        <Alert.Root variant="destructive">
+                            <AlertCircle class="h-4 w-4" />
+                            <Alert.Title>Workspace group access required</Alert.Title>
+                            <Alert.Description>
+                                {groupAccessValidation.error ??
+                                    'Enter your Workspace domain to validate group membership access.'}
+                                The service account must be able to list Workspace groups and group members
+                                before this source can be created.
+                            </Alert.Description>
+                        </Alert.Root>
+                    {/if}
+                {/if}
 
                 {#if saDriveFilters.length > 0 && !allDrivesValidated}
                     <Alert.Root>
@@ -700,7 +900,10 @@
                 onclick={handleSubmit}
                 disabled={isSubmitting ||
                     (activeTab === 'service_account_direct' &&
-                        (!allDrivesValidated || validationInProgress))}
+                        (!allDrivesValidated ||
+                            !groupAccessValidated ||
+                            validationInProgress ||
+                            groupAccessValidation.pending))}
                 class="cursor-pointer">
                 {#if isSubmitting}
                     <Loader2 class="mr-2 h-4 w-4 animate-spin" />

--- a/web/src/lib/components/google-workspace-setup.svelte
+++ b/web/src/lib/components/google-workspace-setup.svelte
@@ -8,14 +8,7 @@
     import * as Alert from '$lib/components/ui/alert'
     import { Loader2, CheckCircle2, XCircle, AlertCircle } from '@lucide/svelte'
     import { AuthType } from '$lib/types'
-    import type {
-        ConnectorActionResponse,
-        DriveAccessStatus,
-        FolderPathFilter,
-        GoogleAuthMode,
-        GoogleSourceConfig,
-        SharedDriveAccessResponse,
-    } from '$lib/types'
+    import type { ConnectorActionResponse } from '$lib/types'
     import { toast } from 'svelte-sonner'
     import { goto } from '$app/navigation'
     import googleDriveLogo from '$lib/images/icons/google-drive.svg'
@@ -23,6 +16,7 @@
     import googleChatLogo from '$lib/images/icons/google-chat.svg'
     import GoogleServiceAccountForm from '$lib/components/google-service-account-form.svelte'
     import GoogleDriveFolderSelector from '$lib/components/google-drive-folder-selector.svelte'
+    import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
 
     interface Props {
         open: boolean
@@ -31,6 +25,32 @@
     }
 
     let { open = false, onSuccess, onCancel }: Props = $props()
+
+    type GoogleAuthMode = 'domain_wide_delegation' | 'service_account_direct'
+
+    interface GoogleSourceConfig {
+        auth_mode: GoogleAuthMode
+        domain?: string | null
+        folder_path_filters?: FolderPathFilter[]
+    }
+
+    interface SharedDriveAccessResult {
+        drive_id: string
+        ok: boolean
+        role: string | null
+        error: string | null
+    }
+
+    interface SharedDriveAccessResponse {
+        drives: SharedDriveAccessResult[]
+    }
+
+    interface DriveAccessStatus {
+        pending: boolean
+        ok: boolean
+        role: string | null
+        error: string | null
+    }
 
     // Active tab: 'dwd' (domain-wide delegation) | 'sa-direct' (shared drive, no DWD)
     let activeTab = $state<GoogleAuthMode>('domain_wide_delegation')
@@ -44,10 +64,14 @@
     let connectChat = $state(false)
     let isSubmitting = $state(false)
     let driveFolderFilters = $state<FolderPathFilter[]>([])
+    let driveSelectorRevision = $state(0)
+    let driveFiltersBeforeCredentialReplacement = $state<FolderPathFilter[] | null>(null)
 
     // SA-direct form state (kept separate so switching tabs preserves each)
     let saServiceAccountJson = $state('')
     let saDriveFilters = $state<FolderPathFilter[]>([])
+    let saSelectorRevision = $state(0)
+    let saFiltersBeforeCredentialReplacement = $state<FolderPathFilter[] | null>(null)
     // Per-drive validation: drive_id -> { pending, ok, role, error }
     let accessValidation = $state<Record<string, DriveAccessStatus>>({})
     let isValidating = $state(false)
@@ -66,10 +90,57 @@
         }
     }
 
+    function invalidateSaValidation() {
+        validationGeneration += 1
+        validationAbort?.abort()
+        validationAbort = null
+        accessValidation = {}
+        isValidating = false
+        isSubmitting = false
+    }
+
+    function handleDwdCredentialsChange() {
+        driveFolderFilters = []
+        driveSelectorRevision += 1
+    }
+
+    function handleDwdAccountDetailsChange() {
+        driveFiltersBeforeCredentialReplacement = null
+        handleDwdCredentialsChange()
+    }
+
+    function handleDwdCredentialReplacementStart() {
+        driveFiltersBeforeCredentialReplacement = [...driveFolderFilters]
+    }
+
+    function handleDwdCredentialReplacementCancel() {
+        if (driveFiltersBeforeCredentialReplacement === null) return
+        driveFolderFilters = driveFiltersBeforeCredentialReplacement
+        driveFiltersBeforeCredentialReplacement = null
+        driveSelectorRevision += 1
+    }
+
+    function handleSaCredentialsChange() {
+        saDriveFilters = []
+        saSelectorRevision += 1
+        invalidateSaValidation()
+    }
+
+    function handleSaCredentialReplacementStart() {
+        saFiltersBeforeCredentialReplacement = [...saDriveFilters]
+    }
+
+    function handleSaCredentialReplacementCancel() {
+        if (saFiltersBeforeCredentialReplacement === null) return
+        saDriveFilters = saFiltersBeforeCredentialReplacement
+        saFiltersBeforeCredentialReplacement = null
+        saSelectorRevision += 1
+        invalidateSaValidation()
+    }
+
     // Event-driven SA-direct access validation. The drive selector reports
-    // every selection change (add/remove/credential-context clear) via
-    // onSelectedChange; validation runs only when both a key and drives are
-    // present, and is invalidated otherwise.
+    // every selection change (add/remove) via onSelectedChange; validation
+    // runs only when both a key and drives are present.
     function handleSaSelectionChange(filters: FolderPathFilter[]) {
         console.log(
             '[google-setup] saSelectionChange',
@@ -78,14 +149,7 @@
         if (saServiceAccountJson.trim() && filters.length > 0) {
             validateAccess(saServiceAccountJson, filters)
         } else {
-            // Invalidate and cancel any in-flight validation so stale results
-            // from a previous key/selection can't land.
-            validationGeneration += 1
-            validationAbort?.abort()
-            validationAbort = null
-            accessValidation = {}
-            isValidating = false
-            isSubmitting = false
+            invalidateSaValidation()
         }
     }
 
@@ -451,9 +515,13 @@
         connectGmail = true
         connectChat = false
         driveFolderFilters = []
+        driveSelectorRevision += 1
+        driveFiltersBeforeCredentialReplacement = null
         saServiceAccountJson = ''
         saDriveFilters = []
-        accessValidation = {}
+        saSelectorRevision += 1
+        saFiltersBeforeCredentialReplacement = null
+        invalidateSaValidation()
         activeTab = 'domain_wide_delegation'
     }
 
@@ -518,7 +586,11 @@
                     bind:serviceAccountJson
                     bind:principalEmail
                     bind:domain
-                    mode="dwd" />
+                    mode="dwd"
+                    onCredentialsChange={handleDwdCredentialsChange}
+                    onAccountDetailsChange={handleDwdAccountDetailsChange}
+                    onCredentialReplacementStart={handleDwdCredentialReplacementStart}
+                    onCredentialReplacementCancel={handleDwdCredentialReplacementCancel} />
 
                 {#if connectDrive}
                     <Card.Root class="border-dashed">
@@ -529,12 +601,14 @@
                             </Card.Description>
                         </Card.Header>
                         <Card.Content>
-                            <GoogleDriveFolderSelector
-                                bind:selected={driveFolderFilters}
-                                {serviceAccountJson}
-                                {principalEmail}
-                                {domain}
-                                authMode="domain_wide_delegation" />
+                            {#key driveSelectorRevision}
+                                <GoogleDriveFolderSelector
+                                    bind:selected={driveFolderFilters}
+                                    {serviceAccountJson}
+                                    {principalEmail}
+                                    {domain}
+                                    authMode="domain_wide_delegation" />
+                            {/key}
                         </Card.Content>
                     </Card.Root>
                 {/if}
@@ -543,7 +617,10 @@
             <Tabs.Content value="service_account_direct" class="space-y-4 pt-4">
                 <GoogleServiceAccountForm
                     bind:serviceAccountJson={saServiceAccountJson}
-                    mode="sa-direct" />
+                    mode="sa-direct"
+                    onCredentialsChange={handleSaCredentialsChange}
+                    onCredentialReplacementStart={handleSaCredentialReplacementStart}
+                    onCredentialReplacementCancel={handleSaCredentialReplacementCancel} />
 
                 {#if saDriveFilters.length > 0 && !allDrivesValidated}
                     <Alert.Root>
@@ -561,14 +638,16 @@
 
                 <Card.Root class="border-dashed">
                     <Card.Content class="space-y-3">
-                        <GoogleDriveFolderSelector
-                            bind:selected={saDriveFilters}
-                            serviceAccountJson={saServiceAccountJson}
-                            authMode="service_account_direct"
-                            label="Shared drives to index"
-                            description="Search and select shared drives to index in full. Only whole drives are supported in this mode, and at least one is required."
-                            disabled={!saServiceAccountJson.trim()}
-                            onSelectedChange={handleSaSelectionChange} />
+                        {#key saSelectorRevision}
+                            <GoogleDriveFolderSelector
+                                bind:selected={saDriveFilters}
+                                serviceAccountJson={saServiceAccountJson}
+                                authMode="service_account_direct"
+                                label="Shared drives to index"
+                                description="Search and select shared drives to index in full. Only whole drives are supported in this mode, and at least one is required."
+                                disabled={!saServiceAccountJson.trim()}
+                                onSelectedChange={handleSaSelectionChange} />
+                        {/key}
                     </Card.Content>
                 </Card.Root>
 

--- a/web/src/lib/components/masked-credential-input.svelte
+++ b/web/src/lib/components/masked-credential-input.svelte
@@ -13,6 +13,9 @@
         placeholder?: string
         rows?: number
         inputClass?: string
+        onValueChange?: () => void
+        onReplacementStart?: () => void
+        onReplacementCancel?: () => void
     }
 
     let {
@@ -25,6 +28,9 @@
         placeholder = '',
         rows = 10,
         inputClass = '',
+        onValueChange,
+        onReplacementStart,
+        onReplacementCancel,
     }: Props = $props()
 
     let replacing = $state(!hasStoredValue)
@@ -34,11 +40,17 @@
     function startReplace() {
         replacing = true
         value = ''
+        onReplacementStart?.()
     }
 
     function cancelReplace() {
         replacing = false
         value = ''
+        onReplacementCancel?.()
+    }
+
+    function handleInput() {
+        onValueChange?.()
     }
 </script>
 
@@ -63,6 +75,7 @@
             {disabled}
             {placeholder}
             {rows}
+            oninput={handleInput}
             class={inputClass ||
                 'max-h-64 overflow-y-auto font-mono text-sm break-all whitespace-pre-wrap'} />
         {#if hasStoredValue}
@@ -79,7 +92,15 @@
     </div>
 {:else}
     <div class="flex items-center gap-2">
-        <Input {id} {name} type="password" bind:value {disabled} {placeholder} class={inputClass} />
+        <Input
+            {id}
+            {name}
+            type="password"
+            bind:value
+            {disabled}
+            {placeholder}
+            oninput={handleInput}
+            class={inputClass} />
         {#if hasStoredValue}
             <Button
                 type="button"

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -86,72 +86,11 @@ export interface ClickUpSourceConfig {
     space_filters?: string[]
 }
 
-export interface FolderPathFilter {
-    id: string
-    name: string
-    path: string
-    driveId: string
-    kind: 'shared_drive_root' | 'folder'
-}
-
-export type GoogleAuthMode = 'domain_wide_delegation' | 'service_account_direct'
-export type GoogleIndexScope = 'all' | 'selected' | 'pending'
-
-export interface GoogleDriveSourceConfig {
-    auth_mode?: GoogleAuthMode
-    index_scope?: GoogleIndexScope
-    folder_path_filters?: FolderPathFilter[]
-    // Future: shared_drive_filters, mime_type_filters, etc.
-}
-
-/**
- * Mirrors the connector's `GoogleSourceConfig` (models.rs).
- * `domain` is used only in domain_wide_delegation mode.
- */
-export interface GoogleSourceConfig {
-    auth_mode: GoogleAuthMode
-    index_scope?: GoogleIndexScope
-    domain?: string | null
-    folder_path_filters?: FolderPathFilter[]
-    space_allowlist?: string[]
-    include_group_chats?: boolean
-}
-
-export interface SharedDriveAccessResult {
-    drive_id: string
-    ok: boolean
-    role: string | null
-    error: string | null
-}
-
-export interface SharedDriveAccessResponse {
-    drives: SharedDriveAccessResult[]
-}
-
-/** Per-drive access-validation status shown in the setup UI. */
-export interface DriveAccessStatus {
-    pending: boolean
-    ok: boolean
-    role: string | null
-    error: string | null
-}
-
-/** Envelope returned by the transient connector action route. */
+/** Envelope returned by a connector action route. */
 export interface ConnectorActionResponse<T = unknown> {
-    status: 'success' | 'error'
+    status: string
     result?: T
     error?: string
-}
-
-export interface GmailSourceConfig {
-    auth_mode?: GoogleAuthMode
-    // Future: label_filters, date_range_filters, etc.
-}
-
-export interface GoogleChatSourceConfig {
-    auth_mode?: GoogleAuthMode
-    space_allowlist?: string[]
-    include_group_chats?: boolean
 }
 
 export interface FilesystemSourceConfig {

--- a/web/src/lib/types.ts
+++ b/web/src/lib/types.ts
@@ -95,9 +95,11 @@ export interface FolderPathFilter {
 }
 
 export type GoogleAuthMode = 'domain_wide_delegation' | 'service_account_direct'
+export type GoogleIndexScope = 'all' | 'selected' | 'pending'
 
 export interface GoogleDriveSourceConfig {
     auth_mode?: GoogleAuthMode
+    index_scope?: GoogleIndexScope
     folder_path_filters?: FolderPathFilter[]
     // Future: shared_drive_filters, mime_type_filters, etc.
 }
@@ -108,6 +110,7 @@ export interface GoogleDriveSourceConfig {
  */
 export interface GoogleSourceConfig {
     auth_mode: GoogleAuthMode
+    index_scope?: GoogleIndexScope
     domain?: string | null
     folder_path_filters?: FolderPathFilter[]
     space_allowlist?: string[]

--- a/web/src/lib/types/search.ts
+++ b/web/src/lib/types/search.ts
@@ -168,6 +168,7 @@ export interface DriveFolderDiscoveryEntry {
 
 export interface DriveFolderDiscoveryResponse {
     items: DriveFolderDiscoveryEntry[]
+    truncated?: boolean
 }
 
 export interface ConnectorActionResponse<T = unknown> {

--- a/web/src/lib/types/search.ts
+++ b/web/src/lib/types/search.ts
@@ -170,9 +170,3 @@ export interface DriveFolderDiscoveryResponse {
     items: DriveFolderDiscoveryEntry[]
     truncated?: boolean
 }
-
-export interface ConnectorActionResponse<T = unknown> {
-    status: string
-    result?: T
-    error?: string
-}

--- a/web/src/lib/utils/google-drive-folder-search.test.ts
+++ b/web/src/lib/utils/google-drive-folder-search.test.ts
@@ -1,0 +1,65 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+    GOOGLE_DRIVE_FOLDER_SEARCH_DEBOUNCE_MS,
+    scheduleGoogleDriveFolderSearch,
+    type GoogleDriveFolderSearchTimer,
+} from './google-drive-folder-search'
+
+describe('scheduleGoogleDriveFolderSearch', () => {
+    beforeEach(() => {
+        vi.useFakeTimers()
+    })
+
+    afterEach(() => {
+        vi.useRealTimers()
+    })
+
+    it('does not schedule empty or one-character searches', () => {
+        const search = vi.fn()
+
+        expect(scheduleGoogleDriveFolderSearch(undefined, '', search)).toBeUndefined()
+        expect(scheduleGoogleDriveFolderSearch(undefined, ' a ', search)).toBeUndefined()
+        expect(scheduleGoogleDriveFolderSearch(undefined, '文', search)).toBeUndefined()
+
+        vi.runAllTimers()
+        expect(search).not.toHaveBeenCalled()
+    })
+
+    it('waits for the debounce period before searching a trimmed query', () => {
+        const search = vi.fn()
+
+        const timer = scheduleGoogleDriveFolderSearch(undefined, '  ab  ', search)
+
+        expect(timer).toBeDefined()
+        vi.advanceTimersByTime(GOOGLE_DRIVE_FOLDER_SEARCH_DEBOUNCE_MS - 1)
+        expect(search).not.toHaveBeenCalled()
+
+        vi.advanceTimersByTime(1)
+        expect(search).toHaveBeenCalledOnce()
+        expect(search).toHaveBeenCalledWith('ab')
+    })
+
+    it('cancels the pending search when the user keeps typing', () => {
+        const search = vi.fn()
+        let timer: GoogleDriveFolderSearchTimer | undefined
+
+        timer = scheduleGoogleDriveFolderSearch(timer, 'ro', search)
+        vi.advanceTimersByTime(GOOGLE_DRIVE_FOLDER_SEARCH_DEBOUNCE_MS - 1)
+        timer = scheduleGoogleDriveFolderSearch(timer, 'roadmap', search)
+        vi.advanceTimersByTime(GOOGLE_DRIVE_FOLDER_SEARCH_DEBOUNCE_MS)
+
+        expect(search).toHaveBeenCalledOnce()
+        expect(search).toHaveBeenCalledWith('roadmap')
+    })
+
+    it('cancels a pending search when the input becomes too short', () => {
+        const search = vi.fn()
+        let timer = scheduleGoogleDriveFolderSearch(undefined, 'roadmap', search)
+
+        timer = scheduleGoogleDriveFolderSearch(timer, 'r', search)
+        expect(timer).toBeUndefined()
+
+        vi.runAllTimers()
+        expect(search).not.toHaveBeenCalled()
+    })
+})

--- a/web/src/lib/utils/google-drive-folder-search.ts
+++ b/web/src/lib/utils/google-drive-folder-search.ts
@@ -1,0 +1,23 @@
+export const GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS = 2
+export const GOOGLE_DRIVE_FOLDER_SEARCH_DEBOUNCE_MS = 250
+
+export type GoogleDriveFolderSearchTimer = ReturnType<typeof setTimeout>
+
+export function googleDriveFolderSearchLength(query: string): number {
+    return Array.from(query.trim()).length
+}
+
+export function scheduleGoogleDriveFolderSearch(
+    pendingTimer: GoogleDriveFolderSearchTimer | undefined,
+    query: string,
+    search: (normalizedQuery: string) => void,
+): GoogleDriveFolderSearchTimer | undefined {
+    if (pendingTimer) clearTimeout(pendingTimer)
+
+    const normalizedQuery = query.trim()
+    if (googleDriveFolderSearchLength(normalizedQuery) < GOOGLE_DRIVE_FOLDER_SEARCH_MIN_CHARS) {
+        return undefined
+    }
+
+    return setTimeout(() => search(normalizedQuery), GOOGLE_DRIVE_FOLDER_SEARCH_DEBOUNCE_MS)
+}

--- a/web/src/lib/utils/google-scopes.ts
+++ b/web/src/lib/utils/google-scopes.ts
@@ -1,0 +1,9 @@
+export const GOOGLE_DRIVE_READ_SCOPE = 'https://www.googleapis.com/auth/drive.readonly'
+export const GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE =
+    'https://www.googleapis.com/auth/admin.directory.group.readonly'
+
+export const GOOGLE_SA_DIRECT_DRIVE_SCOPES = [GOOGLE_DRIVE_READ_SCOPE]
+export const GOOGLE_SA_DIRECT_SCOPES = [
+    ...GOOGLE_SA_DIRECT_DRIVE_SCOPES,
+    GOOGLE_ADMIN_DIRECTORY_GROUP_READ_SCOPE,
+]

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.server.ts
@@ -7,7 +7,7 @@ import { serviceCredentialsRepository } from '$lib/server/repositories/service-c
 import { userRepository } from '$lib/server/db/users'
 import { getConfig } from '$lib/server/config'
 import { AuthType, SourceType } from '$lib/types'
-import type { FolderPathFilter } from '$lib/types'
+import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
 
 export const load: PageServerLoad = async ({ params, locals }) => {
     requireAdmin(locals)

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.server.ts
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.server.ts
@@ -8,6 +8,7 @@ import { userRepository } from '$lib/server/db/users'
 import { getConfig } from '$lib/server/config'
 import { AuthType, SourceType } from '$lib/types'
 import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
+import { GOOGLE_SA_DIRECT_SCOPES } from '$lib/utils/google-scopes'
 
 export const load: PageServerLoad = async ({ params, locals }) => {
     requireAdmin(locals)
@@ -175,8 +176,8 @@ export const actions: Actions = {
                 const domain = ((formData.get('domain') as string) || '').trim()
 
                 if (isSaDirect) {
-                    // SA-direct: no admin email/domain required; the shared drive
-                    // selection is the only scope. Validate it was provided.
+                    // SA-direct does not impersonate an admin user, but group
+                    // membership sync still needs the Workspace domain.
                     const folderPathFilters = parseFolderPathFilters(formData)
                     if (folderPathFilters.length === 0) {
                         throw error(400, 'At least one shared drive is required')
@@ -196,12 +197,19 @@ export const actions: Actions = {
                         }
                     }
 
+                    if (!domain) {
+                        throw error(
+                            400,
+                            'Organization domain is required for SA-direct group membership sync',
+                        )
+                    }
+
                     const mergedConfig: Record<string, unknown> = {
                         ...existingConfig,
                         auth_mode: 'service_account_direct',
+                        domain,
                     }
                     mergedConfig.folder_path_filters = folderPathFilters
-                    delete mergedConfig.domain
 
                     const existingCredConfig: Record<string, unknown> =
                         existingCreds?.config &&
@@ -214,7 +222,8 @@ export const actions: Actions = {
                         principalEmail: null,
                         config: {
                             ...existingCredConfig,
-                            scopes: ['https://www.googleapis.com/auth/drive.readonly'],
+                            domain,
+                            scopes: GOOGLE_SA_DIRECT_SCOPES,
                         },
                         credentials: serviceAccountJson
                             ? { service_account_key: serviceAccountJson }

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
@@ -11,16 +11,13 @@
     import { Search, X, AlertCircle, Info, Loader2 } from '@lucide/svelte'
     import GoogleServiceAccountForm from '$lib/components/google-service-account-form.svelte'
     import GoogleDriveFolderSelector from '$lib/components/google-drive-folder-selector.svelte'
+    import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
     import { onMount } from 'svelte'
     import { beforeNavigate } from '$app/navigation'
     import type { PageProps } from './$types'
-    import type {
-        GoogleDirectoryUser,
-        SearchUsersResponse,
-        ConnectorActionResponse,
-    } from '$lib/types/search'
+    import type { GoogleDirectoryUser, SearchUsersResponse } from '$lib/types/search'
     import { AuthType } from '$lib/types'
-    import type { FolderPathFilter } from '$lib/types'
+    import type { ConnectorActionResponse } from '$lib/types'
     import googleDriveLogo from '$lib/images/icons/google-drive.svg'
 
     let { data }: PageProps = $props()
@@ -45,6 +42,29 @@
     let folderFilters = $state<FolderPathFilter[]>(
         (Array.isArray(data.folderPathFilters) ? data.folderPathFilters : []) as FolderPathFilter[],
     )
+    let folderSelectorRevision = $state(0)
+    let folderFiltersBeforeCredentialReplacement = $state<FolderPathFilter[] | null>(null)
+
+    function handleCredentialChange() {
+        folderFilters = []
+        folderSelectorRevision += 1
+    }
+
+    function handleAccountDetailsChange() {
+        folderFiltersBeforeCredentialReplacement = null
+        handleCredentialChange()
+    }
+
+    function handleCredentialReplacementStart() {
+        folderFiltersBeforeCredentialReplacement = [...folderFilters]
+    }
+
+    function handleCredentialReplacementCancel() {
+        if (folderFiltersBeforeCredentialReplacement === null) return
+        folderFilters = folderFiltersBeforeCredentialReplacement
+        folderFiltersBeforeCredentialReplacement = null
+        folderSelectorRevision += 1
+    }
 
     let searchQuery = $state('')
     let searchResults = $state<GoogleDirectoryUser[]>([])
@@ -362,16 +382,22 @@
                             bind:serviceAccountJson
                             mode="sa-direct"
                             hasStoredKey={data.hasStoredKey}
-                            showSaDirectInfo={false} />
+                            showSaDirectInfo={false}
+                            onCredentialsChange={handleCredentialChange}
+                            onAccountDetailsChange={handleAccountDetailsChange}
+                            onCredentialReplacementStart={handleCredentialReplacementStart}
+                            onCredentialReplacementCancel={handleCredentialReplacementCancel} />
 
-                        <GoogleDriveFolderSelector
-                            bind:selected={folderFilters}
-                            sourceId={data.source.id}
-                            {serviceAccountJson}
-                            authMode="service_account_direct"
-                            label="Shared Drives to Index"
-                            description="Select one or more whole shared drives to index."
-                            disabled={!enabled} />
+                        {#key folderSelectorRevision}
+                            <GoogleDriveFolderSelector
+                                bind:selected={folderFilters}
+                                sourceId={data.source.id}
+                                {serviceAccountJson}
+                                authMode="service_account_direct"
+                                label="Shared Drives to Index"
+                                description="Select one or more whole shared drives to index."
+                                disabled={!enabled} />
+                        {/key}
                         <input
                             type="hidden"
                             name="folder_path_filters"
@@ -393,7 +419,11 @@
                             bind:serviceAccountJson
                             bind:principalEmail
                             bind:domain
-                            hasStoredKey={data.hasStoredKey} />
+                            hasStoredKey={data.hasStoredKey}
+                            onCredentialsChange={handleCredentialChange}
+                            onAccountDetailsChange={handleAccountDetailsChange}
+                            onCredentialReplacementStart={handleCredentialReplacementStart}
+                            onCredentialReplacementCancel={handleCredentialReplacementCancel} />
 
                         {#if data.gmailSiblingId}
                             <Alert.Root>
@@ -410,15 +440,17 @@
 
                     <!-- Folder Path Filter (JWT only) -->
                     <div class="space-y-4 border-t pt-6">
-                        <GoogleDriveFolderSelector
-                            bind:selected={folderFilters}
-                            sourceId={data.source.id}
-                            {serviceAccountJson}
-                            {principalEmail}
-                            {domain}
-                            label="Drive Folder Filters"
-                            description="Optionally restrict indexing to specific shared drives or any accessible folder. All sub-folders within a selected item are included."
-                            disabled={!enabled} />
+                        {#key folderSelectorRevision}
+                            <GoogleDriveFolderSelector
+                                bind:selected={folderFilters}
+                                sourceId={data.source.id}
+                                {serviceAccountJson}
+                                {principalEmail}
+                                {domain}
+                                label="Drive Folder Filters"
+                                description="Optionally restrict indexing to specific shared drives or any accessible folder. All sub-folders within a selected item are included."
+                                disabled={!enabled} />
+                        {/key}
                         <!-- Hidden form value to submit folder filters (always present for JWT, even when empty) -->
                         <input
                             type="hidden"

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
@@ -65,6 +65,13 @@
     let originalDomain = data.domain
     let originalFolderFilters = $state<FolderPathFilter[]>([...folderFilters])
 
+    function driveFolderScopeChanged(): boolean {
+        return (
+            JSON.stringify(folderFilters.map((filter) => filter.id).sort()) !==
+            JSON.stringify(originalFolderFilters.map((filter) => filter.id).sort())
+        )
+    }
+
     async function searchUsers() {
         if (searchQuery.trim().length < 2) {
             searchResults = []
@@ -228,9 +235,7 @@
         const usersChanged =
             JSON.stringify(selectedUsers.sort()) !== JSON.stringify(originalSelectedUsers.sort())
 
-        const foldersChanged =
-            JSON.stringify(folderFilters.map((f) => f.id).sort()) !==
-            JSON.stringify(originalFolderFilters.map((f) => f.id).sort())
+        const foldersChanged = driveFolderScopeChanged()
 
         if (isSaDirect) {
             hasUnsavedChanges =
@@ -333,11 +338,11 @@
                     </Alert.Root>
                     <Alert.Root variant="default" class="mt-2">
                         <Info class="h-4 w-4" />
-                        <Alert.Title>Folder-level filtering unavailable</Alert.Title>
+                        <Alert.Title>Folder-level filtering managed by the owner</Alert.Title>
                         <Alert.Description>
-                            To select specific folders or shared drives for indexing, switch to a
-                            domain-wide delegation (service account) connection. OAuth-connected
-                            sources always index all accessible files.
+                            This org-source admin screen does not edit OAuth folder scope. Personal
+                            OAuth Drive owners can choose folders from My Integrations; this
+                            org-wide OAuth source continues to index all accessible files.
                         </Alert.Description>
                     </Alert.Root>
                 </div>
@@ -371,6 +376,16 @@
                             type="hidden"
                             name="folder_path_filters"
                             value={JSON.stringify(folderFilters)} />
+                        {#if driveFolderScopeChanged()}
+                            <Alert.Root variant="default">
+                                <Info class="h-4 w-4" />
+                                <Alert.Title>Folder selection changed</Alert.Title>
+                                <Alert.Description>
+                                    Saving starts a full sync. Files removed from the selection may
+                                    remain searchable until a later cleanup.
+                                </Alert.Description>
+                            </Alert.Root>
+                        {/if}
                     </div>
                 {:else}
                     <div class="space-y-4">
@@ -402,13 +417,23 @@
                             {principalEmail}
                             {domain}
                             label="Drive Folder Filters"
-                            description="Optionally restrict indexing to specific shared drives and top-level folders. All sub-folders within a selected item are included."
+                            description="Optionally restrict indexing to specific shared drives or any accessible folder. All sub-folders within a selected item are included."
                             disabled={!enabled} />
                         <!-- Hidden form value to submit folder filters (always present for JWT, even when empty) -->
                         <input
                             type="hidden"
                             name="folder_path_filters"
                             value={JSON.stringify(folderFilters)} />
+                        {#if driveFolderScopeChanged()}
+                            <Alert.Root variant="default">
+                                <Info class="h-4 w-4" />
+                                <Alert.Title>Folder selection changed</Alert.Title>
+                                <Alert.Description>
+                                    Saving starts a full sync. Files removed from the selection may
+                                    remain searchable until a later cleanup.
+                                </Alert.Description>
+                            </Alert.Root>
+                        {/if}
                     </div>
 
                     <div class="space-y-4 border-t pt-6">

--- a/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/drive/[sourceId]/+page.svelte
@@ -158,7 +158,14 @@
         }
 
         if (isSaDirect) {
-            // SA-direct: no admin email/domain; at least one whole shared drive.
+            // SA-direct does not impersonate an admin user, but group
+            // membership sync still requires the Workspace domain.
+            if (!domain.trim()) {
+                formErrors = [
+                    ...formErrors,
+                    'Organization domain is required for SA-direct group membership sync',
+                ]
+            }
             if (folderFilters.length === 0) {
                 formErrors = [...formErrors, 'At least one shared drive is required']
             }
@@ -261,7 +268,8 @@
             hasUnsavedChanges =
                 enabled !== originalEnabled ||
                 foldersChanged ||
-                serviceAccountJson.trim().length > 0
+                serviceAccountJson.trim().length > 0 ||
+                domain !== originalDomain
             return
         }
 
@@ -380,9 +388,11 @@
 
                         <GoogleServiceAccountForm
                             bind:serviceAccountJson
+                            bind:domain
                             mode="sa-direct"
                             hasStoredKey={data.hasStoredKey}
                             showSaDirectInfo={false}
+                            showDomain
                             onCredentialsChange={handleCredentialChange}
                             onAccountDetailsChange={handleAccountDetailsChange}
                             onCredentialReplacementStart={handleCredentialReplacementStart}

--- a/web/src/routes/(admin)/admin/settings/integrations/gmail/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/gmail/[sourceId]/+page.svelte
@@ -13,12 +13,9 @@
     import { onMount } from 'svelte'
     import { beforeNavigate } from '$app/navigation'
     import type { PageProps } from './$types'
-    import type {
-        GoogleDirectoryUser,
-        SearchUsersResponse,
-        ConnectorActionResponse,
-    } from '$lib/types/search'
+    import type { GoogleDirectoryUser, SearchUsersResponse } from '$lib/types/search'
     import { AuthType } from '$lib/types'
+    import type { ConnectorActionResponse } from '$lib/types'
     import gmailLogo from '$lib/images/icons/gmail.svg'
 
     let { data }: PageProps = $props()

--- a/web/src/routes/(admin)/admin/settings/integrations/google_chat/[sourceId]/+page.svelte
+++ b/web/src/routes/(admin)/admin/settings/integrations/google_chat/[sourceId]/+page.svelte
@@ -13,12 +13,9 @@
     import { onMount } from 'svelte'
     import { beforeNavigate } from '$app/navigation'
     import type { PageProps } from './$types'
-    import type {
-        GoogleDirectoryUser,
-        SearchUsersResponse,
-        ConnectorActionResponse,
-    } from '$lib/types/search'
+    import type { GoogleDirectoryUser, SearchUsersResponse } from '$lib/types/search'
     import { AuthType } from '$lib/types'
+    import type { ConnectorActionResponse } from '$lib/types'
     import googleChatLogo from '$lib/images/icons/google-chat.svg'
 
     let { data }: PageProps = $props()

--- a/web/src/routes/(app)/settings/integrations/+page.server.ts
+++ b/web/src/routes/(app)/settings/integrations/+page.server.ts
@@ -10,6 +10,8 @@ import {
     oauthServiceBaseUrl,
 } from '$lib/server/oauth/connectorOAuth'
 import { SourceType, supportsDataSync } from '$lib/types'
+import type { FolderPathFilter } from '$lib/types'
+import { getConfig } from '$lib/server/config'
 import type { PageServerLoad, Actions } from './$types'
 
 export const load: PageServerLoad = async ({ locals }) => {
@@ -71,6 +73,71 @@ export const load: PageServerLoad = async ({ locals }) => {
     }
 }
 
+function parsePersonalDriveScope(formData: FormData): {
+    indexScope: 'all' | 'selected'
+    filters: FolderPathFilter[]
+} {
+    const indexScope = formData.get('indexScope')
+    if (indexScope !== 'all' && indexScope !== 'selected') {
+        throw new Error('indexScope must be all or selected')
+    }
+
+    const raw = formData.get('folder_path_filters')
+    let parsed: unknown = []
+    if (typeof raw === 'string' && raw.length > 0) {
+        try {
+            parsed = JSON.parse(raw)
+        } catch {
+            throw new Error('folder_path_filters is not valid JSON')
+        }
+    }
+    if (!Array.isArray(parsed)) {
+        throw new Error('folder_path_filters must be an array')
+    }
+    if (parsed.length > 100) {
+        throw new Error('At most 100 Drive folders can be selected')
+    }
+
+    const seen = new Set<string>()
+    const filters: FolderPathFilter[] = []
+    for (const value of parsed) {
+        if (!value || typeof value !== 'object' || Array.isArray(value)) {
+            throw new Error('Each folder filter must be an object')
+        }
+        const entry = value as Record<string, unknown>
+        const allowedKeys = new Set(['id', 'name', 'path', 'driveId', 'kind'])
+        if (Object.keys(entry).some((key) => !allowedKeys.has(key))) {
+            throw new Error('Folder filters contain an unknown field')
+        }
+        if (
+            typeof entry.id !== 'string' ||
+            typeof entry.name !== 'string' ||
+            typeof entry.path !== 'string' ||
+            typeof entry.driveId !== 'string' ||
+            (entry.kind !== 'folder' && entry.kind !== 'shared_drive_root')
+        ) {
+            throw new Error('Folder filters contain an invalid entry')
+        }
+        if (!entry.id || !entry.name || !entry.path || !entry.driveId) {
+            throw new Error('Folder filters contain an empty value')
+        }
+        if (seen.has(entry.id)) continue
+        seen.add(entry.id)
+        filters.push({
+            id: entry.id,
+            name: entry.name,
+            path: entry.path,
+            driveId: entry.driveId,
+            kind: entry.kind,
+        })
+    }
+
+    if (indexScope === 'selected' && filters.length === 0) {
+        throw new Error('Select at least one Drive folder')
+    }
+    return { indexScope, filters: indexScope === 'all' ? [] : filters }
+}
+
 export const actions: Actions = {
     disable: async ({ request, locals }) => {
         if (!locals.user) {
@@ -125,6 +192,81 @@ export const actions: Actions = {
             return fail(400, { error: 'Source does not support data sync' })
         }
 
+        const sourceConfig =
+            source.config && typeof source.config === 'object' && !Array.isArray(source.config)
+                ? (source.config as Record<string, unknown>)
+                : {}
+        if (
+            source.sourceType === SourceType.GOOGLE_DRIVE &&
+            sourceConfig.index_scope === 'pending'
+        ) {
+            return fail(400, { error: 'Choose a Google Drive indexing scope first' })
+        }
+
         await updateSourceById(sourceId, { isActive: true })
+    },
+
+    configureDrive: async ({ request, locals, fetch }) => {
+        if (!locals.user) {
+            throw redirect(302, '/login')
+        }
+
+        const formData = await request.formData()
+        const sourceId = formData.get('sourceId') as string
+        if (!sourceId) return fail(400, { error: 'Source ID is required' })
+        const [source] = await db
+            .select()
+            .from(sources)
+            .where(
+                and(
+                    eq(sources.id, sourceId),
+                    eq(sources.createdBy, locals.user.id),
+                    eq(sources.scope, 'user'),
+                    eq(sources.isDeleted, false),
+                    eq(sources.sourceType, SourceType.GOOGLE_DRIVE),
+                ),
+            )
+            .limit(1)
+        if (!source) return fail(404, { error: 'Google Drive source not found' })
+
+        let scope: ReturnType<typeof parsePersonalDriveScope>
+        try {
+            scope = parsePersonalDriveScope(formData)
+        } catch (err) {
+            return fail(400, { error: err instanceof Error ? err.message : 'Invalid Drive scope' })
+        }
+
+        const existingConfig =
+            source.config && typeof source.config === 'object' && !Array.isArray(source.config)
+                ? (source.config as Record<string, unknown>)
+                : {}
+        const nextConfig = {
+            ...existingConfig,
+            index_scope: scope.indexScope,
+            folder_path_filters: scope.filters,
+        }
+
+        await updateSourceById(source.id, { isActive: true, config: nextConfig })
+
+        try {
+            const response = await fetch(`${getConfig().services.connectorManagerUrl}/sync`, {
+                method: 'POST',
+                headers: { 'content-type': 'application/json' },
+                body: JSON.stringify({ source_id: source.id, sync_mode: 'full' }),
+            })
+            if (!response.ok && response.status !== 409) {
+                return fail(502, {
+                    error: 'Drive scope saved, but the full sync could not start',
+                    sourceId: source.id,
+                })
+            }
+        } catch {
+            return fail(502, {
+                error: 'Drive scope saved, but the full sync could not start',
+                sourceId: source.id,
+            })
+        }
+
+        return { success: true, sourceId: source.id }
     },
 }

--- a/web/src/routes/(app)/settings/integrations/+page.server.ts
+++ b/web/src/routes/(app)/settings/integrations/+page.server.ts
@@ -10,9 +10,17 @@ import {
     oauthServiceBaseUrl,
 } from '$lib/server/oauth/connectorOAuth'
 import { SourceType, supportsDataSync } from '$lib/types'
-import type { FolderPathFilter } from '$lib/types'
+import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
 import { getConfig } from '$lib/server/config'
 import type { PageServerLoad, Actions } from './$types'
+
+type GoogleIndexScope = 'all' | 'selected' | 'pending'
+
+interface GoogleDriveSourceConfig {
+    auth_mode?: 'domain_wide_delegation' | 'service_account_direct'
+    index_scope?: GoogleIndexScope
+    folder_path_filters?: FolderPathFilter[]
+}
 
 export const load: PageServerLoad = async ({ locals }) => {
     if (!locals.user) {
@@ -84,11 +92,16 @@ function parsePersonalDriveScope(formData: FormData): {
 
     const raw = formData.get('folder_path_filters')
     let parsed: unknown = []
-    if (typeof raw === 'string' && raw.length > 0) {
-        try {
-            parsed = JSON.parse(raw)
-        } catch {
-            throw new Error('folder_path_filters is not valid JSON')
+    if (raw !== null) {
+        if (typeof raw !== 'string') {
+            throw new Error('folder_path_filters must be a JSON string')
+        }
+        if (raw.length > 0) {
+            try {
+                parsed = JSON.parse(raw)
+            } catch {
+                throw new Error('folder_path_filters is not valid JSON')
+            }
         }
     }
     if (!Array.isArray(parsed)) {
@@ -100,12 +113,12 @@ function parsePersonalDriveScope(formData: FormData): {
 
     const seen = new Set<string>()
     const filters: FolderPathFilter[] = []
+    const allowedKeys = new Set(['id', 'name', 'path', 'driveId', 'kind'])
     for (const value of parsed) {
         if (!value || typeof value !== 'object' || Array.isArray(value)) {
             throw new Error('Each folder filter must be an object')
         }
         const entry = value as Record<string, unknown>
-        const allowedKeys = new Set(['id', 'name', 'path', 'driveId', 'kind'])
         if (Object.keys(entry).some((key) => !allowedKeys.has(key))) {
             throw new Error('Folder filters contain an unknown field')
         }
@@ -192,10 +205,7 @@ export const actions: Actions = {
             return fail(400, { error: 'Source does not support data sync' })
         }
 
-        const sourceConfig =
-            source.config && typeof source.config === 'object' && !Array.isArray(source.config)
-                ? (source.config as Record<string, unknown>)
-                : {}
+        const sourceConfig = source.config as GoogleDriveSourceConfig
         if (
             source.sourceType === SourceType.GOOGLE_DRIVE &&
             sourceConfig.index_scope === 'pending'
@@ -236,10 +246,7 @@ export const actions: Actions = {
             return fail(400, { error: err instanceof Error ? err.message : 'Invalid Drive scope' })
         }
 
-        const existingConfig =
-            source.config && typeof source.config === 'object' && !Array.isArray(source.config)
-                ? (source.config as Record<string, unknown>)
-                : {}
+        const existingConfig = source.config as GoogleDriveSourceConfig
         const nextConfig = {
             ...existingConfig,
             index_scope: scope.indexScope,

--- a/web/src/routes/(app)/settings/integrations/+page.svelte
+++ b/web/src/routes/(app)/settings/integrations/+page.svelte
@@ -18,6 +18,7 @@
     import GoogleOAuthSetup from '$lib/components/google-oauth-setup.svelte'
     import WindshiftConnectorSetup from '$lib/components/windshift-connector-setup.svelte'
     import GoogleDriveFolderSelector from '$lib/components/google-drive-folder-selector.svelte'
+    import type { FolderPathFilter } from '$lib/components/google-drive-folder-selector.types'
     import { getSourceIconPath } from '$lib/utils/icons'
     import { formatDate, getSourceNoun } from '$lib/utils/sources'
     import { SourceType } from '$lib/types'
@@ -26,11 +27,17 @@
     import { toast } from 'svelte-sonner'
     import { onMount, onDestroy } from 'svelte'
     import type { SyncRun } from '$lib/server/db/schema'
-    import type { FolderPathFilter } from '$lib/types'
 
     let { data }: PageProps = $props()
 
     type UserSource = (typeof data.userSources)[number]
+    type GoogleIndexScope = 'all' | 'selected' | 'pending'
+
+    interface GoogleDriveSourceConfig {
+        auth_mode?: 'domain_wide_delegation' | 'service_account_direct'
+        index_scope?: GoogleIndexScope
+        folder_path_filters?: FolderPathFilter[]
+    }
 
     let sourceToDisconnect = $state<UserSource | null>(null)
     let togglingSourceId = $state<string | null>(null)
@@ -54,10 +61,7 @@
     onMount(() => {
         const pendingDrive = data.userSources.find((source) => {
             if (source.sourceType !== 'google_drive') return false
-            const config =
-                source.config && typeof source.config === 'object' && !Array.isArray(source.config)
-                    ? (source.config as Record<string, unknown>)
-                    : {}
+            const config = source.config as GoogleDriveSourceConfig
             return config.index_scope === 'pending'
         })
         if (pendingDrive) openDriveScope(pendingDrive)
@@ -156,15 +160,10 @@
     }
 
     function openDriveScope(source: UserSource) {
-        const config =
-            source.config && typeof source.config === 'object' && !Array.isArray(source.config)
-                ? (source.config as Record<string, unknown>)
-                : {}
+        const config = source.config as GoogleDriveSourceConfig
         driveToConfigure = source
         driveScopeMode = config.index_scope === 'selected' ? 'selected' : 'all'
-        driveFolderFilters = Array.isArray(config.folder_path_filters)
-            ? (config.folder_path_filters as FolderPathFilter[])
-            : []
+        driveFolderFilters = config.folder_path_filters ?? []
         originalDriveScopeMode = driveScopeMode
         originalDriveFolderIds = folderFilterIds(driveFolderFilters)
         originalDriveScopeConfigured = config.index_scope !== 'pending'
@@ -266,13 +265,9 @@
                         {@const indexedCount = documentCounts[source.id] ?? 0}
                         {@const isRunning = source.isActive && sync?.status === 'running'}
                         {@const isFailed = source.isActive && sync?.status === 'failed'}
-                        {@const isDrivePending = !!(
+                        {@const isDrivePending =
                             source.sourceType === 'google_drive' &&
-                            source.config &&
-                            typeof source.config === 'object' &&
-                            !Array.isArray(source.config) &&
-                            (source.config as Record<string, unknown>).index_scope === 'pending'
-                        )}
+                            (source.config as GoogleDriveSourceConfig).index_scope === 'pending'}
                         <Card
                             class="group hover:border-foreground/20 gap-0 overflow-hidden py-0 transition-colors">
                             <CardHeader
@@ -372,12 +367,7 @@
                                 </div>
 
                                 {#if source.sourceType === 'google_drive'}
-                                    {@const driveConfig =
-                                        source.config &&
-                                        typeof source.config === 'object' &&
-                                        !Array.isArray(source.config)
-                                            ? (source.config as Record<string, unknown>)
-                                            : {}}
+                                    {@const driveConfig = source.config as GoogleDriveSourceConfig}
                                     <div class="border-t pt-3">
                                         {#if driveConfig.index_scope === 'pending'}
                                             <p class="text-muted-foreground mb-2 text-xs">
@@ -386,11 +376,9 @@
                                             </p>
                                         {:else if driveConfig.index_scope === 'selected'}
                                             <p class="text-muted-foreground mb-2 text-xs">
-                                                Indexing {Array.isArray(
-                                                    driveConfig.folder_path_filters,
-                                                )
-                                                    ? driveConfig.folder_path_filters.length
-                                                    : 0} selected folder(s).
+                                                Indexing {driveConfig.folder_path_filters?.length ??
+                                                    0}
+                                                selected folder(s).
                                             </p>
                                         {:else}
                                             <p class="text-muted-foreground mb-2 text-xs">
@@ -552,13 +540,15 @@
             </div>
 
             {#if driveScopeMode === 'selected'}
-                <GoogleDriveFolderSelector
-                    bind:selected={driveFolderFilters}
-                    sourceId={driveToConfigure?.id ?? ''}
-                    label="Folders to index"
-                    description="Search folders in My Drive and shared drives accessible to this account. Typing searches nested folders too."
-                    authMode="domain_wide_delegation"
-                    action="discover_personal_folders" />
+                {#key driveToConfigure?.id ?? ''}
+                    <GoogleDriveFolderSelector
+                        bind:selected={driveFolderFilters}
+                        sourceId={driveToConfigure?.id ?? ''}
+                        label="Folders to index"
+                        description="Search My Drive and shared drives by name prefix."
+                        authMode="domain_wide_delegation"
+                        action="discover_personal_folders" />
+                {/key}
             {/if}
         </div>
 

--- a/web/src/routes/(app)/settings/integrations/+page.svelte
+++ b/web/src/routes/(app)/settings/integrations/+page.svelte
@@ -10,19 +10,23 @@
     import { Button } from '$lib/components/ui/button'
     import { Switch } from '$lib/components/ui/switch'
     import * as AlertDialog from '$lib/components/ui/alert-dialog'
+    import * as Dialog from '$lib/components/ui/dialog'
     import type { PageProps } from './$types'
     import googleLogo from '$lib/images/icons/google.svg'
     import windshiftLogo from '$lib/images/icons/windshift.png'
     import { Globe, HardDrive, Mail, Trash2 } from '@lucide/svelte'
     import GoogleOAuthSetup from '$lib/components/google-oauth-setup.svelte'
     import WindshiftConnectorSetup from '$lib/components/windshift-connector-setup.svelte'
+    import GoogleDriveFolderSelector from '$lib/components/google-drive-folder-selector.svelte'
     import { getSourceIconPath } from '$lib/utils/icons'
     import { formatDate, getSourceNoun } from '$lib/utils/sources'
     import { SourceType } from '$lib/types'
     import { invalidateAll } from '$app/navigation'
+    import { deserialize } from '$app/forms'
     import { toast } from 'svelte-sonner'
     import { onMount, onDestroy } from 'svelte'
     import type { SyncRun } from '$lib/server/db/schema'
+    import type { FolderPathFilter } from '$lib/types'
 
     let { data }: PageProps = $props()
 
@@ -48,6 +52,16 @@
     })
 
     onMount(() => {
+        const pendingDrive = data.userSources.find((source) => {
+            if (source.sourceType !== 'google_drive') return false
+            const config =
+                source.config && typeof source.config === 'object' && !Array.isArray(source.config)
+                    ? (source.config as Record<string, unknown>)
+                    : {}
+            return config.index_scope === 'pending'
+        })
+        if (pendingDrive) openDriveScope(pendingDrive)
+
         eventSource = new EventSource('/api/indexing/status?scope=user')
         eventSource.onmessage = (event) => {
             try {
@@ -120,6 +134,100 @@
 
     let showGoogleOAuthSetup = $state(false)
     let showWindshiftSetup = $state(false)
+    let driveToConfigure = $state<UserSource | null>(null)
+    let driveScopeMode = $state<'all' | 'selected'>('all')
+    let driveFolderFilters = $state<FolderPathFilter[]>([])
+    let originalDriveScopeMode = $state<'all' | 'selected'>('all')
+    let originalDriveFolderIds = $state<string[]>([])
+    let originalDriveScopeConfigured = $state(false)
+    let showDriveScopeWarning = $state(false)
+    let isSavingDriveScope = $state(false)
+
+    function folderFilterIds(filters: FolderPathFilter[]): string[] {
+        return filters.map((filter) => filter.id).sort()
+    }
+
+    function driveScopeChanged(): boolean {
+        return (
+            driveScopeMode !== originalDriveScopeMode ||
+            JSON.stringify(folderFilterIds(driveFolderFilters)) !==
+                JSON.stringify(originalDriveFolderIds)
+        )
+    }
+
+    function openDriveScope(source: UserSource) {
+        const config =
+            source.config && typeof source.config === 'object' && !Array.isArray(source.config)
+                ? (source.config as Record<string, unknown>)
+                : {}
+        driveToConfigure = source
+        driveScopeMode = config.index_scope === 'selected' ? 'selected' : 'all'
+        driveFolderFilters = Array.isArray(config.folder_path_filters)
+            ? (config.folder_path_filters as FolderPathFilter[])
+            : []
+        originalDriveScopeMode = driveScopeMode
+        originalDriveFolderIds = folderFilterIds(driveFolderFilters)
+        originalDriveScopeConfigured = config.index_scope !== 'pending'
+        showDriveScopeWarning = false
+    }
+
+    async function saveDriveScope() {
+        const source = driveToConfigure
+        if (!source) return
+        if (driveScopeMode === 'selected' && driveFolderFilters.length === 0) {
+            toast.error('Select at least one Drive folder')
+            return
+        }
+
+        if (originalDriveScopeConfigured && driveScopeChanged()) {
+            showDriveScopeWarning = true
+            return
+        }
+
+        await submitDriveScope()
+    }
+
+    async function submitDriveScope() {
+        const source = driveToConfigure
+        if (!source) return
+
+        showDriveScopeWarning = false
+        isSavingDriveScope = true
+        try {
+            const formData = new FormData()
+            formData.set('sourceId', source.id)
+            formData.set('indexScope', driveScopeMode)
+            formData.set('folder_path_filters', JSON.stringify(driveFolderFilters))
+            const response = await fetch('?/configureDrive', {
+                method: 'POST',
+                body: formData,
+                headers: { 'x-sveltekit-action': 'true' },
+            })
+            const actionResult = deserialize<
+                { success: true; sourceId: string },
+                { error?: string; sourceId?: string }
+            >(await response.text())
+            if (actionResult.type !== 'success') {
+                const failureData = actionResult.type === 'failure' ? actionResult.data : undefined
+                if (failureData?.sourceId) {
+                    driveToConfigure = null
+                    await invalidateAll()
+                }
+                const message =
+                    failureData?.error ||
+                    (actionResult.type === 'error' ? actionResult.error.message : undefined) ||
+                    `Failed to save Drive scope (${response.status})`
+                throw new Error(message)
+            }
+            driveToConfigure = null
+            toast.success('Google Drive indexing scope saved')
+            await invalidateAll()
+        } catch (err) {
+            toast.error(err instanceof Error ? err.message : 'Failed to save Drive scope')
+        } finally {
+            isSavingDriveScope = false
+        }
+    }
 
     let hasGoogleDrive = $derived(data.userSources.some((s) => s.sourceType === 'google_drive'))
     let hasGmail = $derived(data.userSources.some((s) => s.sourceType === 'gmail'))
@@ -158,6 +266,13 @@
                         {@const indexedCount = documentCounts[source.id] ?? 0}
                         {@const isRunning = source.isActive && sync?.status === 'running'}
                         {@const isFailed = source.isActive && sync?.status === 'failed'}
+                        {@const isDrivePending = !!(
+                            source.sourceType === 'google_drive' &&
+                            source.config &&
+                            typeof source.config === 'object' &&
+                            !Array.isArray(source.config) &&
+                            (source.config as Record<string, unknown>).index_scope === 'pending'
+                        )}
                         <Card
                             class="group hover:border-foreground/20 gap-0 overflow-hidden py-0 transition-colors">
                             <CardHeader
@@ -181,7 +296,9 @@
                                     <div class="min-w-0">
                                         <div class="truncate font-medium">{source.name}</div>
                                         <div class="text-muted-foreground text-xs">
-                                            {#if !source.isActive}
+                                            {#if isDrivePending}
+                                                Needs setup
+                                            {:else if !source.isActive}
                                                 Sync is paused
                                             {:else if isRunning}
                                                 Syncing now...
@@ -199,7 +316,7 @@
                                 <div class="flex shrink-0 items-center gap-2">
                                     <Switch
                                         checked={source.isActive}
-                                        disabled={togglingSourceId === source.id}
+                                        disabled={togglingSourceId === source.id || isDrivePending}
                                         onCheckedChange={(next) => toggleSource(source, next)}
                                         aria-label="Toggle sync for {source.name}"
                                         class="cursor-pointer" />
@@ -253,6 +370,44 @@
                                         <span>No {noun} indexed yet.</span>
                                     {/if}
                                 </div>
+
+                                {#if source.sourceType === 'google_drive'}
+                                    {@const driveConfig =
+                                        source.config &&
+                                        typeof source.config === 'object' &&
+                                        !Array.isArray(source.config)
+                                            ? (source.config as Record<string, unknown>)
+                                            : {}}
+                                    <div class="border-t pt-3">
+                                        {#if driveConfig.index_scope === 'pending'}
+                                            <p class="text-muted-foreground mb-2 text-xs">
+                                                Choose which Drive folders Omni may index to finish
+                                                setup.
+                                            </p>
+                                        {:else if driveConfig.index_scope === 'selected'}
+                                            <p class="text-muted-foreground mb-2 text-xs">
+                                                Indexing {Array.isArray(
+                                                    driveConfig.folder_path_filters,
+                                                )
+                                                    ? driveConfig.folder_path_filters.length
+                                                    : 0} selected folder(s).
+                                            </p>
+                                        {:else}
+                                            <p class="text-muted-foreground mb-2 text-xs">
+                                                Indexing all files this Google account can access.
+                                            </p>
+                                        {/if}
+                                        <Button
+                                            size="sm"
+                                            variant="outline"
+                                            class="cursor-pointer"
+                                            onclick={() => openDriveScope(source)}>
+                                            {driveConfig.index_scope === 'pending'
+                                                ? 'Choose folders'
+                                                : 'Manage folders'}
+                                        </Button>
+                                    </div>
+                                {/if}
                             </CardContent>
                         </Card>
                     {/each}
@@ -360,6 +515,66 @@
     </div>
 </div>
 
+<Dialog.Root
+    open={driveToConfigure !== null}
+    onOpenChange={(open) => {
+        if (!open && !isSavingDriveScope) driveToConfigure = null
+    }}>
+    <Dialog.Content class="max-w-2xl">
+        <Dialog.Header>
+            <Dialog.Title>Choose Google Drive folders</Dialog.Title>
+            <Dialog.Description>
+                Omni will only index files inside the folders you select. Google still grants the
+                read-only Drive permission required to browse your account.
+            </Dialog.Description>
+        </Dialog.Header>
+
+        <div class="space-y-4 py-2">
+            <div class="grid gap-2 sm:grid-cols-2">
+                <button
+                    type="button"
+                    class={`cursor-pointer rounded-lg border p-3 text-left ${driveScopeMode === 'all' ? 'border-primary bg-primary/5' : ''}`}
+                    onclick={() => (driveScopeMode = 'all')}>
+                    <div class="font-medium">Entire Drive</div>
+                    <div class="text-muted-foreground text-xs">
+                        Index all files accessible to this Google account.
+                    </div>
+                </button>
+                <button
+                    type="button"
+                    class={`cursor-pointer rounded-lg border p-3 text-left ${driveScopeMode === 'selected' ? 'border-primary bg-primary/5' : ''}`}
+                    onclick={() => (driveScopeMode = 'selected')}>
+                    <div class="font-medium">Selected folders</div>
+                    <div class="text-muted-foreground text-xs">
+                        Include all files and subfolders beneath your selections.
+                    </div>
+                </button>
+            </div>
+
+            {#if driveScopeMode === 'selected'}
+                <GoogleDriveFolderSelector
+                    bind:selected={driveFolderFilters}
+                    sourceId={driveToConfigure?.id ?? ''}
+                    label="Folders to index"
+                    description="Search folders in My Drive and shared drives accessible to this account. Typing searches nested folders too."
+                    authMode="domain_wide_delegation"
+                    action="discover_personal_folders" />
+            {/if}
+        </div>
+
+        <Dialog.Footer>
+            <Button
+                variant="outline"
+                class="cursor-pointer"
+                disabled={isSavingDriveScope}
+                onclick={() => (driveToConfigure = null)}>Cancel</Button>
+            <Button class="cursor-pointer" disabled={isSavingDriveScope} onclick={saveDriveScope}>
+                {isSavingDriveScope ? 'Saving…' : 'Save and start indexing'}
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>
+
 <GoogleOAuthSetup
     open={showGoogleOAuthSetup}
     connectedSourceTypes={data.userSources.map((s) => s.sourceType)}
@@ -370,6 +585,28 @@
     open={showWindshiftSetup}
     baseUrl={data.windshiftBaseUrl}
     onCancel={() => (showWindshiftSetup = false)} />
+
+<AlertDialog.Root
+    open={showDriveScopeWarning}
+    onOpenChange={(open) => {
+        if (!open && !isSavingDriveScope) showDriveScopeWarning = false
+    }}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>Change Google Drive folders?</AlertDialog.Title>
+            <AlertDialog.Description>
+                This will start a full sync using the new folder selection. Newly selected files
+                will be added, but files removed from the selection may remain searchable until a
+                later cleanup.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel class="cursor-pointer">Keep editing</AlertDialog.Cancel>
+            <AlertDialog.Action class="cursor-pointer" onclick={submitDriveScope}
+                >Save and start indexing</AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>
 
 <AlertDialog.Root
     open={sourceToDisconnect !== null}

--- a/web/src/routes/api/connectors/[sourceType]/action/+server.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/+server.ts
@@ -140,15 +140,16 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
                 throw error(400, 'discover_folders auth_mode conflicts with authMode')
             }
         }
-        if (params && 'query' in params) {
-            const query = params.query
-            if (typeof query !== 'string') {
-                throw error(400, 'discover_folders query must be a string')
-            }
-            const queryLength = Array.from(query.trim()).length
-            if (queryLength < 2 || queryLength > 200) {
-                throw error(400, 'discover_folders query must contain 2–200 characters')
-            }
+        if (!params || !('query' in params)) {
+            throw error(400, 'discover_folders query is required')
+        }
+        const query = params.query
+        if (typeof query !== 'string') {
+            throw error(400, 'discover_folders query must be a string')
+        }
+        const queryLength = Array.from(query.trim()).length
+        if (queryLength < 2 || queryLength > 200) {
+            throw error(400, 'discover_folders query must contain 2–200 characters')
         }
     }
     if (action === 'validate_shared_drive_access') {

--- a/web/src/routes/api/connectors/[sourceType]/action/+server.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/+server.ts
@@ -3,6 +3,7 @@ import type { RequestHandler } from './$types'
 import { getConfig } from '$lib/server/config'
 import { logger } from '$lib/server/logger'
 import { SourceType } from '$lib/types'
+import { GOOGLE_SA_DIRECT_DRIVE_SCOPES, GOOGLE_SA_DIRECT_SCOPES } from '$lib/utils/google-scopes'
 
 /**
  * Invokes an action directly on a connector before a source exists.
@@ -11,12 +12,15 @@ import { SourceType } from '$lib/types'
  * endpoint and is never stored or returned.
  *
  * SECURITY: Strictly allowlisted — currently only google_drive's
- * discover_folders and validate_shared_drive_access actions with JWT
- * credentials are accepted. Unknown actions, fields, or auth modes fail
- * closed.
+ * discovery and setup-validation actions with JWT credentials are accepted.
+ * Unknown actions, fields, or auth modes fail closed.
  */
 
-const ALLOWED_ACTIONS = new Set(['discover_folders', 'validate_shared_drive_access'])
+const ALLOWED_ACTIONS = new Set([
+    'discover_folders',
+    'validate_shared_drive_access',
+    'validate_sa_direct_group_access',
+])
 const ALLOWED_AUTH_MODES = ['domain_wide_delegation', 'service_account_direct'] as const
 type GoogleAuthMode = (typeof ALLOWED_AUTH_MODES)[number]
 
@@ -192,6 +196,31 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
             )
         }
     }
+    if (action === 'validate_sa_direct_group_access') {
+        if (authMode !== 'service_account_direct') {
+            throw error(
+                400,
+                'validate_sa_direct_group_access requires authMode=service_account_direct',
+            )
+        }
+        if (!params || typeof params !== 'object' || Array.isArray(params)) {
+            throw error(400, 'validate_sa_direct_group_access requires params')
+        }
+        for (const key of Object.keys(params)) {
+            if (key !== 'auth_mode') {
+                throw error(400, `Unknown validate_sa_direct_group_access param: '${key}'`)
+            }
+        }
+        if (params.auth_mode !== 'service_account_direct') {
+            throw error(400, 'validate_sa_direct_group_access auth_mode is invalid')
+        }
+        if (typeof domain !== 'string' || domain.trim().length === 0) {
+            throw error(
+                400,
+                'An organization domain is required to validate SA-direct group membership access',
+            )
+        }
+    }
 
     // Transient credentials must be provided for preview (not optional).
     if (!serviceAccountJson) {
@@ -227,11 +256,18 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
         const config = getConfig()
         const connectorManagerUrl = config.services.connectorManagerUrl
 
-        // Build the transient credential config: SA-direct carries only the
-        // drive.readonly scope; DWD carries the domain for impersonation.
+        // Build the transient credential config. Group validation needs the
+        // Admin Directory scope and the Workspace domain; ordinary SA-direct
+        // Drive actions remain limited to Drive read access.
         const transientConfig: Record<string, unknown> = {}
         if (authMode === 'service_account_direct') {
-            transientConfig.scopes = ['https://www.googleapis.com/auth/drive.readonly']
+            transientConfig.scopes =
+                action === 'validate_sa_direct_group_access'
+                    ? GOOGLE_SA_DIRECT_SCOPES
+                    : GOOGLE_SA_DIRECT_DRIVE_SCOPES
+            if (action === 'validate_sa_direct_group_access') {
+                transientConfig.domain = domain.trim()
+            }
         } else {
             transientConfig.domain = domain
         }

--- a/web/src/routes/api/connectors/[sourceType]/action/+server.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/+server.ts
@@ -122,17 +122,66 @@ export const POST: RequestHandler = async ({ params: routeParams, request, local
         }
     }
     if (action === 'discover_folders') {
-        // params is optional; when present it may carry auth_mode.
-        if (params && Object.keys(params).length > 0 && !('auth_mode' in params)) {
-            throw error(400, 'discover_folders accepts only an optional auth_mode param')
+        const allowedParamFields = ['auth_mode', 'query']
+        for (const key of Object.keys(params ?? {})) {
+            if (!allowedParamFields.includes(key)) {
+                throw error(400, `Unknown discover_folders param: '${key}'`)
+            }
+        }
+        if (params && 'auth_mode' in params) {
+            const paramAuthMode = params.auth_mode
+            if (
+                typeof paramAuthMode !== 'string' ||
+                !ALLOWED_AUTH_MODES.includes(paramAuthMode as GoogleAuthMode)
+            ) {
+                throw error(400, 'discover_folders auth_mode is invalid')
+            }
+            if (paramAuthMode !== authMode) {
+                throw error(400, 'discover_folders auth_mode conflicts with authMode')
+            }
+        }
+        if (params && 'query' in params) {
+            const query = params.query
+            if (typeof query !== 'string') {
+                throw error(400, 'discover_folders query must be a string')
+            }
+            const queryLength = Array.from(query.trim()).length
+            if (queryLength < 2 || queryLength > 200) {
+                throw error(400, 'discover_folders query must contain 2–200 characters')
+            }
         }
     }
     if (action === 'validate_shared_drive_access') {
         if (!params || typeof params !== 'object' || Array.isArray(params)) {
             throw error(400, 'validate_shared_drive_access requires params')
         }
+        const allowedParamFields = ['auth_mode', 'drive_ids']
+        for (const key of Object.keys(params)) {
+            if (!allowedParamFields.includes(key)) {
+                throw error(400, `Unknown validate_shared_drive_access param: '${key}'`)
+            }
+        }
+        if ('auth_mode' in params) {
+            const paramAuthMode = params.auth_mode
+            if (
+                typeof paramAuthMode !== 'string' ||
+                !ALLOWED_AUTH_MODES.includes(paramAuthMode as GoogleAuthMode)
+            ) {
+                throw error(400, 'validate_shared_drive_access auth_mode is invalid')
+            }
+            if (paramAuthMode !== authMode) {
+                throw error(400, 'validate_shared_drive_access auth_mode conflicts with authMode')
+            }
+        }
         const driveIds = params.drive_ids
-        if (!Array.isArray(driveIds) || driveIds.length === 0) {
+        if (
+            !Array.isArray(driveIds) ||
+            driveIds.length === 0 ||
+            !driveIds.every(
+                (driveId): driveId is string =>
+                    typeof driveId === 'string' && driveId.trim().length > 0,
+            )
+        ) {
             throw error(400, 'validate_shared_drive_access requires a non-empty drive_ids array')
         }
         if (authMode !== 'service_account_direct') {

--- a/web/src/routes/api/connectors/[sourceType]/action/+server.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/+server.ts
@@ -3,7 +3,6 @@ import type { RequestHandler } from './$types'
 import { getConfig } from '$lib/server/config'
 import { logger } from '$lib/server/logger'
 import { SourceType } from '$lib/types'
-import type { GoogleAuthMode } from '$lib/types'
 
 /**
  * Invokes an action directly on a connector before a source exists.
@@ -18,7 +17,8 @@ import type { GoogleAuthMode } from '$lib/types'
  */
 
 const ALLOWED_ACTIONS = new Set(['discover_folders', 'validate_shared_drive_access'])
-const ALLOWED_AUTH_MODES: GoogleAuthMode[] = ['domain_wide_delegation', 'service_account_direct']
+const ALLOWED_AUTH_MODES = ['domain_wide_delegation', 'service_account_direct'] as const
+type GoogleAuthMode = (typeof ALLOWED_AUTH_MODES)[number]
 
 export const POST: RequestHandler = async ({ params: routeParams, request, locals }) => {
     // Admin-only

--- a/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { GOOGLE_SA_DIRECT_DRIVE_SCOPES, GOOGLE_SA_DIRECT_SCOPES } from '$lib/utils/google-scopes'
 
 // Mock server dependencies before importing the handler.
 vi.mock('$lib/server/config', () => ({
@@ -281,7 +282,7 @@ describe('POST /api/connectors/[sourceType]/action', () => {
                 credentials: {
                     service_account_key: '{"client_email":"sa@example.iam.gserviceaccount.com"}',
                 },
-                config: { scopes: ['https://www.googleapis.com/auth/drive.readonly'] },
+                config: { scopes: GOOGLE_SA_DIRECT_DRIVE_SCOPES },
             },
         })
     })
@@ -315,6 +316,57 @@ describe('POST /api/connectors/[sourceType]/action', () => {
             action: 'validate_shared_drive_access',
             params: { drive_ids: ['d1', 'd2'], auth_mode: 'service_account_direct' },
         })
+    })
+
+    it('forwards SA-direct group access validation with the Workspace domain and Admin scope', async () => {
+        const connectorResponse = {
+            status: 'success',
+            result: { domain: 'example.com', groups: 2, memberships: 3 },
+        }
+        const connectorFetch = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify(connectorResponse), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        )
+        vi.stubGlobal('fetch', connectorFetch)
+
+        const response = await callPost({
+            action: 'validate_sa_direct_group_access',
+            serviceAccountJson: '{"client_email":"sa@example.iam.gserviceaccount.com"}',
+            authMode: 'service_account_direct',
+            domain: 'example.com',
+            params: { auth_mode: 'service_account_direct' },
+        })
+
+        expect(response.status).toBe(200)
+        const [, init] = connectorFetch.mock.calls[0] as [string, RequestInit]
+        const forwarded = JSON.parse(String(init.body)) as Record<string, unknown>
+        expect(forwarded).toMatchObject({
+            action: 'validate_sa_direct_group_access',
+            params: { auth_mode: 'service_account_direct' },
+            transient_credentials: {
+                config: {
+                    domain: 'example.com',
+                    scopes: GOOGLE_SA_DIRECT_SCOPES,
+                },
+            },
+        })
+    })
+
+    it('requires a domain for SA-direct group access validation', async () => {
+        const connectorFetch = vi.fn()
+        vi.stubGlobal('fetch', connectorFetch)
+
+        const response = await callPost({
+            action: 'validate_sa_direct_group_access',
+            serviceAccountJson: '{}',
+            authMode: 'service_account_direct',
+            params: { auth_mode: 'service_account_direct' },
+        })
+
+        expect(response.status).toBe(400)
+        expect(connectorFetch).not.toHaveBeenCalled()
     })
 
     it('rejects validate_shared_drive_access without drive ids or outside SA-direct', async () => {

--- a/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
@@ -136,11 +136,71 @@ describe('POST /api/connectors/[sourceType]/action', () => {
         })
     })
 
-    it('rejects unknown actions and unknown top-level fields', async () => {
+    it('rejects unknown actions and unknown fields', async () => {
         expect((await callPost({ action: 'bogus', serviceAccountJson: '{}' })).status).toBe(400)
         expect(
             (await callPost({ action: 'discover_folders', serviceAccountJson: '{}', evil: 1 }))
                 .status,
+        ).toBe(400)
+        expect(
+            (
+                await callPost({
+                    action: 'discover_folders',
+                    serviceAccountJson: '{}',
+                    params: { query: 'roadmap', evil: 1 },
+                })
+            ).status,
+        ).toBe(400)
+    })
+
+    it('forwards DWD folder search queries with the injected auth mode', async () => {
+        const connectorFetch = vi.fn().mockResolvedValue(
+            new Response(JSON.stringify({ status: 'success', result: { items: [] } }), {
+                status: 200,
+                headers: { 'Content-Type': 'application/json' },
+            }),
+        )
+        vi.stubGlobal('fetch', connectorFetch)
+
+        const response = await callPost({
+            action: 'discover_folders',
+            serviceAccountJson: '{}',
+            principalEmail: 'admin@example.com',
+            domain: 'example.com',
+            params: { query: 'roadmap' },
+        })
+
+        expect(response.status).toBe(200)
+        const [, init] = connectorFetch.mock.calls[0] as [string, RequestInit]
+        const forwarded = JSON.parse(String(init.body)) as Record<string, unknown>
+        expect(forwarded).toMatchObject({
+            action: 'discover_folders',
+            params: { query: 'roadmap', auth_mode: 'domain_wide_delegation' },
+        })
+    })
+
+    it('rejects conflicting or invalid folder search auth params', async () => {
+        expect(
+            (
+                await callPost({
+                    action: 'discover_folders',
+                    serviceAccountJson: '{}',
+                    principalEmail: 'admin@example.com',
+                    domain: 'example.com',
+                    params: { auth_mode: 'service_account_direct', query: 'roadmap' },
+                })
+            ).status,
+        ).toBe(400)
+        expect(
+            (
+                await callPost({
+                    action: 'discover_folders',
+                    serviceAccountJson: '{}',
+                    principalEmail: 'admin@example.com',
+                    domain: 'example.com',
+                    params: { query: 'x' },
+                })
+            ).status,
         ).toBe(400)
     })
 
@@ -245,6 +305,16 @@ describe('POST /api/connectors/[sourceType]/action', () => {
                     action: 'validate_shared_drive_access',
                     serviceAccountJson: '{}',
                     params: { drive_ids: ['d1'] },
+                })
+            ).status,
+        ).toBe(400)
+        expect(
+            (
+                await callPost({
+                    action: 'validate_shared_drive_access',
+                    serviceAccountJson: '{}',
+                    authMode: 'service_account_direct',
+                    params: { drive_ids: ['   '] },
                 })
             ).status,
         ).toBe(400)

--- a/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
+++ b/web/src/routes/api/connectors/[sourceType]/action/action.test.ts
@@ -110,7 +110,7 @@ describe('POST /api/connectors/[sourceType]/action', () => {
             serviceAccountJson: '{"client_email":"service@example.com"}',
             principalEmail: 'admin@example.com',
             domain: 'example.com',
-            params: {},
+            params: { query: 'roadmap' },
         })
 
         expect(response).toEqual({ status: 200, body: connectorResponse })
@@ -123,7 +123,7 @@ describe('POST /api/connectors/[sourceType]/action', () => {
             source_type: 'google_drive',
             user_id: 'admin-1',
             action: 'discover_folders',
-            params: {},
+            params: { query: 'roadmap', auth_mode: 'domain_wide_delegation' },
             transient_credentials: {
                 provider: 'google',
                 auth_type: 'jwt',
@@ -177,6 +177,35 @@ describe('POST /api/connectors/[sourceType]/action', () => {
             action: 'discover_folders',
             params: { query: 'roadmap', auth_mode: 'domain_wide_delegation' },
         })
+    })
+
+    it('requires a non-empty folder search query without forwarding a request', async () => {
+        const connectorFetch = vi.fn()
+        vi.stubGlobal('fetch', connectorFetch)
+
+        expect(
+            (
+                await callPost({
+                    action: 'discover_folders',
+                    serviceAccountJson: '{}',
+                    principalEmail: 'admin@example.com',
+                    domain: 'example.com',
+                    params: {},
+                })
+            ).status,
+        ).toBe(400)
+        expect(
+            (
+                await callPost({
+                    action: 'discover_folders',
+                    serviceAccountJson: '{}',
+                    principalEmail: 'admin@example.com',
+                    domain: 'example.com',
+                    params: { query: 'x' },
+                })
+            ).status,
+        ).toBe(400)
+        expect(connectorFetch).not.toHaveBeenCalled()
     })
 
     it('rejects conflicting or invalid folder search auth params', async () => {
@@ -235,7 +264,7 @@ describe('POST /api/connectors/[sourceType]/action', () => {
             action: 'discover_folders',
             serviceAccountJson: '{"client_email":"sa@example.iam.gserviceaccount.com"}',
             authMode: 'service_account_direct',
-            params: { auth_mode: 'service_account_direct' },
+            params: { auth_mode: 'service_account_direct', query: 'drive' },
         })
 
         expect(response.status).toBe(200)
@@ -244,7 +273,7 @@ describe('POST /api/connectors/[sourceType]/action', () => {
         const forwarded = JSON.parse(String(init.body)) as Record<string, unknown>
         expect(forwarded).toMatchObject({
             action: 'discover_folders',
-            params: { auth_mode: 'service_account_direct' },
+            params: { auth_mode: 'service_account_direct', query: 'drive' },
             transient_credentials: {
                 provider: 'google',
                 auth_type: 'jwt',

--- a/web/src/routes/api/oauth/callback/+server.ts
+++ b/web/src/routes/api/oauth/callback/+server.ts
@@ -1,13 +1,13 @@
 import { error, redirect } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
 import { db } from '$lib/server/db'
-import { sources } from '$lib/server/db/schema'
+import { serviceCredentials, sources } from '$lib/server/db/schema'
 import { ulid } from 'ulid'
 import { eq } from 'drizzle-orm'
 import { exchangeCodeAndIdentify } from '$lib/server/oauth/connectorOAuth'
 import { OAuthStateManager } from '$lib/server/oauth/state'
 import { serviceCredentialsRepository } from '$lib/server/repositories/service-credentials'
-import { decryptConfig } from '$lib/server/crypto/encryption'
+import { decryptConfig, encryptConfig } from '$lib/server/crypto/encryption'
 import { logger } from '$lib/server/logger'
 import { getConfig } from '$lib/server/config'
 import { getSourceById, getSourcesByType } from '$lib/server/db/sources'
@@ -266,12 +266,12 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
     // user's personal source. Org-level sources are managed separately under
     // /admin/settings/integrations.
     const connectedSourceIds: string[] = []
+    const incrementalSyncSourceIds = new Set<string>()
     for (const sourceType of flow.sourceTypes) {
         const sourcesOfType = await getSourcesByType(sourceType)
         const existing = sourcesOfType.find((s) => s.scope === 'user' && s.createdBy === user.id)
 
         if (existing) {
-            // Source already exists for this user — refresh its creds in place.
             const existingCredential = await serviceCredentialsRepository.getByUserAndSource(
                 existing.id,
                 user.id,
@@ -279,6 +279,63 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
             const existingCredentials = existingCredential
                 ? decryptConfig(existingCredential.credentials)
                 : {}
+            const accountChanged =
+                sourceType === SourceType.GOOGLE_DRIVE &&
+                (!existingCredential ||
+                    typeof principalEmail !== 'string' ||
+                    principalEmail.length === 0 ||
+                    typeof existingCredential.principalEmail !== 'string' ||
+                    existingCredential.principalEmail.length === 0 ||
+                    existingCredential.principalEmail.trim().toLowerCase() !==
+                        principalEmail.trim().toLowerCase())
+
+            if (accountChanged) {
+                // A personal Drive source is account-scoped. Do not reuse its
+                // documents or folder scope for a different Google identity.
+                // The old generation is hidden immediately and cleaned up by
+                // connector-manager; the new account starts in pending setup.
+                const replacementId = ulid()
+                const replacementCredentials = credentialsWithRefreshFallback({})
+                await db.transaction(async (tx) => {
+                    await tx.insert(sources).values({
+                        id: replacementId,
+                        name: existing.name,
+                        sourceType: existing.sourceType,
+                        integrationType: existing.integrationType,
+                        config: { index_scope: 'pending', folder_path_filters: [] },
+                        isActive: false,
+                        isDeleted: false,
+                        scope: 'user',
+                        userFilterMode: existing.userFilterMode,
+                        userWhitelist: existing.userWhitelist,
+                        userBlacklist: existing.userBlacklist,
+                        createdBy: existing.createdBy,
+                        syncIntervalSeconds: existing.syncIntervalSeconds,
+                    })
+                    await tx.insert(serviceCredentials).values({
+                        id: ulid(),
+                        sourceId: replacementId,
+                        userId: user.id,
+                        provider: credentialProvider,
+                        authType: 'oauth',
+                        principalEmail,
+                        credentials: encryptConfig(replacementCredentials),
+                        config: { granted_scopes: effectiveGrantedScopes },
+                        expiresAt,
+                    })
+                    await tx
+                        .update(sources)
+                        .set({ isActive: false, isDeleted: true, updatedAt: new Date() })
+                        .where(eq(sources.id, existing.id))
+                    await tx
+                        .delete(serviceCredentials)
+                        .where(eq(serviceCredentials.sourceId, existing.id))
+                })
+                connectedSourceIds.push(replacementId)
+                continue
+            }
+
+            // Same Google identity — refresh its creds in place and preserve scope.
             await serviceCredentialsRepository.createForUser({
                 sourceId: existing.id,
                 userId: user.id,
@@ -293,9 +350,13 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
                 expiresAt,
             })
             connectedSourceIds.push(existing.id)
+            if (sourceType === SourceType.GOOGLE_DRIVE) {
+                incrementalSyncSourceIds.add(existing.id)
+            }
             continue
         }
 
+        const isGoogleDrive = sourceType === SourceType.GOOGLE_DRIVE
         const [newSource] = await db
             .insert(sources)
             .values({
@@ -303,9 +364,10 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
                 name: getSourceDisplayName(sourceType as SourceType) ?? sourceType,
                 sourceType,
                 scope: 'user',
-                config: {},
+                config: isGoogleDrive ? { index_scope: 'pending', folder_path_filters: [] } : {},
                 createdBy: user.id,
-                isActive: true,
+                // Drive must wait for the owner to choose its indexing scope.
+                isActive: !isGoogleDrive,
             })
             .returning()
 
@@ -327,10 +389,26 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
     const connectorManagerUrl = getConfig().services.connectorManagerUrl
     for (const sourceId of connectedSourceIds) {
         await notifyOAuthCredentialReady(sourceId, user.id)
+        const connectedSource = await getSourceById(sourceId)
+        // Personal Drive is intentionally inactive until its owner chooses an
+        // explicit scope in My Integrations. Other services retain the old
+        // immediate-sync behavior.
+        if (
+            connectedSource?.sourceType === SourceType.GOOGLE_DRIVE &&
+            (connectedSource.config as { index_scope?: unknown } | null)?.index_scope === 'pending'
+        ) {
+            continue
+        }
         try {
-            const syncResponse = await fetch(`${connectorManagerUrl}/sync/${sourceId}`, {
-                method: 'POST',
-            })
+            const syncResponse = incrementalSyncSourceIds.has(sourceId)
+                ? await fetch(`${connectorManagerUrl}/sync`, {
+                      method: 'POST',
+                      headers: { 'content-type': 'application/json' },
+                      body: JSON.stringify({ source_id: sourceId, sync_mode: 'incremental' }),
+                  })
+                : await fetch(`${connectorManagerUrl}/sync/${sourceId}`, {
+                      method: 'POST',
+                  })
             if (!syncResponse.ok && syncResponse.status !== 409) {
                 logger.warn('Failed to trigger personal source sync after OAuth', {
                     sourceId,

--- a/web/src/routes/api/sources/[sourceId]/action/+server.ts
+++ b/web/src/routes/api/sources/[sourceId]/action/+server.ts
@@ -2,6 +2,44 @@ import { json, error } from '@sveltejs/kit'
 import type { RequestHandler } from './$types'
 import { getConfig } from '$lib/server/config'
 import { logger } from '$lib/server/logger'
+import { sourcesRepository } from '$lib/server/repositories/sources'
+import { SourceType } from '$lib/types'
+
+const FOLDER_DISCOVERY_ACTIONS = new Set(['discover_folders', 'discover_personal_folders'])
+const FOLDER_DISCOVERY_AUTH_MODES = new Set(['domain_wide_delegation', 'service_account_direct'])
+
+function validateFolderDiscoveryParams(action: string, actionParams: unknown): void {
+    if (!FOLDER_DISCOVERY_ACTIONS.has(action)) return
+    if (actionParams === undefined || actionParams === null) return
+    if (typeof actionParams !== 'object' || Array.isArray(actionParams)) {
+        throw error(400, `${action} params must be a JSON object`)
+    }
+
+    const params = actionParams as Record<string, unknown>
+    const allowedFields = new Set(['auth_mode', 'query'])
+    for (const key of Object.keys(params)) {
+        if (!allowedFields.has(key)) {
+            throw error(400, `Unknown ${action} param: '${key}'`)
+        }
+    }
+    if ('auth_mode' in params) {
+        if (
+            typeof params.auth_mode !== 'string' ||
+            !FOLDER_DISCOVERY_AUTH_MODES.has(params.auth_mode)
+        ) {
+            throw error(400, `${action} auth_mode is invalid`)
+        }
+    }
+    if ('query' in params) {
+        if (typeof params.query !== 'string') {
+            throw error(400, `${action} query must be a string`)
+        }
+        const queryLength = Array.from(params.query.trim()).length
+        if (queryLength < 2 || queryLength > 200) {
+            throw error(400, `${action} query must contain 2–200 characters`)
+        }
+    }
+}
 
 // This route is only meant to handle "actions" that originate in the UI.
 //
@@ -16,10 +54,6 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
         throw error(401, 'Unauthorized')
     }
 
-    if (locals.user.role !== 'admin') {
-        throw error(403, 'Admin access required')
-    }
-
     const { sourceId } = params
     if (!sourceId) {
         throw error(400, 'Source ID is required')
@@ -31,6 +65,29 @@ export const POST: RequestHandler = async ({ params, locals, request }) => {
     if (!action) {
         throw error(400, 'Action is required')
     }
+
+    // Personal users may only browse folders on their own Google Drive source.
+    // All other connector actions remain admin-only. Keep this fast path before
+    // source lookup so admin-only actions retain their existing behavior.
+    if (locals.user.role !== 'admin' && action !== 'discover_personal_folders') {
+        throw error(403, 'Admin access required')
+    }
+
+    if (locals.user.role !== 'admin') {
+        const source = await sourcesRepository.getById(sourceId)
+        if (!source || source.isDeleted) {
+            throw error(404, 'Source not found')
+        }
+        if (
+            source.sourceType !== SourceType.GOOGLE_DRIVE ||
+            source.scope !== 'user' ||
+            source.createdBy !== locals.user.id
+        ) {
+            throw error(403, 'Admin access required')
+        }
+    }
+
+    validateFolderDiscoveryParams(action, actionParams)
 
     try {
         const config = getConfig()

--- a/web/src/routes/api/sources/[sourceId]/action/+server.ts
+++ b/web/src/routes/api/sources/[sourceId]/action/+server.ts
@@ -10,7 +10,9 @@ const FOLDER_DISCOVERY_AUTH_MODES = new Set(['domain_wide_delegation', 'service_
 
 function validateFolderDiscoveryParams(action: string, actionParams: unknown): void {
     if (!FOLDER_DISCOVERY_ACTIONS.has(action)) return
-    if (actionParams === undefined || actionParams === null) return
+    if (actionParams === undefined || actionParams === null) {
+        throw error(400, `${action} params with a query are required`)
+    }
     if (typeof actionParams !== 'object' || Array.isArray(actionParams)) {
         throw error(400, `${action} params must be a JSON object`)
     }
@@ -30,14 +32,15 @@ function validateFolderDiscoveryParams(action: string, actionParams: unknown): v
             throw error(400, `${action} auth_mode is invalid`)
         }
     }
-    if ('query' in params) {
-        if (typeof params.query !== 'string') {
-            throw error(400, `${action} query must be a string`)
-        }
-        const queryLength = Array.from(params.query.trim()).length
-        if (queryLength < 2 || queryLength > 200) {
-            throw error(400, `${action} query must contain 2–200 characters`)
-        }
+    if (!('query' in params)) {
+        throw error(400, `${action} query is required`)
+    }
+    if (typeof params.query !== 'string') {
+        throw error(400, `${action} query must be a string`)
+    }
+    const queryLength = Array.from(params.query.trim()).length
+    if (queryLength < 2 || queryLength > 200) {
+        throw error(400, `${action} query must contain 2–200 characters`)
     }
 }
 

--- a/web/src/routes/api/sources/[sourceId]/action/action.test.ts
+++ b/web/src/routes/api/sources/[sourceId]/action/action.test.ts
@@ -1,0 +1,170 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('$lib/server/config', () => ({
+    getConfig: vi.fn(() => ({
+        services: { connectorManagerUrl: 'http://cm.test' },
+    })),
+}))
+
+vi.mock('$lib/server/logger', () => ({
+    logger: { error: vi.fn() },
+}))
+
+vi.mock('$lib/server/repositories/sources', () => ({
+    sourcesRepository: { getById: vi.fn() },
+}))
+
+const { POST } = await import('./+server')
+const { sourcesRepository } = await import('$lib/server/repositories/sources')
+
+function mockRequest(body: unknown): Request {
+    return new Request('http://localhost/api/sources/source-1/action', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify(body),
+    })
+}
+
+async function callPost(
+    body: unknown,
+    user: { id: string; role: 'admin' | 'member' },
+): Promise<{ status: number; body?: unknown }> {
+    try {
+        const response = await POST({
+            params: { sourceId: 'source-1' },
+            request: mockRequest(body),
+            locals: { user },
+        } as unknown as Parameters<typeof POST>[0])
+        return { status: response.status, body: await response.json().catch(() => undefined) }
+    } catch (err: unknown) {
+        const httpError = err as { status?: number; body?: unknown }
+        if (httpError.status !== undefined) {
+            return { status: httpError.status, body: httpError.body }
+        }
+        throw err
+    }
+}
+
+describe('POST /api/sources/[sourceId]/action', () => {
+    afterEach(() => {
+        vi.clearAllMocks()
+        vi.unstubAllGlobals()
+    })
+
+    it('allows the owner to discover folders on their personal Drive source', async () => {
+        vi.mocked(sourcesRepository.getById).mockResolvedValue({
+            id: 'source-1',
+            isDeleted: false,
+            sourceType: 'google_drive',
+            scope: 'user',
+            createdBy: 'owner-1',
+        } as never)
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ status: 'success', result: { items: [] } }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            ),
+        )
+
+        const response = await callPost(
+            { action: 'discover_personal_folders', params: { query: 'roadmap' } },
+            { id: 'owner-1', role: 'member' },
+        )
+
+        expect(response.status).toBe(200)
+        expect(fetch).toHaveBeenCalledOnce()
+    })
+
+    it('denies non-owners, org sources, and admin discovery to members', async () => {
+        const source = {
+            id: 'source-1',
+            isDeleted: false,
+            sourceType: 'google_drive',
+            scope: 'user',
+            createdBy: 'owner-1',
+        }
+        vi.mocked(sourcesRepository.getById).mockResolvedValue(source as never)
+
+        expect(
+            (
+                await callPost(
+                    { action: 'discover_personal_folders' },
+                    { id: 'member-2', role: 'member' },
+                )
+            ).status,
+        ).toBe(403)
+        vi.mocked(sourcesRepository.getById).mockResolvedValue({
+            ...source,
+            scope: 'org',
+        } as never)
+        expect(
+            (
+                await callPost(
+                    { action: 'discover_personal_folders' },
+                    { id: 'member-2', role: 'member' },
+                )
+            ).status,
+        ).toBe(403)
+        vi.mocked(sourcesRepository.getById).mockResolvedValue(source as never)
+        vi.mocked(sourcesRepository.getById).mockClear()
+        expect(
+            (await callPost({ action: 'discover_folders' }, { id: 'owner-1', role: 'member' }))
+                .status,
+        ).toBe(403)
+        expect(sourcesRepository.getById).not.toHaveBeenCalled()
+    })
+
+    it('allows admins to forward unrelated actions without a source lookup or folder validation', async () => {
+        vi.stubGlobal(
+            'fetch',
+            vi.fn().mockResolvedValue(
+                new Response(JSON.stringify({ status: 'success' }), {
+                    status: 200,
+                    headers: { 'Content-Type': 'application/json' },
+                }),
+            ),
+        )
+
+        const response = await callPost(
+            { action: 'send_message', params: { query: 'x', unrelated: true } },
+            { id: 'admin-1', role: 'admin' },
+        )
+
+        expect(response.status).toBe(200)
+        expect(sourcesRepository.getById).not.toHaveBeenCalled()
+        expect(fetch).toHaveBeenCalledOnce()
+    })
+
+    it('strictly validates persisted folder-discovery params without affecting other actions', async () => {
+        vi.mocked(sourcesRepository.getById).mockResolvedValue({
+            id: 'source-1',
+            isDeleted: false,
+            sourceType: 'google_drive',
+            scope: 'user',
+            createdBy: 'owner-1',
+        } as never)
+
+        expect(
+            (
+                await callPost(
+                    { action: 'discover_personal_folders', params: { query: 'x' } },
+                    { id: 'owner-1', role: 'member' },
+                )
+            ).status,
+        ).toBe(400)
+        expect(
+            (
+                await callPost(
+                    {
+                        action: 'discover_personal_folders',
+                        params: { query: 'roadmap', unrelated: true },
+                    },
+                    { id: 'owner-1', role: 'member' },
+                )
+            ).status,
+        ).toBe(400)
+    })
+})

--- a/web/src/routes/api/sources/[sourceId]/action/action.test.ts
+++ b/web/src/routes/api/sources/[sourceId]/action/action.test.ts
@@ -146,7 +146,17 @@ describe('POST /api/sources/[sourceId]/action', () => {
             scope: 'user',
             createdBy: 'owner-1',
         } as never)
+        const connectorFetch = vi.fn()
+        vi.stubGlobal('fetch', connectorFetch)
 
+        expect(
+            (
+                await callPost(
+                    { action: 'discover_personal_folders' },
+                    { id: 'owner-1', role: 'member' },
+                )
+            ).status,
+        ).toBe(400)
         expect(
             (
                 await callPost(
@@ -166,5 +176,6 @@ describe('POST /api/sources/[sourceId]/action', () => {
                 )
             ).status,
         ).toBe(400)
+        expect(connectorFetch).not.toHaveBeenCalled()
     })
 })


### PR DESCRIPTION
- Let personal OAuth Drive sources select folders or shared drives and recursively index only their descendants.
- Add bounded discovery and strict scope validation so users can limit indexing to intended content.
- Preserve effective shared-drive permissions across scoped DWD and SA-direct syncs.
- Validate SA-direct Workspace group access during setup to prevent incomplete permission indexing.