### PR TITLE
feat(web): group and streamline tool-call displays

### DIFF
--- a/web/e2e/chat-stream.spec.ts
+++ b/web/e2e/chat-stream.spec.ts
@@ -969,7 +969,7 @@ test('chat renders citation chips and Sources drawer', async ({ page }) => {
     }
 })
 
-test('branched chat renders streamed tool calls from the SSE stream endpoint', async ({ page }) => {
+test('branched chat groups tool calls and collapses completed work', async ({ page }) => {
     let seeded: SeededChat | null = null
     try {
         seeded = await seedChatFromTemplateFixture()
@@ -982,16 +982,23 @@ test('branched chat renders streamed tool calls from the SSE stream endpoint', a
         await page.keyboard.press('Enter')
 
         await expect(page.getByText('Replay the failing stream')).toBeVisible()
-        await expect(
-            page.getByText("I'll search for more documents related to Nepanagar and NEPA."),
-        ).toBeVisible()
         await expect(page.locator('.thinking-container')).toBeVisible()
 
-        const earlierStepsButton = page.getByRole('button', { name: /earlier steps?/ })
-        await expect(earlierStepsButton).toBeVisible({ timeout: 10_000 })
-        await earlierStepsButton.click()
-        await expect(page.getByText('searched: Nepanagar NEPA mill township')).toBeVisible()
-        await expect(page.getByText(/search for more documents related to Nepanagar/)).toBeVisible()
+        await expect(page.getByRole('button', { name: /earlier steps?/ })).toHaveCount(0)
+        const workedButton = page.getByRole('button', { name: /Worked for/ }).last()
+        await expect(workedButton).toBeVisible({ timeout: 10_000 })
+        await expect(
+            page.getByText('The document appears to be in a binary format.', { exact: false }),
+        ).toBeVisible()
+
+        // The three searches emitted by the first model iteration become one row,
+        // and their individual queries/results are available on expansion.
+        await workedButton.click()
+        const groupedSearchButton = page.getByRole('button', { name: /searched 3 queries/ })
+        await expect(groupedSearchButton).toBeVisible()
+        await groupedSearchButton.click()
+        await expect(page.getByText('Nepanagar NEPA mill township')).toBeVisible()
+        await expect(page.getByText('National Environment Protection Authority')).toBeVisible()
     } finally {
         await cleanupChat(seeded)
     }
@@ -1034,6 +1041,9 @@ test('branched chat keeps the second streamed assistant response on delayed tool
             )
         await page.keyboard.press('Enter')
 
+        const workedButton = page.getByRole('button', { name: /Worked for/ }).last()
+        await expect(workedButton).toBeVisible()
+        await workedButton.click()
         await expect(
             page.getByText('searched: synthetic recent project status in:team-channel'),
         ).toBeVisible()

--- a/web/src/lib/components/tool-calls-group.svelte
+++ b/web/src/lib/components/tool-calls-group.svelte
@@ -8,6 +8,7 @@
         formatDuration,
         groupToolCallContent,
         isToolCallComplete,
+        isToolCallFailed,
         splitToolCallContent,
         type ToolCallDisplayItem,
     } from '$lib/utils/tool-call-display'
@@ -70,9 +71,7 @@
     let allToolsComplete = $derived(
         toolBlocks.length > 0 && toolBlocks.every((block) => isToolCallComplete(block)),
     )
-    let hasToolError = $derived(
-        toolBlocks.some((block) => block.failed || block.actionResult?.isError === true),
-    )
+    let hasToolError = $derived(toolBlocks.some(isToolCallFailed))
     let canCollapseWork = $derived(
         !isStreaming &&
             !hasError &&

--- a/web/src/lib/components/tool-calls-group.svelte
+++ b/web/src/lib/components/tool-calls-group.svelte
@@ -1,20 +1,28 @@
 <script lang="ts">
+    import * as Accordion from '$lib/components/ui/accordion'
     import type { MessageContent, OAuthRequired, ToolMessageContent } from '$lib/types/message'
     import ToolMessage from './tool-message.svelte'
     import MarkdownMessage from './markdown-message.svelte'
     import OAuthRequiredCard from '$lib/components/oauth-integrations/oauth-required-card.svelte'
-    import { ChevronRight } from '@lucide/svelte'
-    import { fly } from 'svelte/transition'
+    import {
+        formatDuration,
+        groupToolCallContent,
+        isToolCallComplete,
+        splitToolCallContent,
+        type ToolCallDisplayItem,
+    } from '$lib/utils/tool-call-display'
+    import { fly, slide } from 'svelte/transition'
 
     type Props = {
         content: MessageContent
         isStreaming: boolean
         stripThinkingContent: (text: string, tag: string) => string
         isAdmin?: boolean
+        hasError?: boolean
+        startedAt?: Date
+        completedAt?: Date
         onOAuthComplete?: () => void
     }
-
-    const MAX_VISIBLE_TOOLS = 4
 
     type OAuthCardEntry = {
         key: string
@@ -27,47 +35,71 @@
         isStreaming,
         stripThinkingContent,
         isAdmin = false,
+        hasError = false,
+        startedAt,
+        completedAt,
         onOAuthComplete = () => {},
     }: Props = $props()
-    let expanded = $state(false)
 
-    let visibleBlocks = $derived(content)
+    let workExpanded = $state<string>()
+    let contentParts = $derived(splitToolCallContent(content))
+    let allWorkItems = $derived(groupToolCallContent(contentParts.work))
+    let workItems = $derived(
+        allWorkItems.filter((item) =>
+            item.type === 'tools'
+                ? item.group.toolName !== 'present_artifact'
+                : stripThinkingContent(item.block.text, 'thinking').trim().length > 0,
+        ),
+    )
+    let artifactItems = $derived(
+        allWorkItems.filter(
+            (item): item is Extract<ToolCallDisplayItem, { type: 'tools' }> =>
+                item.type === 'tools' && item.group.toolName === 'present_artifact',
+        ),
+    )
     let toolBlocks = $derived(
-        visibleBlocks.filter((b): b is ToolMessageContent => b.type === 'tool'),
+        content.filter((block): block is ToolMessageContent => block.type === 'tool'),
     )
-    let collapsibleCount = $derived(Math.max(0, toolBlocks.length - MAX_VISIBLE_TOOLS))
-
-    // Split content into earlier (collapsible) and recent blocks
-    let cutoffIndex = $derived.by(() => {
-        if (collapsibleCount <= 0) return 0
-        const visibleTools = new Set(toolBlocks.slice(-MAX_VISIBLE_TOOLS).map((b) => b.id))
-        const idx = visibleBlocks.findIndex((b) => visibleTools.has(b.id))
-        return idx >= 0 ? idx : 0
-    })
-
-    let earlierBlocks = $derived(collapsibleCount > 0 ? visibleBlocks.slice(0, cutoffIndex) : [])
-    let recentBlocks = $derived(
-        collapsibleCount > 0 ? visibleBlocks.slice(cutoffIndex) : visibleBlocks,
+    let finalResponseBlocks = $derived(contentParts.response)
+    let hasCollapsibleWork = $derived(workItems.length > 0)
+    let hasFinalResponse = $derived(
+        finalResponseBlocks.some(
+            (block) => stripThinkingContent(block.text, 'thinking').trim().length > 0,
+        ),
     )
+    let allToolsComplete = $derived(
+        toolBlocks.length > 0 && toolBlocks.every((block) => isToolCallComplete(block)),
+    )
+    let hasToolError = $derived(
+        toolBlocks.some((block) => block.failed || block.actionResult?.isError === true),
+    )
+    let canCollapseWork = $derived(
+        !isStreaming &&
+            !hasError &&
+            !hasToolError &&
+            hasFinalResponse &&
+            allToolsComplete &&
+            hasCollapsibleWork,
+    )
+    let duration = $derived(formatDuration(startedAt, completedAt))
 
     function blockRenderKey(block: MessageContent[number]): string {
-        // Keep streamed text mounted so its incremental renderer can preserve
-        // previously committed DOM nodes while the source grows.
-        if (block.type === 'text') {
-            return `text:${block.id}`
-        }
-
+        if (block.type === 'text') return `text:${block.id}`
         return `${block.type}:${block.id}`
     }
 
+    function workItemKey(item: ToolCallDisplayItem): string {
+        return item.type === 'text' ? `text:${item.block.id}` : item.group.key
+    }
+
     function oauthCardEntries(blocks: MessageContent): OAuthCardEntry[] {
-        const seen = new Set<string>()
+        const seen: string[] = []
         const entries: OAuthCardEntry[] = []
         for (const block of blocks) {
             if (block.type !== 'tool' || !block.oauthRequired) continue
             const key = `${block.oauthRequired.sourceId}:${block.oauthRequired.provider}`
-            if (seen.has(key)) continue
-            seen.add(key)
+            if (seen.includes(key)) continue
+            seen.push(key)
             entries.push({
                 key,
                 toolName: block.toolUse.name,
@@ -78,78 +110,85 @@
     }
 </script>
 
-{#if collapsibleCount > 0}
-    <button
-        class="text-muted-foreground hover:text-foreground hover:bg-muted/60 mb-3 flex cursor-pointer items-center gap-1.5 rounded-full px-2.5 py-1 text-xs font-medium transition-colors"
-        onclick={() => (expanded = !expanded)}>
-        <ChevronRight
-            class="h-3 w-3 transition-transform duration-200 {expanded ? 'rotate-90' : ''}" />
-        {#if expanded}
-            hide {collapsibleCount} earlier step{collapsibleCount > 1 ? 's' : ''}
-        {:else}
-            {collapsibleCount} earlier step{collapsibleCount > 1 ? 's' : ''}
-        {/if}
-    </button>
-
-    <!-- Earlier blocks: scrollable container when expanded -->
-    <div
-        class="overflow-hidden transition-all duration-300 ease-in-out"
-        class:max-h-0={!expanded}
-        class:opacity-0={!expanded}
-        class:pointer-events-none={!expanded}>
-        <div class="mb-3 max-h-64 overflow-y-auto pr-1 opacity-80">
-            {#each earlierBlocks as block (blockRenderKey(block))}
-                {#if block.type === 'text'}
-                    <div class="min-w-0 overflow-x-auto">
-                        <MarkdownMessage
-                            content={stripThinkingContent(block.text, 'thinking')}
-                            citations={block.citations}
-                            {isStreaming} />
-                    </div>
-                {:else if block.type === 'tool'}
-                    <div class="mb-1">
-                        <ToolMessage
-                            message={block}
-                            {isAdmin}
-                            {onOAuthComplete}
-                            showOAuthCard={false} />
-                    </div>
-                {/if}
-            {/each}
-            {#each oauthCardEntries(earlierBlocks) as entry (`oauth:${entry.key}`)}
-                <div class="mt-2 mb-1">
-                    <OAuthRequiredCard
-                        oauthRequired={entry.oauthRequired}
-                        toolName={entry.toolName}
-                        {isAdmin}
-                        onComplete={onOAuthComplete} />
+{#snippet workTimeline()}
+    <div class="space-y-2">
+        {#each workItems as item (workItemKey(item))}
+            {#if item.type === 'text'}
+                <div class="min-w-0 overflow-x-auto">
+                    <MarkdownMessage
+                        content={stripThinkingContent(item.block.text, 'thinking')}
+                        citations={item.block.citations}
+                        {isStreaming} />
                 </div>
-            {/each}
-        </div>
+            {:else}
+                <div in:fly={{ y: 4, duration: 300 }}>
+                    <ToolMessage
+                        messages={item.group.messages}
+                        groupKey={item.group.key}
+                        {isStreaming}
+                        {isAdmin}
+                        {onOAuthComplete}
+                        showOAuthCard={false} />
+                </div>
+            {/if}
+        {/each}
+        {#each oauthCardEntries(contentParts.work) as entry (`oauth:${entry.key}`)}
+            <div>
+                <OAuthRequiredCard
+                    oauthRequired={entry.oauthRequired}
+                    toolName={entry.toolName}
+                    {isAdmin}
+                    onComplete={onOAuthComplete} />
+            </div>
+        {/each}
+    </div>
+{/snippet}
+
+{#if canCollapseWork}
+    <div transition:slide={{ duration: 200 }}>
+        <Accordion.Root type="single" bind:value={workExpanded} class="tool-calls-group-accordion">
+            <Accordion.Item value="work" class="border-0 [&>h3]:m-0">
+                <Accordion.Trigger
+                    class="text-muted-foreground hover:text-foreground inline-flex !h-8 !w-fit max-w-full flex-none cursor-pointer !items-center justify-start !gap-1.5 border-0 px-0 !py-1.5 text-sm font-normal whitespace-nowrap hover:no-underline">
+                    Worked for {duration}
+                </Accordion.Trigger>
+                <Accordion.Content class="border-0 px-0">
+                    <div>{@render workTimeline()}</div>
+                </Accordion.Content>
+            </Accordion.Item>
+        </Accordion.Root>
+    </div>
+{:else}
+    <div transition:slide={{ duration: 200 }}>
+        <div>{@render workTimeline()}</div>
     </div>
 {/if}
 
-<!-- Recent blocks: always visible -->
-{#each recentBlocks as block (blockRenderKey(block))}
-    {#if block.type === 'text'}
-        <div class="min-w-0 overflow-x-auto">
-            <MarkdownMessage
-                content={stripThinkingContent(block.text, 'thinking')}
-                citations={block.citations}
-                {isStreaming} />
+<div class="space-y-2">
+    {#each artifactItems as item (workItemKey(item))}
+        <div in:fly={{ y: 4, duration: 300 }}>
+            <ToolMessage
+                messages={item.group.messages}
+                groupKey={item.group.key}
+                {isStreaming}
+                {isAdmin}
+                {onOAuthComplete}
+                showOAuthCard={false} />
         </div>
-    {:else if block.type === 'tool'}
-        <div in:fly={{ y: 4, duration: 300 }} class="mb-1">
-            <ToolMessage message={block} {isAdmin} {onOAuthComplete} showOAuthCard={false} />
-        </div>
-    {/if}
-{/each}
-{#each oauthCardEntries(recentBlocks) as entry (`oauth:${entry.key}`)}
-    <div in:fly={{ y: 4, duration: 300 }} class="mt-2 mb-1">
-        <OAuthRequiredCard
-            oauthRequired={entry.oauthRequired}
-            toolName={entry.toolName}
-            {isAdmin}
-            onComplete={onOAuthComplete} />
+    {/each}
+</div>
+
+{#each finalResponseBlocks as block (blockRenderKey(block))}
+    <div class="min-w-0 overflow-x-auto">
+        <MarkdownMessage
+            content={stripThinkingContent(block.text, 'thinking')}
+            citations={block.citations}
+            {isStreaming} />
     </div>
 {/each}
+
+<style>
+    :global(.tool-calls-group-accordion [data-slot='accordion-content'][data-state='closed']) {
+        display: none;
+    }
+</style>

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -168,15 +168,17 @@
             .join(', ')
     }
 
-    function sourceValues(message: ToolMessageContent): string[] {
-        const value = inputValue(message, 'sources')
-        return Array.isArray(value)
-            ? value.filter((source): source is string => typeof source === 'string')
-            : []
-    }
-
-    let sources = $derived(
-        Array.from(new Set(messages.flatMap((message) => sourceValues(message)))),
+    const MAX_VISIBLE_RESULT_SOURCES = 3
+    let resultSources = $derived(
+        Array.from(
+            new Set(
+                messages.flatMap((message) =>
+                    (message.toolResult?.content ?? [])
+                        .map((result) => result.source_type)
+                        .filter((source): source is string => Boolean(source)),
+                ),
+            ),
+        ).slice(0, MAX_VISIBLE_RESULT_SOURCES),
     )
     let resultCount = $derived(
         messages.reduce((count, message) => count + (message.toolResult?.content.length ?? 0), 0),
@@ -314,7 +316,22 @@
                     ? ' tool-row-shimmer'
                     : ''}">
                 <div class="flex min-w-0 flex-1 items-center gap-2">
-                    {#if isSearch && (toolName === 'search' || toolName === 'search_documents')}
+                    {#if isSearch && toolName === 'web_search'}
+                        <Globe class="h-4 w-4 shrink-0" />
+                    {:else if isSearch && resultSources.length > 0}
+                        <div class="flex shrink-0 items-center gap-1">
+                            {#each resultSources as source (source)}
+                                {@const sourceIcon = getSourceIconPath(source)}
+                                {#if sourceIcon}
+                                    <img
+                                        src={sourceIcon}
+                                        alt={getSourceDisplayName(source as SourceType) || source}
+                                        title={getSourceDisplayName(source as SourceType) || source}
+                                        class="!m-0 h-4 w-4 shrink-0" />
+                                {/if}
+                            {/each}
+                        </div>
+                    {:else if isSearch && (toolName === 'search' || toolName === 'search_documents')}
                         <img
                             src={themeStore.current.omniLogoLight}
                             alt="Omni"
@@ -323,20 +340,6 @@
                             src={themeStore.current.omniLogoDark}
                             alt="Omni"
                             class="omni-logo-dark h-4 w-4 shrink-0 rounded-sm" />
-                    {:else if isSearch && toolName === 'web_search'}
-                        <Globe class="h-4 w-4 shrink-0" />
-                    {:else if isSearch && sources.length > 0}
-                        <div class="flex shrink-0 items-center gap-1">
-                            {#each sources as source (source)}
-                                {#if getSourceIconPath(source)}
-                                    <img
-                                        src={getSourceIconPath(source)}
-                                        alt={getSourceDisplayName(source as SourceType) || source}
-                                        title={getSourceDisplayName(source as SourceType) || source}
-                                        class="!m-0 h-4 w-4" />
-                                {/if}
-                            {/each}
-                        </div>
                     {:else if isSearch}
                         <Search class="h-4 w-4 shrink-0" />
                     {:else if toolName === 'run_python'}

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -61,6 +61,8 @@
         run_python: { loading: 'Running', loaded: 'Ran' },
         present_artifact: { loading: 'Presenting', loaded: 'Presented' },
         search_people: { loading: 'Searching people', loaded: 'Searched people' },
+        search_chats: { loading: 'Searching chats', loaded: 'Searched chats' },
+        read_chat: { loading: 'Reading chat', loaded: 'Read chat' },
         tool_search: { loading: 'Searching tools', loaded: 'Searched tools' },
         load_tool: { loading: 'Loading tool', loaded: 'Loaded tool' },
         load_tool_set: { loading: 'Loading tool set', loaded: 'Loaded tool set' },
@@ -81,6 +83,8 @@
         run_python: 'code',
         present_artifact: 'title',
         search_people: 'query',
+        search_chats: 'query',
+        read_chat: 'chat_id',
         tool_search: 'query',
         load_tool: 'tool_name',
         skill_search: 'query',
@@ -340,12 +344,16 @@
                             class="omni-logo-dark h-4 w-4 shrink-0 rounded-sm" />
                     {:else if isSearch}
                         <Search class="h-4 w-4 shrink-0" />
+                    {:else if toolName === 'search_chats'}
+                        <Search class="h-4 w-4 shrink-0" />
                     {:else if toolName === 'run_python'}
                         <FileCode class="h-4 w-4 shrink-0 text-blue-600" />
                     {:else if toolName === 'run_bash'}
                         <Terminal class="h-4 w-4 shrink-0 text-green-600" />
                     {:else if toolName === 'read_document'}
                         <TextSearch class="h-4 w-4 shrink-0" />
+                    {:else if toolName === 'read_chat'}
+                        <BookOpen class="h-4 w-4 shrink-0" />
                     {:else if toolName === 'search_people'}
                         <Users class="h-4 w-4 shrink-0 text-blue-600" />
                     {:else if toolName === 'write_file'}

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -21,7 +21,7 @@
     import { ToolApprovalStatus } from '$lib/types/message'
     import OAuthRequiredCard from '$lib/components/oauth-integrations/oauth-required-card.svelte'
     import { cn } from '$lib/utils'
-    import { isToolCallComplete } from '$lib/utils/tool-call-display'
+    import { isToolCallComplete, isToolCallFailed } from '$lib/utils/tool-call-display'
     import {
         getIconFromSearchResult,
         getSourceIconPath,
@@ -108,9 +108,7 @@
     let accordionKey = $derived(groupKey ?? `tool:${primaryMessage.toolUse.id}`)
     let selectedItem = $state<string>()
     let isComplete = $derived(messages.every(isToolCallComplete))
-    let hasError = $derived(
-        messages.some((message) => message.failed || message.actionResult?.isError === true),
-    )
+    let hasError = $derived(messages.some(isToolCallFailed))
     let needsAuth = $derived(messages.some((message) => Boolean(message.oauthRequired)))
     let isRunning = $derived(isStreaming && !needsAuth && !hasError && !isComplete)
     let isSearch = $derived(
@@ -403,7 +401,7 @@
                                     <pre
                                         class={cn(
                                             'text-foreground max-h-48 overflow-auto rounded-md p-3 text-xs leading-relaxed whitespace-pre-wrap',
-                                            message.actionResult.isError
+                                            isToolCallFailed(message)
                                                 ? 'bg-destructive/10 text-destructive'
                                                 : 'bg-muted/50',
                                         )}>{message.actionResult.text}</pre>
@@ -466,7 +464,7 @@
                                             </span>
                                         {/if}
                                     </div>
-                                {:else if message.failed || message.actionResult?.isError}
+                                {:else if isToolCallFailed(message)}
                                     <div class="text-destructive text-xs">
                                         {message.actionResult?.text ?? 'Search failed.'}
                                     </div>
@@ -490,11 +488,11 @@
                                     <pre
                                         class={cn(
                                             'text-foreground max-h-48 overflow-auto rounded-md p-3 text-xs leading-relaxed whitespace-pre-wrap',
-                                            message.actionResult.isError
+                                            isToolCallFailed(message)
                                                 ? 'bg-destructive/10 text-destructive'
                                                 : 'bg-muted/50',
                                         )}>{message.actionResult.text}</pre>
-                                {:else if message.failed}
+                                {:else if isToolCallFailed(message)}
                                     <div class="text-destructive text-xs">
                                         People search failed.
                                     </div>
@@ -518,7 +516,7 @@
                                     <pre
                                         class={cn(
                                             'text-foreground max-h-48 overflow-auto rounded-md p-3 text-xs leading-relaxed whitespace-pre-wrap',
-                                            message.actionResult.isError
+                                            isToolCallFailed(message)
                                                 ? 'bg-destructive/10 text-destructive'
                                                 : 'bg-muted/50',
                                         )}>{message.actionResult.text}</pre>

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -15,94 +15,63 @@
         Mail,
         PackageSearch,
         ToolCase,
+        Globe,
     } from '@lucide/svelte'
     import type { ToolMessageContent, ToolName } from '$lib/types/message'
     import { ToolApprovalStatus } from '$lib/types/message'
     import OAuthRequiredCard from '$lib/components/oauth-integrations/oauth-required-card.svelte'
     import { cn } from '$lib/utils'
+    import { isToolCallComplete } from '$lib/utils/tool-call-display'
     import {
         getIconFromSearchResult,
         getSourceIconPath,
         getSourceDisplayName,
     } from '$lib/utils/icons'
     import { SourceType } from '$lib/types'
+    import { themeStore } from '$lib/themes/store.svelte'
 
     type Props = {
-        message: ToolMessageContent
+        messages: ToolMessageContent[]
+        groupKey?: string
+        isStreaming?: boolean
         isAdmin?: boolean
         onOAuthComplete?: () => void
         showOAuthCard?: boolean
     }
 
+    type SearchResult = NonNullable<ToolMessageContent['toolResult']>['content'][number]
+
+    type ArtifactData = {
+        key: string
+        url: string
+        title: string
+        content_type: string
+        size_bytes: number
+    }
+
     const ToolIndicators: Record<string, { loading: string; loaded: string }> = {
-        search: {
-            loading: 'searching',
-            loaded: 'searched',
-        },
-        web_search: {
-            loading: 'searching web',
-            loaded: 'searched web',
-        },
-        fetch_web_page: {
-            loading: 'fetching web page',
-            loaded: 'fetched web page',
-        },
-        read_document: {
-            loading: 'fetching',
-            loaded: 'fetched',
-        },
-        write_file: {
-            loading: 'writing',
-            loaded: 'wrote',
-        },
-        read_file: {
-            loading: 'reading',
-            loaded: 'read',
-        },
-        run_bash: {
-            loading: 'running',
-            loaded: 'ran',
-        },
-        run_python: {
-            loading: 'running',
-            loaded: 'ran',
-        },
-        present_artifact: {
-            loading: 'presenting',
-            loaded: 'presented',
-        },
-        search_people: {
-            loading: 'searching people',
-            loaded: 'searched people',
-        },
-        tool_search: {
-            loading: 'searching tools',
-            loaded: 'searched tools',
-        },
-        load_tool: {
-            loading: 'loading tool',
-            loaded: 'loaded tool',
-        },
-        load_tool_set: {
-            loading: 'loading tool set',
-            loaded: 'loaded tool set',
-        },
-        skill_search: {
-            loading: 'searching skills',
-            loaded: 'searched skills',
-        },
-        load_skill: {
-            loading: 'loading skill',
-            loaded: 'loaded skill',
-        },
-        send_email: {
-            loading: 'sending email',
-            loaded: 'sent email',
-        },
+        search: { loading: 'Searching', loaded: 'Searched' },
+        search_documents: { loading: 'Searching', loaded: 'Searched' },
+        web_search: { loading: 'Searching web', loaded: 'Searched web' },
+        fetch_web_page: { loading: 'Fetching web page', loaded: 'Fetched web page' },
+        read_document: { loading: 'Fetching', loaded: 'Fetched' },
+        write_file: { loading: 'Writing', loaded: 'Wrote' },
+        read_file: { loading: 'Reading', loaded: 'Read' },
+        run_bash: { loading: 'Running', loaded: 'Ran' },
+        run_python: { loading: 'Running', loaded: 'Ran' },
+        present_artifact: { loading: 'Presenting', loaded: 'Presented' },
+        search_people: { loading: 'Searching people', loaded: 'Searched people' },
+        tool_search: { loading: 'Searching tools', loaded: 'Searched tools' },
+        load_tool: { loading: 'Loading tool', loaded: 'Loaded tool' },
+        load_tool_set: { loading: 'Loading tool set', loaded: 'Loaded tool set' },
+        skill_search: { loading: 'Searching skills', loaded: 'Searched skills' },
+        load_skill: { loading: 'Loading skill', loaded: 'Loaded skill' },
+        send_email: { loading: 'Sending email', loaded: 'Sent email' },
     }
 
     const ToolInputKey: Record<string, string> = {
         search: 'query',
+        search_documents: 'query',
         web_search: 'query',
         fetch_web_page: 'url',
         read_document: 'name',
@@ -119,37 +88,39 @@
         send_email: 'subject',
     }
 
-    const ToolApprovalColors: Record<
-        ToolApprovalStatus,
-        { borderColor: string; bgColor: string; color: string }
-    > = {
-        [ToolApprovalStatus.Pending]: {
-            borderColor: 'border-warning',
-            bgColor: 'bg-warning',
-            color: 'text-warning-foreground',
-        },
-        [ToolApprovalStatus.Approved]: {
-            borderColor: 'border-success',
-            bgColor: 'bg-success',
-            color: 'text-success-foreground',
-        },
-        [ToolApprovalStatus.Denied]: {
-            borderColor: 'border-destructive/30',
-            bgColor: 'bg-destructive/10',
-            color: 'text-destructive',
-        },
+    const ToolApprovalColors: Record<ToolApprovalStatus, string> = {
+        [ToolApprovalStatus.Pending]: 'text-warning-foreground',
+        [ToolApprovalStatus.Approved]: 'text-success-foreground',
+        [ToolApprovalStatus.Denied]: 'text-destructive',
     }
 
     let {
-        message,
+        messages,
+        groupKey,
+        isStreaming = false,
         isAdmin = false,
         onOAuthComplete = () => {},
         showOAuthCard = true,
     }: Props = $props()
-    let toolName = $derived(message.toolUse.name as ToolName)
 
-    // Determine if this is a connector action (contains __)
+    let primaryMessage = $derived(messages[0])
+    let toolName = $derived(primaryMessage.toolUse.name as ToolName)
+    let accordionKey = $derived(groupKey ?? `tool:${primaryMessage.toolUse.id}`)
+    let selectedItem = $state<string>()
+    let isComplete = $derived(messages.every(isToolCallComplete))
+    let hasError = $derived(
+        messages.some((message) => message.failed || message.actionResult?.isError === true),
+    )
+    let needsAuth = $derived(messages.some((message) => Boolean(message.oauthRequired)))
+    let isRunning = $derived(isStreaming && !needsAuth && !hasError && !isComplete)
+    let isSearch = $derived(
+        toolName === 'search' || toolName === 'search_documents' || toolName === 'web_search',
+    )
+    let isPeopleSearch = $derived(toolName === 'search_people')
+    let isScript = $derived(toolName === 'run_python' || toolName === 'run_bash')
     let isConnectorAction = $derived(toolName.includes('__'))
+    let isMetaTool = $derived(['tool_search', 'load_tool', 'load_tool_set'].includes(toolName))
+    let isSkillTool = $derived(['skill_search', 'load_skill'].includes(toolName))
     let connectorSourceType = $derived(isConnectorAction ? toolName.split('__')[0] : null)
     let connectorIconPath = $derived(
         connectorSourceType ? getSourceIconPath(connectorSourceType) : null,
@@ -157,359 +128,476 @@
     let connectorDisplayName = $derived(
         isConnectorAction ? toolName.replace('__', ' > ') : toolName,
     )
+    let toolInputKey = $derived(ToolInputKey[toolName] || (isConnectorAction ? null : 'query'))
 
-    let statusIndicator = $derived(
-        message.oauthRequired
-            ? 'needs auth'
-            : message.actionResult?.isError
-              ? 'failed'
-              : message.toolResult || message.actionResult
-                ? ToolIndicators[toolName]?.loaded || 'completed'
-                : ToolIndicators[toolName]?.loading || 'running',
-    )
-
-    let toolInputKey = $derived(ToolInputKey[toolName] || (isConnectorAction ? '' : 'query'))
-
-    let sources = $derived<string[]>(message.toolUse.input?.sources || [])
-
-    const summarizeValue = (value: unknown, maxLength = 80): string => {
-        if (value === null || value === undefined) return ''
-        const encoded = typeof value === 'string' ? value : JSON.stringify(value)
-        const text = encoded ?? String(value)
-        return text.length > maxLength ? text.substring(0, maxLength) + '...' : text
+    function inputRecord(message: ToolMessageContent): Record<string, unknown> {
+        const input: unknown = message.toolUse.input
+        if (typeof input !== 'object' || input === null || Array.isArray(input)) return {}
+        return input as Record<string, unknown>
     }
 
-    // Get a short summary of the tool input for display
-    let inputSummary = $derived(() => {
+    function inputValue(message: ToolMessageContent, key: string | null): unknown {
+        if (!key) return null
+        return inputRecord(message)[key]
+    }
+
+    function stringInput(message: ToolMessageContent, key: string | null): string | null {
+        const value = inputValue(message, key)
+        return typeof value === 'string' ? value : null
+    }
+
+    function summarizeValue(value: unknown, maxLength = 80): string | null {
+        if (value === null || value === undefined) return null
+        const encoded = typeof value === 'string' ? value : JSON.stringify(value)
+        const text = encoded ?? String(value)
+        return text.length > maxLength ? `${text.substring(0, maxLength)}...` : text
+    }
+
+    function inputSummary(message: ToolMessageContent): string | null {
         if (toolName === 'load_tool_set') {
-            return summarizeValue(message.toolUse.input?.source_type)
+            return summarizeValue(inputValue(message, 'source_type'))
         }
-        if (toolInputKey && message.toolUse.input?.[toolInputKey]) {
-            return summarizeValue(message.toolUse.input[toolInputKey])
-        }
-        const params = Object.entries(message.toolUse.input || {})
-        if (params.length === 0) return ''
+        const directValue = summarizeValue(inputValue(message, toolInputKey))
+        if (directValue) return directValue
+
+        const params = Object.entries(inputRecord(message))
+        if (params.length === 0) return null
         return params
             .slice(0, 2)
-            .map(([k, v]) => `${k}: ${summarizeValue(v, 40)}`)
+            .map(([key, value]) => `${key}: ${summarizeValue(value, 40) ?? 'missing'}`)
             .join(', ')
+    }
+
+    function sourceValues(message: ToolMessageContent): string[] {
+        const value = inputValue(message, 'sources')
+        return Array.isArray(value)
+            ? value.filter((source): source is string => typeof source === 'string')
+            : []
+    }
+
+    let sources = $derived(
+        Array.from(new Set(messages.flatMap((message) => sourceValues(message)))),
+    )
+    let resultCount = $derived(
+        messages.reduce((count, message) => count + (message.toolResult?.content.length ?? 0), 0),
+    )
+    const MAX_VISIBLE_SEARCH_RESULTS = 5
+    let statusIndicator = $derived(
+        needsAuth
+            ? 'Needs auth'
+            : hasError
+              ? 'Failed'
+              : isComplete
+                ? ToolIndicators[toolName]?.loaded || 'Completed'
+                : ToolIndicators[toolName]?.loading || 'Running',
+    )
+
+    let summary = $derived.by(() => {
+        if (toolName === 'run_python') {
+            if (hasError) return 'Failed to run script'
+            return isComplete ? 'Wrote script' : 'Writing script'
+        }
+        if (toolName === 'run_bash') {
+            if (hasError) return 'Failed to run command'
+            return isComplete ? 'Ran command' : 'Running command'
+        }
+
+        if (isSearch) {
+            const verb = hasError
+                ? 'Failed'
+                : isComplete
+                  ? toolName === 'web_search'
+                      ? 'Searched web'
+                      : 'Searched'
+                  : toolName === 'web_search'
+                    ? 'Searching web'
+                    : 'Searching'
+            if (messages.length > 1) return `${verb} ${messages.length} queries`
+            return `${verb}: ${stringInput(primaryMessage, 'query') ?? 'missing query'}`
+        }
+
+        const detail = isConnectorAction ? connectorDisplayName : inputSummary(primaryMessage)
+        if (!detail) return statusIndicator
+        if (isConnectorAction) return `${statusIndicator}: ${detail}`
+        return selectedItem === accordionKey ? `${statusIndicator} (${detail})` : statusIndicator
     })
 
-    let selectedItem = $state<string>()
+    function scriptText(message: ToolMessageContent): string | null {
+        return stringInput(message, toolName === 'run_python' ? 'code' : 'command')
+    }
 
-    const getSearchResultIconPath = (result: { source: string; source_type?: string | null }) => {
+    function getSearchResultIconPath(result: SearchResult): string | null {
         if (result.source_type) {
             return getSourceIconPath(result.source_type) ?? getIconFromSearchResult(result.source)
         }
         return getIconFromSearchResult(result.source)
     }
 
-    // Determine if this is a sandbox tool
-    let isSandboxTool = $derived(
-        ['write_file', 'read_file', 'run_bash', 'run_python', 'present_artifact'].includes(
-            toolName,
-        ),
-    )
+    function searchResultLabel(result: SearchResult): string {
+        if (toolName === 'web_search') {
+            try {
+                return new URL(result.source).hostname
+            } catch {
+                return result.title
+            }
+        }
+        return result.title
+    }
 
-    let isMetaTool = $derived(['tool_search', 'load_tool', 'load_tool_set'].includes(toolName))
-    let isSkillTool = $derived(['skill_search', 'load_skill'].includes(toolName))
-
-    // Parse artifact data for present_artifact tool
-    let artifactData = $derived.by(() => {
+    function parseArtifact(message: ToolMessageContent): Omit<ArtifactData, 'key'> | null {
         if (toolName !== 'present_artifact' || !message.actionResult?.text) return null
         try {
-            return JSON.parse(message.actionResult.text) as {
-                url: string
-                title: string
-                content_type: string
-                size_bytes: number
+            const parsed: unknown = JSON.parse(message.actionResult.text)
+            if (typeof parsed !== 'object' || parsed === null) return null
+            const candidate = parsed as Record<string, unknown>
+            if (
+                typeof candidate.url !== 'string' ||
+                typeof candidate.title !== 'string' ||
+                typeof candidate.content_type !== 'string' ||
+                typeof candidate.size_bytes !== 'number'
+            ) {
+                return null
+            }
+            return {
+                url: candidate.url,
+                title: candidate.title,
+                content_type: candidate.content_type,
+                size_bytes: candidate.size_bytes,
             }
         } catch {
             return null
         }
-    })
+    }
+
+    let artifactData = $derived(
+        messages
+            .map((message, index) => {
+                const artifact = parseArtifact(message)
+                return artifact ? { ...artifact, key: `${message.toolUse.id}:${index}` } : null
+            })
+            .filter((artifact): artifact is ArtifactData => artifact !== null),
+    )
+
+    let isArtifact = $derived(toolName === 'present_artifact' && artifactData.length > 0)
 </script>
 
-{#if toolName === 'search_people'}
-    <div
-        class={cn(
-            'border-border flex w-full min-w-0 cursor-pointer items-center justify-between rounded-md border px-3 py-3 text-sm hover:no-underline',
-        )}>
-        <div class="flex w-full items-center justify-between">
-            <div class="flex min-w-0 flex-1 items-center gap-2">
-                <Users class="h-5 w-5 shrink-0 text-blue-600" />
-                <div class="min-w-0 truncate text-sm font-normal">
-                    {statusIndicator}: {inputSummary()}
-                </div>
-            </div>
-        </div>
-    </div>
-{:else if toolName === 'read_document'}
-    <div
-        class={cn(
-            'border-border flex w-full min-w-0 cursor-pointer items-center justify-between rounded-md border px-3 py-3 text-sm hover:no-underline',
-        )}>
-        <div class="flex w-full items-center justify-between">
-            <div class="flex min-w-0 flex-1 items-center gap-2">
-                <TextSearch class="h-5 w-5 shrink-0" />
-                <div class="min-w-0 truncate text-sm font-normal">
-                    {statusIndicator}: {inputSummary()}
-                </div>
-            </div>
-        </div>
-    </div>
-{:else if isSandboxTool}
-    {#if toolName === 'present_artifact' && artifactData}
+{#if isArtifact}
+    {#each artifactData as artifact (artifact.key)}
         <div class="mt-2">
-            {#if artifactData.content_type.startsWith('image/')}
+            {#if artifact.content_type.startsWith('image/')}
                 <figure class="border-border rounded-lg border p-2">
-                    <img
-                        src={artifactData.url}
-                        alt={artifactData.title}
-                        class="!m-0 max-w-full rounded" />
+                    <img src={artifact.url} alt={artifact.title} class="!m-0 max-w-full rounded" />
                     <figcaption class="text-muted-foreground mt-1 text-center text-xs">
-                        {artifactData.title}
+                        {artifact.title}
                     </figcaption>
                 </figure>
             {:else}
                 <a
-                    href={artifactData.url}
+                    href={artifact.url}
                     download
+                    rel="external"
                     class="border-border hover:bg-muted text-foreground inline-flex items-center gap-2 rounded-lg border px-3 py-2 text-sm no-underline">
                     <Download class="h-4 w-4" />
-                    <span>{artifactData.title}</span>
+                    <span>{artifact.title}</span>
                     <span class="text-muted-foreground text-xs">
-                        ({Math.round(artifactData.size_bytes / 1024)} KB)
+                        ({Math.round(artifact.size_bytes / 1024)} KB)
                     </span>
                 </a>
             {/if}
         </div>
-    {:else}
-        <div
-            class={cn(
-                'border-border flex w-full min-w-0 cursor-pointer items-center justify-between rounded-md border px-3 py-3 text-sm hover:no-underline',
-            )}>
-            <div class="flex w-full items-center justify-between">
-                <div class="flex min-w-0 flex-1 items-center gap-2">
-                    {#if toolName === 'present_artifact'}
-                        <Image class="h-5 w-5 shrink-0 text-violet-600" />
-                    {:else if toolName === 'run_python'}
-                        <FileCode class="h-5 w-5 shrink-0 text-blue-600" />
-                    {:else if toolName === 'run_bash'}
-                        <Terminal class="h-5 w-5 shrink-0 text-green-600" />
-                    {:else if toolName === 'write_file'}
-                        <Pencil class="h-5 w-5 shrink-0 text-amber-600" />
-                    {:else}
-                        <FileText class="h-5 w-5 shrink-0" />
-                    {/if}
-                    <div class="min-w-0 truncate text-sm font-normal">
-                        {statusIndicator}: {inputSummary()}
-                    </div>
-                </div>
-            </div>
-        </div>
-    {/if}
-{:else if isSkillTool}
-    <div
-        class={cn(
-            'border-border flex w-full min-w-0 cursor-pointer items-center justify-between rounded-md border px-3 py-3 text-sm hover:no-underline',
-        )}>
-        <div class="flex w-full items-center justify-between">
-            <div class="flex min-w-0 flex-1 items-center gap-2">
-                <BookOpen class="h-5 w-5 shrink-0 text-indigo-600" />
-                <div class="min-w-0 truncate text-sm font-normal">
-                    {statusIndicator}: {inputSummary()}
-                </div>
-            </div>
-        </div>
-    </div>
-{:else if isConnectorAction}
-    <div
-        class={cn(
-            'border-border flex w-full min-w-0 cursor-pointer items-center justify-between rounded-md border px-3 py-3 text-sm hover:no-underline',
-            message.approval && ToolApprovalColors[message.approval.status]?.borderColor,
-            message.approval && ToolApprovalColors[message.approval.status]?.bgColor,
-        )}>
-        <div class="flex w-full items-center justify-between">
-            <div class="flex min-w-0 flex-1 items-center gap-2">
-                {#if connectorIconPath}
-                    <img
-                        src={connectorIconPath}
-                        alt={connectorSourceType}
-                        class="!m-0 h-5 w-5 shrink-0" />
-                {:else}
-                    <Play class="h-5 w-5 shrink-0 text-purple-600" />
-                {/if}
-                <div class="min-w-0 truncate text-sm font-normal">
-                    {statusIndicator}: {connectorDisplayName}
-                    {#if inputSummary()}
-                        <span class="text-muted-foreground"> ({inputSummary()})</span>
-                    {/if}
-                </div>
-            </div>
-            {#if message.approval}
-                <div
-                    class={cn(
-                        'text-xs font-medium',
-                        ToolApprovalColors[message.approval.status]?.color,
-                    )}>
-                    {message.approval.status}
-                </div>
-            {/if}
-        </div>
-    </div>
-    {#if showOAuthCard && message.oauthRequired}
-        <div class="mt-2">
-            <OAuthRequiredCard
-                oauthRequired={message.oauthRequired}
-                {toolName}
-                {isAdmin}
-                onComplete={onOAuthComplete} />
-        </div>
-    {/if}
-{:else if isMetaTool || toolName === 'send_email'}
-    <div
-        class={cn(
-            'border-border flex cursor-pointer items-center justify-between rounded-md border px-3 py-3 text-sm hover:no-underline',
-            message.approval && ToolApprovalColors[message.approval.status]?.borderColor,
-            message.approval && ToolApprovalColors[message.approval.status]?.bgColor,
-        )}>
-        <div class="flex w-full items-center justify-between">
-            <div class="flex min-w-0 items-center gap-2">
-                {#if toolName === 'send_email'}
-                    <Mail class="h-5 w-5 text-rose-600" />
-                {:else if toolName === 'tool_search'}
-                    <PackageSearch class="h-5 w-5 text-purple-600" />
-                {:else}
-                    <ToolCase class="h-5 w-5 text-purple-600" />
-                {/if}
-                <div class="max-w-screen-md truncate text-sm font-normal">
-                    {statusIndicator}{#if inputSummary()}: {inputSummary()}{/if}
-                </div>
-            </div>
-            {#if message.approval}
-                <div
-                    class={cn(
-                        'text-xs font-medium',
-                        ToolApprovalColors[message.approval.status]?.color,
-                    )}>
-                    {message.approval.status}
-                </div>
-            {/if}
-        </div>
-    </div>
-{:else if toolName === 'search' || toolName === 'web_search'}
-    <Accordion.Root type="single" bind:value={selectedItem}>
-        <Accordion.Item value={message.toolUse.id}>
+    {/each}
+{:else}
+    <Accordion.Root type="single" bind:value={selectedItem} class="tool-message-accordion">
+        <Accordion.Item value={accordionKey} class="border-0 [&>h3]:m-0">
             <Accordion.Trigger
-                class={cn(
-                    'border-border flex w-full min-w-0 cursor-pointer items-center justify-between border px-3 py-3 text-sm hover:no-underline',
-                    selectedItem === message.toolUse.id && 'bg-card rounded-b-none border-b-0',
-                )}>
-                <div class="flex w-full items-center justify-between">
-                    <div class="flex min-w-0 flex-1 items-center gap-2">
-                        {#if sources.length > 0}
-                            <div class="flex shrink-0 items-center gap-1">
-                                {#each sources as source}
-                                    {#if getSourceIconPath(source)}
-                                        <img
-                                            src={getSourceIconPath(source)}
-                                            alt={getSourceDisplayName(source as SourceType) ||
-                                                source}
-                                            title={getSourceDisplayName(source as SourceType) ||
-                                                source}
-                                            class="!m-0 h-4 w-4" />
-                                    {/if}
-                                {/each}
-                            </div>
+                class="text-muted-foreground hover:text-foreground inline-flex !h-8 !w-fit max-w-full flex-none cursor-pointer !items-center justify-start !gap-1.5 border-0 px-0 !py-1.5 text-sm font-normal whitespace-nowrap hover:no-underline [&:hover>svg]:opacity-100 [&>svg]:opacity-0{isRunning
+                    ? ' tool-row-shimmer'
+                    : ''}">
+                <div class="flex min-w-0 flex-1 items-center gap-2">
+                    {#if isSearch && (toolName === 'search' || toolName === 'search_documents')}
+                        <img
+                            src={themeStore.current.omniLogoLight}
+                            alt="Omni"
+                            class="omni-logo-light h-4 w-4 shrink-0 rounded-sm" />
+                        <img
+                            src={themeStore.current.omniLogoDark}
+                            alt="Omni"
+                            class="omni-logo-dark h-4 w-4 shrink-0 rounded-sm" />
+                    {:else if isSearch && toolName === 'web_search'}
+                        <Globe class="h-4 w-4 shrink-0" />
+                    {:else if isSearch && sources.length > 0}
+                        <div class="flex shrink-0 items-center gap-1">
+                            {#each sources as source (source)}
+                                {#if getSourceIconPath(source)}
+                                    <img
+                                        src={getSourceIconPath(source)}
+                                        alt={getSourceDisplayName(source as SourceType) || source}
+                                        title={getSourceDisplayName(source as SourceType) || source}
+                                        class="!m-0 h-4 w-4" />
+                                {/if}
+                            {/each}
+                        </div>
+                    {:else if isSearch}
+                        <Search class="h-4 w-4 shrink-0" />
+                    {:else if toolName === 'run_python'}
+                        <FileCode class="h-4 w-4 shrink-0 text-blue-600" />
+                    {:else if toolName === 'run_bash'}
+                        <Terminal class="h-4 w-4 shrink-0 text-green-600" />
+                    {:else if toolName === 'read_document'}
+                        <TextSearch class="h-4 w-4 shrink-0" />
+                    {:else if toolName === 'search_people'}
+                        <Users class="h-4 w-4 shrink-0 text-blue-600" />
+                    {:else if toolName === 'write_file'}
+                        <Pencil class="h-4 w-4 shrink-0 text-amber-600" />
+                    {:else if toolName === 'present_artifact'}
+                        <Image class="h-4 w-4 shrink-0 text-violet-600" />
+                    {:else if isSkillTool}
+                        <BookOpen class="h-4 w-4 shrink-0 text-indigo-600" />
+                    {:else if toolName === 'send_email'}
+                        <Mail class="h-4 w-4 shrink-0 text-rose-600" />
+                    {:else if toolName === 'tool_search'}
+                        <PackageSearch class="h-4 w-4 shrink-0 text-purple-600" />
+                    {:else if isMetaTool}
+                        <ToolCase class="h-4 w-4 shrink-0 text-purple-600" />
+                    {:else if isConnectorAction}
+                        {#if connectorIconPath}
+                            <img
+                                src={connectorIconPath}
+                                alt={connectorSourceType}
+                                class="!m-0 h-4 w-4 shrink-0" />
                         {:else}
-                            <Search class="h-4 w-4 shrink-0" />
+                            <Play class="h-4 w-4 shrink-0 text-purple-600" />
                         {/if}
-                        <div class="min-w-0 truncate text-sm font-normal">
-                            {#if sources.length > 0}
-                                {statusIndicator}
-                                {sources
-                                    .map((s) => getSourceDisplayName(s as SourceType) || s)
-                                    .join(', ')}: {message.toolUse.input[toolInputKey]}
-                            {:else}
-                                {statusIndicator}: {message.toolUse.input[toolInputKey]}
-                            {/if}
-                        </div>
-                    </div>
-                    {#if message.toolResult}
-                        <div class="text-muted-foreground text-xs">
-                            {message.toolResult.content.length} results
-                        </div>
+                    {:else}
+                        <FileText class="h-4 w-4 shrink-0" />
+                    {/if}
+                    <span class="min-w-0 truncate text-left">{summary}</span>
+                    {#if isSearch && resultCount > 0}
+                        <span class="text-muted-foreground shrink-0 text-xs">
+                            {resultCount}
+                            {resultCount === 1 ? 'result' : 'results'}
+                        </span>
                     {/if}
                 </div>
             </Accordion.Trigger>
-            {#if message.toolResult && message.toolResult.content.length > 0}
-                <Accordion.Content
-                    class="bg-card border-border max-h-48 overflow-y-auto rounded-b-md border border-t-0">
-                    <div class="px-4 py-2">
-                        <div class="flex flex-col gap-2">
-                            {#each message.toolResult.content as result}
-                                <div class="flex min-w-0 items-center gap-2">
-                                    {#if getSearchResultIconPath(result)}
-                                        <img
-                                            src={getSearchResultIconPath(result)}
-                                            alt=""
-                                            class="!m-0 h-4 w-4 flex-shrink-0" />
-                                    {:else}
-                                        <FileText
-                                            class="text-muted-foreground h-4 w-4 flex-shrink-0" />
-                                    {/if}
-                                    {#if result.source?.startsWith('http://') || result.source?.startsWith('https://')}
-                                        <a
-                                            href={result.source.split('#')[0]}
-                                            target="_blank"
-                                            rel="noopener noreferrer"
-                                            class="block min-w-0 flex-1 truncate font-normal no-underline hover:underline">
-                                            {result.title}
-                                        </a>
-                                    {:else}
-                                        <span class="block min-w-0 flex-1 truncate font-normal">
-                                            {result.title}
-                                        </span>
-                                    {/if}
-                                </div>
-                            {/each}
-                        </div>
+            <Accordion.Content class={cn('border-0 px-0', isSearch && 'pt-2')}>
+                {#if isScript}
+                    <div class="space-y-3 pl-6">
+                        {#each messages as message (message.toolUse.id)}
+                            <div class="space-y-1">
+                                {#if messages.length > 1}
+                                    <div class="text-muted-foreground text-xs">
+                                        {toolName === 'run_python'
+                                            ? 'Python script'
+                                            : 'Bash command'}
+                                    </div>
+                                {/if}
+                                <pre
+                                    class="bg-muted/50 max-h-64 overflow-auto rounded-md p-3 text-xs leading-relaxed"><code
+                                        >{scriptText(message) ??
+                                            'Missing script input.'}</code></pre>
+                                {#if message.actionResult}
+                                    <pre
+                                        class={cn(
+                                            'text-foreground max-h-48 overflow-auto rounded-md p-3 text-xs leading-relaxed whitespace-pre-wrap',
+                                            message.actionResult.isError
+                                                ? 'bg-destructive/10 text-destructive'
+                                                : 'bg-muted/50',
+                                        )}>{message.actionResult.text}</pre>
+                                {/if}
+                            </div>
+                        {/each}
                     </div>
-                </Accordion.Content>
-            {:else}
-                <Accordion.Content class="bg-card border-border rounded-b-md border border-t-0">
-                    <div class="px-4 py-2 text-center text-sm">No results found</div>
-                </Accordion.Content>
-            {/if}
+                {:else if isSearch}
+                    <div class="space-y-3 pl-6">
+                        {#each messages as message (message.toolUse.id)}
+                            <div class="space-y-2">
+                                {#if messages.length > 1}
+                                    <div class="text-muted-foreground text-xs">
+                                        {stringInput(message, 'query') ?? 'Missing query.'}
+                                    </div>
+                                {/if}
+                                {#if message.toolResult && message.toolResult.content.length > 0}
+                                    {@const results = message.toolResult.content}
+                                    {@const visibleResults = results.slice(
+                                        0,
+                                        MAX_VISIBLE_SEARCH_RESULTS,
+                                    )}
+                                    <div class="flex flex-wrap gap-1.5">
+                                        {#each visibleResults as result, resultIndex (`${message.toolUse.id}:${resultIndex}`)}
+                                            {@const resultIcon = getSearchResultIconPath(result)}
+                                            {@const resultLabel = searchResultLabel(result)}
+                                            {#if result.source.startsWith('http://') || result.source.startsWith('https://')}
+                                                <a
+                                                    href={result.source.split('#')[0]}
+                                                    target="_blank"
+                                                    rel="external noopener noreferrer"
+                                                    title={result.title}
+                                                    class="bg-muted/50 hover:bg-muted text-muted-foreground inline-flex max-w-56 items-center gap-1 rounded-full px-2 py-1 text-xs no-underline transition-colors">
+                                                    {#if resultIcon}
+                                                        <img
+                                                            src={resultIcon}
+                                                            alt=""
+                                                            class="!m-0 h-3.5 w-3.5 shrink-0 rounded-full" />
+                                                    {/if}
+                                                    <span class="truncate">{resultLabel}</span>
+                                                </a>
+                                            {:else}
+                                                <span
+                                                    title={result.title}
+                                                    class="bg-muted/50 text-muted-foreground inline-flex max-w-56 items-center gap-1 rounded-full px-2 py-1 text-xs">
+                                                    {#if resultIcon}
+                                                        <img
+                                                            src={resultIcon}
+                                                            alt=""
+                                                            class="!m-0 h-3.5 w-3.5 shrink-0 rounded-full" />
+                                                    {/if}
+                                                    <span class="truncate">{resultLabel}</span>
+                                                </span>
+                                            {/if}
+                                        {/each}
+                                        {#if results.length > visibleResults.length}
+                                            <span
+                                                class="bg-muted/50 text-muted-foreground inline-flex items-center rounded-full px-2 py-1 text-xs">
+                                                and {results.length - visibleResults.length} more
+                                            </span>
+                                        {/if}
+                                    </div>
+                                {:else if message.failed || message.actionResult?.isError}
+                                    <div class="text-destructive text-xs">
+                                        {message.actionResult?.text ?? 'Search failed.'}
+                                    </div>
+                                {:else if isToolCallComplete(message)}
+                                    <div class="text-muted-foreground text-xs">
+                                        No results found
+                                    </div>
+                                {:else}
+                                    <div class="text-muted-foreground text-xs">
+                                        Waiting for results...
+                                    </div>
+                                {/if}
+                            </div>
+                        {/each}
+                    </div>
+                {:else if isPeopleSearch}
+                    <div class="space-y-3 pl-6">
+                        {#each messages as message (message.toolUse.id)}
+                            <div class="space-y-1 text-sm">
+                                {#if message.actionResult}
+                                    <pre
+                                        class={cn(
+                                            'text-foreground max-h-48 overflow-auto rounded-md p-3 text-xs leading-relaxed whitespace-pre-wrap',
+                                            message.actionResult.isError
+                                                ? 'bg-destructive/10 text-destructive'
+                                                : 'bg-muted/50',
+                                        )}>{message.actionResult.text}</pre>
+                                {:else if message.failed}
+                                    <div class="text-destructive text-xs">
+                                        People search failed.
+                                    </div>
+                                {:else if isToolCallComplete(message)}
+                                    <div class="text-muted-foreground text-xs">
+                                        No people found matching the query.
+                                    </div>
+                                {:else}
+                                    <div class="text-muted-foreground text-xs">
+                                        Waiting for results...
+                                    </div>
+                                {/if}
+                            </div>
+                        {/each}
+                    </div>
+                {:else}
+                    <div class="space-y-3 pl-6">
+                        {#each messages as message (message.toolUse.id)}
+                            <div class="space-y-1 text-sm">
+                                {#if message.actionResult}
+                                    <pre
+                                        class={cn(
+                                            'text-foreground max-h-48 overflow-auto rounded-md p-3 text-xs leading-relaxed whitespace-pre-wrap',
+                                            message.actionResult.isError
+                                                ? 'bg-destructive/10 text-destructive'
+                                                : 'bg-muted/50',
+                                        )}>{message.actionResult.text}</pre>
+                                {/if}
+                                {#if message.approval}
+                                    <div
+                                        class={cn(
+                                            'text-xs font-medium',
+                                            ToolApprovalColors[message.approval.status],
+                                        )}>
+                                        {message.approval.status}
+                                    </div>
+                                {/if}
+                            </div>
+                        {/each}
+                    </div>
+                {/if}
+            </Accordion.Content>
         </Accordion.Item>
     </Accordion.Root>
-{:else}
-    <div
-        class={cn(
-            'border-border flex cursor-pointer items-center justify-between rounded-md border px-3 py-3 text-sm hover:no-underline',
-            message.approval && ToolApprovalColors[message.approval.status]?.borderColor,
-            message.approval && ToolApprovalColors[message.approval.status]?.bgColor,
-        )}>
-        <div class="flex w-full items-center justify-between">
-            <div class="flex min-w-0 items-center gap-2">
-                <Play class="h-5 w-5 text-purple-600" />
-                <div class="max-w-screen-md truncate text-sm font-normal">
-                    {statusIndicator}: {connectorDisplayName}
-                    {#if inputSummary()}
-                        <span class="text-muted-foreground"> ({inputSummary()})</span>
-                    {/if}
-                </div>
-            </div>
-            {#if message.approval}
-                <div
-                    class={cn(
-                        'text-xs font-medium',
-                        ToolApprovalColors[message.approval.status]?.color,
-                    )}>
-                    {message.approval.status}
-                </div>
-            {/if}
-        </div>
-    </div>
 {/if}
+
+{#if showOAuthCard}
+    {#each messages as message (message.toolUse.id)}
+        {#if message.oauthRequired}
+            <div class="mt-2">
+                <OAuthRequiredCard
+                    oauthRequired={message.oauthRequired}
+                    {toolName}
+                    {isAdmin}
+                    onComplete={onOAuthComplete} />
+            </div>
+        {/if}
+    {/each}
+{/if}
+
+<style>
+    :global(.tool-message-accordion [data-slot='accordion-content'][data-state='closed']) {
+        display: none;
+    }
+
+    :global {
+        /* A running tool call stands in for the standalone loading indicator,
+           so it gets the same shine sweep while it is in progress. */
+        .tool-row-shimmer {
+            position: relative;
+            overflow: hidden;
+        }
+
+        .tool-row-shimmer::after {
+            content: '';
+            position: absolute;
+            top: 0;
+            left: -100%;
+            width: 50%;
+            height: 100%;
+            background: linear-gradient(
+                120deg,
+                transparent 0%,
+                rgba(255, 255, 255, 0.6) 50%,
+                transparent 100%
+            );
+            animation: tool-row-shine-sweep 2s ease-in-out infinite;
+            pointer-events: none;
+        }
+
+        .dark .tool-row-shimmer::after {
+            background: linear-gradient(
+                120deg,
+                transparent 0%,
+                rgba(255, 255, 255, 0.3) 50%,
+                transparent 100%
+            );
+        }
+
+        @keyframes tool-row-shine-sweep {
+            0% {
+                left: -100%;
+            }
+            100% {
+                left: 200%;
+            }
+        }
+    }
+</style>

--- a/web/src/lib/types/message.ts
+++ b/web/src/lib/types/message.ts
@@ -54,6 +54,13 @@ export type OAuthRequired = {
 export type ToolMessageContent = {
     id: number
     type: 'tool'
+    // The assistant message that emitted this tool call. Used only to group
+    // calls that were emitted together in one model iteration.
+    batchId?: string
+    // Explicitly set when a tool_result has been received. Some tools return
+    // an empty result, so the presence of result payload is not sufficient.
+    completed?: boolean
+    failed?: boolean
     toolUse: {
         id: string
         name: string
@@ -155,6 +162,10 @@ export type ProcessedMessage = {
     siblingIds?: string[]
     siblingIndex?: number
     createdAt?: Date
+    // Bounds of the raw messages merged into this display message. These are
+    // used to show how long a completed tool-assisted response took.
+    startedAt?: Date
+    completedAt?: Date
     // Present when the assistant turn failed; rendered as an inline error alert.
     error?: ChatStreamError | null
 }

--- a/web/src/lib/types/message.ts
+++ b/web/src/lib/types/message.ts
@@ -51,16 +51,21 @@ export type OAuthRequired = {
     status: OAuthRequiredStatus
 }
 
+export type ToolCallStatus = 'running' | 'completed' | 'failed'
+
+export type ToolActionResult = {
+    toolUseId: string
+    text: string
+}
+
 export type ToolMessageContent = {
     id: number
     type: 'tool'
     // The assistant message that emitted this tool call. Used only to group
     // calls that were emitted together in one model iteration.
     batchId?: string
-    // Explicitly set when a tool_result has been received. Some tools return
-    // an empty result, so the presence of result payload is not sufficient.
-    completed?: boolean
-    failed?: boolean
+    // A single discriminant prevents contradictory completion and failure flags.
+    status: ToolCallStatus
     toolUse: {
         id: string
         name: string
@@ -75,11 +80,7 @@ export type ToolMessageContent = {
         }[]
     }
     // For connector action tools
-    actionResult?: {
-        toolUseId: string
-        text: string
-        isError: boolean
-    }
+    actionResult?: ToolActionResult
     // Approval state for write actions
     approval?: ToolApproval
     // OAuth-required state when a connector tool surfaces needs_user_auth

--- a/web/src/lib/utils/tool-call-display.test.ts
+++ b/web/src/lib/utils/tool-call-display.test.ts
@@ -4,6 +4,7 @@ import {
     formatDuration,
     groupToolCallContent,
     isToolCallComplete,
+    isToolCallFailed,
     splitToolCallContent,
 } from './tool-call-display'
 
@@ -16,6 +17,7 @@ function tool(
     return {
         id: 0,
         type: 'tool',
+        status: 'running',
         batchId,
         toolUse: { id, name, input },
     }
@@ -64,7 +66,14 @@ describe('tool call display helpers', () => {
     it('recognizes empty tool results as complete', () => {
         const message = tool('search-1', 'search', 'assistant-1')
         expect(isToolCallComplete(message)).toBe(false)
-        expect(isToolCallComplete({ ...message, completed: true })).toBe(true)
+        expect(isToolCallComplete({ ...message, status: 'completed' })).toBe(true)
+        expect(isToolCallComplete({ ...message, status: 'failed' })).toBe(true)
+    })
+
+    it('uses failed as the only failure state', () => {
+        const message = tool('search-1', 'search', 'assistant-1')
+        expect(isToolCallFailed(message)).toBe(false)
+        expect(isToolCallFailed({ ...message, status: 'failed' })).toBe(true)
     })
 
     it('formats elapsed work time compactly', () => {

--- a/web/src/lib/utils/tool-call-display.test.ts
+++ b/web/src/lib/utils/tool-call-display.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import type { MessageContent, ToolMessageContent } from '$lib/types/message'
+import {
+    formatDuration,
+    groupToolCallContent,
+    isToolCallComplete,
+    splitToolCallContent,
+} from './tool-call-display'
+
+function tool(
+    id: string,
+    name: string,
+    batchId: string,
+    input: Record<string, unknown> = {},
+): ToolMessageContent {
+    return {
+        id: 0,
+        type: 'tool',
+        batchId,
+        toolUse: { id, name, input },
+    }
+}
+
+describe('tool call display helpers', () => {
+    it('groups same-type calls emitted in one assistant iteration', () => {
+        const content: MessageContent = [
+            tool('search-1', 'search', 'assistant-1', { query: 'alpha' }),
+            tool('search-2', 'search', 'assistant-1', { query: 'beta' }),
+            tool('bash-1', 'run_bash', 'assistant-1', { command: 'pwd' }),
+        ]
+
+        const items = groupToolCallContent(content)
+
+        expect(items).toHaveLength(2)
+        expect(items[0]).toMatchObject({ type: 'tools', group: { toolName: 'search' } })
+        expect(items[0].type === 'tools' && items[0].group.messages).toHaveLength(2)
+        expect(items[1]).toMatchObject({ type: 'tools', group: { toolName: 'run_bash' } })
+    })
+
+    it('keeps same-type calls from later iterations separate', () => {
+        const content: MessageContent = [
+            tool('search-1', 'search', 'assistant-1'),
+            tool('search-2', 'search', 'assistant-2'),
+        ]
+
+        const items = groupToolCallContent(content)
+
+        expect(items).toHaveLength(2)
+    })
+
+    it('puts only text after the final tool into the final response', () => {
+        const content: MessageContent = [
+            { id: 0, type: 'text', text: 'I will look this up.' },
+            tool('search-1', 'search', 'assistant-1'),
+            { id: 2, type: 'text', text: 'Here is the answer.' },
+        ]
+
+        const parts = splitToolCallContent(content)
+
+        expect(parts.work).toHaveLength(2)
+        expect(parts.response).toEqual([{ id: 2, type: 'text', text: 'Here is the answer.' }])
+    })
+
+    it('recognizes empty tool results as complete', () => {
+        const message = tool('search-1', 'search', 'assistant-1')
+        expect(isToolCallComplete(message)).toBe(false)
+        expect(isToolCallComplete({ ...message, completed: true })).toBe(true)
+    })
+
+    it('formats elapsed work time compactly', () => {
+        const start = new Date('2026-01-01T00:00:00.000Z')
+        expect(formatDuration(start, new Date('2026-01-01T00:00:01.000Z'))).toBe('1s')
+        expect(formatDuration(start, new Date('2026-01-01T00:01:10.000Z'))).toBe('1m 10s')
+        expect(formatDuration(start, new Date('2026-01-01T01:00:00.000Z'))).toBe('1h')
+    })
+})

--- a/web/src/lib/utils/tool-call-display.ts
+++ b/web/src/lib/utils/tool-call-display.ts
@@ -74,7 +74,11 @@ export function groupToolCallContent(content: MessageContent): ToolCallDisplayIt
 }
 
 export function isToolCallComplete(message: ToolMessageContent): boolean {
-    return Boolean(message.completed || message.toolResult || message.actionResult)
+    return message.status !== 'running'
+}
+
+export function isToolCallFailed(message: ToolMessageContent): boolean {
+    return message.status === 'failed'
 }
 
 export function formatDuration(start: Date | undefined, end: Date | undefined): string {

--- a/web/src/lib/utils/tool-call-display.ts
+++ b/web/src/lib/utils/tool-call-display.ts
@@ -1,0 +1,95 @@
+import type { MessageContent, TextMessageContent, ToolMessageContent } from '$lib/types/message'
+
+export type ToolCallDisplayGroup = {
+    key: string
+    toolName: string
+    messages: ToolMessageContent[]
+}
+
+export type ToolCallDisplayItem =
+    | { type: 'text'; block: TextMessageContent }
+    | { type: 'tools'; group: ToolCallDisplayGroup }
+
+export type ToolCallContentParts = {
+    work: MessageContent
+    response: TextMessageContent[]
+}
+
+/**
+ * The final assistant text is everything after the last tool call. Text before
+ * a tool call is model narration and belongs to the expandable work history.
+ */
+export function splitToolCallContent(content: MessageContent): ToolCallContentParts {
+    const lastToolIndex = content.findLastIndex((block) => block.type === 'tool')
+
+    if (lastToolIndex === -1) {
+        return {
+            work: [],
+            response: content.filter((block): block is TextMessageContent => block.type === 'text'),
+        }
+    }
+
+    return {
+        work: content.slice(0, lastToolIndex + 1),
+        response: content
+            .slice(lastToolIndex + 1)
+            .filter((block): block is TextMessageContent => block.type === 'text'),
+    }
+}
+
+/**
+ * Groups tool calls emitted by the same assistant message and having the same
+ * tool name. The first occurrence determines the group's position in the
+ * timeline, while later result updates append to the existing group.
+ */
+export function groupToolCallContent(content: MessageContent): ToolCallDisplayItem[] {
+    const items: ToolCallDisplayItem[] = []
+    const groups = new Map<string, ToolCallDisplayGroup>()
+
+    for (const block of content) {
+        if (block.type === 'text') {
+            items.push({ type: 'text', block })
+            continue
+        }
+        if (block.type !== 'tool') continue
+
+        const batchId = block.batchId ?? `tool:${block.toolUse.id}`
+        const key = `${batchId}:${block.toolUse.name}`
+        const existing = groups.get(key)
+        if (existing) {
+            existing.messages.push(block)
+            continue
+        }
+
+        const group: ToolCallDisplayGroup = {
+            key,
+            toolName: block.toolUse.name,
+            messages: [block],
+        }
+        groups.set(key, group)
+        items.push({ type: 'tools', group })
+    }
+
+    return items
+}
+
+export function isToolCallComplete(message: ToolMessageContent): boolean {
+    return Boolean(message.completed || message.toolResult || message.actionResult)
+}
+
+export function formatDuration(start: Date | undefined, end: Date | undefined): string {
+    if (!start || !end) return '0s'
+
+    const seconds = Math.max(0, Math.round((end.getTime() - start.getTime()) / 1000))
+    if (seconds < 60) return `${seconds}s`
+
+    const minutes = Math.floor(seconds / 60)
+    const remainingSeconds = seconds % 60
+    if (minutes < 60) {
+        return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`
+    }
+
+    const hours = Math.floor(minutes / 60)
+    const remainingMinutes = minutes % 60
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m` : `${hours}h`
+}

--- a/web/src/routes/(app)/agents/[agentId]/runs/[runId]/+page.svelte
+++ b/web/src/routes/(app)/agents/[agentId]/runs/[runId]/+page.svelte
@@ -74,6 +74,8 @@
                         const searchResults = resultContent.filter(
                             (b: any) => b.type === 'search_result',
                         )
+                        toolMsg.completed = true
+                        toolMsg.failed = Boolean(block.is_error)
                         if (
                             toolMsg.toolUse.name === 'search' ||
                             toolMsg.toolUse.name === 'web_search'
@@ -188,7 +190,7 @@
                                     </button>
                                 {/if}
                             {:else if block.type === 'tool'}
-                                <ToolMessage message={block.content} />
+                                <ToolMessage messages={[block.content]} />
                             {/if}
                         {/each}
                     </div>

--- a/web/src/routes/(app)/agents/[agentId]/runs/[runId]/+page.svelte
+++ b/web/src/routes/(app)/agents/[agentId]/runs/[runId]/+page.svelte
@@ -54,6 +54,7 @@
                         const toolMsg: ToolMessageContent = {
                             id: 0,
                             type: 'tool',
+                            status: 'running',
                             toolUse: {
                                 id: block.id,
                                 name: block.name,
@@ -74,8 +75,7 @@
                         const searchResults = resultContent.filter(
                             (b: any) => b.type === 'search_result',
                         )
-                        toolMsg.completed = true
-                        toolMsg.failed = Boolean(block.is_error)
+                        toolMsg.status = block.is_error ? 'failed' : 'completed'
                         if (
                             toolMsg.toolUse.name === 'search' ||
                             toolMsg.toolUse.name === 'web_search'
@@ -96,7 +96,6 @@
                             toolMsg.actionResult = {
                                 toolUseId,
                                 text: textBlocks.map((b: any) => b.text).join('\n'),
-                                isError: block.is_error || false,
                             }
                         }
 

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -957,9 +957,7 @@
         const updateToolResults = (toolResult: ToolMessageContent['toolResult']) => {
             if (!toolResult) return
             updateToolBlock(toolResult.toolUseId, (block) =>
-                SEARCH_TOOLS.has(block.toolUse.name)
-                    ? { ...block, toolResult, completed: true }
-                    : block,
+                SEARCH_TOOLS.has(block.toolUse.name) ? { ...block, toolResult } : block,
             )
         }
 
@@ -968,10 +966,11 @@
             text: string
             isError: boolean
         }) => {
+            const { isError, ...result } = actionResult
             updateToolBlock(actionResult.toolUseId, (block) => ({
                 ...block,
-                actionResult,
-                completed: true,
+                actionResult: result,
+                status: isError ? 'failed' : 'completed',
                 oauthRequired: undefined,
             }))
         }
@@ -1117,6 +1116,7 @@
                             const toolMsgContent: ToolMessageContent = {
                                 id: 0,
                                 type: 'tool',
+                                status: 'running',
                                 batchId: chatMsg.id,
                                 toolUse: {
                                     id: block.id,
@@ -1155,10 +1155,6 @@
                             processedMessage.content.push(toolMsgContent)
                         } else if (block.type === 'tool_result') {
                             const toolUseId = block.tool_use_id
-                            updateToolBlock(toolUseId, (toolBlock) => ({
-                                ...toolBlock,
-                                failed: Boolean(block.is_error),
-                            }))
                             const searchResults = Array.isArray(block.content)
                                 ? (block.content.filter(
                                       (b: any) => b.type === 'search_result',
@@ -1237,7 +1233,7 @@
                             } else if (!promptHandled) {
                                 updateToolBlock(toolUseId, (toolBlock) => ({
                                     ...toolBlock,
-                                    completed: true,
+                                    status: block.is_error ? 'failed' : 'completed',
                                 }))
                             }
                         }

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -52,7 +52,6 @@
     import type { MentionedDocument } from '$lib/types/message'
     import { OmniToolResultKind, tryParseOmniEnvelope } from '$lib/types/omni-tool-result'
     import { fetchChatStreamStatus } from '$lib/utils/stream-status'
-    import ToolMessage from '$lib/components/tool-message.svelte'
     import ToolCallsGroup from '$lib/components/tool-calls-group.svelte'
     import { cn } from '$lib/utils'
     import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources'
@@ -276,6 +275,7 @@
 
     const toolVerbMap: Record<string, string[]> = {
         search: ['Searching', 'Looking it up', 'Digging through results'],
+        search_documents: ['Searching', 'Looking it up', 'Digging through results'],
         web_search: ['Searching the web', 'Checking public sources'],
         fetch_web_page: ['Fetching web page', 'Reading web page'],
         read_document: ['Reading document', 'Reviewing document'],
@@ -496,6 +496,22 @@
 
     let processedMessages = $derived(processMessages(chatMessages))
     let lastUserMessageIndex = $derived(processedMessages.findLastIndex((m) => m.role === 'user'))
+    // The streaming assistant message doubles as its own progress indicator once
+    // it has anything visible (a tool call row or response text). Only show the
+    // standalone loader while a response is starting and there is nothing to
+    // display yet.
+    let streamingContentVisible = $derived.by(() => {
+        if (!isStreaming) return false
+        const lastMessage = processedMessages[processedMessages.length - 1]
+        if (!lastMessage || lastMessage.role !== 'assistant') return false
+        return lastMessage.content.some((block) => {
+            if (block.type === 'tool') return true
+            if (block.type === 'text') {
+                return stripThinkingContent(block.text, 'thinking').trim().length > 0
+            }
+            return false
+        })
+    })
     let drawerOpenByKey = $state<Record<string, boolean>>({})
 
     async function copyMessageToClipboard(message: ProcessedMessage) {
@@ -822,12 +838,14 @@
                     ? {
                           ...lastMessage,
                           sourceMessageIds,
-                          renderKey: sourceMessageIds.join('+'),
+                          renderKey: lastMessage.renderKey,
                           origMessageId: message.origMessageId,
                           parentMessageId: message.parentMessageId,
                           siblingIds: message.siblingIds,
                           siblingIndex: message.siblingIndex,
                           createdAt: message.createdAt,
+                          startedAt: lastMessage.startedAt ?? lastMessage.createdAt,
+                          completedAt: message.completedAt ?? message.createdAt,
                           content: [...lastMessage.content],
                           // A later error row that merges into this display
                           // message (e.g. after a tool-call turn) must not lose
@@ -837,7 +855,7 @@
                     : {
                           id: result.length,
                           sourceMessageIds,
-                          renderKey: sourceMessageIds.join('+'),
+                          renderKey: sourceMessageIds[0],
                           origMessageId: message.origMessageId,
                           role: message.role,
                           content: [] as MessageContent,
@@ -845,6 +863,8 @@
                           siblingIds: message.siblingIds,
                           siblingIndex: message.siblingIndex,
                           createdAt: message.createdAt,
+                          startedAt: message.startedAt ?? message.createdAt,
+                          completedAt: message.completedAt ?? message.createdAt,
                           error: message.error ?? null,
                       }
 
@@ -900,7 +920,7 @@
         // pulled from `search_result` content blocks). Search tools render that
         // shape; everything else surfaces output via actionResult / oauthRequired
         // and should stay as a compact status row.
-        const SEARCH_TOOLS = new Set(['search', 'web_search'])
+        const SEARCH_TOOLS = new Set(['search', 'search_documents', 'web_search'])
         const updateToolBlock = (
             toolUseId: string,
             updateBlock: (block: ToolMessageContent) => ToolMessageContent,
@@ -937,7 +957,9 @@
         const updateToolResults = (toolResult: ToolMessageContent['toolResult']) => {
             if (!toolResult) return
             updateToolBlock(toolResult.toolUseId, (block) =>
-                SEARCH_TOOLS.has(block.toolUse.name) ? { ...block, toolResult } : block,
+                SEARCH_TOOLS.has(block.toolUse.name)
+                    ? { ...block, toolResult, completed: true }
+                    : block,
             )
         }
 
@@ -949,6 +971,7 @@
             updateToolBlock(actionResult.toolUseId, (block) => ({
                 ...block,
                 actionResult,
+                completed: true,
                 oauthRequired: undefined,
             }))
         }
@@ -1026,6 +1049,14 @@
                         chatMsg.createdAt instanceof Date
                             ? chatMsg.createdAt
                             : new Date(chatMsg.createdAt),
+                    startedAt:
+                        chatMsg.createdAt instanceof Date
+                            ? chatMsg.createdAt
+                            : new Date(chatMsg.createdAt),
+                    completedAt:
+                        chatMsg.createdAt instanceof Date
+                            ? chatMsg.createdAt
+                            : new Date(chatMsg.createdAt),
                 }
 
                 addMessage(processedUserMessage)
@@ -1042,6 +1073,14 @@
                     siblingIds: info?.siblingIds,
                     siblingIndex: info?.siblingIndex,
                     createdAt:
+                        chatMsg.createdAt instanceof Date
+                            ? chatMsg.createdAt
+                            : new Date(chatMsg.createdAt),
+                    startedAt:
+                        chatMsg.createdAt instanceof Date
+                            ? chatMsg.createdAt
+                            : new Date(chatMsg.createdAt),
+                    completedAt:
                         chatMsg.createdAt instanceof Date
                             ? chatMsg.createdAt
                             : new Date(chatMsg.createdAt),
@@ -1078,6 +1117,7 @@
                             const toolMsgContent: ToolMessageContent = {
                                 id: 0,
                                 type: 'tool',
+                                batchId: chatMsg.id,
                                 toolUse: {
                                     id: block.id,
                                     name: block.name,
@@ -1115,6 +1155,10 @@
                             processedMessage.content.push(toolMsgContent)
                         } else if (block.type === 'tool_result') {
                             const toolUseId = block.tool_use_id
+                            updateToolBlock(toolUseId, (toolBlock) => ({
+                                ...toolBlock,
+                                failed: Boolean(block.is_error),
+                            }))
                             const searchResults = Array.isArray(block.content)
                                 ? (block.content.filter(
                                       (b: any) => b.type === 'search_result',
@@ -1190,6 +1234,11 @@
                                     text,
                                     isError: block.is_error || false,
                                 })
+                            } else if (!promptHandled) {
+                                updateToolBlock(toolUseId, (toolBlock) => ({
+                                    ...toolBlock,
+                                    completed: true,
+                                }))
                             }
                         }
                     }
@@ -1700,6 +1749,10 @@
                             }
                         }
                     } else if (data.type == 'tool_result') {
+                        // The tool has finished; the next visible content will be
+                        // the model's follow-up. Reset the loader verb so the
+                        // transition never echoes the completed tool.
+                        updateThinkingForText()
                         collectStreamingResponse(data)
                     }
 
@@ -2545,6 +2598,10 @@
                                     isStreaming={isStreaming && i === processedMessages.length - 1}
                                     {stripThinkingContent}
                                     isAdmin={data.user.role === 'admin'}
+                                    hasError={Boolean(message.error) ||
+                                        (Boolean(error) && i === processedMessages.length - 1)}
+                                    startedAt={message.startedAt}
+                                    completedAt={message.completedAt}
                                     onOAuthComplete={() => streamResponse(data.chat.id)} />
                             </div>
                             {#if message.error}
@@ -2835,7 +2892,7 @@
                 {/if}
 
                 <!-- Streaming AI Response -->
-                {#if isStreaming || (error && processedMessages[processedMessages.length - 1]?.role !== 'assistant')}
+                {#if (isStreaming && !streamingContentVisible) || (error && processedMessages[processedMessages.length - 1]?.role !== 'assistant')}
                     <div class="flex px-2">
                         {#if error}
                             <Alert.Root variant="destructive" title={error}>


### PR DESCRIPTION
- Group same-tool calls per assistant iteration into compact expandable rows while preserving individual results and artifacts.
- Improve tool-call rendering with search chips, script output, readable responses, OAuth/error states, and non-redundant expanded arguments.
- Use active tool rows as shimmer progress indicators and smoothly transition into the collapsed “Worked for …” summary.
- Support legacy `search_documents` calls so historical chats render correctly after the tool rename.
- Add utility and streaming UI coverage for grouping and completion behavior.