### PR TITLE
fix(chat): avoid unsupported ParadeDB chat-search query shape

### DIFF
--- a/services/ai/db/chats.py
+++ b/services/ai/db/chats.py
@@ -78,7 +78,7 @@ class ChatsRepository:
                     c.title,
                     c.updated_at,
                     NULL::varchar AS matched_message_id,
-                    preview.content_text AS snippet,
+                    NULL::text AS snippet,
                     (
                         SELECT COUNT(*)::integer
                         FROM chat_messages count_cm
@@ -87,15 +87,6 @@ class ChatsRepository:
                     pdb.score(c.id) AS score,
                     'title'::text AS source
                 FROM chats c
-                LEFT JOIN LATERAL (
-                    SELECT cm.content_text
-                    FROM chat_messages cm
-                    WHERE cm.chat_id = c.id
-                      AND cm.content_text IS NOT NULL
-                      AND btrim(cm.content_text) <> ''
-                    ORDER BY cm.message_seq_num ASC
-                    LIMIT 1
-                ) preview ON TRUE
                 WHERE c.title IS NOT NULL
                   AND c.title ||| $2
                   AND c.user_id = $1
@@ -152,7 +143,7 @@ class ChatsRepository:
                     CASE
                         WHEN message.matched_message_id IS NOT NULL
                             THEN message.snippet
-                        ELSE ranked.snippet
+                        ELSE COALESCE(preview.preview_snippet, ranked.snippet)
                     END,
                     500
                 ) AS snippet,
@@ -163,6 +154,16 @@ class ChatsRepository:
                 END AS source
             FROM ranked_matches ranked
             LEFT JOIN message_matches message ON message.id = ranked.id
