### PR TITLE
fix(ai): clean chunk boundaries and char-based offsets

### DIFF
--- a/services/ai/db/documents.py
+++ b/services/ai/db/documents.py
@@ -89,7 +89,7 @@ class DocumentsRepository:
 
         pool = await self._get_pool()
         rows = await pool.fetch(
-            f"SELECT {_COLUMNS} FROM documents WHERE id = ANY($1)",
+            f"SELECT {_COLUMNS} FROM documents d WHERE d.id = ANY($1)",
             document_ids,
         )
 

--- a/services/ai/embeddings/batch_processor.py
+++ b/services/ai/embeddings/batch_processor.py
@@ -22,6 +22,7 @@ from db import (
     QueueStatus,
     get_db_pool,
 )
+from processing import Chunker
 from state import AppState
 
 from . import Chunk
@@ -258,18 +259,20 @@ class EmbeddingBatchProcessor:
                 self._docs_failed += 1
                 return
 
-            # Generate embeddings using sliding window over the document
+            # Generate embeddings over sentence-aligned windows of the document.
+            # Each window starts and ends at a sentence boundary, so chunk spans
+            # produced inside a window never start or end mid-sentence in the
+            # source text, and windows do not re-embed overlapping content.
             try:
                 window_size = (
                     EMBEDDING_MAX_MODEL_LEN * 3
                 )  # TODO: address 3 chars per token assumption here
-                overlap = window_size // 4
-                stride = window_size - overlap
 
                 all_chunks = []
-                offset = 0
-                while offset < len(content_text):
-                    piece = content_text[offset : offset + window_size]
+                for offset, window_end in Chunker.window_spans(
+                    content_text, window_size
+                ):
+                    piece = content_text[offset:window_end]
                     t0 = time.monotonic()
                     chunk_results = await self.embedding_provider.generate_embeddings(
                         text=piece,
@@ -292,8 +295,6 @@ class EmbeddingBatchProcessor:
                                 offset + chunk.span[1],
                             )
                             all_chunks.append(Chunk(adjusted_span, chunk.embedding))
-
-                    offset += stride
 
                 chunks = all_chunks
 

