### PR TITLE
fix(ai): isolate model providers and unblock Bedrock calls

### DIFF
--- a/services/ai/db/model_providers.py
+++ b/services/ai/db/model_providers.py
@@ -107,7 +107,7 @@ class ModelsRepository:
                    mp.provider_type, mp.config, mp.updated_at AS provider_updated_at
             FROM models m
             JOIN model_providers mp ON m.model_provider_id = mp.id
-            WHERE m.id = $1
+            WHERE m.id = $1 AND mp.is_deleted = FALSE
         """
         async with pool.acquire() as conn:
             row = await conn.fetchrow(query, model_id)

--- a/services/ai/provider_cache.py
+++ b/services/ai/provider_cache.py
@@ -3,23 +3,21 @@
 Replaces the old in-memory ``app_state.models`` dict that could silently
 drift from the database.  On every request we read the model record (and
 its provider row) from the DB.  The SDK client instance (httpx connection
-pool) is cached by ``model_provider_id`` and reused across requests.
+pool) is cached by model record and reused across requests.
 
-Staleness: the cached entry stores the provider row's ``updated_at``
-timestamp.  If the DB row is newer (admin edited config / rotated key),
-the cached client is discarded and rebuilt automatically.
+Staleness: the cached entry stores the model and provider ``updated_at``
+timestamps. If either DB row is newer, the cached client is discarded and
+rebuilt automatically.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Any
 
-from providers import LLMProvider, ProviderType
-from providers.types import ProviderError
+from providers import LLMProvider
 from db.model_providers import ModelsRepository, ModelRecord
 
 logger = logging.getLogger(__name__)
@@ -29,8 +27,7 @@ logger = logging.getLogger(__name__)
 class ResolvedModel:
     """Result of resolving a model record to a provider client.
 
-    ``provider`` — the cached SDK client (connection pool), shared across
-    all model records under the same provider config.
+    ``provider`` — the cached SDK client for this model record.
     ``model_record_id`` — the ``models.id`` to use in usage tracking.
     ``model_name`` — the wire model string (e.g. ``"claude-haiku-4-5"``)
     to pass into ``stream_response(…, model=…)``.
@@ -44,11 +41,13 @@ class ResolvedModel:
 @dataclass
 class _CachedEntry:
     provider: LLMProvider
+    model_provider_id: str
     provider_updated_at: datetime | None
+    model_updated_at: datetime
 
 
 class ProviderCache:
-    """Cache of LLMProvider SDK clients, keyed by ``model_provider_id``.
+    """Cache of LLMProvider SDK clients, keyed by model record ID.
 
     The database is the source of truth for *which models exist* and *which*
     model to use.  This cache only prevents re-building the httpx connection
@@ -60,7 +59,7 @@ class ProviderCache:
         self._lock = asyncio.Lock()
 
     def _cache_key(self, record: ModelRecord) -> str:
-        return record.model_provider_id
+        return record.id
 
     async def resolve_for_model(self, model_record_id: str) -> ResolvedModel | None:
         """Resolve a model record id to a ``ResolvedModel``.
@@ -116,10 +115,9 @@ class ProviderCache:
     async def _get_or_build(self, record: ModelRecord) -> LLMProvider | None:
         """Return a cached or freshly-built provider for a model record.
 
