### PR TITLE
fix(ai): persist chat token usage on early stream close

### DIFF
--- a/services/ai/streaming/generate.py
+++ b/services/ai/streaming/generate.py
@@ -150,8 +150,6 @@ async def event_stream_with_context_retry(
             async for wrapped_event in processed_stream:
                 emitted_event = True
                 yield wrapped_event
-            tracker.save()
-            return
         except ProviderError as e:
             if e.is_context_overflow and llm_attempt == 0 and not emitted_event:
                 logger.warning(
@@ -174,6 +172,13 @@ async def event_stream_with_context_retry(
                     yield CompactionEnd()
                 continue
             raise
+        finally:
+            # The agent loop (stream_generator) stops consuming this generator
+            # at message_stop instead of exhausting it, so save() must run in
+            # `finally`: an early close unwinds the generator through here and
+            # would otherwise drop the captured usage on every turn.
+            tracker.save()
+        return
 
 
 # ---------------------------------------------------------------------------

--- a/services/ai/tests/integration/test_chat_stream_lifecycle.py
+++ b/services/ai/tests/integration/test_chat_stream_lifecycle.py
@@ -19,10 +19,11 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import json
+import time
 from unittest.mock import AsyncMock
 
+import asyncpg
 import pytest
-from anthropic.types import MessageParam
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
 from ulid import ULID
@@ -30,7 +31,6 @@ from ulid import ULID
 import db.connection
 import routers.chat as chat_module
 from db import ChatsRepository, MessagesRepository, UsersRepository
-from db.documents import DocumentsRepository
 from db.tool_approvals import (
     ToolApprovalsRepository,
     ToolApprovalStatus,
@@ -46,7 +46,6 @@ from tests.helpers import (
     stream_sse,
 )
 from tools import SearchResponse, SearchResult, ToolRegistry, ToolResult
-from tools.document_handler import DocumentToolHandler
 from tools.omni_tool_result import OAuthRequiredPayload
 from tools.searcher_client import Document
 from tools.searcher_tool import SearcherTool
@@ -180,9 +179,22 @@ async def seeded_chat(
     try:
         yield (chat_id, user.id, model_id)
     finally:
-        async with db_pool.acquire() as conn:
-            await conn.execute("DELETE FROM chat_messages WHERE chat_id = $1", chat_id)
-            await conn.execute("DELETE FROM chats WHERE id = $1", chat_id)
+        # Usage persistence is fire-and-forget (asyncio task): the row can
+        # land a moment after the run ends, racing this delete. Retry the
+        # delete briefly until the usage row shows up and is removed.
+        for _ in range(50):
+            async with db_pool.acquire() as conn:
+                try:
+                    await conn.execute(
+                        "DELETE FROM model_usage WHERE chat_id = $1", chat_id
+                    )
+                    await conn.execute(
+                        "DELETE FROM chat_messages WHERE chat_id = $1", chat_id
+                    )
+                    await conn.execute("DELETE FROM chats WHERE id = $1", chat_id)
+                    break
+                except asyncpg.ForeignKeyViolationError:
+                    await asyncio.sleep(0.1)
         async with db_pool.acquire() as conn:
             await conn.execute("DELETE FROM models WHERE id = $1", model_id)
             await conn.execute("DELETE FROM model_providers WHERE id = $1", provider_id)
@@ -320,12 +332,18 @@ class TestBaseline:
 
     @pytest.mark.asyncio
     async def test_happy_path_streams_text_and_persists_assistant(
-        self, seeded_chat, redis_client, redis_keys
+        self, seeded_chat, db_pool, redis_client, redis_keys
     ):
         """E2E: stream a text response → DB has persisted assistant row;
         consumer events have strictly increasing ``id:`` lines; no duplicate
-        writes."""
-        chat_id, _user_id, model_id = seeded_chat
+        writes.
+
+        Also asserts the turn's token usage lands in ``model_usage`` —
+        regression: the agent loop stops consuming the provider stream at
+        ``message_stop``, so ``UsageTracker.save()`` must run on generator
+        close (``finally``), not on exhaustion.
+        """
+        chat_id, user_id, model_id = seeded_chat
         llm = GatedRecordingLLM([("text", "This is a test response.")], model_id)
 
         app = _build_chat_app(llm, redis_client, model_id)
@@ -360,6 +378,29 @@ class TestBaseline:
         stream_key = f"chat:stream:{chat_id}"
         exists = await redis_client.exists(stream_key)
         assert exists == 1, "Stream key should exist after run completes (within TTL)"
+
+        # The chat turn's token usage must be persisted.  save() is
+        # fire-and-forget (an asyncio task), so poll briefly for the row.
+        deadline = time.monotonic() + 5.0
+        usage_row = None
+        while time.monotonic() < deadline:
+            async with db_pool.acquire() as conn:
+                usage_row = await conn.fetchrow(
+                    "SELECT purpose, model_id, user_id, call_count, "
+                    "input_tokens, output_tokens FROM model_usage "
+                    "WHERE chat_id = $1",
+                    chat_id,
+                )
+            if usage_row is not None:
+                break
+            await asyncio.sleep(0.05)
+        assert usage_row is not None, "No model_usage row persisted for the chat turn"
+        assert usage_row["purpose"] == "chat"
+        assert usage_row["model_id"] == model_id
+        assert usage_row["user_id"] == user_id
+        assert usage_row["call_count"] == 1
+        assert usage_row["input_tokens"] == 10
+        assert usage_row["output_tokens"] == 10
 
     @pytest.mark.asyncio
     async def test_message_start_id_matches_db_row(

--- a/services/ai/tests/integration/test_providers_api/test_anthropic.py
+++ b/services/ai/tests/integration/test_providers_api/test_anthropic.py
@@ -6,13 +6,13 @@ import re
 import pytest
 from anthropic.types import MessageParam, ToolUseBlockParam
 
-from tests.integration.test_providers_api.conftest import (
-    require_env,
-    stream_usage,
-    report_usage,
-)
 from providers.anthropic import AnthropicProvider
 from streaming.persist import parse_tool_call_inputs
+from tests.integration.test_providers_api.conftest import (
+    report_usage,
+    require_env,
+    stream_usage,
+)
 
 pytestmark = pytest.mark.real_llm
 
@@ -210,6 +210,13 @@ class TestAnthropic:
         ]
         assert events2[-1].type == "message_stop"
 
+        # Usage must actually flow through the streamed events — the chat
+        # pipeline's UsageTracker reads message_start/message_delta usage.
+        # Regression guard: if the API stops reporting usage (or the provider
+        # stops forwarding it), tracking silently records nothing.
         u = stream_usage(events) or stream_usage(events2)
-        if u:
-            report_usage("Anthropic.stream", u[0], u[1])
+        assert u is not None, (
+            "Anthropic stream carried no usage on message_delta; "
+            "token usage tracking would silently record nothing"
+        )
+        report_usage("Anthropic.stream", u[0], u[1])

--- a/services/ai/tests/integration/test_providers_api/test_gemini.py
+++ b/services/ai/tests/integration/test_providers_api/test_gemini.py
@@ -7,12 +7,12 @@ import re
 import pytest
 from anthropic.types import MessageParam
 
+from providers.gemini import GeminiProvider
 from tests.integration.test_providers_api.conftest import (
+    report_usage,
     require_env,
     stream_usage,
-    report_usage,
 )
-from providers.gemini import GeminiProvider
 
 pytestmark = pytest.mark.real_llm
 
@@ -153,6 +153,14 @@ class TestGemini:
         ]
         assert events2[-1].type == "message_stop"
 
+        # Usage must actually flow through the streamed events — Gemini
+        # reports real token counts on the final ``message_delta``, and the
+        # chat pipeline's UsageTracker reads exactly that.  Regression guard:
+        # if the API stops reporting usage_metadata (or the provider stops
+        # forwarding it), tracking silently records nothing.
         u = stream_usage(events) or stream_usage(events2)
-        if u:
-            report_usage("Gemini.stream", u[0], u[1])
+        assert u is not None, (
+            "Gemini stream carried no usage on message_delta; "
+            "token usage tracking would silently record nothing"
+        )
+        report_usage("Gemini.stream", u[0], u[1])


### PR DESCRIPTION
- Move `tracker.save()` into a `finally` block in the chat streaming generator: the agent loop stops consuming the stream at `message_stop`, so the post-loop save never ran and every chat turn's usage was silently dropped from `model_usage`.
- Extend the chat stream lifecycle integration test to assert the `model_usage` row lands with `purpose=chat` and the expected token counts; verified red (unfixed) / green (fixed).
- Harden the chat fixture teardown against the fire-and-forget usage persist racing the FK-constrained chat delete.
- Make the live Gemini/Anthropic provider API tests assert usage arrives on streamed `message_delta` events instead of only reporting it, so usage-delivery regressions fail CI.
