### PR TITLE
fix(ai): exclude cached tokens from gemini input token usage

### DIFF
--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -431,7 +431,7 @@ class GeminiProvider(LLMProvider):
                             )
 
             if last_usage_metadata:
-                input_tokens = (
+                prompt_tokens = (
                     getattr(last_usage_metadata, "prompt_token_count", 0) or 0
                 )
                 output_tokens = (
@@ -444,7 +444,11 @@ class GeminiProvider(LLMProvider):
                     type="message_delta",
                     delta=Delta(stop_reason="end_turn"),
                     usage=MessageDeltaUsage(
-                        input_tokens=input_tokens,
+                        # prompt_token_count is the TOTAL prompt size and
+                        # includes the cached portion; report only the
+                        # uncached input so cached tokens are not double
+                        # counted against cache_read_input_tokens.
+                        input_tokens=max(prompt_tokens - cached_tokens, 0),
                         output_tokens=output_tokens,
                         cache_read_input_tokens=cached_tokens,
                     ),
@@ -485,10 +489,15 @@ class GeminiProvider(LLMProvider):
             usage = TokenUsage()
             if hasattr(response, "usage_metadata") and response.usage_metadata:
                 um = response.usage_metadata
+                prompt_tokens = getattr(um, "prompt_token_count", 0) or 0
+                cached_tokens = getattr(um, "cached_content_token_count", 0) or 0
                 usage = TokenUsage(
-                    input_tokens=getattr(um, "prompt_token_count", 0) or 0,
+                    # prompt_token_count includes the cached portion; report
+                    # only the uncached input (same accounting as the stream
+                    # path above).
+                    input_tokens=max(prompt_tokens - cached_tokens, 0),
                     output_tokens=getattr(um, "candidates_token_count", 0) or 0,
-                    cache_read_tokens=getattr(um, "cached_content_token_count", 0) or 0,
+                    cache_read_tokens=cached_tokens,
                 )
 
             if not response.text:

--- a/services/ai/tests/integration/test_providers_api/test_gemini.py
+++ b/services/ai/tests/integration/test_providers_api/test_gemini.py
@@ -3,11 +3,15 @@
 import json
 import os
 import re
+from pathlib import Path
+from unittest.mock import AsyncMock
 
 import pytest
 from anthropic.types import MessageParam
+from dotenv import load_dotenv
 
 from providers.gemini import GeminiProvider
+from services.usage import UsageContext, UsagePurpose, UsageTracker
 from tests.integration.test_providers_api.conftest import (
     report_usage,
     require_env,
@@ -16,8 +20,14 @@ from tests.integration.test_providers_api.conftest import (
 
 pytestmark = pytest.mark.real_llm
 
-API_KEY = require_env("TEST_GEMINI_API_KEY")
-MODEL = os.environ.get("TEST_GEMINI_MODEL", "gemini-2.5-flash")
+# Local verification reads the key from a repo-root .env.test
+# (GEMINI_API_KEY); CI provides TEST_GEMINI_API_KEY.
+_env_test = Path(__file__).resolve().parents[5] / ".env.test"
+if _env_test.exists():
+    load_dotenv(_env_test)
+
+API_KEY = os.environ.get("GEMINI_API_KEY") or require_env("TEST_GEMINI_API_KEY")
+MODEL = os.environ.get("TEST_GEMINI_MODEL", "gemini-3.5-flash-lite")
 
 _WEATHER_TOOL = {
     "name": "get_weather",
@@ -164,3 +174,121 @@ class TestGemini:
             "token usage tracking would silently record nothing"
         )
         report_usage("Gemini.stream", u[0], u[1])
+
+
+class TestGeminiCachedUsage:
+    """Cache-hit usage accounting against the real API.
+
+    Gemini's ``usage_metadata.prompt_token_count`` is the TOTAL prompt size
+    and includes the cached portion; the provider must report
+    ``input_tokens`` as ``prompt - cached`` so cached tokens are not double
+    counted against ``cache_read_input_tokens``.  Uses an explicitly created
+    context cache so the hit is guaranteed.
+    """
+
+    @staticmethod
+    def _delta_usage(events: list) -> tuple[int, int, int] | None:
+        """Extract (input, output, cache_read) from the message_delta usage."""
+        for event in events:
+            if event.type == "message_delta" and event.usage is not None:
+                u = event.usage
+                return (
+                    getattr(u, "input_tokens", 0) or 0,
+                    getattr(u, "output_tokens", 0) or 0,
+                    getattr(u, "cache_read_input_tokens", 0) or 0,
+                )
+        return None
+
+    async def test_cached_input_tokens_exclude_cache_hits(self) -> None:
+        """Cached input tokens must be excluded from ``input_tokens``.
+
+        Gemini's ``prompt_token_count`` is the TOTAL prompt size and
+        includes the cached portion (verified against the live API:
+        prompt = content + cached).  The provider must report
+        ``input_tokens`` as ``total - cached`` (with ``cache_read`` carrying
+        the cached portion), otherwise cached tokens are double counted.
+        ``count_tokens`` gives the independent uncached total to check
+        against.  Fails on the old mapping (input = full prompt total).
+        """
+        from google.genai import types
+
+        provider = GeminiProvider(api_key=API_KEY, model=MODEL)
+        long_text = "The quick brown fox jumps over the lazy dog. " * 600
+        messages: list[MessageParam] = [{"role": "user", "content": long_text}]
+
+        # Explicit context cache over the same content → guaranteed cache hit.
+        cache = await provider.client.aio.caches.create(
+            model=MODEL,
+            config=types.CreateCachedContentConfig(
+                display_name="omni-usage-test",
+                contents=[
+                    types.Content(role="user", parts=[types.Part(text=long_text)])
+                ],
+                ttl="300s",
+            ),
+        )
+        try:
+            real_stream = provider.client.aio.models.generate_content_stream
+
+            def _stream_with_cache(**kwargs):
+                # Inject the cached content into the request the provider
+                # builds, keeping the real provider stream path intact.
+                cfg = kwargs.get("config")
+                if cfg is not None:
+                    cfg_dump = cfg.model_dump()
+                    cfg_dump["cached_content"] = cache.name
+                    kwargs["config"] = types.GenerateContentConfig(**cfg_dump)
+                else:
+                    kwargs["config"] = types.GenerateContentConfig(
+                        cached_content=cache.name, max_output_tokens=32
+                    )
+                return real_stream(**kwargs)
+
+            provider.client.aio.models.generate_content_stream = _stream_with_cache
+
+            # Through the real pipeline UsageTracker.
+            tracker = UsageTracker(
+                repo=AsyncMock(),
+                ctx=UsageContext(
+                    user_id="u",
+                    model_id="m",
+                    model_name=MODEL,
+                    provider_type="gemini",
+                    purpose=UsagePurpose.CHAT,
+                ),
+            )
+            events = [
+                e
+                async for e in tracker.wrap_stream(
+                    provider.stream_response(
+                        prompt="", messages=messages, max_tokens=32
+                    )
+                )
+            ]
+        finally:
+            await provider.client.aio.caches.delete(name=cache.name)
+
+        assert events[-1].type == "message_stop"
+        u = self._delta_usage(events)
+        assert u is not None, "No usage on message_delta"
+        input_uncached, out, cached = u
+
+        # Independent uncached total: the request content's own token count.
+        count = await provider.client.aio.models.count_tokens(
+            model=MODEL, contents=long_text
+        )
+        expected_uncached = count.total_tokens
+        assert cached > 0, (
+            "Expected a cache hit from the explicit context cache "
+            f"(model={MODEL}); cached tokens = {cached}"
+        )
+        assert input_uncached == expected_uncached, (
+            f"uncached input ({input_uncached}) != count_tokens "
+            f"({expected_uncached}); cached tokens are being double counted"
+        )
+        assert out > 0
+
+        # The pipeline's UsageTracker must capture the same split.
+        assert tracker.input_tokens == input_uncached
+        assert tracker.cache_read_tokens == cached
+        assert tracker.output_tokens == out


### PR DESCRIPTION
- Fix Gemini token usage double counting: `prompt_token_count` is the TOTAL prompt size including the cached portion, so reporting it verbatim as `input_tokens` double counted cached tokens (they also land in `cache_read_input_tokens`). Subtract `cached_content_token_count` in both the streaming and non-streaming paths.
- Add a live-API regression test (`TestGeminiCachedUsage`) that creates an explicit context cache and asserts uncached input equals `count_tokens` of the content while `cache_read` carries the cached portion; verified red (old mapping) / green (fixed) against the real API.
- Bump the stale default test model to `gemini-3.5-flash-lite` (`gemini-2.5-flash` returns empty responses on the current API version); local runs can use `GEMINI_API_KEY` from a repo-root `.env.test`, CI keeps `TEST_GEMINI_API_KEY`.