-        Thread-safe: concurrent callers for the same provider id will
-        serialise on ``_lock`` (intended for burst startup, not steady
-        state — the first call builds the client; subsequent calls find
-        a fresh-enough entry and skip the lock).
+        Thread-safe: concurrent callers for the same model will serialise
+        on ``_lock`` (intended for burst startup, not steady state — the
+        first call builds the client; subsequent calls find a fresh entry).
         """
         key = self._cache_key(record)
 
@@ -140,7 +138,9 @@ class ProviderCache:
 
             self._cache[key] = _CachedEntry(
                 provider=provider,
+                model_provider_id=record.model_provider_id,
                 provider_updated_at=record.provider_updated_at,
+                model_updated_at=record.updated_at,
             )
             logger.info(
                 "Cached provider %s (type=%s, model=%s)",
@@ -149,8 +149,14 @@ class ProviderCache:
             return provider
 
     def invalidate(self, model_provider_id: str) -> None:
-        """Explicitly drop a cached entry (e.g. after admin config edit)."""
-        self._cache.pop(model_provider_id, None)
+        """Drop all cached models belonging to a provider configuration."""
+        keys = [
+            key
+            for key, entry in self._cache.items()
+            if entry.model_provider_id == model_provider_id
+        ]
+        for key in keys:
+            self._cache.pop(key)
 
     def clear(self) -> None:
         """Drop all cached providers (e.g. on full reload)."""
@@ -162,7 +168,10 @@ def _entry_is_fresh(entry: _CachedEntry, record: ModelRecord) -> bool:
     if entry.provider_updated_at is None or record.provider_updated_at is None:
         # No timestamps available — assume stale and rebuild.
         return False
-    return entry.provider_updated_at == record.provider_updated_at
+    return (
+        entry.provider_updated_at == record.provider_updated_at
+        and entry.model_updated_at == record.updated_at
+    )
 
 
 def _build_provider_from_record(record: ModelRecord) -> LLMProvider | None:

--- a/services/ai/providers/bedrock.py
+++ b/services/ai/providers/bedrock.py
@@ -2,6 +2,7 @@
 AWS Bedrock Provider for Claude models.
 """
 
+import asyncio
 import json
 import logging
 import time
@@ -9,7 +10,7 @@ from collections.abc import AsyncIterator
 from typing import Any, ClassVar, cast
 
 import boto3
