### PR TITLE
feat(web): fold completed agent steps and show between-round progress

### DIFF
--- a/web/e2e/chat-stream.spec.ts
+++ b/web/e2e/chat-stream.spec.ts
@@ -156,6 +156,96 @@ function finalAssistantTextSse(text: string): string {
     ].join('')
 }
 
+/**
+ * One agent round: narration text, a search tool call, the persisted assistant
+ * row id, the tool result (flushed by the next message_id), and an optional
+ * pause that opens a deterministic waiting-indicator window in the UI.
+ */
+function agentRoundSse(round: number, narration: string, query: string, gapMs: number): string[] {
+    const toolUseId = `toolu_long_run_${round}`
+    const toolIndex = narration ? 1 : 0
+    return [
+        assistantStart(),
+        ...(narration
+            ? [
+                  sseMessage({
+                      type: 'content_block_start',
+                      index: 0,
+                      content_block: { type: 'text', text: '' },
+                  }),
+                  sseMessage({
+                      type: 'content_block_delta',
+                      index: 0,
+                      delta: { type: 'text_delta', text: narration },
+                  }),
+                  sseMessage({ type: 'content_block_stop', index: 0 }),
+              ]
+            : []),
+        ...assistantSearchToolEvents(toolIndex, toolUseId, query),
+        searchToolResult(toolUseId),
+        `event: message_id\ndata: ${ulid()}\n\n`,
+        gapMs > 0 ? `event: test_sleep\ndata: ${gapMs}\n\n` : '',
+    ]
+}
+
+function longAgentRunSse(gapMs = 8000): string {
+    return [
+        ...agentRoundSse(
+            1,
+            'First, I will search for background context.',
+            'round one query',
+            gapMs,
+        ),
+        ...agentRoundSse(
+            2,
+            'The first results look relevant; searching for details.',
+            'round two query',
+            gapMs,
+        ),
+        ...agentRoundSse(
+            3,
+            'Let me narrow this down with one more search.',
+            'round three query',
+            0,
+        ),
+        ...agentRoundSse(4, 'One more pass over the remaining sources.', 'round four query', 0),
+        ...agentRoundSse(5, 'Almost there, checking the final detail.', 'round five query', 0),
+        ...agentRoundSse(6, '', 'round six query', gapMs),
+        finalAssistantTextSse('Synthetic final answer after six rounds.'),
+        'event: end_of_stream\ndata: {}\n\n',
+    ].join('')
+}
+
+function writeFileToolSse(): string {
+    const toolUseId = `toolu_write_file_${ulid()}`
+
+    return [
+        assistantStart(),
+        sseMessage({
+            type: 'content_block_start',
+            index: 0,
+            content_block: {
+                type: 'tool_use',
+                id: toolUseId,
+                name: 'write_file',
+                input: {},
+            },
+        }),
+        sseMessage({
+            type: 'content_block_delta',
+            index: 0,
+            delta: {
+                type: 'input_json_delta',
+                partial_json: JSON.stringify({ path: 'result.py', content: 'print(42)' }),
+            },
+        }),
+        sseMessage({ type: 'content_block_stop', index: 0 }),
+        sseMessage({ type: 'message_stop' }),
+        `event: message_id\ndata: ${ulid()}\n\n`,
+        'event: test_sleep\ndata: 2000\n\n',
+    ].join('')
+}
+
 function nestedMarkdownSse(): string {
     const chunks = [
         '*   **High-Quality Feedback Loops**\n    *   The Hacker News audience is',
@@ -584,6 +674,90 @@ test('chat page renders streamed assistant markdown from the SSE stream endpoint
     }
 })
 