--- a/services/ai/processing/chunking.py
+++ b/services/ai/processing/chunking.py
@@ -18,8 +18,12 @@ _chunking_executor = ThreadPoolExecutor(
 class Chunker:
 
     @staticmethod
-    def chunk_sentences_by_chars(text: str, max_chars: int) -> list[tuple[int, int]]:
-        """Chunk text by sentences, keeping chunks under max_chars (character-based)."""
+    def sentence_spans(text: str) -> list[tuple[int, int]]:
+        """Split text into contiguous sentence spans.
+
+        A sentence ends at terminal punctuation followed by whitespace, so each
+        returned span starts where the previous one ended and covers all text.
+        """
         sentence_pattern = r"[.!?]+[\s]+"
         sentences = []
         last_end = 0
@@ -33,8 +37,82 @@ class Chunker:
         if last_end < len(text):
             sentences.append((last_end, len(text)))
 
-        if not sentences:
-            return Chunker.chunk_by_chars(text, max_chars) or [(0, len(text))]
+        return sentences
+
+    @staticmethod
+    def window_spans(text: str, window_size: int) -> list[tuple[int, int]]:
+        """Split long text into sentence-aligned sub-chunk windows.
+
+        Each window starts and ends on a sentence boundary of ``text``, so
+        sentence-chunking a window never produces chunks that begin or end
+        mid-sentence in the original text. A window may exceed ``window_size``
+        only when it contains a single sentence longer than the limit.
+        """
+        if not text or window_size < 1:
+            return []
+
+        windows = []
+        window_start = 0
+        for sent_start, sent_end in Chunker.sentence_spans(text):
+            if (
+                sent_start > window_start
+                and sent_end - window_start > window_size
+            ):
+                windows.append((window_start, sent_start))
+                window_start = sent_start
+
+        if window_start < len(text):
+            windows.append((window_start, len(text)))
+
+        return windows
+
+    @staticmethod
+    def _split_long_sentence(
+        text: str, start: int, end: int, max_chars: int
+    ) -> list[tuple[int, int]]:
+        """Split a single sentence longer than max_chars into smaller pieces.
+
+        Cuts prefer the last word start at or before the hard character limit so
+        words are not split and no piece begins with the separating whitespace.
+        Pieces that end up containing only punctuation or whitespace are folded
+        into the previous piece so stray characters are not embedded on their
+        own.
+        """
+        pieces = []
+        pos = start
+        while pos < end:
+            limit = min(pos + max_chars, end)
+            if limit >= end:
+                pieces.append((pos, end))
+                break
+
+            # Prefer to cut at the last word start at or before the limit.
+            cut = limit
+            while cut > pos:
+                if not text[cut].isspace() and text[cut - 1].isspace():
+                    break
+                cut -= 1
+            if cut == pos:
+                cut = limit  # no word boundary in range; hard cut required
+
+            pieces.append((pos, cut))
+            pos = cut
+
+        cleaned = []
+        for piece in pieces:
+            if cleaned and not any(ch.isalnum() for ch in text[piece[0] : piece[1]]):
+                cleaned[-1] = (cleaned[-1][0], piece[1])
+            else:
+                cleaned.append(piece)
+        return cleaned
+
+    @staticmethod
+    def chunk_sentences_by_chars(text: str, max_chars: int) -> list[tuple[int, int]]:
+        """Chunk text by sentences, keeping chunks under max_chars (character-based)."""
+        if not text or max_chars < 1:
+            return []
+
+        sentences = Chunker.sentence_spans(text)
 
         chunks = []
         chunk_start = 0
@@ -52,17 +130,12 @@ class Chunker:
         if chunk_start < len(text):
             chunks.append((chunk_start, len(text)))
 
-        if not chunks:
-            return [(0, len(text))]
-
         final_chunks = []
         for start, end in chunks:
             if end - start > max_chars:
-                pos = start
-                while pos < end:
-                    chunk_end = min(pos + max_chars, end)
-                    final_chunks.append((pos, chunk_end))
-                    pos = chunk_end
+                final_chunks.extend(
+                    Chunker._split_long_sentence(text, start, end, max_chars)
+                )
             else:
                 final_chunks.append((start, end))
 

--- a/services/ai/tests/integration/test_batch_processor.py
+++ b/services/ai/tests/integration/test_batch_processor.py
@@ -260,7 +260,7 @@ async def test_online_handles_empty_content(
 
 
 @pytest.fixture
-async def online_processor_with_sliding_window(
+async def online_processor_with_sentence_aligned_windows(
     db_pool,
     documents_repo,
     queue_repo,
@@ -287,14 +287,14 @@ async def online_processor_with_sliding_window(
 
 
 @pytest.mark.integration
-async def test_online_processes_large_document_with_sliding_window(
+async def test_online_processes_large_document_with_sentence_aligned_windows(
     db_pool,
-    online_processor_with_sliding_window,
+    online_processor_with_sentence_aligned_windows,
     queue_repo,
     embeddings_repo,
     monkeypatch,
 ):
-    """Large documents are split via sliding window and each window is embedded."""
+    """Large documents are split into sentence-aligned windows, each embedded."""
     import embeddings.batch_processor as bp
 
     monkeypatch.setattr(bp, "EMBEDDING_MAX_MODEL_LEN", 33)
@@ -302,13 +302,15 @@ async def test_online_processes_large_document_with_sliding_window(
     user_id = await create_test_user(db_pool)
     source_id = await create_test_source(db_pool, user_id)
 
-    # 500 chars -> window_size=100, overlap=25, stride=75
-    # Windows at offsets: 0, 75, 150, 225, 300, 375, 450
+    # 20 x 25-char sentences = 500 chars. Each window holds up to
+    # window_size = 33 * 3 = 99 chars and starts/ends on a sentence boundary,
+    # so the windows tile the document without overlap:
+    # (0,75), (75,150), (150,225), (225,300), (300,375), (375,450), (450,500)
     large_content = "This is a test sentence. " * 20  # 500 chars
     doc_id = await create_test_document(db_pool, source_id, large_content)
     queue_id = await enqueue_document(db_pool, doc_id)
 
-    await online_processor_with_sliding_window._process_online_batch()
+    await online_processor_with_sentence_aligned_windows._process_online_batch()
 
     queue_item = await queue_repo.get_by_id(queue_id)
     assert queue_item.status == "completed"
@@ -317,12 +319,12 @@ async def test_online_processes_large_document_with_sliding_window(
     assert len(embeddings) == 7
 
     expected_spans = [
-        (0, 99),
-        (75, 174),
-        (150, 249),
-        (225, 324),
-        (300, 399),
-        (375, 474),
+        (0, 75),
+        (75, 150),
+        (150, 225),
+        (225, 300),
+        (300, 375),
+        (375, 450),
         (450, 500),
     ]
     actual_spans = [(e.chunk_start_offset, e.chunk_end_offset) for e in embeddings]
@@ -331,7 +333,7 @@ async def test_online_processes_large_document_with_sliding_window(
     for emb in embeddings:
         assert len(emb.embedding) == 1024
 
-    provider = online_processor_with_sliding_window.embedding_provider
+    provider = online_processor_with_sentence_aligned_windows.embedding_provider
     assert provider.generate_embeddings.call_count == 7
 
 

--- a/services/ai/tests/integration/test_batch_processor.py
+++ b/services/ai/tests/integration/test_batch_processor.py
@@ -8,7 +8,9 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 import ulid
 
+from embeddings import Chunk
 from embeddings.batch_processor import EmbeddingBatchProcessor
+from processing import Chunker
 from state import AppState
 from tests.helpers import (
     create_test_document as create_document_record,
@@ -51,6 +53,29 @@ def _build_app_state(
     state.embedding_provider_type = provider_type
     state.content_storage = content_storage
     return state
+
+
+def _embedding_dimensions(embedding) -> int:
+    """Return the vector dimension; DB reads may return pgvector.Vector."""
+    to_list = getattr(embedding, "to_list", None)
+    return len(to_list()) if to_list else len(embedding)
+
+
+class _CharSentenceChunkingProvider:
+    """Mimics the OpenAI/Cohere sentence-mode providers: chunk each input text
+    with the real char-based sentence chunker and return one Chunk per span."""
+
+    def __init__(self, chunk_max_chars: int):
+        self.chunk_max_chars = chunk_max_chars
+
+    def get_model_name(self) -> str:
+        return "test-embedding-model"
+
+    async def generate_embeddings(
+        self, text: str, task: str, chunk_size: int | None, chunking_mode: str
+    ) -> list[Chunk]:
+        spans = Chunker.chunk_sentences_by_chars(text, self.chunk_max_chars)
+        return [Chunk((start, end), [0.1] * 8) for start, end in spans]
 
 
 # =============================================================================
@@ -96,7 +121,7 @@ async def test_online_processes_document_end_to_end(
 
     embeddings = await embeddings_repo.get_for_document(doc_id)
     assert len(embeddings) >= 1
-    assert len(embeddings[0].embedding) == 1024
+    assert _embedding_dimensions(embeddings[0].embedding) == 1024
 
     queue_item = await queue_repo.get_by_id(queue_id)
     assert queue_item.status == "completed"
@@ -230,7 +255,7 @@ async def test_online_does_not_clone_from_donor_with_unresolved_embedding_work(
     assert queue_item.status == "completed"
     target_embeddings = await embeddings_repo.get_for_document(target_doc_id)
     assert len(target_embeddings) == 1
-    assert len(target_embeddings[0].embedding) == 1024
+    assert _embedding_dimensions(target_embeddings[0].embedding) == 1024
     mock_embedding_provider.generate_embeddings.assert_called_once()
 
 
@@ -331,10 +356,98 @@ async def test_online_processes_large_document_with_sentence_aligned_windows(
     assert actual_spans == expected_spans
 
     for emb in embeddings:
-        assert len(emb.embedding) == 1024
+        assert _embedding_dimensions(emb.embedding) == 1024
 
     provider = online_processor_with_sentence_aligned_windows.embedding_provider
     assert provider.generate_embeddings.call_count == 7
+
+
+@pytest.fixture
+async def online_processor_with_char_chunker(
+    db_pool,
+    documents_repo,
+    queue_repo,
+    embeddings_repo,
+):
+    """Processor whose provider chunks each window with the real char-based
+    sentence chunker, like the OpenAI/Cohere sentence-mode providers do."""
+    provider = _CharSentenceChunkingProvider(chunk_max_chars=250)
+
+    return EmbeddingBatchProcessor(
+        documents_repo=documents_repo,
+        queue_repo=queue_repo,
+        embeddings_repo=embeddings_repo,
+        app_state=_build_app_state(db_pool, provider),
+    )
+
+
+@pytest.mark.integration
+async def test_online_stores_clean_char_chunks_for_large_document(
+    db_pool,
+    online_processor_with_char_chunker,
+    queue_repo,
+    embeddings_repo,
+    monkeypatch,
+):
+    """Long documents are chunked by the real sentence chunker inside
+    sentence-aligned windows; the offsets persisted to Postgres must slice the
+    source text into whole sentences that tile the document with no overlap or
+    gaps."""
+    import embeddings.batch_processor as bp
+
+    monkeypatch.setattr(bp, "EMBEDDING_MAX_MODEL_LEN", 200)  # window_size = 600
+
+    user_id = await create_test_user(db_pool)
+    source_id = await create_test_source(db_pool, user_id)
+
+    sentences = [
+        "The quick brown fox jumps over the lazy dog near the riverbank.",
+        "Pack my box with five dozen liquor jugs of various sizes.",
+        "How vexingly quick daft zebras jump when provoked by loud noises!",
+        "Voilà un café délicieux et très chaud.",
+        "今日はとても良い天気ですね。",
+        "Sphinx of black quartz, judge my vow and then decide.",
+        "The five boxing wizards jump quickly while eating pancakes.",
+        "Jackdaws love my big sphinx of quartz, a truly odd sight.",
+        "Grumpy wizards make toxic brew for the evil Queen and Jack.",
+        "Amazingly few discotheques provide jukeboxes these days, sadly.",
+    ]
+    content = " ".join(s for _ in range(4) for s in sentences)
+
+    doc_id = await create_test_document(db_pool, source_id, content)
+    queue_id = await enqueue_document(db_pool, doc_id)
+
+    await online_processor_with_char_chunker._process_online_batch()
+
+    queue_item = await queue_repo.get_by_id(queue_id)
+    assert queue_item.status == "completed"
+
+    embeddings = await embeddings_repo.get_for_document(doc_id)
+    assert len(embeddings) > 1
+
+    spans = [(e.chunk_start_offset, e.chunk_end_offset) for e in embeddings]
+    # Windows are sentence-aligned and each window tiles its span, so the stored
+    # chunks must tile the document: contiguous, non-overlapping, full coverage.
+    assert spans[0][0] == 0
+    assert spans[-1][1] == len(content)
+    for i in range(len(spans) - 1):
+        assert spans[i][1] == spans[i + 1][0], (
+            f"chunks overlap or gap: {spans[i]} then {spans[i + 1]}"
+        )
+        assert spans[i][0] < spans[i][1]
+
+    chunk_texts = [content[start:end] for start, end in spans]
+    assert "".join(chunk_texts) == content
+
+    for text in chunk_texts:
+        assert text.rstrip().endswith((".", "!", "?", "。")), (
+            f"stored chunk does not end at a sentence boundary: {text[-60:]!r}"
+        )
+        assert len(text) <= 250
+
+    for emb in embeddings:
+        assert emb.model_name == "test-embedding-model"
+        assert _embedding_dimensions(emb.embedding) == 8
 
 
 # =============================================================================

--- a/services/ai/tests/unit/test_batch_processor_chunk_translation.py
+++ b/services/ai/tests/unit/test_batch_processor_chunk_translation.py
@@ -1,0 +1,140 @@
+"""
+Exercises EmbeddingBatchProcessor's chunk-index translation on the real
+char-based chunking path.
+
+For long documents the batch processor splits the content into
+sentence-aligned windows (level 1) via Chunker.window_spans, sentence-chunks
+each window with Chunker.chunk_sentences_by_chars (level 2), and translates the
+piece-relative chunk spans back onto document offsets via ``offset +
+chunk.span``. Those translated offsets are persisted as chunk_start_offset /
+chunk_end_offset and are later used verbatim to slice chunk content out of the
+source document during retrieval, so they must point at clean boundaries in the
+original text.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from embeddings import Chunk
+from embeddings import batch_processor as bp
+from embeddings.batch_processor import EmbeddingBatchProcessor
+from processing import Chunker
+from state import AppState
+
+SENTENCES = [
+    "The quick brown fox jumps over the lazy dog near the riverbank.",
+    "Pack my box with five dozen liquor jugs of various sizes.",
+    "How vexingly quick daft zebras jump when provoked by loud noises!",
+    "Sphinx of black quartz, judge my vow and then decide.",
+    "The five boxing wizards jump quickly while eating pancakes.",
+    "Jackdaws love my big sphinx of quartz, a truly odd sight.",
+    "Grumpy wizards make toxic brew for the evil Queen and Jack.",
+    "Amazingly few discotheques provide jukeboxes these days, sadly.",
+]
+
+
+class SentenceChunkingProvider:
+    """OpenAI/Cohere-style sentence-mode provider: char chunking per window.
+
+    Records each window piece plus the piece-relative spans the chunker
+    returned, so tests can verify how those spans are translated to document
+    offsets by the processor.
+    """
+
+    def __init__(self, chunk_max_chars: int):
+        self.chunk_max_chars = chunk_max_chars
+        self.calls: list[tuple[str, list[tuple[int, int]]]] = []
+
+    def get_model_name(self) -> str:
+        return "test-embedding-model"
+
+    async def generate_embeddings(
+        self, text: str, task: str, chunk_size: int | None, chunking_mode: str
+    ) -> list[Chunk]:
+        spans = Chunker.chunk_sentences_by_chars(text, self.chunk_max_chars)
+        self.calls.append((text, spans))
+        return [Chunk((start, end), [0.1] * 8) for start, end in spans]
+
+
+@pytest.mark.unit
+class TestBatchProcessorChunkIndexTranslation:
+    """Tests that the sub-chunk -> document offset translation performed by
+    EmbeddingBatchProcessor yields offsets that slice clean chunk content."""
+
+    @staticmethod
+    async def _process_content(content: str) -> list[dict]:
+        # Callers patch bp.EMBEDDING_MAX_MODEL_LEN to 200 so that the
+        # sentence-aligned windows are capped at window_size = 200 * 3 = 600.
+        provider = SentenceChunkingProvider(chunk_max_chars=250)
+
+        state = AppState()
+        state.embedding_provider = provider
+        state.embedding_provider_type = "openai"
+        state.content_storage = AsyncMock()
+        state.content_storage.get_text = AsyncMock(return_value=content)
+
+        embeddings_repo = AsyncMock()
+        processor = EmbeddingBatchProcessor(
+            documents_repo=AsyncMock(),
+            queue_repo=AsyncMock(),
+            embeddings_repo=embeddings_repo,
+            app_state=state,
+        )
+
+        doc = MagicMock()
+        doc.id = "doc-1"
+        doc.content_id = "content-1"
+        doc.external_id = "ext-1"
+
+        item = MagicMock()
+        item.id = "item-1"
+        item.document_id = doc.id
+        item.retry_count = 0
+
+        await processor._process_single_document(item, doc)
+
+        return embeddings_repo.bulk_insert.await_args.args[0]
+
+    async def test_translated_offsets_match_window_chunk_spans(self, monkeypatch):
+        """Control: the persisted offsets must be exactly the piece-relative
+        chunk spans shifted by their window offset (offset + span). This pins
+        the translation arithmetic in the real processor code."""
+        monkeypatch.setattr(bp, "EMBEDDING_MAX_MODEL_LEN", 200)
+        content = " ".join(s for _ in range(4) for s in SENTENCES)
+
+        window_size = bp.EMBEDDING_MAX_MODEL_LEN * 3
+
+        expected: list[tuple[int, int]] = []
+        for offset, window_end in Chunker.window_spans(content, window_size):
+            piece = content[offset:window_end]
+            for start, end in Chunker.chunk_sentences_by_chars(piece, 250):
+                expected.append((offset + start, offset + end))
+
+        rows = await TestBatchProcessorChunkIndexTranslation._process_content(content)
+        actual = [(r["chunk_start_offset"], r["chunk_end_offset"]) for r in rows]
+
+        assert sorted(actual) == sorted(expected)
+
+    async def test_stored_offsets_slice_clean_sentence_spans(self, monkeypatch):
+        """Chunk content is later recovered by slicing the source document at
+        the saved start/end offsets, so each stored offset pair must begin and
+        end at a sentence boundary of the original text."""
+        monkeypatch.setattr(bp, "EMBEDDING_MAX_MODEL_LEN", 200)
+        content = " ".join(s for _ in range(4) for s in SENTENCES)
+        rows = await TestBatchProcessorChunkIndexTranslation._process_content(content)
+
+        assert len(rows) >= 6  # sanity: document spans multiple windows
+
+        for row in rows:
+            start, end = row["chunk_start_offset"], row["chunk_end_offset"]
+            if start > 0:
+                assert content[:start].rstrip().endswith((".", "!", "?")), (
+                    f"stored chunk starts mid-sentence at {start}: "
+                    f"{content[start : start + 40]!r}"
+                )
+            if end < len(content):
+                assert content[:end].rstrip().endswith((".", "!", "?")), (
+                    f"stored chunk ends mid-sentence at {end}: "
+                    f"...{content[end - 40 : end]!r}"
+                )

--- a/services/ai/tests/unit/test_chunking.py
+++ b/services/ai/tests/unit/test_chunking.py
@@ -2,6 +2,8 @@
 """
 Unit tests for the chunking functions.
 """
+import re
+
 import pytest
 from transformers import AutoTokenizer
 from processing import Chunker
@@ -240,6 +242,144 @@ class TestCharacterBasedChunking:
 
         reconstructed = "".join(chunks)
         assert reconstructed == text
+
+    def test_chunk_sentences_by_chars_never_strands_terminal_punctuation(self):
+        """When an over-long unbroken run is split by the char fallback, its
+        terminal punctuation must stay attached to the text instead of being
+        emitted as a punctuation-only chunk."""
+        text = "Lead sentence. " + ("x" * 200) + "."
+        max_chars = 100
+        spans = Chunker.chunk_sentences_by_chars(text, max_chars)
+
+        chunks = [text[start:end] for start, end in spans]
+
+        # Sanity: the over-long run had to be hard-split into several chunks.
+        assert len(chunks) >= 3
+
+        for chunk in chunks:
+            stripped = chunk.strip()
+            assert stripped, f"chunk is whitespace only: {chunk!r}"
+            assert not re.fullmatch(r"[.!?]+", stripped), (
+                f"terminal punctuation stranded in its own chunk: {chunk!r}"
+            )
+
+    def test_chunk_sentences_by_chars_boundaries_do_not_split_words(self):
+        """Char fallback splits of an over-long run should fall between words
+        when the text has word boundaries, and should not leave a chunk that
+        starts with the separator whitespace."""
+        run = "lorem ipsum dolor sit amet consectetur adipiscing elit " * 40
+        text = "Short intro sentence. " + run  # over-long run with word boundaries
+        max_chars = 500
+        spans = Chunker.chunk_sentences_by_chars(text, max_chars)
+
+        for start, end in spans:
+            if start > 0:
+                assert not text[start].isspace(), (
+                    f"chunk begins with separator whitespace at {start}: "
+                    f"{text[start:end][:40]!r}"
+                )
+                assert not (text[start - 1].isalnum() and text[start].isalnum()), (
+                    f"chunk boundary splits a word at {start}: "
+                    f"{text[start - 20 : start + 20]!r}"
+                )
+            if end < len(text):
+                assert not (text[end - 1].isalnum() and text[end].isalnum()), (
+                    f"chunk boundary splits a word at {end}: "
+                    f"{text[end - 20 : end + 20]!r}"
+                )
+
+
+@pytest.mark.unit
+class TestLongDocumentTwoLevelChunking:
+    """Covers the two-level chunking used for long documents.
+
+    Level 1 splits the document into sentence-aligned windows
+    (Chunker.window_spans, as used by EmbeddingBatchProcessor). Level 2
+    sentence-chunks each window via chunk_sentences_by_chars. The
+    piece-relative chunk spans are then translated back into document offsets
+    (offset + span) and stored; retrieval later slices the source document at
+    those saved offsets. These tests check that the translated offsets point at
+    clean boundaries in the source text.
+    """
+
+    SENTENCES = [
+        "The quick brown fox jumps over the lazy dog near the riverbank.",
+        "Pack my box with five dozen liquor jugs of various sizes.",
+        "How vexingly quick daft zebras jump when provoked by loud noises!",
+        "Sphinx of black quartz, judge my vow and then decide.",
+        "The five boxing wizards jump quickly while eating pancakes.",
+        "Jackdaws love my big sphinx of quartz, a truly odd sight.",
+        "Grumpy wizards make toxic brew for the evil Queen and Jack.",
+        "Amazingly few discotheques provide jukeboxes these days, sadly.",
+    ]
+
+    # Mirrors the batch processor constants (window_size = EMBEDDING_MAX_MODEL_LEN
+    # * 3), scaled down so the test stays fast.
+    WINDOW_SIZE = 600
+    MAX_CHARS = 250
+
+    @staticmethod
+    def _two_level_spans(text: str) -> list[tuple[int, int]]:
+        """Translate window chunk spans back to document offsets, exactly like
+        EmbeddingBatchProcessor does before storing chunk_start/end offsets."""
+        max_chars = TestLongDocumentTwoLevelChunking.MAX_CHARS
+
+        spans: list[tuple[int, int]] = []
+        for offset, window_end in Chunker.window_spans(
+            text, TestLongDocumentTwoLevelChunking.WINDOW_SIZE
+        ):
+            piece = text[offset:window_end]
+            for start, end in Chunker.chunk_sentences_by_chars(piece, max_chars):
+                spans.append((offset + start, offset + end))
+        return spans
+
+    def test_translated_spans_are_consistent_with_window_chunking(self):
+        """Control: each translated span must slice the same text the window
+        chunker embedded. The offset arithmetic itself is not the bug."""
+        text = " ".join(s for _ in range(4) for s in self.SENTENCES)
+
+        for offset, window_end in Chunker.window_spans(
+            text, self.WINDOW_SIZE
+        ):
+            piece = text[offset:window_end]
+            window_spans = Chunker.chunk_sentences_by_chars(piece, self.MAX_CHARS)
+            for start, end in window_spans:
+                assert text[offset + start : offset + end] == piece[start:end]
+
+    def test_long_document_chunk_offsets_point_at_sentence_boundaries(self):
+        """Chunk content is later recovered by slicing the source document at the
+        saved start/end offsets, so each chunk must begin and end at a sentence
+        boundary of the original text (not mid-word inside a sentence)."""
+        text = " ".join(s for _ in range(4) for s in self.SENTENCES)
+        spans = self._two_level_spans(text)
+
+        assert len(spans) >= 6  # sanity: document spans multiple windows
+
+        for start, end in spans:
+            if start > 0:
+                assert text[:start].rstrip().endswith((".", "!", "?")), (
+                    f"chunk starts mid-sentence at {start}: {text[start:start + 40]!r}"
+                )
+            if end < len(text):
+                assert text[:end].rstrip().endswith((".", "!", "?")), (
+                    f"chunk ends mid-sentence at {end}: ...{text[end - 40 : end]!r}"
+                )
+
+    def test_long_document_chunk_offsets_do_not_split_words(self):
+        """Window seams must not cut through a word in the source document, since
+        the saved offsets are used verbatim to slice chunk content on retrieval."""
+        text = " ".join(s for _ in range(4) for s in self.SENTENCES)
+        spans = self._two_level_spans(text)
+
+        for start, end in spans:
+            if start > 0:
+                assert not (text[start - 1].isalnum() and text[start].isalnum()), (
+                    f"chunk starts mid-word at {start}: {text[start - 20 : start + 20]!r}"
+                )
+            if end < len(text):
+                assert not (text[end - 1].isalnum() and text[end].isalnum()), (
+                    f"chunk ends mid-word at {end}: {text[end - 20 : end + 20]!r}"
+                )
 
 
 if __name__ == "__main__":

--- a/services/searcher/src/search.rs
+++ b/services/searcher/src/search.rs
@@ -673,14 +673,13 @@ impl SearchEngine {
         start_offset: i32,
         end_offset: i32,
     ) -> String {
-        let start = start_offset as usize;
-        let end = end_offset as usize;
-
-        if start >= content.len() || end > content.len() || start >= end {
+        // Offsets are character offsets into the stored content (see the
+        // chunking pipeline); safe_str_slice clamps out-of-range ranges.
+        if start_offset < 0 || end_offset < 0 || start_offset >= end_offset {
             return String::new();
         }
 
-        safe_str_slice(content, start, end).to_string()
+        safe_str_slice(content, start_offset as usize, end_offset as usize).to_string()
     }
 
     /// Read a specific document by ID, returning full content for small documents

--- a/services/searcher/src/suggested_questions.rs
+++ b/services/searcher/src/suggested_questions.rs
@@ -1,6 +1,6 @@
 use crate::models::{SuggestedQuestion, SuggestedQuestionsResponse};
 use crate::{Result as SearcherResult, SearcherError};
-use anyhow::{anyhow, Context, Result};
+use anyhow::{Context, Result, anyhow};
 use dashmap::DashSet;
 use futures_util::StreamExt;
 use redis::AsyncCommands;
@@ -378,10 +378,10 @@ impl SuggestedQuestionsGenerator {
         prompt_template: &str,
         expect_question_mark: bool,
     ) -> Result<String> {
-        let excerpt = if content.len() > 2000 {
+        let excerpt = if content.chars().count() > 2000 {
             debug!(
                 "Truncating content from {} to 2000 chars for document {}",
-                content.len(),
+                content.chars().count(),
                 document_id
             );
             safe_str_slice(content, 0, 2000)

--- a/services/searcher/tests/integration_tests.rs
+++ b/services/searcher/tests/integration_tests.rs
@@ -2016,7 +2016,7 @@ async fn insert_public_document_with_embedding(
     )
     .bind(Ulid::new().to_string())
     .bind(&doc_id)
-    .bind(content.len() as i32)
+    .bind(content.chars().count() as i32)
     .bind(&embedding)
     .execute(pool)
     .await?;

--- a/shared/src/content_chunker.rs
+++ b/shared/src/content_chunker.rs
@@ -3,13 +3,19 @@ use crate::models::DocumentChunk;
 pub struct ContentChunker;
 
 impl ContentChunker {
-    /// Chunk document content into smaller pieces for embedding generation
+    /// Chunk document content into smaller pieces for embedding generation.
+    ///
+    /// Positions and `max_chunk_size` are measured in characters, consistent
+    /// with the Python chunker, so cuts never land inside a multi-byte UTF-8
+    /// character.
     pub fn chunk_content(content: &str, max_chunk_size: usize) -> Vec<DocumentChunk> {
-        if content.is_empty() {
+        let chars: Vec<char> = content.chars().collect();
+        let char_count = chars.len();
+
+        if char_count == 0 {
             return vec![];
         }
-
-        if content.len() <= max_chunk_size {
+        if max_chunk_size == 0 || char_count <= max_chunk_size {
             return vec![DocumentChunk {
                 text: content.to_string(),
                 index: 0,
@@ -20,42 +26,38 @@ impl ContentChunker {
         let mut current_pos = 0;
         let mut chunk_index = 0;
 
-        while current_pos < content.len() {
-            let end_pos = std::cmp::min(current_pos + max_chunk_size, content.len());
+        while current_pos < char_count {
+            let end_pos = std::cmp::min(current_pos + max_chunk_size, char_count);
 
             // Try to break at sentence boundaries for better semantic coherence
-            let chunk_text = if end_pos < content.len() {
+            let chunk_end = if end_pos < char_count {
                 // Look for sentence endings within the last 100 characters
                 let search_start = std::cmp::max(current_pos, end_pos.saturating_sub(100));
-                let search_slice = &content[search_start..end_pos];
+                let search_window = &chars[search_start..end_pos];
 
-                if let Some(sentence_end) = search_slice.rfind('.') {
-                    let actual_end = search_start + sentence_end + 1;
-                    content[current_pos..actual_end].to_string()
-                } else if let Some(paragraph_end) = search_slice.rfind('\n') {
-                    let actual_end = search_start + paragraph_end + 1;
-                    content[current_pos..actual_end].to_string()
+                if let Some(sentence_end) = search_window.iter().rposition(|&c| c == '.') {
+                    search_start + sentence_end + 1
+                } else if let Some(paragraph_end) = search_window.iter().rposition(|&c| c == '\n') {
+                    search_start + paragraph_end + 1
                 } else {
-                    // Fallback to character boundary
-                    content[current_pos..end_pos].to_string()
+                    end_pos
                 }
             } else {
-                content[current_pos..end_pos].to_string()
+                char_count
             };
 
-            let chunk_end = current_pos + chunk_text.len();
+            let chunk_text: String = chars[current_pos..chunk_end].iter().collect();
             chunks.push(DocumentChunk {
                 text: chunk_text,
                 index: chunk_index,
             });
 
-            current_pos = chunk_end;
-            chunk_index += 1;
-
-            // Prevent infinite loops
-            if current_pos >= content.len() {
+            if chunk_end <= current_pos {
+                // Prevent infinite loops on degenerate inputs
                 break;
             }
+            current_pos = chunk_end;
+            chunk_index += 1;
         }
 
         chunks
@@ -175,5 +177,31 @@ mod tests {
         let indices: Vec<i32> = chunks.iter().map(|c| c.index).collect();
         let expected: Vec<i32> = (0..chunks.len() as i32).collect();
         assert_eq!(indices, expected);
+    }
+
+    #[test]
+    fn test_chunk_multibyte_cut_never_panics() {
+        // Cut positions are byte-based, so a chunk boundary can land inside a
+        // multi-byte UTF-8 character (accented text, emoji, CJK). Slicing must
+        // not panic and must still reproduce the source text exactly.
+        let content = "H\u{e9}llo world! ".repeat(10);
+        let chunks = ContentChunker::chunk_content(&content, 30);
+
+        let reconstructed: String = chunks.iter().map(|c| c.text.as_str()).collect();
+        assert_eq!(reconstructed, content);
+    }
+
+    #[test]
+    fn test_chunk_size_limit_is_character_based() {
+        // The Python chunker sizes chunks in characters. The Rust chunker must
+        // use the same unit, so that a max_chunk_size chunk holds up to
+        // max_chunk_size characters rather than bytes.
+        let content = "H\u{e9}llo world! ".repeat(10);
+        let chunks = ContentChunker::chunk_content(&content, 30);
+
+        assert!(chunks.len() > 1);
+        for chunk in &chunks[..chunks.len() - 1] {
+            assert_eq!(chunk.text.chars().count(), 30);
+        }
     }
 }

--- a/shared/src/test_environment.rs
+++ b/shared/src/test_environment.rs
@@ -379,7 +379,7 @@ impl MockAIServer {
                 let embedding = generate_test_embedding(text);
                 embeddings.push(vec![embedding]);
                 chunks_count.push(1);
-                chunks.push(vec![(0, text.len() as i32)]);
+                chunks.push(vec![(0, text.chars().count() as i32)]);
             }
 
             Json(EmbeddingResponse {

--- a/shared/src/test_utils.rs
+++ b/shared/src/test_utils.rs
@@ -488,7 +488,7 @@ pub async fn create_test_documents_with_embeddings(pool: &PgPool) -> Result<Vec<
         .bind(doc_id)
         .bind(0) // chunk_index
         .bind(0) // chunk_start_offset
-        .bind(docs[i].content.len() as i32) // chunk_end_offset
+        .bind(docs[i].content.chars().count() as i32) // chunk_end_offset
         .bind(&embedding)
         .bind("test-model") // model_name — matches mock AI server
         .bind(1024_i16) // dimensions

--- a/shared/src/utils.rs
+++ b/shared/src/utils.rs
@@ -12,50 +12,47 @@ pub fn generate_ulid() -> String {
         .to_string()
 }
 
-/// Safely slices a string at the given byte positions, adjusting to char boundaries.
+/// Safely slices a string at the given CHARACTER positions, clamping to the
+/// string's bounds.
+///
+/// Chunk start/end offsets are character offsets (the Python chunker measures
+/// them with `len()`, i.e. characters). Interpreting them as byte positions
+/// mis-slices any text containing multi-byte UTF-8 characters, so this helper
+/// converts the character range to byte positions before slicing.
 ///
 /// # Arguments
 /// * `content` - The string to slice
-/// * `start` - Start byte position (will be adjusted to char boundary if needed)
-/// * `end` - End byte position (will be adjusted to char boundary if needed)
+/// * `start` - Start character position
+/// * `end` - End character position
 ///
 /// # Returns
-/// A string slice from the adjusted start to adjusted end
+/// A string slice from the character at `start` to the character before `end`
 pub fn safe_str_slice(content: &str, start: usize, end: usize) -> &str {
-    if start >= content.len() {
-        panic!(
-            "safe_str_slice: start ({}) >= content length ({})",
-            start,
-            content.len()
-        );
+    if start > end {
+        panic!("safe_str_slice: start ({}) > end ({})", start, end);
     }
     if start == end {
         return "";
     }
 
-    if start > end {
-        panic!("safe_str_slice: start ({}) >= end ({})", start, end);
+    let char_count = content.chars().count();
+    if start >= char_count {
+        return "";
     }
+    let end = end.min(char_count);
 
-    let mut adjusted_start = start.min(content.len());
-    let mut adjusted_end = end.min(content.len());
+    let start_byte = content
+        .char_indices()
+        .nth(start)
+        .map(|(byte, _)| byte)
+        .unwrap_or(content.len());
+    let end_byte = content
+        .char_indices()
+        .nth(end)
+        .map(|(byte, _)| byte)
+        .unwrap_or(content.len());
 
-    while adjusted_start > 0 && !content.is_char_boundary(adjusted_start) {
-        adjusted_start -= 1;
-    }
-
-    while adjusted_end < content.len() && !content.is_char_boundary(adjusted_end) {
-        adjusted_end += 1;
-    }
-
-    if adjusted_start >= adjusted_end {
-        panic!(
-            "safe_str_slice: adjusted bounds invalid - start ({}) >= end ({})",
-            adjusted_start, adjusted_end
-        );
-    }
-
-    &content[adjusted_start..adjusted_end]
+    &content[start_byte..end_byte]
 }
 
 /// Normalizes whitespace in text content for clean storage and indexing.
@@ -146,21 +143,21 @@ mod tests {
     }
 
     #[test]
-    fn test_safe_str_slice_multibyte_adjusted_to_boundary() {
-        // \u{1F600} is 4 bytes: bytes 0..4
+    fn test_safe_str_slice_multibyte_char_offsets() {
+        // \u{1F600} is 4 bytes, so byte-based slicing would shift the window.
+        // Offsets are character positions and must ignore the byte width.
         let content = "\u{1F600}abc";
-        // Slicing at byte 2 (mid-emoji) should adjust start back to 0
-        let result = safe_str_slice(content, 0, 4);
-        assert_eq!(result, "\u{1F600}");
+        assert_eq!(safe_str_slice(content, 0, 1), "\u{1F600}");
+        assert_eq!(safe_str_slice(content, 1, 3), "ab");
+        assert_eq!(safe_str_slice(content, 1, 4), "abc");
     }
 
     #[test]
-    fn test_safe_str_slice_end_mid_char_adjusts_forward() {
-        // \u{00E9} (é) is 2 bytes
-        let content = "caf\u{00E9}!";
-        // byte 4 is mid-char for é (which spans bytes 3..5), end should adjust to 5
-        let result = safe_str_slice(content, 0, 4);
-        assert_eq!(result, "caf\u{00E9}");
+    fn test_safe_str_slice_accented_text() {
+        // \u{00E9} (é) is 2 bytes; offsets are characters so [0,4) is "café".
+        let content = "caf\u{00E9} au lait";
+        assert_eq!(safe_str_slice(content, 0, 4), "caf\u{00E9}");
+        assert_eq!(safe_str_slice(content, 4, 7), " au");
     }
 
     #[test]
@@ -176,9 +173,24 @@ mod tests {
     }
 
     #[test]
-    #[should_panic(expected = "start")]
-    fn test_safe_str_slice_start_past_end_panics() {
-        safe_str_slice("hello", 10, 15);
+    fn test_safe_str_slice_offsets_are_character_positions() {
+        // The embedding pipeline stores chunk start/end offsets as CHARACTER
+        // offsets (Python len()), and retrieval slices chunk content back out of
+        // the source text with them. Slicing at the same numeric positions as
+        // BYTES must not shift the window: for "😀😀hello world" chars [2,7)
+        // is "hello".
+        let content = "\u{1F600}\u{1F600}hello world";
+        let start = 2;
+        let end = 7;
+        let expected: String = content.chars().skip(start).take(end - start).collect();
+        assert_eq!(expected, "hello");
+        assert_eq!(safe_str_slice(content, start, end), expected);
+    }
+
+    #[test]
+    fn test_safe_str_slice_start_beyond_length_returns_empty() {
+        let content = "hello";
+        assert_eq!(safe_str_slice(content, 10, 15), "");
     }
 
     #[test]


### PR DESCRIPTION
- Make the char-based sentence chunker split over-long sentences at word boundaries and never strand terminal punctuation or whitespace into its own chunk, so embeddings and retrieval no longer surface degenerate content like a `"."` chunk.
- Replace the batch processor's overlapping fixed-character sliding windows with sentence-aligned, non-overlapping windows, so persisted chunk start/end offsets always fall on sentence boundaries and the same source text is not embedded twice.
- Interpret stored chunk offsets as character positions (matching the Python chunker) in the Rust searcher's `safe_str_slice` and chunk-content extraction instead of byte positions, fixing shifted or wrong retrieved chunk text for non-ASCII content.
- Make the shared Rust `ContentChunker` character-based so `max_chunk_size` matches Python semantics and cuts can no longer panic mid-way through a multi-byte UTF-8 character (emoji/CJK/accented text).
- Truncate suggested-question document excerpts by characters rather than bytes, matching the reported "2000 chars" limit.
- Add regression tests for punctuation stranding, word-splitting and window-seam offsets; update batch-processor, searcher and shared test helpers to the new sentence-aligned windows and character-count offsets.