-from anthropic import APIStatusError, AnthropicBedrock
+from anthropic import APIStatusError, AsyncAnthropicBedrock as AnthropicBedrock
 from anthropic.types import (
     MessageParam,
     Message,
@@ -46,6 +47,16 @@ from .anthropic_message_adapter import (
 from .types import ProviderError, ProviderType
 
 logger = logging.getLogger(__name__)
+
+_STREAM_END = object()
+
+
+def _next_stream_item(iterator: Any) -> Any:
+    """Read one sync stream item without propagating StopIteration via a Future."""
+    try:
+        return next(iterator)
+    except StopIteration:
+        return _STREAM_END
 
 
 def sanitize_document_name(name: str) -> str:
@@ -500,9 +511,12 @@ class BedrockProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         max_tokens: int | None = None,
         system_prompt: str | None = None,
+        *,
+        model: str | None = None,
     ) -> AsyncIterator[MessageStreamEvent]:
         """Stream response from AWS Bedrock models."""
         try:
+            active_model = model or self.model_id
             if self.model_family == "anthropic":
                 msg_list = (
                     build_messages_for_anthropic_api(cast(list[MessageParam], messages))
@@ -512,7 +526,7 @@ class BedrockProvider(LLMProvider):
 
                 # Prepare the request body for Claude models
                 request_params: dict[str, Any] = {
-                    "model": self.model_id,
+                    "model": active_model,
                     "messages": msg_list,
                     "max_tokens": max_tokens or 4096,
                     "stream": True,
@@ -528,7 +542,7 @@ class BedrockProvider(LLMProvider):
                     logger.info(f"[BEDROCK] Sending request without tools")
 
                 logger.info(
-                    f"[BEDROCK] Model: {self.model_id}, Messages: {len(msg_list)}, Max tokens: {request_params['max_tokens']}"
+                    f"[BEDROCK] Model: {active_model}, Messages: {len(msg_list)}, Max tokens: {request_params['max_tokens']}"
                 )
                 logger.debug(
                     f"[BEDROCK] Full request body: {json.dumps({k: v for k, v in request_params.items() if k != 'messages'}, indent=2)}"
@@ -537,19 +551,19 @@ class BedrockProvider(LLMProvider):
 
                 # Invoke with streaming response
                 logger.info(
-                    f"[BEDROCK] Invoking model {self.model_id} with streaming response"
+                    f"[BEDROCK] Invoking model {active_model} with streaming response"
                 )
 
                 if system_prompt:
                     request_params["system"] = system_prompt
 
-                stream = self.client.messages.create(**request_params)
+                stream = await self.client.messages.create(**request_params)
 
                 logger.info(
                     f"[BEDROCK] Stream created successfully, starting to process events"
                 )
                 event_count = 0
-                for event in stream:
+                async for event in stream:
                     event_count += 1
                     logger.debug(f"[ANTHROPIC] Event {event_count}: {event.type}")
                     if event.type == "content_block_start":
@@ -622,11 +636,18 @@ class BedrockProvider(LLMProvider):
                 if tools:
                     request_params["toolConfig"] = {"tools": tools}
 
-                response = self.client.converse_stream(**request_params)
+                response = await asyncio.to_thread(
+                    self.client.converse_stream,
+                    **request_params,
+                )
 
                 logger.info(f"[BEDROCK-AMAZON] Stream created, processing chunks")
                 chunk_count = 0
-                for chunk in response["stream"]:
+                iterator = iter(response["stream"])
+                while True:
+                    chunk = await asyncio.to_thread(_next_stream_item, iterator)
+                    if chunk is _STREAM_END:
+                        break
                     chunk_count += 1
                     logger.debug(
                         f"[BEDROCK-AMAZON] Chunk {chunk_count}: {list(chunk.keys())}"
@@ -683,7 +704,7 @@ class BedrockProvider(LLMProvider):
                 }
 
                 # Invoke the model
-                message = self.client.messages.create(**request_params)
+                message = await self.client.messages.create(**request_params)
 
                 usage = TokenUsage(
                     input_tokens=message.usage.input_tokens,
@@ -708,7 +729,8 @@ class BedrockProvider(LLMProvider):
             elif self.model_family == "amazon":
                 conversation = [{"role": "user", "content": [{"text": prompt}]}]
 
-                response = self.client.converse(
+                response = await asyncio.to_thread(
+                    self.client.converse,
                     modelId=active_model,
                     messages=conversation,
                     inferenceConfig={
@@ -744,19 +766,24 @@ class BedrockProvider(LLMProvider):
         """Check if AWS Bedrock service is accessible."""
         try:
             active_model = model or self.model_id
-            # Try a minimal request to check service accessibility
-            body = {
-                "anthropic_version": "bedrock-2023-05-31",
-                "max_tokens": 1,
-                "messages": [{"role": "user", "content": "Hello"}],
-            }
-
-            response = self.client.invoke_model(
-                modelId=active_model,
-                body=json.dumps(body),
-                contentType="application/json",
-                accept="application/json",
-            )
+            # Use the same async/synchronous client path as normal requests.
+            if self.model_family == "anthropic":
+                await self.client.messages.create(
+                    model=active_model,
+                    messages=[{"role": "user", "content": "Hello"}],
+                    max_tokens=1,
+                )
+            elif self.model_family == "amazon":
+                await asyncio.to_thread(
+                    self.client.converse,
+                    modelId=active_model,
+                    messages=[
+                        {"role": "user", "content": [{"text": "Hello"}]}
+                    ],
+                    inferenceConfig={"maxTokens": 1},
+                )
+            else:
+                return False
             return True
         except Exception:
             return False

--- a/services/ai/tests/integration/test_provider_cache.py
+++ b/services/ai/tests/integration/test_provider_cache.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import pytest
+from ulid import ULID
+
+import db.connection
+import provider_cache
+from provider_cache import ProviderCache
+
+pytestmark = pytest.mark.integration
+
+
+@dataclass
+class FakeProvider:
+    model_id: str
+
+
+@pytest.mark.asyncio
+async def test_model_resolution_is_isolated_and_deleted_providers_are_unresolvable(
+    db_pool, monkeypatch
+):
+    """Exercise DB resolution and caching with two models on one provider."""
+    monkeypatch.setattr(db.connection, "_db_pool", db_pool)
+    provider_id = str(ULID())
+    first_model_id = str(ULID())
+    second_model_id = str(ULID())
+
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO model_providers (id, name, provider_type, config)
+            VALUES ($1, $2, $3, $4::jsonb)
+            """,
+            provider_id,
+            "cache test provider",
+            "anthropic",
+            "{}",
+        )
+        await conn.executemany(
+            """
+            INSERT INTO models (id, model_provider_id, model_id, display_name)
+            VALUES ($1, $2, $3, $4)
+            """,
+            [
+                (first_model_id, provider_id, "model-one", "Model One"),
+                (second_model_id, provider_id, "model-two", "Model Two"),
+            ],
+        )
+
+    monkeypatch.setattr(
+        provider_cache,
+        "_build_provider_from_record",
+        lambda record: FakeProvider(record.model_id),
+    )
+    cache = ProviderCache()
+
+    try:
+        first = await cache.resolve_for_model(first_model_id)
+        second = await cache.resolve_for_model(second_model_id)
+        first_again = await cache.resolve_for_model(first_model_id)
+
+        assert first is not None
+        assert second is not None
+        assert first.provider is not second.provider
+        assert first.provider is first_again.provider
+        assert first.model_name == "model-one"
+        assert second.model_name == "model-two"
+
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE models SET model_id = $1 WHERE id = $2",
+                "model-one-updated",
+                first_model_id,
+            )
+        first_after_model_update = await cache.resolve_for_model(first_model_id)
+        assert first_after_model_update is not None
+        assert first_after_model_update.provider is not first.provider
+        assert first_after_model_update.model_name == "model-one-updated"
+
+        cache.invalidate(provider_id)
+        first_after_invalidation = await cache.resolve_for_model(first_model_id)
+        assert first_after_invalidation is not None
+        assert first_after_invalidation.provider is not first.provider
+
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                "UPDATE model_providers SET is_deleted = TRUE WHERE id = $1",
+                provider_id,
+            )
+
+        assert await cache.resolve_for_model(first_model_id) is None
+    finally:
+        async with db_pool.acquire() as conn:
+            await conn.execute("DELETE FROM models WHERE model_provider_id = $1", provider_id)
+            await conn.execute("DELETE FROM model_providers WHERE id = $1", provider_id)

--- a/services/ai/tests/unit/test_bedrock_provider.py
+++ b/services/ai/tests/unit/test_bedrock_provider.py
@@ -39,14 +39,39 @@ class _RecordingMessagesClient:
     def __init__(self) -> None:
         self.request_params = None
 
-    def create(self, **kwargs):
+    async def create(self, **kwargs):
         self.request_params = kwargs
-        return []
+
+        async def empty_stream():
+            if False:
+                yield None
+
+        return empty_stream()
 
 
 class _RecordingAnthropicBedrockClient:
     def __init__(self) -> None:
         self.messages = _RecordingMessagesClient()
+
+
+class _RecordingAmazonBedrockClient:
+    def __init__(self) -> None:
+        self.request_params = None
+
+    def converse_stream(self, **kwargs):
+        self.request_params = kwargs
+        return {
+            "stream": iter(
+                [
+                    {
+                        "contentBlockDelta": {
+                            "contentBlockIndex": 0,
+                            "delta": {"text": "hello"},
+                        }
+                    }
+                ]
+            )
+        }
 
 
 @pytest.mark.asyncio
@@ -78,6 +103,19 @@ async def test_anthropic_stream_sanitizes_search_result_extras_without_mutating_
     internal_search_result = messages[0]["content"][0]["content"][0]
     assert internal_search_result["source_type"] == "jira"
     assert internal_search_result["internal_extra"] == "must-not-be-sent"
+
+
+@pytest.mark.asyncio
+async def test_amazon_stream_bridges_synchronous_bedrock_iterator():
+    provider = BedrockProvider.__new__(BedrockProvider)
+    provider.model_id = "amazon.nova-lite-v1:0"
+    provider.model_family = "amazon"
+    provider.client = _RecordingAmazonBedrockClient()
+
+    events = [event async for event in provider.stream_response(prompt="hello")]
+
+    assert [event.delta.text for event in events] == ["hello"]
+    assert provider.client.request_params["modelId"] == "amazon.nova-lite-v1:0"
 
 
 def test_amazon_message_adapter_does_not_forward_search_result_extras():


### PR DESCRIPTION
## Summary

- Cache LLM clients by model record instead of provider configuration, preventing different model families from sharing the wrong client or wire protocol.
- Rebuild cached clients when model/provider configuration timestamps change and refuse to resolve models whose provider has been soft-deleted.
- Use the async Anthropic Bedrock client and bridge synchronous boto3 calls/stream iteration through worker threads so Bedrock work does not block the event loop.
- Add one Postgres-backed integration test covering model isolation, cache invalidation, model updates, and deleted-provider resolution.
- Add focused unit coverage for the synchronous Amazon Bedrock stream bridge.

## Tests

- `cd services/ai && uv run pytest -m integration tests/integration/test_provider_cache.py`
- `cd services/ai && uv run pytest -m unit tests/unit/test_bedrock_provider.py`

No live Bedrock integration test is included; these changes do not require Bedrock credentials or API access to validate locally.