+test('streaming write-file calls remain visible while they are running', async ({ page }) => {
+    let seeded: SeededChat | null = null
+    const fixtureName = `write-file-${ulid()}.sse`
+    const fixturePath = new URL(`./fixtures/${fixtureName}`, import.meta.url)
+
+    try {
+        seeded = await seedChat()
+        await authenticate(page, seeded)
+        await selectReplayFixture(page, fixtureName)
+        await writeFile(fixturePath, writeFileToolSse())
+
+        await page.goto(`/chat/${seeded.chatId}`)
+        await page.getByRole('main').getByRole('textbox').fill('Write a file')
+        await page.keyboard.press('Enter')
+
+        await expect(page.getByRole('button', { name: 'Writing' })).toBeVisible()
+        await expect
+            .poll(async () =>
+                page
+                    .getByTestId('chat-content')
+                    .evaluate((element) =>
+                        Number.parseFloat(getComputedStyle(element).paddingBottom),
+                    ),
+            )
+            .toBeGreaterThan(0)
+    } finally {
+        await unlink(fixturePath).catch(() => undefined)
+        await cleanupChat(seeded)
+    }
+})
+
+test('long agent runs fold older steps and show a waiting indicator between rounds', async ({
+    page,
+}) => {
+    let seeded: SeededChat | null = null
+    const fixtureName = `long-agent-run-${ulid()}.sse`
+    const fixturePath = new URL(`./fixtures/${fixtureName}`, import.meta.url)
+
+    try {
+        seeded = await seedChat()
+        await authenticate(page, seeded)
+        await selectReplayFixture(page, fixtureName)
+        await writeFile(fixturePath, longAgentRunSse())
+
+        await page.goto(`/chat/${seeded.chatId}`)
+        await page.getByRole('main').getByRole('textbox').fill('Run the long agent journey')
+        await page.keyboard.press('Enter')
+
+        // Once six rounds have completed, only the three latest steps stay
+        // expanded; the older finished rows fold into "3 previous steps".
+        const stepsTrigger = page.getByRole('button', { name: /3 previous steps/ })
+        await expect(stepsTrigger).toBeVisible({ timeout: 20_000 })
+        await expect(
+            page.getByRole('button', { name: /Searched: round one query/ }),
+        ).not.toBeVisible()
+        await expect(
+            page.getByRole('button', { name: /Searched: round three query/ }),
+        ).not.toBeVisible()
+        await expect(page.getByRole('button', { name: /Searched: round four query/ })).toBeVisible()
+        await expect(page.getByRole('button', { name: /Searched: round six query/ })).toBeVisible()
+
+        // In the gap after the last tool result, the shine/rotating-verb
+        // indicator keeps the chat from looking frozen.
+        await expect(page.getByTestId('thinking-indicator')).toBeVisible()
+
+        // Expanding reveals the folded rows.
+        await stepsTrigger.click()
+        await expect(page.getByRole('button', { name: /Searched: round one query/ })).toBeVisible()
+
+        // Once the final response completes, the timeline collapses into the
+        // existing "Worked for X seconds" section instead.
+        await expect(page.getByText('Synthetic final answer after six rounds.')).toBeVisible({
+            timeout: 20_000,
+        })
+        const workedButton = page.getByRole('button', { name: /Worked for/ }).last()
+        await expect(workedButton).toBeVisible({ timeout: 20_000 })
+        await expect(page.getByRole('button', { name: /previous steps/ })).toHaveCount(0)
+        await expect(page.getByTestId('thinking-indicator')).toHaveCount(0)
+    } finally {
+        await unlink(fixturePath).catch(() => undefined)
+        await cleanupChat(seeded)
+    }
+})
+
 test('chat preserves nested streamed Markdown nodes', async ({ page }) => {
     let seeded: SeededChat | null = null
     const fixtureName = `nested-markdown-${ulid()}.sse`
@@ -982,7 +1156,10 @@ test('branched chat groups tool calls and collapses completed work', async ({ pa
         await page.keyboard.press('Enter')
 
         await expect(page.getByText('Replay the failing stream')).toBeVisible()
-        await expect(page.locator('.thinking-container')).toBeVisible()
+        // Once the first tool block arrives it replaces the standalone thinking indicator.
+        await expect(
+            page.getByRole('button', { name: /Searching|Searched|Running|Ran/ }).first(),
+        ).toBeVisible()
 
         await expect(page.getByRole('button', { name: /earlier steps?/ })).toHaveCount(0)
         const workedButton = page.getByRole('button', { name: /Worked for/ }).last()
@@ -994,11 +1171,14 @@ test('branched chat groups tool calls and collapses completed work', async ({ pa
         // The three searches emitted by the first model iteration become one row,
         // and their individual queries/results are available on expansion.
         await workedButton.click()
-        const groupedSearchButton = page.getByRole('button', { name: /searched 3 queries/ })
+        await expect(page.getByRole('button', { name: /Read: Nepanagar/ })).toBeVisible()
+        const groupedSearchButton = page.getByRole('button', { name: /Ran 3 searches/ })
         await expect(groupedSearchButton).toBeVisible()
         await groupedSearchButton.click()
         await expect(page.getByText('Nepanagar NEPA mill township')).toBeVisible()
-        await expect(page.getByText('National Environment Protection Authority')).toBeVisible()
+        await expect(
+            page.getByText('National Environment Protection Authority', { exact: true }),
+        ).toBeVisible()
     } finally {
         await cleanupChat(seeded)
     }
@@ -1045,10 +1225,14 @@ test('branched chat keeps the second streamed assistant response on delayed tool
         await expect(workedButton).toBeVisible()
         await workedButton.click()
         await expect(
-            page.getByText('searched: synthetic recent project status in:team-channel'),
+            page.getByRole('button', {
+                name: /Searched: synthetic recent project status in:team-channel/,
+            }),
         ).toBeVisible()
         await expect(
-            page.getByText('searched: synthetic stakeholder update in:team-channel'),
+            page.getByRole('button', {
+                name: /Searched: synthetic stakeholder update in:team-channel/,
+            }),
         ).toBeVisible()
         await expect(
             page.getByRole('heading', {

--- a/web/src/lib/components/thinking-indicator.svelte
+++ b/web/src/lib/components/thinking-indicator.svelte
@@ -1,0 +1,67 @@
+<script lang="ts">
+    import { themeStore } from '$lib/themes/store.svelte'
+
+    type Props = {
+        text: string
+    }
+
+    let { text }: Props = $props()
+</script>
+
+<span data-testid="thinking-indicator" class="thinking-container flex items-center gap-1.5">
+    <img
+        src={themeStore.current.omniLogoLight}
+        alt="Thinking"
+        class="omni-logo-light thinking-logo !m-0 rounded opacity-60"
+        width="20"
+        height="20" />
+    <img
+        src={themeStore.current.omniLogoDark}
+        alt="Thinking"
+        class="omni-logo-dark thinking-logo !m-0 rounded opacity-60"
+        width="20"
+        height="20" />
+    <span class="text-muted-foreground text-sm">{text}...</span>
+</span>
+
+<style>
+    @keyframes shine-sweep {
+        0% {
+            left: -100%;
+        }
+        100% {
+            left: 200%;
+        }
+    }
+
+    .thinking-container {
+        position: relative;
+        overflow: hidden;
+    }
+
+    .thinking-container::after {
+        content: '';
+        position: absolute;
+        top: 0;
+        left: -100%;
+        width: 50%;
+        height: 100%;
+        background: linear-gradient(
+            120deg,
+            transparent 0%,
+            rgba(255, 255, 255, 0.6) 50%,
+            transparent 100%
+        );
+        animation: shine-sweep 2s ease-in-out infinite;
+        pointer-events: none;
+    }
+
+    :global(.dark) .thinking-container::after {
+        background: linear-gradient(
+            120deg,
+            transparent 0%,
+            rgba(255, 255, 255, 0.3) 50%,
+            transparent 100%
+        );
+    }
+</style>

--- a/web/src/lib/components/tool-calls-group.ssr.test.ts
+++ b/web/src/lib/components/tool-calls-group.ssr.test.ts
@@ -1,0 +1,39 @@
+import { render } from 'svelte/server'
+import { describe, expect, it } from 'vitest'
+import type { MessageContent } from '$lib/types/message'
+import ToolCallsGroup from './tool-calls-group.svelte'
+
+const content: MessageContent = [
+    { id: 0, type: 'text', text: 'I checked the source.' },
+    {
+        id: 1,
+        type: 'tool',
+        status: 'completed',
+        batchId: 'assistant-1',
+        toolUse: {
+            id: 'tool-1',
+            name: 'search',
+            input: { query: 'pipeline' },
+        },
+        toolResult: {
+            toolUseId: 'tool-1',
+            content: [],
+        },
+    },
+    { id: 2, type: 'text', text: 'Here is the answer.' },
+]
+
+describe('ToolCallsGroup SSR', () => {
+    it('renders completed work inside the final summary accordion', () => {
+        const { body } = render(ToolCallsGroup, {
+            props: {
+                content,
+                isStreaming: false,
+                stripThinkingContent: (text: string) => text,
+            },
+        })
+
+        expect(body).toContain('Worked for 0s')
+        expect(body).toContain('Here is the answer.')
+    })
+})

--- a/web/src/lib/components/tool-calls-group.svelte
+++ b/web/src/lib/components/tool-calls-group.svelte
@@ -9,10 +9,12 @@
         groupToolCallContent,
         isToolCallComplete,
         isToolCallFailed,
+        partitionStreamingWork,
         splitToolCallContent,
         type ToolCallDisplayItem,
     } from '$lib/utils/tool-call-display'
     import { fly, slide } from 'svelte/transition'
+    import ThinkingIndicator from './thinking-indicator.svelte'
 
     type Props = {
         content: MessageContent
@@ -23,6 +25,11 @@
         startedAt?: Date
         completedAt?: Date
         onOAuthComplete?: () => void
+        // Rotating verb for the between-rounds waiting indicator, e.g. 'Thinking'.
+        thinkingText?: string | null
+        // The run is live but paused (approval/OAuth card) and the stream flag
+        // is off; keep older steps folded instead of expanding the full list.
+        isPaused?: boolean
     }
 
     type OAuthCardEntry = {
@@ -40,6 +47,8 @@
         startedAt,
         completedAt,
         onOAuthComplete = () => {},
+        thinkingText = null,
+        isPaused = false,
     }: Props = $props()
 
     let workExpanded = $state<string>()
@@ -71,6 +80,16 @@
     let allToolsComplete = $derived(
         toolBlocks.length > 0 && toolBlocks.every((block) => isToolCallComplete(block)),
     )
+    // The model is working between rounds: every tool call has finished, and no
+    // response text has started streaming yet. This replaces the per-row shimmer
+    // while the agent decides what to do next.
+    let awaitingModel = $derived(
+        isStreaming &&
+            allToolsComplete &&
+            !finalResponseBlocks.some(
+                (block) => stripThinkingContent(block.text, 'thinking').trim().length > 0,
+            ),
+    )
     let hasToolError = $derived(toolBlocks.some(isToolCallFailed))
     let canCollapseWork = $derived(
         !isStreaming &&
@@ -80,6 +99,7 @@
             allToolsComplete &&
             hasCollapsibleWork,
     )
+    let streamingPartition = $derived(partitionStreamingWork(workItems, isStreaming || isPaused))
     let duration = $derived(formatDuration(startedAt, completedAt))
 
     function blockRenderKey(block: MessageContent[number]): string {
@@ -91,11 +111,11 @@
         return item.type === 'text' ? `text:${item.block.id}` : item.group.key
     }
 
-    function oauthCardEntries(blocks: MessageContent): OAuthCardEntry[] {
+    function oauthCardEntries(blocks: ToolMessageContent[]): OAuthCardEntry[] {
         const seen: string[] = []
         const entries: OAuthCardEntry[] = []
         for (const block of blocks) {
-            if (block.type !== 'tool' || !block.oauthRequired) continue
+            if (!block.oauthRequired) continue
             const key = `${block.oauthRequired.sourceId}:${block.oauthRequired.provider}`
             if (seen.includes(key)) continue
             seen.push(key)
@@ -107,13 +127,17 @@
         }
         return entries
     }
+
+    function toolBlocksOf(items: ToolCallDisplayItem[]): ToolMessageContent[] {
+        return items.flatMap((item) => (item.type === 'tools' ? item.group.messages : []))
+    }
 </script>
 
-{#snippet workTimeline()}
+{#snippet workTimeline(items = workItems)}
     <div class="space-y-2">
-        {#each workItems as item (workItemKey(item))}
+        {#each items as item (workItemKey(item))}
             {#if item.type === 'text'}
-                <div class="min-w-0 overflow-x-auto">
+                <div class="min-w-0 overflow-x-auto [&_ol]:my-1 [&_p]:my-1 [&_ul]:my-1">
                     <MarkdownMessage
                         content={stripThinkingContent(item.block.text, 'thinking')}
                         citations={item.block.citations}
@@ -131,7 +155,7 @@
                 </div>
             {/if}
         {/each}
-        {#each oauthCardEntries(contentParts.work) as entry (`oauth:${entry.key}`)}
+        {#each oauthCardEntries(toolBlocksOf(items)) as entry (`oauth:${entry.key}`)}
             <div>
                 <OAuthRequiredCard
                     oauthRequired={entry.oauthRequired}
@@ -159,7 +183,33 @@
     </div>
 {:else}
     <div transition:slide={{ duration: 200 }}>
-        <div>{@render workTimeline()}</div>
+        <div class="space-y-2">
+            {#if streamingPartition.collapseActive}
+                <Accordion.Root
+                    type="single"
+                    bind:value={workExpanded}
+                    class="tool-calls-group-accordion">
+                    <Accordion.Item value="steps" class="border-0 [&>h3]:m-0">
+                        <Accordion.Trigger
+                            class="text-muted-foreground hover:text-foreground inline-flex !h-8 !w-fit max-w-full flex-none cursor-pointer !items-center justify-start !gap-1.5 border-0 px-0 !py-1.5 text-sm font-normal whitespace-nowrap hover:no-underline">
+                            {streamingPartition.previousStepsCount} previous step{streamingPartition.previousStepsCount ===
+                            1
+                                ? ''
+                                : 's'}
+                        </Accordion.Trigger>
+                        <Accordion.Content class="border-0 px-0">
+                            <div>{@render workTimeline(streamingPartition.collapsed)}</div>
+                        </Accordion.Content>
+                    </Accordion.Item>
+                </Accordion.Root>
+            {/if}
+            <div>{@render workTimeline(streamingPartition.visible)}</div>
+            {#if awaitingModel}
+                <div class="flex pt-2">
+                    <ThinkingIndicator text={thinkingText ?? 'Thinking'} />
+                </div>
+            {/if}
+        </div>
     </div>
 {/if}
 

--- a/web/src/lib/components/tool-calls-group.svelte
+++ b/web/src/lib/components/tool-calls-group.svelte
@@ -94,7 +94,6 @@
     let canCollapseWork = $derived(
         !isStreaming &&
             !hasError &&
-            !hasToolError &&
             hasFinalResponse &&
             allToolsComplete &&
             hasCollapsibleWork,

--- a/web/src/lib/components/tool-calls-group.svelte
+++ b/web/src/lib/components/tool-calls-group.svelte
@@ -8,7 +8,6 @@
         formatDuration,
         groupToolCallContent,
         isToolCallComplete,
-        isToolCallFailed,
         partitionStreamingWork,
         splitToolCallContent,
         type ToolCallDisplayItem,
@@ -90,13 +89,8 @@
                 (block) => stripThinkingContent(block.text, 'thinking').trim().length > 0,
             ),
     )
-    let hasToolError = $derived(toolBlocks.some(isToolCallFailed))
     let canCollapseWork = $derived(
-        !isStreaming &&
-            !hasError &&
-            hasFinalResponse &&
-            allToolsComplete &&
-            hasCollapsibleWork,
+        !isStreaming && !hasError && hasFinalResponse && allToolsComplete && hasCollapsibleWork,
     )
     let streamingPartition = $derived(partitionStreamingWork(workItems, isStreaming || isPaused))
     let duration = $derived(formatDuration(startedAt, completedAt))
@@ -132,7 +126,7 @@
     }
 </script>
 
-{#snippet workTimeline(items = workItems)}
+{#snippet workTimeline(items)}
     <div class="space-y-2">
         {#each items as item (workItemKey(item))}
             {#if item.type === 'text'}
@@ -175,7 +169,7 @@
                     Worked for {duration}
                 </Accordion.Trigger>
                 <Accordion.Content class="border-0 px-0">
-                    <div>{@render workTimeline()}</div>
+                    <div>{@render workTimeline(workItems)}</div>
                 </Accordion.Content>
             </Accordion.Item>
         </Accordion.Root>

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -54,7 +54,7 @@
         search_documents: { loading: 'Searching', loaded: 'Searched' },
         web_search: { loading: 'Searching web', loaded: 'Searched web' },
         fetch_web_page: { loading: 'Fetching web page', loaded: 'Fetched web page' },
-        read_document: { loading: 'Fetching', loaded: 'Fetched' },
+        read_document: { loading: 'Reading', loaded: 'Read' },
         write_file: { loading: 'Writing', loaded: 'Wrote' },
         read_file: { loading: 'Reading', loaded: 'Read' },
         run_bash: { loading: 'Running', loaded: 'Ran' },
@@ -216,13 +216,19 @@
                   : toolName === 'web_search'
                     ? 'Searching web'
                     : 'Searching'
-            if (messages.length > 1) return `${verb} ${messages.length} queries`
+            if (messages.length > 1) {
+                if (hasError) return `Failed after ${messages.length} searches`
+                if (isComplete && resultCount > 0) return `Ran ${messages.length} searches ·`
+                if (isComplete) return `Ran ${messages.length} searches`
+                return `Running ${messages.length} searches`
+            }
             return `${verb}: ${stringInput(primaryMessage, 'query') ?? 'missing query'}`
         }
 
         const detail = isConnectorAction ? connectorDisplayName : inputSummary(primaryMessage)
         if (!detail) return statusIndicator
         if (isConnectorAction) return `${statusIndicator}: ${detail}`
+        if (toolName === 'read_document') return `${statusIndicator}: ${detail}`
         return selectedItem === accordionKey ? `${statusIndicator} (${detail})` : statusIndicator
     })
 
@@ -337,11 +343,11 @@
                         <img
                             src={themeStore.current.omniLogoLight}
                             alt="Omni"
-                            class="omni-logo-light h-4 w-4 shrink-0 rounded-sm" />
+                            class="omni-logo-light !m-0 h-4 w-4 shrink-0 rounded-sm" />
                         <img
                             src={themeStore.current.omniLogoDark}
                             alt="Omni"
-                            class="omni-logo-dark h-4 w-4 shrink-0 rounded-sm" />
+                            class="omni-logo-dark !m-0 h-4 w-4 shrink-0 rounded-sm" />
                     {:else if isSearch}
                         <Search class="h-4 w-4 shrink-0" />
                     {:else if toolName === 'search_chats'}

--- a/web/src/lib/utils/tool-call-display.test.ts
+++ b/web/src/lib/utils/tool-call-display.test.ts
@@ -5,7 +5,9 @@ import {
     groupToolCallContent,
     isToolCallComplete,
     isToolCallFailed,
+    partitionStreamingWork,
     splitToolCallContent,
+    type ToolCallDisplayItem,
 } from './tool-call-display'
 
 function tool(
@@ -81,5 +83,112 @@ describe('tool call display helpers', () => {
         expect(formatDuration(start, new Date('2026-01-01T00:00:01.000Z'))).toBe('1s')
         expect(formatDuration(start, new Date('2026-01-01T00:01:10.000Z'))).toBe('1m 10s')
         expect(formatDuration(start, new Date('2026-01-01T01:00:00.000Z'))).toBe('1h')
+    })
+})
+
+describe('partitionStreamingWork', () => {
+    function groupItem(
+        id: string,
+        name: string,
+        status: ToolMessageContent['status'] = 'completed',
+    ): Extract<ToolCallDisplayItem, { type: 'tools' }> {
+        return {
+            type: 'tools',
+            group: {
+                key: `${id}:${name}`,
+                toolName: name,
+                messages: [{ ...tool(id, name, `assistant-${id}`, {}), status }],
+            },
+        }
+    }
+
+    function textItem(text: string): Extract<ToolCallDisplayItem, { type: 'text' }> {
+        return { type: 'text', block: { id: 0, type: 'text', text } }
+    }
+
+    it('does not collapse while there are up to four tool groups', () => {
+        const items = [
+            groupItem('g1', 'search'),
+            groupItem('g2', 'read_document'),
+            groupItem('g3', 'search'),
+            groupItem('g4', 'run_bash'),
+        ]
+
+        const partition = partitionStreamingWork(items, true)
+
+        expect(partition.collapseActive).toBe(false)
+        expect(partition.visible).toBe(items)
+        expect(partition.collapsed).toHaveLength(0)
+        expect(partition.previousStepsCount).toBe(0)
+    })
+
+    it('collapses everything before the three latest steps, counting completed groups', () => {
+        const items = [
+            textItem('First narration.'),
+            groupItem('g1', 'search'),
+            textItem('Between one and two.'),
+            groupItem('g2', 'search'),
+            groupItem('g3', 'read_document'),
+            textItem('Leading into the final rounds.'),
+            groupItem('g4', 'search'),
+            groupItem('g5', 'run_bash'),
+            groupItem('g6', 'search'),
+        ]
+
+        const partition = partitionStreamingWork(items, true)
+
+        expect(partition.collapseActive).toBe(true)
+        expect(partition.previousStepsCount).toBe(3)
+        expect(partition.collapsed).toEqual([
+            textItem('First narration.'),
+            groupItem('g1', 'search'),
+            textItem('Between one and two.'),
+            groupItem('g2', 'search'),
+            groupItem('g3', 'read_document'),
+            textItem('Leading into the final rounds.'),
+        ])
+        expect(partition.visible).toEqual([
+            groupItem('g4', 'search'),
+            groupItem('g5', 'run_bash'),
+            groupItem('g6', 'search'),
+        ])
+    })
+
+    it('keeps narrations of the latest steps visible alongside the running group', () => {
+        const items = [
+            groupItem('g1', 'search'),
+            groupItem('g2', 'search'),
+            groupItem('g3', 'search'),
+            groupItem('g4', 'read_document'),
+            textItem('Checking the file now.'),
+            groupItem('g5', 'read_file', 'running'),
+        ]
+
+        const partition = partitionStreamingWork(items, true)
+
+        expect(partition.collapseActive).toBe(true)
+        expect(partition.previousStepsCount).toBe(2)
+        expect(partition.collapsed).toEqual([groupItem('g1', 'search'), groupItem('g2', 'search')])
+        expect(partition.visible).toEqual([
+            groupItem('g3', 'search'),
+            groupItem('g4', 'read_document'),
+            textItem('Checking the file now.'),
+            groupItem('g5', 'read_file', 'running'),
+        ])
+    })
+
+    it('never collapses output when the stream is not active', () => {
+        const items = [
+            groupItem('g1', 'search'),
+            groupItem('g2', 'search'),
+            groupItem('g3', 'search'),
+            groupItem('g4', 'search'),
+            groupItem('g5', 'search'),
+        ]
+
+        const partition = partitionStreamingWork(items, false)
+
+        expect(partition.collapseActive).toBe(false)
+        expect(partition.visible).toBe(items)
     })
 })

--- a/web/src/lib/utils/tool-call-display.ts
+++ b/web/src/lib/utils/tool-call-display.ts
@@ -77,6 +77,53 @@ export function isToolCallComplete(message: ToolMessageContent): boolean {
     return message.status !== 'running'
 }
 
+export type StreamingWorkPartition = {
+    collapseActive: boolean
+    collapsed: ToolCallDisplayItem[]
+    visible: ToolCallDisplayItem[]
+    previousStepsCount: number
+}
+
+function isGroupComplete(group: ToolCallDisplayGroup): boolean {
+    return group.messages.every((message) => isToolCallComplete(message))
+}
+
+/**
+ * While a multi-round agent run is live (streaming, or paused on an
+ * approval/OAuth card that keeps the run open), keep only the newest steps
+ * expanded and fold older completed work into a "N previous steps" section.
+ * Once the run finishes the caller switches to the single "Worked for X
+ * seconds" collapse instead.
+ */
+export function partitionStreamingWork(
+    items: ToolCallDisplayItem[],
+    isLive: boolean,
+): StreamingWorkPartition {
+    const noCollapse: StreamingWorkPartition = {
+        collapseActive: false,
+        collapsed: [],
+        visible: items,
+        previousStepsCount: 0,
+    }
+    if (!isLive) return noCollapse
+
+    const toolGroupIndexes = items
+        .map((item, index) => (item.type === 'tools' ? index : -1))
+        .filter((index) => index !== -1)
+    // Keep up to four completed steps visible before folding older work, and
+    // leave the three latest steps expanded once folding starts.
+    if (toolGroupIndexes.length <= 4) return noCollapse
+
+    const visibleStart = toolGroupIndexes[toolGroupIndexes.length - 3]
+    const collapsed = items.slice(0, visibleStart)
+    const visible = items.slice(visibleStart)
+    const previousStepsCount = collapsed.filter(
+        (item): item is Extract<ToolCallDisplayItem, { type: 'tools' }> =>
+            item.type === 'tools' && isGroupComplete(item.group),
+    ).length
+    return { collapseActive: true, collapsed, visible, previousStepsCount }
+}
+
 export function isToolCallFailed(message: ToolMessageContent): boolean {
     return message.status === 'failed'
 }

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -53,6 +53,7 @@
     import { OmniToolResultKind, tryParseOmniEnvelope } from '$lib/types/omni-tool-result'
     import { fetchChatStreamStatus } from '$lib/utils/stream-status'
     import ToolCallsGroup from '$lib/components/tool-calls-group.svelte'
+    import ThinkingIndicator from '$lib/components/thinking-indicator.svelte'
     import { cn } from '$lib/utils'
     import type { ToolResultBlockParam } from '@anthropic-ai/sdk/resources'
     import * as Tooltip from '$lib/components/ui/tooltip'
@@ -84,7 +85,6 @@
     import MarkdownMessage from '$lib/components/markdown-message.svelte'
     import ImapCitationSource from '$lib/components/search-results/imap-citation-source.svelte'
     import * as Drawer from '$lib/components/ui/drawer'
-    import { themeStore } from '$lib/themes/store.svelte'
     import { formatChatTimestamp } from '$lib/utils/datetime'
 
     let { data }: PageProps = $props()
@@ -492,7 +492,10 @@
     let activeStreamingMessageId = $state<string | null>(null)
     let isAwayFromBottom = $state(false)
     let showTopShadow = $state(false)
-    let bottomPadding = $state(80)
+    // The Tailwind class supplies the minimum. A numeric override is used only when
+    // the scroll position requires more room than the composer spacing provides.
+    let minChatBottomPadding = $state<number | null>(null)
+    let bottomPadding = $state<number | null>(null)
 
     let processedMessages = $derived(processMessages(chatMessages))
     let lastUserMessageIndex = $derived(processedMessages.findLastIndex((m) => m.role === 'user'))
@@ -954,10 +957,15 @@
             }
         }
 
-        const updateToolResults = (toolResult: ToolMessageContent['toolResult']) => {
+        const updateToolResults = (
+            toolResult: ToolMessageContent['toolResult'],
+            isError: boolean,
+        ) => {
             if (!toolResult) return
             updateToolBlock(toolResult.toolUseId, (block) =>
-                SEARCH_TOOLS.has(block.toolUse.name) ? { ...block, toolResult } : block,
+                SEARCH_TOOLS.has(block.toolUse.name)
+                    ? { ...block, toolResult, status: isError ? 'failed' : 'completed' }
+                    : block,
             )
         }
 
@@ -1089,6 +1097,12 @@
                 const contentBlocks = Array.isArray(message.content)
                     ? message.content
                     : [{ type: 'text', text: message.content } as TextBlockParam]
+                const hasToolResult = contentBlocks.some((block) => block.type === 'tool_result')
+
+                // Tool-result rows carry completion data for tool blocks rendered by an
+                // earlier assistant row. Add the empty display row first so those blocks
+                // are available to the result update callbacks below.
+                if (hasToolResult) addMessage(processedMessage)
 
                 for (let blockIdx = 0; blockIdx < contentBlocks.length; blockIdx++) {
                     const block = contentBlocks[blockIdx]
@@ -1160,14 +1174,17 @@
                                       (b: any) => b.type === 'search_result',
                                   ) as SearchResultBlockParam[])
                                 : []
-                            updateToolResults({
-                                toolUseId,
-                                content: searchResults.map((r) => ({
-                                    title: r.title,
-                                    source: r.source,
-                                    source_type: (r as any).source_type ?? null,
-                                })),
-                            })
+                            updateToolResults(
+                                {
+                                    toolUseId,
+                                    content: searchResults.map((r) => ({
+                                        title: r.title,
+                                        source: r.source,
+                                        source_type: (r as any).source_type ?? null,
+                                    })),
+                                },
+                                Boolean(block.is_error),
+                            )
 
                             // Extract text content for non-search tool results (e.g., present_artifact)
                             const textBlocks: TextBlockParam[] = Array.isArray(block.content)
@@ -1240,7 +1257,7 @@
                     }
                 }
 
-                addMessage(processedMessage)
+                if (!hasToolResult) addMessage(processedMessage)
             }
         }
 
@@ -1267,13 +1284,18 @@
     }
 
     function recalcBottomPadding() {
-        if (!lastUserMessageRef || !chatContainerRef) return
+        if (!lastUserMessageRef || !chatContainerRef || !chatContentRef) return
         const containerHeight = chatContainerRef.clientHeight
         const userMsgTop = lastUserMessageRef.offsetTop - chatContainerRef.offsetTop - 24
-        const contentHeight = chatContainerRef.scrollHeight - bottomPadding
+        minChatBottomPadding ??= Number.parseFloat(getComputedStyle(chatContentRef).paddingBottom)
+        if (!Number.isFinite(minChatBottomPadding)) {
+            throw new Error('Chat bottom padding is not a valid computed value')
+        }
+        const currentPadding = bottomPadding ?? minChatBottomPadding
+        const contentHeight = chatContainerRef.scrollHeight - currentPadding
         // Pad so that max scroll aligns the last user message near the top of the viewport (with some breathing room).
-        // Minimum 48px so the final assistant response doesn't sit flush against the input box.
-        bottomPadding = Math.max(48, userMsgTop + containerHeight - contentHeight)
+        const requiredPadding = userMsgTop + containerHeight - contentHeight
+        bottomPadding = requiredPadding > minChatBottomPadding ? requiredPadding : null
     }
 
     function updateScrollState() {
@@ -1354,6 +1376,10 @@
         let streamCompleted = false
         let messageEventsReceived = 0
         let pauseEventReceived = false
+        const pendingToolResults: Array<{
+            block: ToolResultBlockParam
+            targetMessageId: string | null
+        }> = []
         reconnectAttempts = 0
 
         const missingStreamMessageId = (reason: string) => {
@@ -1371,8 +1397,12 @@
                 | ToolResultBlockParam
                 | CitationsDelta,
             blockIdx?: number, // This should be defined for all block types above except ToolResultBlockParam (since this one doesn't come from the LLM)
+            targetMessageIdOverride?: string | null,
         ) => {
-            let targetMessageId = activeStreamingMessageId
+            const targetMessageId =
+                targetMessageIdOverride === undefined
+                    ? activeStreamingMessageId
+                    : targetMessageIdOverride
             let targetMessageIndex = targetMessageId
                 ? chatMessages.findIndex((message) => message.id === targetMessageId)
                 : -1
@@ -1530,12 +1560,48 @@
                     const messageId = (block as ToolResultBlockParam & { message_id?: string })
                         .message_id
                     if (!messageId) {
-                        missingStreamMessageId('tool-result-message')
+                        pendingToolResults.push({
+                            block,
+                            targetMessageId: activeStreamingMessageId,
+                        })
                         return
                     }
                     const displayPath = getDisplayPath(chatMessages)
                     const toolParentId =
-                        displayPath.length > 0 ? displayPath[displayPath.length - 1].id : undefined
+                        targetMessageId ??
+                        (displayPath.length > 0
+                            ? displayPath[displayPath.length - 1].id
+                            : undefined)
+                    const existingToolResultIndex = chatMessages.findIndex(
+                        (message) => message.id === messageId,
+                    )
+                    const targetIsActive = targetMessageId === activeStreamingMessageId
+                    if (existingToolResultIndex !== -1) {
+                        const existingToolResult = chatMessages[existingToolResultIndex]
+                        if (
+                            existingToolResult.message.role !== 'user' ||
+                            !Array.isArray(existingToolResult.message.content)
+                        ) {
+                            throw new Error(`Message id ${messageId} is not a tool-result message`)
+                        }
+                        chatMessages = [
+                            ...chatMessages.slice(0, existingToolResultIndex),
+                            {
+                                ...existingToolResult,
+                                message: {
+                                    ...existingToolResult.message,
+                                    content: [...existingToolResult.message.content, block],
+                                },
+                            },
+                            ...chatMessages.slice(existingToolResultIndex + 1),
+                        ]
+                        if (targetIsActive) {
+                            activeStreamingMessageId = existingToolResult.id
+                            selectBranch(existingToolResult.parentId, existingToolResult.id)
+                        }
+                        return
+                    }
+
                     const toolResultMessage: ChatMessage = {
                         id: messageId,
                         chatId,
@@ -1550,8 +1616,28 @@
                         createdAt: new Date(),
                     }
                     chatMessages = [...chatMessages, toolResultMessage]
-                    activeStreamingMessageId = toolResultMessage.id
-                    selectBranch(toolResultMessage.parentId, toolResultMessage.id)
+                    if (targetIsActive) {
+                        activeStreamingMessageId = toolResultMessage.id
+                        selectBranch(toolResultMessage.parentId, toolResultMessage.id)
+                    } else {
+                        // A follow-up assistant message may have started before the
+                        // previous tool-result id arrived. Reparent that in-flight
+                        // response beneath the newly materialized tool-result row.
+                        const activeMessage = activeStreamingMessageId
+                            ? chatMessages.find(
+                                  (message) => message.id === activeStreamingMessageId,
+                              )
+                            : undefined
+                        if (activeMessage?.parentId === targetMessageId) {
+                            chatMessages = chatMessages.map((message) =>
+                                message.id === activeMessage.id
+                                    ? { ...message, parentId: toolResultMessage.id }
+                                    : message,
+                            )
+                            selectBranch(toolResultMessage.parentId, toolResultMessage.id)
+                            selectBranch(toolResultMessage.id, activeMessage.id)
+                        }
+                    }
                 }
 
                 return
@@ -1590,6 +1676,17 @@
                 streamLastEventId = event.lastEventId || streamLastEventId
                 lastStreamEventAt = Date.now()
                 reconnectAttempts = 0
+
+                const messageId = (event as MessageEvent<string>).data.trim()
+                if (!messageId || pendingToolResults.length === 0) return
+                const pending = pendingToolResults.splice(0)
+                for (const { block, targetMessageId } of pending) {
+                    collectStreamingResponse(
+                        { ...block, message_id: messageId } as ToolResultBlockParam,
+                        undefined,
+                        targetMessageId,
+                    )
+                }
             })
 
             eventSource.addEventListener('not_resumable', () => {
@@ -2541,8 +2638,9 @@
             class="flex h-full w-full flex-col overflow-x-hidden overflow-y-auto px-4 pt-6">
             <div
                 bind:this={chatContentRef}
-                class="mx-auto flex w-full max-w-4xl min-w-0 flex-1 flex-col gap-1"
-                style:padding-bottom="{bottomPadding}px">
+                data-testid="chat-content"
+                class="mx-auto flex w-full max-w-4xl min-w-0 flex-1 flex-col gap-1 pb-20"
+                style:padding-bottom={bottomPadding !== null ? `${bottomPadding}px` : undefined}>
                 {#if data.agent}
                     <div
                         class="bg-muted/50 mb-4 flex items-center justify-between rounded-lg border px-4 py-2">
@@ -2598,7 +2696,10 @@
                                         (Boolean(error) && i === processedMessages.length - 1)}
                                     startedAt={message.startedAt}
                                     completedAt={message.completedAt}
-                                    onOAuthComplete={() => streamResponse(data.chat.id)} />
+                                    onOAuthComplete={() => streamResponse(data.chat.id)}
+                                    {thinkingText}
+                                    isPaused={(Boolean(pendingApproval) || oauthBlockerActive) &&
+                                        i === processedMessages.length - 1} />
                             </div>
                             {#if message.error}
                                 <div class="flex px-2">
@@ -2632,7 +2733,7 @@
                                     .slice(1)
                                     .join('__')}
                                 {@const connectorIcon = getSourceIconPath(connectorName)}
-                                <Card.Root class="gap-0 overflow-hidden py-0">
+                                <Card.Root class="mt-3 gap-0 overflow-hidden py-0">
                                     <!-- Header -->
                                     <Card.Header
                                         class="flex items-center gap-3 border-b px-5 py-3 [.border-b]:py-3">
@@ -2779,9 +2880,6 @@
                                     i !== processedMessages.length - 1 &&
                                         'opacity-0 transition-opacity group-hover:opacity-100',
                                 )}>
-                                {#if message.siblingIds && message.siblingIds.length > 1}
-                                    {@render branchNavigation(message)}
-                                {/if}
                                 {#if !(isStreaming && i === processedMessages.length - 1) && !(error && i === processedMessages.length - 1)}
                                     {@render messageControls(message)}
                                 {/if}
@@ -2794,7 +2892,7 @@
                     {@const connectorName = pendingApproval.tool_name.split('__')[0]}
                     {@const actionName = pendingApproval.tool_name.split('__').slice(1).join('__')}
                     {@const connectorIcon = getSourceIconPath(connectorName)}
-                    <Card.Root class="gap-0 overflow-hidden py-0">
+                    <Card.Root class="mt-3 gap-0 overflow-hidden py-0">
                         <Card.Header
                             class="flex items-center gap-3 border-b px-5 py-3 [.border-b]:py-3">
                             {#if connectorIcon}
@@ -2899,20 +2997,8 @@
                                 {/if}
                             </Alert.Root>
                         {:else if isStreaming}
-                            <span class="thinking-container mt-2 flex items-center gap-1.5">
-                                <img
-                                    src={themeStore.current.omniLogoLight}
-                                    alt="Thinking"
-                                    class="omni-logo-light thinking-logo rounded opacity-60"
-                                    width="20"
-                                    height="20" />
-                                <img
-                                    src={themeStore.current.omniLogoDark}
-                                    alt="Thinking"
-                                    class="omni-logo-dark thinking-logo rounded opacity-60"
-                                    width="20"
-                                    height="20" />
-                                <span class="text-muted-foreground text-sm">{thinkingText}...</span>
+                            <span class="mt-2">
+                                <ThinkingIndicator text={thinkingText} />
                             </span>
                         {/if}
                     </div>
@@ -2987,45 +3073,3 @@
         </div>
     </div>
 </div>
-
-<style>
-    @keyframes shine-sweep {
-        0% {
-            left: -100%;
-        }
-        100% {
-            left: 200%;
-        }
-    }
-
-    .thinking-container {
-        position: relative;
-        overflow: hidden;
-    }
-
-    .thinking-container::after {
-        content: '';
-        position: absolute;
-        top: 0;
-        left: -100%;
-        width: 50%;
-        height: 100%;
-        background: linear-gradient(
-            120deg,
-            transparent 0%,
-            rgba(255, 255, 255, 0.6) 50%,
-            transparent 100%
-        );
-        animation: shine-sweep 2s ease-in-out infinite;
-        pointer-events: none;
-    }
-
-    :global(.dark) .thinking-container::after {
-        background: linear-gradient(
-            120deg,
-            transparent 0%,
-            rgba(255, 255, 255, 0.3) 50%,
-            transparent 100%
-        );
-    }
-</style>


### PR DESCRIPTION
- Collapse completed agent work into “N previous steps” during long live runs, keeping the three latest steps visible and restoring the final “Worked for” summary after completion.
- Show progress between tool rounds and preserve the collapsed view during approval/OAuth pauses.
- Fix streamed tool-result association, grouping, labels, and timeline spacing.
- Prevent tool-rich chats from returning 500 during SSR by passing derived timeline values explicitly; add regression coverage.
- Add unit and end-to-end coverage for streaming collapse and progress states.