+            LEFT JOIN LATERAL (
+                SELECT cm.content_text AS preview_snippet
+                FROM chat_messages cm
+                WHERE ranked.source = 'title'
+                  AND cm.chat_id = ranked.id
+                  AND cm.content_text IS NOT NULL
+                  AND btrim(cm.content_text) <> ''
+                ORDER BY cm.message_seq_num ASC
+                LIMIT 1
+            ) preview ON TRUE
             ORDER BY ranked.score DESC, ranked.updated_at DESC, ranked.id
             LIMIT $4
         """

--- a/services/ai/tests/integration/test_chat_history_repository.py
+++ b/services/ai/tests/integration/test_chat_history_repository.py
@@ -34,7 +34,10 @@ async def test_chat_search_scopes_results_and_supports_title_and_message_matches
     )
     await messages.create(
         matching_chat.id,
-        {"role": "user", "content": "We decided the xylophone launch should happen in March."},
+        {
+            "role": "user",
+            "content": "We decided the xylophone launch should happen in March.",
+        },
     )
 
     title_only_chat = await chats.create(
@@ -58,7 +61,9 @@ async def test_chat_search_scopes_results_and_supports_title_and_message_matches
         {"role": "user", "content": "Launch details that should be hidden."},
     )
     async with db_pool.acquire() as conn:
-        await conn.execute("UPDATE chats SET is_deleted = TRUE WHERE id = $1", deleted_chat.id)
+        await conn.execute(
+            "UPDATE chats SET is_deleted = TRUE WHERE id = $1", deleted_chat.id
+        )
 
     message_hits = await chats.search(
         history_user.id,
@@ -83,6 +88,7 @@ async def test_chat_search_scopes_results_and_supports_title_and_message_matches
     )
     assert [hit.chat_id for hit in title_hits] == [title_only_chat.id]
     assert title_hits[0].source == "title"
+    assert title_hits[0].snippet == "A short unrelated note."
 
 
 @pytest.mark.asyncio
@@ -109,7 +115,9 @@ async def test_chat_search_deduplicates_messages_before_limiting(db_pool, histor
 
 
 @pytest.mark.asyncio
-async def test_get_active_path_can_read_an_older_branch_by_anchor(db_pool, history_user):
+async def test_get_active_path_can_read_an_older_branch_by_anchor(
+    db_pool, history_user
+):
     chats = ChatsRepository(pool=db_pool)
     messages = MessagesRepository(pool=db_pool)
     chat = await chats.create(history_user.id, title="Branching chat")

--- a/web/src/lib/server/db/chats.ts
+++ b/web/src/lib/server/db/chats.ts
@@ -185,18 +185,9 @@ export class ChatRepository {
         const results = await this.db.execute<ChatSearchSqlRow>(sql`
             WITH title_matches AS (
                 SELECT c.id, c.user_id, c.title, c.is_starred, c.model_id, c.agent_id, c.is_deleted, c.created_at, c.updated_at,
-                       preview.message_id, preview.content_text,
+                       NULL::varchar AS message_id, NULL::text AS content_text,
                        pdb.score(c.id) AS score, 'title'::text AS source
                 FROM chats c
-                LEFT JOIN LATERAL (
-                    SELECT cm.id AS message_id, cm.content_text
-                    FROM chat_messages cm
-                    WHERE cm.chat_id = c.id
-                      AND cm.content_text IS NOT NULL
-                      AND btrim(cm.content_text) <> ''
-                    ORDER BY cm.message_seq_num ASC
-                    LIMIT 1
-                ) preview ON TRUE
                 WHERE c.title ||| ${query}
                   AND c.user_id = ${userId}
                   AND c.is_deleted = FALSE
@@ -253,22 +244,32 @@ export class ChatRepository {
                        plainto_tsquery(${TEXT_SEARCH_CONFIG}::regconfig, ${query}),
                        ${TITLE_HEADLINE_OPTIONS}
                    ) AS "titleHeadline",
-                   message_id AS "snippetMessageId",
-                   source AS "snippetSource",
+                   COALESCE(final_candidates.message_id, preview.preview_message_id) AS "snippetMessageId",
+                   final_candidates.source AS "snippetSource",
                    CASE
-                       WHEN source = 'message' THEN ts_headline(
+                       WHEN final_candidates.source = 'message' THEN ts_headline(
                            ${TEXT_SEARCH_CONFIG}::regconfig,
-                           COALESCE(content_text, ''),
+                           COALESCE(final_candidates.content_text, ''),
                            plainto_tsquery(${TEXT_SEARCH_CONFIG}::regconfig, ${query}),
                            ${SNIPPET_HEADLINE_OPTIONS}
                        )
                        ELSE NULLIF(
-                           left(regexp_replace(COALESCE(content_text, ''), '[[:space:]]+', ' ', 'g'), 180),
+                           left(regexp_replace(COALESCE(preview.preview_content_text, ''), '[[:space:]]+', ' ', 'g'), 180),
                            ''
                        )
                    END AS "snippetHeadline"
             FROM final_candidates
-            ORDER BY score DESC
+            LEFT JOIN LATERAL (
+                SELECT cm.id AS preview_message_id, cm.content_text AS preview_content_text
+                FROM chat_messages cm
+                WHERE final_candidates.source = 'title'
+                  AND cm.chat_id = final_candidates.id
+                  AND cm.content_text IS NOT NULL
+                  AND btrim(cm.content_text) <> ''
+                ORDER BY cm.message_seq_num ASC
+                LIMIT 1
+            ) preview ON TRUE
+            ORDER BY final_candidates.score DESC
         `)
 
         return results.map((row) => {


### PR DESCRIPTION
## Summary

- Move title-match preview lookups outside ParadeDB BM25 search CTEs in the web and AI chat repositories.
- Preserve title preview content and matching message IDs after ranking/limiting search candidates.
- Extend the AI integration coverage to assert title-match snippets are returned.

The previous query placed a `LEFT JOIN LATERAL` inside the BM25 query. On ParadeDB 0.24 with the deployed index/data state, that produced `Unsupported query shape` errors for both the sidebar chat search endpoint and the AI `search_chats` tool.

## Tests

- `cd web && npm run test:integ -- src/lib/server/db/chats.test.ts`
- `cd services/ai && uv run pytest -q tests/integration/test_chat_history_repository.py tests/integration/test_chat_history_tools.py`

Both suites pass against ParadeDB 0.24 Testcontainers.
