### PR TITLE
test(ai): enforce normalized provider contracts

### DIFF
--- a/services/ai/providers/gemini.py
+++ b/services/ai/providers/gemini.py
@@ -29,6 +29,7 @@ from anthropic.types import (
     RawMessageDeltaEvent,
     RawContentBlockStartEvent,
     RawContentBlockDeltaEvent,
+    RawContentBlockStopEvent,
     RawMessageStopEvent,
     ToolUseBlock,
     TextBlock,
@@ -400,6 +401,13 @@ class GeminiProvider(LLMProvider):
 
                     # Handle function call parts
                     elif part.function_call is not None:
+                        if text_started:
+                            yield RawContentBlockStopEvent(
+                                type="content_block_stop",
+                                index=current_text_index,
+                            )
+                            text_started = False
+
                         block_index = next_block_index
                         next_block_index += 1
                         tool_call_id = f"toolu_{time.time_ns()}"
@@ -429,6 +437,16 @@ class GeminiProvider(LLMProvider):
                                     partial_json=json.dumps(dict(args)),
                                 ),
                             )
+                        yield RawContentBlockStopEvent(
+                            type="content_block_stop",
+                            index=block_index,
+                        )
+
+            if text_started:
+                yield RawContentBlockStopEvent(
+                    type="content_block_stop",
+                    index=current_text_index,
+                )
 
             if last_usage_metadata:
                 prompt_tokens = (

--- a/services/ai/providers/openai_compatible.py
+++ b/services/ai/providers/openai_compatible.py
@@ -479,7 +479,8 @@ class OpenAICompatibleProvider(LLMProvider):
 
                 # Handle finish_reason
                 if chunk.choices[0].finish_reason is not None:
-                    break
+                    # Continue through the provider's final usage-only chunk.
+                    continue
 
             # Close any open blocks
             if text_started:

--- a/services/ai/tests/provider_contract.py
+++ b/services/ai/tests/provider_contract.py
@@ -1,0 +1,521 @@
+from __future__ import annotations
+
+import json
+from collections.abc import AsyncIterator, Callable, Sequence
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Protocol
+from unittest.mock import AsyncMock, MagicMock
+
+from anthropic.types import (
+    InputJSONDelta,
+    Message,
+    MessageDeltaUsage,
+    RawContentBlockDeltaEvent,
+    RawContentBlockStartEvent,
+    RawContentBlockStopEvent,
+    RawMessageDeltaEvent,
+    RawMessageStartEvent,
+    RawMessageStopEvent,
+    TextBlock,
+    TextDelta,
+    ToolUseBlock,
+    Usage,
+)
+from anthropic.types.message_stream_event import MessageStreamEvent
+from anthropic.types.raw_message_delta_event import Delta
+
+from providers import LLMProvider, ProviderError, TokenUsage
+from providers.anthropic import AnthropicProvider
+from providers.azure_foundry import AzureFoundryProvider
+from providers.bedrock import BedrockProvider
+from providers.gemini import GeminiProvider
+from providers.openai import OpenAIProvider
+from providers.openai_compatible import OpenAICompatibleProvider
+from providers.types import ProviderType
+from providers.vertex_ai import VertexAIProvider
+
+
+class ContractProvider(Protocol):
+    def stream_response(self, **kwargs: object) -> AsyncIterator[MessageStreamEvent]: ...
+
+    async def generate_response(
+        self, prompt: str, **kwargs: object
+    ) -> tuple[str, TokenUsage]: ...
+
+
+class AsyncEventStream:
+    def __init__(self, events: Sequence[object]) -> None:
+        self.events = events
+
+    def __aiter__(self) -> AsyncIterator[object]:
+        return self._iterate()
+
+    async def _iterate(self) -> AsyncIterator[object]:
+        for event in self.events:
+            yield event
+
+
+@dataclass
+class StreamCase:
+    provider: LLMProvider
+    request: AsyncMock | MagicMock
+    expected_input_tokens: int
+    expected_cache_read_tokens: int = 0
+    request_model_key: str = "model"
+
+
+@dataclass
+class GenerateCase:
+    provider: LLMProvider
+    request: AsyncMock | MagicMock
+    expected_usage: TokenUsage
+    request_model_key: str = "model"
+
+
+_WEATHER_TOOL = {
+    "name": "get_weather",
+    "description": "Get the weather for a city.",
+    "input_schema": {
+        "type": "object",
+        "properties": {"city": {"type": "string"}},
+        "required": ["city"],
+    },
+}
+
+
+def _anthropic_events(model: str = "configured-model") -> list[MessageStreamEvent]:
+    return [
+        RawMessageStartEvent(
+            type="message_start",
+            message=Message(
+                id="msg_test",
+                type="message",
+                role="assistant",
+                content=[],
+                model=model,
+                usage=Usage(input_tokens=0, output_tokens=0),
+            ),
+        ),
+        RawContentBlockStartEvent(
+            type="content_block_start",
+            index=0,
+            content_block=TextBlock(type="text", text=""),
+        ),
+        RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=0,
+            delta=TextDelta(type="text_delta", text="Weather: "),
+        ),
+        RawContentBlockStopEvent(type="content_block_stop", index=0),
+        RawContentBlockStartEvent(
+            type="content_block_start",
+            index=1,
+            content_block=ToolUseBlock(
+                type="tool_use", id="toolu_test", name="get_weather", input={}
+            ),
+        ),
+        RawContentBlockDeltaEvent(
+            type="content_block_delta",
+            index=1,
+            delta=InputJSONDelta(
+                type="input_json_delta", partial_json='{"city":"Bengaluru"}'
+            ),
+        ),
+        RawContentBlockStopEvent(type="content_block_stop", index=1),
+        RawMessageDeltaEvent(
+            type="message_delta",
+            delta=Delta(stop_reason="tool_use"),
+            usage=MessageDeltaUsage(input_tokens=11, output_tokens=7),
+        ),
+        RawMessageStopEvent(type="message_stop"),
+    ]
+
+
+def _openai_response_events() -> list[object]:
+    usage = SimpleNamespace(
+        input_tokens=11,
+        output_tokens=7,
+        input_tokens_details=SimpleNamespace(cached_tokens=0),
+    )
+    response = SimpleNamespace(
+        id="response_test",
+        model="configured-model",
+        usage=usage,
+        error=None,
+    )
+    function_call = SimpleNamespace(
+        type="function_call", id="item_test", call_id="toolu_test", name="get_weather"
+    )
+    return [
+        SimpleNamespace(type="response.created", response=response),
+        SimpleNamespace(type="response.output_text.delta", delta="Weather: "),
+        SimpleNamespace(type="response.output_text.done"),
+        SimpleNamespace(type="response.output_item.added", item=function_call),
+        SimpleNamespace(
+            type="response.function_call_arguments.delta",
+            item_id="item_test",
+            delta='{"city":"Bengaluru"}',
+        ),
+        SimpleNamespace(type="response.output_item.done", item=function_call),
+        SimpleNamespace(type="response.completed", response=response),
+    ]
+
+
+def _openai_compatible_chunks() -> list[object]:
+    def chunk(content=None, tool_calls=None, finish_reason=None, usage=None):
+        delta = SimpleNamespace(content=content, tool_calls=tool_calls)
+        return SimpleNamespace(
+            choices=(
+                []
+                if usage is not None
+                else [SimpleNamespace(delta=delta, finish_reason=finish_reason)]
+            ),
+            usage=usage,
+        )
+
+    first_tool_delta = SimpleNamespace(
+        index=0,
+        id="toolu_test",
+        function=SimpleNamespace(name="get_weather", arguments='{"city":"'),
+    )
+    second_tool_delta = SimpleNamespace(
+        index=0,
+        id=None,
+        function=SimpleNamespace(name=None, arguments='Bengaluru"}'),
+    )
+    return [
+        chunk(content="Weather: "),
+        chunk(tool_calls=[first_tool_delta]),
+        chunk(tool_calls=[second_tool_delta], finish_reason="tool_calls"),
+        chunk(usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7)),
+    ]
+
+
+def _gemini_chunks() -> list[object]:
+    usage = SimpleNamespace(
+        prompt_token_count=11,
+        cached_content_token_count=2,
+        candidates_token_count=7,
+    )
+    text_part = SimpleNamespace(text="Weather: ", function_call=None, thought_signature=None)
+    tool_part = SimpleNamespace(
+        text=None,
+        function_call=SimpleNamespace(
+            name="get_weather", args={"city": "Bengaluru"}
+        ),
+        thought_signature=None,
+    )
+    return [
+        SimpleNamespace(
+            candidates=[
+                SimpleNamespace(
+                    content=SimpleNamespace(parts=[text_part]),
+                )
+            ],
+            usage_metadata=None,
+        ),
+        SimpleNamespace(
+            candidates=[
+                SimpleNamespace(
+                    content=SimpleNamespace(parts=[tool_part]),
+                )
+            ],
+            usage_metadata=usage,
+        ),
+    ]
+
+
+def _bedrock_amazon_events() -> list[dict[str, object]]:
+    return [
+        {"messageStart": {"role": "assistant"}},
+        {
+            "contentBlockStart": {
+                "contentBlockIndex": 0,
+                "start": {},
+            }
+        },
+        {
+            "contentBlockDelta": {
+                "contentBlockIndex": 0,
+                "delta": {"text": "Weather: "},
+            }
+        },
+        {"contentBlockStop": {"contentBlockIndex": 0}},
+        {
+            "contentBlockStart": {
+                "contentBlockIndex": 1,
+                "start": {
+                    "toolUse": {"toolUseId": "toolu_test", "name": "get_weather"}
+                },
+            }
+        },
+        {
+            "contentBlockDelta": {
+                "contentBlockIndex": 1,
+                "delta": {"toolUse": {"input": '{"city":"Bengaluru"}'}},
+            }
+        },
+        {"contentBlockStop": {"contentBlockIndex": 1}},
+        {"metadata": {"usage": {"inputTokens": 11, "outputTokens": 7}}},
+        {"messageStop": {"stopReason": "tool_use"}},
+    ]
+
+
+def _anthropic_stream_case() -> StreamCase:
+    request = AsyncMock(return_value=AsyncEventStream(_anthropic_events()))
+    provider = AnthropicProvider.__new__(AnthropicProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider, "client", SimpleNamespace(messages=SimpleNamespace(create=request))
+    )
+    return StreamCase(provider, request, expected_input_tokens=11)
+
+
+def _openai_stream_case() -> StreamCase:
+    request = AsyncMock(return_value=AsyncEventStream(_openai_response_events()))
+    provider = OpenAIProvider.__new__(OpenAIProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider, "client", SimpleNamespace(responses=SimpleNamespace(create=request))
+    )
+    return StreamCase(provider, request, expected_input_tokens=11)
+
+
+def _openai_compatible_stream_case() -> StreamCase:
+    request = AsyncMock(return_value=AsyncEventStream(_openai_compatible_chunks()))
+    provider = OpenAICompatibleProvider.__new__(OpenAICompatibleProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider,
+        "client",
+        SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=request))),
+    )
+    return StreamCase(provider, request, expected_input_tokens=11)
+
+
+def _gemini_stream_case() -> StreamCase:
+    request = AsyncMock(return_value=AsyncEventStream(_gemini_chunks()))
+    provider = GeminiProvider.__new__(GeminiProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider,
+        "client",
+        SimpleNamespace(
+            aio=SimpleNamespace(models=SimpleNamespace(generate_content_stream=request))
+        ),
+    )
+    return StreamCase(
+        provider,
+        request,
+        expected_input_tokens=9,
+        expected_cache_read_tokens=2,
+    )
+
+
+def _bedrock_anthropic_stream_case() -> StreamCase:
+    request = AsyncMock(return_value=AsyncEventStream(_anthropic_events()))
+    provider = BedrockProvider.__new__(BedrockProvider)
+    provider.model_id = "configured-model"
+    provider.model_name = "configured-model"
+    provider.model_family = "anthropic"
+    object.__setattr__(
+        provider, "client", SimpleNamespace(messages=SimpleNamespace(create=request))
+    )
+    return StreamCase(provider, request, expected_input_tokens=11)
+
+
+def _bedrock_amazon_stream_case() -> StreamCase:
+    request = MagicMock(return_value={"stream": iter(_bedrock_amazon_events())})
+    provider = BedrockProvider.__new__(BedrockProvider)
+    provider.model_id = "configured-model"
+    provider.model_name = "configured-model"
+    provider.model_family = "amazon"
+    object.__setattr__(provider, "client", SimpleNamespace(converse_stream=request))
+    return StreamCase(
+        provider,
+        request,
+        expected_input_tokens=11,
+        request_model_key="modelId",
+    )
+
+
+def stream_cases() -> list[tuple[str, Callable[[], StreamCase]]]:
+    return [
+        ("anthropic", _anthropic_stream_case),
+        ("openai", _openai_stream_case),
+        ("openai-compatible", _openai_compatible_stream_case),
+        ("gemini", _gemini_stream_case),
+        ("bedrock-anthropic", _bedrock_anthropic_stream_case),
+        ("bedrock-amazon", _bedrock_amazon_stream_case),
+    ]
+
+
+def _anthropic_generate_case() -> GenerateCase:
+    request = AsyncMock(
+        return_value=SimpleNamespace(
+            content=[SimpleNamespace(text="Weather: sunny")],
+            usage=SimpleNamespace(
+                input_tokens=11,
+                output_tokens=7,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            ),
+        )
+    )
+    provider = AnthropicProvider.__new__(AnthropicProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider, "client", SimpleNamespace(messages=SimpleNamespace(create=request))
+    )
+    return GenerateCase(provider, request, TokenUsage(11, 7))
+
+
+def _openai_generate_case() -> GenerateCase:
+    request = AsyncMock(
+        return_value=SimpleNamespace(
+            output_text="Weather: sunny",
+            status="completed",
+            usage=SimpleNamespace(
+                input_tokens=11,
+                output_tokens=7,
+                input_tokens_details=SimpleNamespace(cached_tokens=0),
+            ),
+        )
+    )
+    provider = OpenAIProvider.__new__(OpenAIProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider, "client", SimpleNamespace(responses=SimpleNamespace(create=request))
+    )
+    return GenerateCase(provider, request, TokenUsage(11, 7))
+
+
+def _openai_compatible_generate_case() -> GenerateCase:
+    request = AsyncMock(
+        return_value=SimpleNamespace(
+            choices=[SimpleNamespace(message=SimpleNamespace(content="Weather: sunny"))],
+            usage=SimpleNamespace(prompt_tokens=11, completion_tokens=7),
+        )
+    )
+    provider = OpenAICompatibleProvider.__new__(OpenAICompatibleProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider,
+        "client",
+        SimpleNamespace(chat=SimpleNamespace(completions=SimpleNamespace(create=request))),
+    )
+    return GenerateCase(provider, request, TokenUsage(11, 7))
+
+
+def _gemini_generate_case() -> GenerateCase:
+    request = AsyncMock(
+        return_value=SimpleNamespace(
+            text="Weather: sunny",
+            usage_metadata=SimpleNamespace(
+                prompt_token_count=11,
+                cached_content_token_count=2,
+                candidates_token_count=7,
+            ),
+        )
+    )
+    provider = GeminiProvider.__new__(GeminiProvider)
+    provider.model = "configured-model"
+    provider.model_name = "configured-model"
+    object.__setattr__(
+        provider,
+        "client",
+        SimpleNamespace(
+            aio=SimpleNamespace(models=SimpleNamespace(generate_content=request))
+        ),
+    )
+    return GenerateCase(provider, request, TokenUsage(9, 7, cache_read_tokens=2))
+
+
+def _bedrock_anthropic_generate_case() -> GenerateCase:
+    request = AsyncMock(
+        return_value=SimpleNamespace(
+            content=[SimpleNamespace(text="Weather: sunny")],
+            usage=SimpleNamespace(
+                input_tokens=11,
+                output_tokens=7,
+                cache_read_input_tokens=0,
+                cache_creation_input_tokens=0,
+            ),
+        )
+    )
+    provider = BedrockProvider.__new__(BedrockProvider)
+    provider.model_id = "configured-model"
+    provider.model_name = "configured-model"
+    provider.model_family = "anthropic"
+    object.__setattr__(
+        provider, "client", SimpleNamespace(messages=SimpleNamespace(create=request))
+    )
+    return GenerateCase(provider, request, TokenUsage(11, 7))
+
+
+def _bedrock_amazon_generate_case() -> GenerateCase:
+    request = MagicMock(
+        return_value={
+            "usage": {"inputTokens": 11, "outputTokens": 7},
+            "output": {"message": {"content": [{"text": "Weather: sunny"}]}},
+        }
+    )
+    provider = BedrockProvider.__new__(BedrockProvider)
+    provider.model_id = "configured-model"
+    provider.model_name = "configured-model"
+    provider.model_family = "amazon"
+    object.__setattr__(provider, "client", SimpleNamespace(converse=request))
+    return GenerateCase(provider, request, TokenUsage(11, 7), request_model_key="modelId")
+
+
+def generate_cases() -> list[tuple[str, Callable[[], GenerateCase]]]:
+    return [
+        ("anthropic", _anthropic_generate_case),
+        ("openai", _openai_generate_case),
+        ("openai-compatible", _openai_compatible_generate_case),
+        ("gemini", _gemini_generate_case),
+        ("bedrock-anthropic", _bedrock_anthropic_generate_case),
+        ("bedrock-amazon", _bedrock_amazon_generate_case),
+    ]
+
+
+class RecordingDelegate:
+    def __init__(self) -> None:
+        self.stream_kwargs: dict[str, object] | None = None
+        self.generate_kwargs: dict[str, object] | None = None
+        self.stream_events = _anthropic_events()
+        self.error: ProviderError | None = None
+
+    async def stream_response(self, **kwargs: object) -> AsyncIterator[MessageStreamEvent]:
+        self.stream_kwargs = kwargs
+        for event in self.stream_events:
+            yield event
+
+    async def generate_response(self, **kwargs: object) -> tuple[str, TokenUsage]:
+        self.generate_kwargs = kwargs
+        if self.error is not None:
+            raise self.error
+        return "ok", TokenUsage(input_tokens=1, output_tokens=2)
+
+
+def wrapper_cases() -> list[tuple[type[AzureFoundryProvider] | type[VertexAIProvider], ProviderType]]:
+    return [
+        (AzureFoundryProvider, ProviderType.AZURE_FOUNDRY),
+        (VertexAIProvider, ProviderType.VERTEX_AI),
+    ]
+
+
+# Keep this imported here so provider contract tests can use one JSON assertion helper.
+def parse_tool_input(partial_json: str) -> dict[str, object]:
+    value = json.loads(partial_json)
+    if not isinstance(value, dict):
+        raise AssertionError("tool input was not a JSON object")
+    return value

--- a/services/ai/tests/unit/test_provider_contract.py
+++ b/services/ai/tests/unit/test_provider_contract.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import copy
+from collections.abc import Callable
+from typing import cast
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from providers import ProviderError, ProviderType, TokenUsage
+from providers.azure_foundry import AzureFoundryProvider
+from providers.vertex_ai import VertexAIProvider
+from tests.provider_contract import (
+    ContractProvider,
+    GenerateCase,
+    RecordingDelegate,
+    StreamCase,
+    generate_cases,
+    parse_tool_input,
+    stream_cases,
+    wrapper_cases,
+)
+
+pytestmark = pytest.mark.unit
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_name", "case_factory"),
+    stream_cases(),
+    ids=[name for name, _ in stream_cases()],
+)
+async def test_stream_response_normalizes_provider_streams(
+    provider_name: str, case_factory: Callable[[], StreamCase]
+) -> None:
+    case = case_factory()
+    requested_model = "request-time-model"
+    stream_kwargs: dict[str, object] = {
+        "prompt": "Call get_weather for Bengaluru.",
+        "tools": [copy.deepcopy(_weather_tool())],
+        "system_prompt": "Be concise.",
+        "model": requested_model,
+    }
+
+    provider = cast(ContractProvider, case.provider)
+    events = [event async for event in provider.stream_response(**stream_kwargs)]
+    event_types = [event.type for event in events]
+
+    assert event_types[0] == "message_start"
+    assert event_types[-1] == "message_stop"
+    assert event_types.count("message_stop") == 1
+    assert all(
+        event_type
+        in {
+            "message_start",
+            "content_block_start",
+            "content_block_delta",
+            "content_block_stop",
+            "message_delta",
+            "message_stop",
+        }
+        for event_type in event_types
+    ), f"{provider_name} emitted an unknown event"
+
+    started: set[int] = set()
+    stopped: set[int] = set()
+    text_parts: list[str] = []
+    tool_json_parts: list[str] = []
+    tool_block = None
+    message_delta = None
+
+    for event in events:
+        if event.type == "content_block_start":
+            assert event.index not in started
+            started.add(event.index)
+            if event.content_block.type == "tool_use":
+                tool_block = event.content_block
+        elif event.type == "content_block_delta":
+            assert event.index in started
+            assert event.index not in stopped
+            if event.delta.type == "text_delta":
+                text_parts.append(event.delta.text)
+            elif event.delta.type == "input_json_delta":
+                tool_json_parts.append(event.delta.partial_json)
+        elif event.type == "content_block_stop":
+            assert event.index in started
+            assert event.index not in stopped
+            stopped.add(event.index)
+        elif event.type == "message_delta":
+            message_delta = event
+
+    assert started == stopped, f"{provider_name} left a content block open"
+    assert "".join(text_parts) == "Weather: "
+    assert tool_block is not None
+    assert tool_block.id
+    assert tool_block.name == "get_weather"
+    assert parse_tool_input("".join(tool_json_parts)) == {"city": "Bengaluru"}
+    assert message_delta is not None
+    assert message_delta.usage.input_tokens == case.expected_input_tokens
+    assert message_delta.usage.output_tokens == 7
+    assert (getattr(message_delta.usage, "cache_read_input_tokens", 0) or 0) == (
+        case.expected_cache_read_tokens
+    )
+
+    request_kwargs = _request_kwargs(case.request)
+    assert request_kwargs[case.request_model_key] == requested_model
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_name", "case_factory"),
+    generate_cases(),
+    ids=[name for name, _ in generate_cases()],
+)
+async def test_generate_response_returns_text_and_usage(
+    provider_name: str, case_factory: Callable[[], GenerateCase]
+) -> None:
+    case = case_factory()
+    requested_model = "request-time-model"
+    kwargs: dict[str, object] = {
+        "max_tokens": 32,
+        "model": requested_model,
+    }
+
+    provider = cast(ContractProvider, case.provider)
+    text, usage = await provider.generate_response("Summarize the weather.", **kwargs)
+
+    assert text == "Weather: sunny", provider_name
+    assert usage == case.expected_usage
+    request_kwargs = _request_kwargs(case.request)
+    assert request_kwargs[case.request_model_key] == requested_model
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider_class", "provider_type"),
+    wrapper_cases(),
+    ids=[name for name in ("azure-foundry", "vertex-ai")],
+)
+async def test_cloud_wrappers_forward_contract_and_rewrap_errors(
+    provider_class: type[AzureFoundryProvider] | type[VertexAIProvider],
+    provider_type: ProviderType,
+) -> None:
+    delegate = RecordingDelegate()
+    provider = provider_class.__new__(provider_class)
+    provider.model_name = "configured-model"
+    object.__setattr__(provider, "_delegate", delegate)
+    contract_provider = cast(ContractProvider, provider)
+
+    events = [
+        event
+        async for event in contract_provider.stream_response(
+            prompt="hello",
+            max_tokens=32,
+            tools=[copy.deepcopy(_weather_tool())],
+            messages=[{"role": "user", "content": "hello"}],
+            system_prompt="Be concise.",
+            model="request-time-model",
+        )
+    ]
+    assert events == delegate.stream_events
+    assert delegate.stream_kwargs == {
+        "prompt": "hello",
+        "max_tokens": 32,
+        "tools": [
+            {
+                "name": "get_weather",
+                "description": "Get the weather for a city.",
+                "input_schema": {
+                    "type": "object",
+                    "properties": {"city": {"type": "string"}},
+                    "required": ["city"],
+                },
+            }
+        ],
+        "messages": [{"role": "user", "content": "hello"}],
+        "system_prompt": "Be concise.",
+        "model": "request-time-model",
+    }
+
+    assert await contract_provider.generate_response("hello", model="request-time-model") == (
+        "ok",
+        TokenUsage(input_tokens=1, output_tokens=2),
+    )
+    assert delegate.generate_kwargs == {
+        "prompt": "hello",
+        "max_tokens": None,
+        "model": "request-time-model",
+    }
+
+    delegate.error = ProviderError(
+        "delegate failed",
+        provider_type=ProviderType.OPENAI,
+        model="request-time-model",
+        status_code=503,
+        is_context_overflow=True,
+    )
+    with pytest.raises(ProviderError) as raised:
+        await contract_provider.generate_response("hello", model="request-time-model")
+
+    assert raised.value.provider_type is provider_type
+    assert raised.value.message == "delegate failed"
+    assert raised.value.model == "request-time-model"
+    assert raised.value.status_code == 503
+    assert raised.value.is_context_overflow
+
+
+def _weather_tool() -> dict[str, object]:
+    return {
+        "name": "get_weather",
+        "description": "Get the weather for a city.",
+        "input_schema": {
+            "type": "object",
+            "properties": {"city": {"type": "string"}},
+            "required": ["city"],
+        },
+    }
+
+
+def _request_kwargs(request: AsyncMock | MagicMock) -> dict[str, object]:
+    call = request.await_args if isinstance(request, AsyncMock) else request.call_args
+    assert call is not None
+    return dict(call.kwargs)
+


### PR DESCRIPTION
- Add a compact parameterized contract suite covering normalized streaming events and non-streaming text/usage across Anthropic, OpenAI, OpenAI-compatible, Gemini, Bedrock Claude, and Bedrock Nova paths.
- Verify text and tool-call reconstruction, balanced content blocks, usage accounting, completion ordering, request-time model overrides, and cloud-wrapper delegation/error propagation.
- Close Gemini content blocks consistently and consume the final usage-only chunk from OpenAI-compatible streams, fixes surfaced by the shared contract.
- Keep the suite deterministic by mocking SDK responses; real-provider smoke tests remain separate and no live API credentials are required.