### PR TITLE
feat(atlassian): add native Rovo MCP integration

### DIFF
--- a/connectors/atlassian/src/connector.rs
+++ b/connectors/atlassian/src/connector.rs
@@ -1,14 +1,16 @@
+use std::collections::HashMap;
 use std::sync::Arc;
 
-use anyhow::Result;
+use anyhow::{Result, anyhow};
 use async_trait::async_trait;
 use axum::http::StatusCode;
 use axum::response::Response;
 use omni_connector_sdk::{
-    ActionDefinition, ActionMode, ActionResponse, Connector, SearchOperator, ServiceCredential,
-    Source, SourceType, SyncContext, SyncType,
+    ActionDefinition, ActionMode, ActionResponse, Connector, HttpMcpServer, McpCredentials,
+    McpServer, OAuthManifestConfig, OAuthScopeSet, OAuthTokenEndpointAuthMethod, SearchOperator,
+    ServiceCredential, Source, SourceType, SyncContext, SyncType,
 };
-use serde_json::{json, Value as JsonValue};
+use serde_json::{Value as JsonValue, json};
 use tracing::info;
 
 use crate::auth::{AtlassianCredentials, AuthManager};
@@ -21,8 +23,70 @@ pub struct AtlassianConnector {
 }
 
 impl AtlassianConnector {
+    pub const ROVO_MCP_URL: &'static str = "https://mcp.atlassian.com/v1/mcp";
+    pub const ROVO_AUTH_URL: &'static str = "https://mcp.atlassian.com/v1/authorize";
+    pub const ROVO_TOKEN_URL: &'static str = "https://mcp.atlassian.com/v1/token";
+    pub const ROVO_REGISTER_URL: &'static str = "https://mcp.atlassian.com/v1/register";
+    pub const ROVO_PROVIDER: &'static str = "atlassian";
+
     pub fn new(sync_manager: Arc<SyncManager>) -> Self {
         Self { sync_manager }
+    }
+
+    fn rovo_scopes() -> HashMap<String, OAuthScopeSet> {
+        HashMap::from([
+            (
+                "confluence".to_string(),
+                OAuthScopeSet {
+                    read: vec!["read:confluence-content.all".to_string()],
+                    write: vec![
+                        "read:confluence-content.all".to_string(),
+                        "write:confluence-content".to_string(),
+                    ],
+                },
+            ),
+            (
+                "jira".to_string(),
+                OAuthScopeSet {
+                    read: vec!["read:jira-work".to_string()],
+                    write: vec!["read:jira-work".to_string(), "write:jira-work".to_string()],
+                },
+            ),
+        ])
+    }
+
+    fn rovo_oauth_config() -> OAuthManifestConfig {
+        OAuthManifestConfig {
+            provider: Self::ROVO_PROVIDER.to_string(),
+            auth_endpoint: Self::ROVO_AUTH_URL.to_string(),
+            token_endpoint: Self::ROVO_TOKEN_URL.to_string(),
+            userinfo_endpoint: None,
+            userinfo_email_field: "email".to_string(),
+            identity_scopes: vec![],
+            scopes: Self::rovo_scopes(),
+            extra_auth_params: HashMap::from([(
+                "resource".to_string(),
+                Self::ROVO_MCP_URL.to_string(),
+            )]),
+            scope_separator: " ".to_string(),
+            enrich_endpoint: None,
+            registration_endpoint: Some(Self::ROVO_REGISTER_URL.to_string()),
+            token_endpoint_auth_method: OAuthTokenEndpointAuthMethod::None,
+            resource: Some(Self::ROVO_MCP_URL.to_string()),
+        }
+    }
+
+    fn rovo_headers(credentials: &McpCredentials) -> Result<HashMap<String, String>> {
+        let access_token = credentials
+            .credentials
+            .get("access_token")
+            .and_then(|value| value.as_str())
+            .filter(|token| !token.is_empty())
+            .ok_or_else(|| anyhow!("Rovo MCP requires a per-user OAuth access_token"))?;
+        Ok(HashMap::from([(
+            "Authorization".to_string(),
+            format!("Bearer {access_token}"),
+        )]))
     }
 }
 
@@ -54,6 +118,21 @@ impl Connector for AtlassianConnector {
 
     fn sync_modes(&self) -> Vec<SyncType> {
         vec![SyncType::Full, SyncType::Incremental]
+    }
+
+    fn mcp_server(&self) -> Option<McpServer> {
+        Some(McpServer::Http(HttpMcpServer::new(Self::ROVO_MCP_URL)))
+    }
+
+    async fn prepare_mcp_headers(
+        &self,
+        credentials: &McpCredentials,
+    ) -> Result<HashMap<String, String>> {
+        AtlassianConnector::rovo_headers(credentials)
+    }
+
+    fn oauth_config(&self) -> Option<OAuthManifestConfig> {
+        Some(Self::rovo_oauth_config())
     }
 
     fn actions(&self) -> Vec<ActionDefinition> {
@@ -238,5 +317,54 @@ pub async fn handle_search_spaces(
             "Invalid type: {}. Must be 'confluence' or 'jira'",
             search_type
         )),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rovo_oauth_uses_direct_public_client_endpoints() {
+        let config = AtlassianConnector::rovo_oauth_config();
+        assert_eq!(config.provider, "atlassian");
+        assert_eq!(config.auth_endpoint, AtlassianConnector::ROVO_AUTH_URL);
+        assert_eq!(config.token_endpoint, AtlassianConnector::ROVO_TOKEN_URL);
+        assert_eq!(
+            config.registration_endpoint.as_deref(),
+            Some(AtlassianConnector::ROVO_REGISTER_URL)
+        );
+        assert_eq!(
+            config.resource.as_deref(),
+            Some(AtlassianConnector::ROVO_MCP_URL)
+        );
+        assert_eq!(config.userinfo_endpoint, None);
+        assert_eq!(
+            config.token_endpoint_auth_method,
+            OAuthTokenEndpointAuthMethod::None
+        );
+        assert_eq!(
+            config.extra_auth_params.get("resource").map(String::as_str),
+            Some(AtlassianConnector::ROVO_MCP_URL)
+        );
+    }
+
+    #[test]
+    fn rovo_headers_require_only_the_per_user_access_token() {
+        let headers = AtlassianConnector::rovo_headers(&McpCredentials {
+            credentials: json!({"access_token": "user-token", "sa_token": "must-not-be-used"}),
+            ..Default::default()
+        })
+        .unwrap();
+        assert_eq!(headers.get("Authorization").unwrap(), "Bearer user-token");
+        assert!(
+            AtlassianConnector::rovo_headers(&McpCredentials {
+                credentials: json!({"sa_token": "service-token"}),
+                ..Default::default()
+            })
+            .unwrap_err()
+            .to_string()
+            .contains("per-user OAuth access_token")
+        );
     }
 }

--- a/connectors/clickup/clickup_connector/config.py
+++ b/connectors/clickup/clickup_connector/config.py
@@ -4,7 +4,6 @@ CLICKUP_MCP_URL = "https://mcp.clickup.com/mcp"
 CLICKUP_OAUTH_AUTH_ENDPOINT = "https://mcp.clickup.com/oauth/authorize"
 CLICKUP_OAUTH_TOKEN_ENDPOINT = "https://mcp.clickup.com/oauth/token"
 CLICKUP_OAUTH_REGISTRATION_ENDPOINT = "https://mcp.clickup.com/oauth/register"
-CLICKUP_OAUTH_USERINFO_ENDPOINT = "https://api.clickup.com/api/v2/user"
 CLICKUP_OAUTH_SCOPES = ["read", "write"]
 CLICKUP_OAUTH_RESOURCE = CLICKUP_MCP_URL
 

--- a/connectors/clickup/clickup_connector/connector.py
+++ b/connectors/clickup/clickup_connector/connector.py
@@ -26,7 +26,6 @@ from .config import (
     CLICKUP_OAUTH_RESOURCE,
     CLICKUP_OAUTH_SCOPES,
     CLICKUP_OAUTH_TOKEN_ENDPOINT,
-    CLICKUP_OAUTH_USERINFO_ENDPOINT,
 )
 from .mappers import (
     HierarchyLookup,
@@ -155,7 +154,6 @@ class ClickUpConnector(Connector):
             provider="clickup",
             auth_endpoint=CLICKUP_OAUTH_AUTH_ENDPOINT,
             token_endpoint=CLICKUP_OAUTH_TOKEN_ENDPOINT,
-            userinfo_endpoint=CLICKUP_OAUTH_USERINFO_ENDPOINT,
             userinfo_email_field="user.email",
             identity_scopes=[],
             scopes={

--- a/connectors/google/src/connector.rs
+++ b/connectors/google/src/connector.rs
@@ -1571,7 +1571,7 @@ impl Connector for GoogleConnector {
             provider: "google".to_string(),
             auth_endpoint: "https://accounts.google.com/o/oauth2/v2/auth".to_string(),
             token_endpoint: "https://oauth2.googleapis.com/token".to_string(),
-            userinfo_endpoint: "https://www.googleapis.com/oauth2/v3/userinfo".to_string(),
+            userinfo_endpoint: Some("https://www.googleapis.com/oauth2/v3/userinfo".to_string()),
             userinfo_email_field: "email".to_string(),
             identity_scopes: vec!["email".to_string(), "profile".to_string()],
             scopes,

--- a/sdk/python/omni_connector/models.py
+++ b/sdk/python/omni_connector/models.py
@@ -272,7 +272,7 @@ class OAuthManifestConfig(BaseModel):
     provider: str
     auth_endpoint: str
     token_endpoint: str
-    userinfo_endpoint: str
+    userinfo_endpoint: str | None = None
     userinfo_email_field: str = "email"
     identity_scopes: list[str] = Field(default_factory=list)
     scopes: dict[str, OAuthScopeSet] = Field(default_factory=dict)

--- a/sdk/python/tests/test_mcp_server.py
+++ b/sdk/python/tests/test_mcp_server.py
@@ -8,7 +8,11 @@ Supports both transports:
 
 import sys
 
+import anyio
+from mcp import types
 from mcp.server.fastmcp import FastMCP
+from mcp.server.lowlevel import Server
+from mcp.server.stdio import stdio_server
 from mcp.types import ToolAnnotations
 
 server = FastMCP("test")
@@ -38,11 +42,46 @@ def summarize(text: str) -> str:
     return f"Please summarize: {text}"
 
 
+tools_only_server = Server("tools-only")
+
+
+@tools_only_server.list_tools()
+async def list_tools() -> list[types.Tool]:
+    return [
+        types.Tool(
+            name="greet",
+            description="Greet someone",
+            inputSchema={
+                "type": "object",
+                "properties": {"name": {"type": "string"}},
+                "required": ["name"],
+            },
+            annotations=ToolAnnotations(readOnlyHint=True),
+        )
+    ]
+
+
+@tools_only_server.call_tool()
+async def call_tool(name: str, arguments: dict[str, object]) -> list[types.TextContent]:
+    return [types.TextContent(type="text", text=f"Hello, {arguments['name']}!")]
+
+
+async def run_tools_only_server() -> None:
+    async with stdio_server() as (read_stream, write_stream):
+        await tools_only_server.run(
+            read_stream,
+            write_stream,
+            tools_only_server.create_initialization_options(),
+        )
+
+
 if __name__ == "__main__":
     if len(sys.argv) > 1 and sys.argv[1] == "http":
         port = int(sys.argv[2]) if len(sys.argv) > 2 else 8765
         server.settings.host = "127.0.0.1"
         server.settings.port = port
         server.run(transport="streamable-http")
+    elif len(sys.argv) > 1 and sys.argv[1] == "tools-only":
+        anyio.run(run_tools_only_server)
     else:
         server.run(transport="stdio")

--- a/sdk/rust/src/lib.rs
+++ b/sdk/rust/src/lib.rs
@@ -11,9 +11,9 @@ pub use context::SyncContext;
 pub use mcp_adapter::{HttpMcpServer, McpAdapter, McpServer, StdioMcpServer};
 pub use models::{
     ActionRequest, ActionResponse, CancelRequest, CancelResponse, McpCredentials,
-    OAuthManifestConfig, OAuthScopeSet, OAuthTokenEndpointAuthMethod, PromptRequest,
-    ResourceRequest, SkillRequest, SkillResponse, SyncRequest, SyncResponse, SyncStatusResponse,
-    UserRole,
+    OAuthCredentialReadyRequest, OAuthManifestConfig, OAuthScopeSet, OAuthTokenEndpointAuthMethod,
+    PromptRequest, ResourceRequest, SkillRequest, SkillResponse, SyncRequest, SyncResponse,
+    SyncStatusResponse, UserRole,
 };
 pub use server::{ServerConfig, create_router, serve, serve_with_config, serve_with_extra_routes};
 

--- a/sdk/rust/src/mcp_adapter.rs
+++ b/sdk/rust/src/mcp_adapter.rs
@@ -198,8 +198,25 @@ impl McpAdapter {
     ) -> Result<()> {
         let client = self.connect(env, headers).await?;
         let actions = fetch_actions(&client).await?;
-        let resources = fetch_resources(&client).await?;
-        let prompts = fetch_prompts(&client).await?;
+
+        // Tools are the required part of an MCP catalog. Some servers, such
+        // as Atlassian Rovo, implement tools but return Method not found for
+        // optional resources and prompts methods. Do not discard a valid tool
+        // catalog because those optional capabilities are unavailable.
+        let resources = match fetch_resources(&client).await {
+            Ok(resources) => resources,
+            Err(error) => {
+                warn!("MCP resource discovery unavailable; continuing with tools: {error:#}");
+                Vec::new()
+            }
+        };
+        let prompts = match fetch_prompts(&client).await {
+            Ok(prompts) => prompts,
+            Err(error) => {
+                warn!("MCP prompt discovery unavailable; continuing with tools: {error:#}");
+                Vec::new()
+            }
+        };
         let _ = client.cancel().await;
         info!(
             "MCP discovery complete: {} tools, {} resources, {} prompts",

--- a/sdk/rust/src/mcp_adapter.rs
+++ b/sdk/rust/src/mcp_adapter.rs
@@ -3,6 +3,7 @@ use std::path::PathBuf;
 use std::time::Duration;
 
 use anyhow::{Context, Result};
+use rmcp::ServiceExt;
 use rmcp::model::{
     CallToolRequestParams, GetPromptRequestParams, PaginatedRequestParams, PromptMessageContent,
     RawContent, ReadResourceRequestParams, ResourceContents,
@@ -10,7 +11,6 @@ use rmcp::model::{
 use rmcp::service::RunningService;
 use rmcp::transport::streamable_http_client::StreamableHttpClientTransportConfig;
 use rmcp::transport::{StreamableHttpClientTransport, TokioChildProcess};
-use rmcp::ServiceExt;
 use serde_json::Value as JsonValue;
 use shared::models::{
     ActionDefinition, ActionMode, McpPromptArgument, McpPromptDefinition, McpResourceDefinition,
@@ -90,9 +90,34 @@ type RmcpClient = RunningService<rmcp::RoleClient, ()>;
 
 impl McpAdapter {
     pub fn has_cached_catalog(&self) -> bool {
-        self.cached_actions.blocking_read().is_some()
-            || self.cached_resources.blocking_read().is_some()
-            || self.cached_prompts.blocking_read().is_some()
+        self.cached_actions
+            .try_read()
+            .map(|catalog| catalog.is_some())
+            .unwrap_or(false)
+            || self
+                .cached_resources
+                .try_read()
+                .map(|catalog| catalog.is_some())
+                .unwrap_or(false)
+            || self
+                .cached_prompts
+                .try_read()
+                .map(|catalog| catalog.is_some())
+                .unwrap_or(false)
+    }
+
+    pub async fn clear_cached_catalog(&self) {
+        *self.cached_actions.write().await = None;
+        *self.cached_resources.write().await = None;
+        *self.cached_prompts.write().await = None;
+    }
+
+    pub async fn has_cached_action(&self, name: &str) -> bool {
+        self.cached_actions
+            .read()
+            .await
+            .as_ref()
+            .is_some_and(|actions| actions.iter().any(|action| action.name == name))
     }
 
     pub fn new(server: McpServer) -> Self {
@@ -186,6 +211,18 @@ impl McpAdapter {
         *self.cached_resources.write().await = Some(resources);
         *self.cached_prompts.write().await = Some(prompts);
         Ok(())
+    }
+
+    pub async fn get_action_definitions_live(
+        &self,
+        env: Option<HashMap<String, String>>,
+        headers: Option<HashMap<String, String>>,
+    ) -> Result<Vec<ActionDefinition>> {
+        let client = self.connect(env, headers).await?;
+        let actions = fetch_actions(&client).await?;
+        let _ = client.cancel().await;
+        *self.cached_actions.write().await = Some(actions.clone());
+        Ok(actions)
     }
 
     pub async fn get_action_definitions(

--- a/sdk/rust/src/models.rs
+++ b/sdk/rust/src/models.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 pub use shared::models::{
     ActionRequest, ActionResponse, CancelRequest, CancelResponse, McpCredentials, PromptRequest,
     ResourceRequest, SkillRequest, SkillResponse, SyncRequest, SyncResponse, SyncStatusResponse,
@@ -20,9 +21,11 @@ pub struct OAuthManifestConfig {
     pub provider: String,
     pub auth_endpoint: String,
     pub token_endpoint: String,
-    /// GET endpoint that returns a JSON object with the authenticated user's
-    /// email at `userinfo_email_field`.
-    pub userinfo_endpoint: String,
+    /// Optional GET endpoint that returns the authenticated user's email at
+    /// `userinfo_email_field`. Providers without a userinfo endpoint must use
+    /// an explicit trusted identity binding in the OAuth callback.
+    #[serde(default)]
+    pub userinfo_endpoint: Option<String>,
     #[serde(default = "default_email_field")]
     pub userinfo_email_field: String,
     /// Identity-only scopes always added to every authorization request
@@ -77,6 +80,20 @@ pub struct OAuthScopeSet {
     pub read: Vec<String>,
     #[serde(default)]
     pub write: Vec<String>,
+}
+
+/// Notification sent by connector-manager after a user OAuth credential is
+/// stored. Native MCP connectors use it to perform authenticated discovery
+/// and return a refreshed manifest.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct OAuthCredentialReadyRequest {
+    pub source_id: String,
+    #[serde(default)]
+    pub user_id: Option<String>,
+    pub provider: String,
+    pub flow: String,
+    #[serde(default)]
+    pub credentials: JsonValue,
 }
 
 fn default_email_field() -> String {

--- a/sdk/rust/src/models.rs
+++ b/sdk/rust/src/models.rs
@@ -22,8 +22,8 @@ pub struct OAuthManifestConfig {
     pub auth_endpoint: String,
     pub token_endpoint: String,
     /// Optional GET endpoint that returns the authenticated user's email at
-    /// `userinfo_email_field`. Providers without a userinfo endpoint must use
-    /// an explicit trusted identity binding in the OAuth callback.
+    /// `userinfo_email_field`. When absent, the OAuth callback binds the
+    /// credential to the already-authenticated Omni user.
     #[serde(default)]
     pub userinfo_endpoint: Option<String>,
     #[serde(default = "default_email_field")]

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -609,7 +609,9 @@ where
         })?;
 
     if let Err(error) = adapter.discover(env, headers).await {
-        adapter.clear_cached_catalog().await;
+        // Keep any previously authenticated catalog available. A transient
+        // OAuth or MCP failure should not make already-discovered tools
+        // disappear from the connector manifest.
         warn!("OAuth credential-ready MCP discovery failed: {error:#}");
         return Err((
             StatusCode::BAD_REQUEST,

--- a/sdk/rust/src/server.rs
+++ b/sdk/rust/src/server.rs
@@ -3,8 +3,9 @@ use crate::connector::{Connector, SyncRequestValidationError};
 use crate::context::SyncContext;
 use crate::mcp_adapter::{McpAdapter, McpServer};
 use crate::models::{
-    ActionRequest, ActionResponse, CancelRequest, CancelResponse, McpCredentials, PromptRequest,
-    ResourceRequest, SkillRequest, SkillResponse, SyncRequest, SyncResponse, SyncStatusResponse,
+    ActionRequest, ActionResponse, CancelRequest, CancelResponse, McpCredentials,
+    OAuthCredentialReadyRequest, PromptRequest, ResourceRequest, SkillRequest, SkillResponse,
+    SyncRequest, SyncResponse, SyncStatusResponse,
 };
 use anyhow::{Context, Result};
 use axum::{
@@ -179,6 +180,7 @@ where
         .route("/sync", post(trigger_sync::<C>))
         .route("/sync/:sync_run_id", get(sync_status::<C>))
         .route("/cancel", post(cancel_sync::<C>))
+        .route("/oauth/credential-ready", post(oauth_credential_ready::<C>))
         .route("/action", post(execute_action::<C>))
         .route("/resource", post(read_resource::<C>))
         .route("/prompt", post(get_prompt::<C>))
@@ -307,7 +309,16 @@ where
             Ok(mcp_actions) => {
                 let manual: std::collections::HashSet<String> =
                     manifest.actions.iter().map(|a| a.name.clone()).collect();
-                for action in mcp_actions {
+                for mut action in mcp_actions {
+                    if action.source_types.is_empty() {
+                        action.source_types = manifest
+                            .source_types
+                            .iter()
+                            .filter_map(|source_type| {
+                                SourceType::try_from(source_type.as_str()).ok()
+                            })
+                            .collect();
+                    }
                     if !manual.contains(&action.name) {
                         manifest.actions.push(action);
                     }
@@ -568,6 +579,47 @@ where
     )
 }
 
+async fn oauth_credential_ready<C>(
+    State(state): State<Arc<ServerState<C>>>,
+    Json(request): Json<OAuthCredentialReadyRequest>,
+) -> Result<Response, (StatusCode, Json<serde_json::Value>)>
+where
+    C: Connector,
+{
+    let Some(adapter) = state.mcp_adapter() else {
+        return Ok((StatusCode::NO_CONTENT, "").into_response());
+    };
+
+    let credentials: McpCredentials =
+        serde_json::from_value(request.credentials).map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({
+                    "error": format!("Invalid MCP OAuth credentials: {error}")
+                })),
+            )
+        })?;
+    let (env, headers) = build_mcp_auth(&*state.connector, &credentials)
+        .await
+        .map_err(|error| {
+            (
+                StatusCode::BAD_REQUEST,
+                Json(serde_json::json!({ "error": error.to_string() })),
+            )
+        })?;
+
+    if let Err(error) = adapter.discover(env, headers).await {
+        adapter.clear_cached_catalog().await;
+        warn!("OAuth credential-ready MCP discovery failed: {error:#}");
+        return Err((
+            StatusCode::BAD_REQUEST,
+            Json(serde_json::json!({ "error": error.to_string() })),
+        ));
+    }
+
+    Ok(Json(build_manifest_with_mcp(&state).await).into_response())
+}
+
 async fn execute_action<C>(
     State(state): State<Arc<ServerState<C>>>,
     Json(request): Json<ActionRequest>,
@@ -597,21 +649,48 @@ where
             }
         };
         match adapter
-            .get_action_definitions(env.clone(), headers.clone())
+            .get_action_definitions_live(env.clone(), headers.clone())
             .await
         {
-            Ok(actions) if actions.iter().any(|a| a.name == request.action) => {
-                let response = adapter
-                    .execute_tool(&request.action, request.params.clone(), env, headers)
-                    .await;
-                let status = match response.status.as_str() {
-                    "success" => StatusCode::OK,
-                    _ => StatusCode::BAD_REQUEST,
-                };
-                return Ok(response.into_response_with_status(status));
+            Ok(actions) => {
+                if let Some(action) = actions.iter().find(|a| a.name == request.action) {
+                    let source_read_only = request
+                        .source
+                        .as_ref()
+                        .and_then(|source| source.config.get("read_only"))
+                        .and_then(|value| value.as_bool())
+                        .unwrap_or(false);
+                    if (state.connector.read_only() || source_read_only)
+                        && action.mode == shared::models::ActionMode::Write
+                    {
+                        return Ok(ActionResponse::failure(format!(
+                            "Action '{}' is not allowed: source is read-only",
+                            request.action
+                        ))
+                        .into_response_with_status(StatusCode::BAD_REQUEST));
+                    }
+                    let response = adapter
+                        .execute_tool(&request.action, request.params.clone(), env, headers)
+                        .await;
+                    let status = match response.status.as_str() {
+                        "success" => StatusCode::OK,
+                        _ => StatusCode::BAD_REQUEST,
+                    };
+                    return Ok(response.into_response_with_status(status));
+                }
             }
-            Ok(_) => { /* not an MCP tool — fall through */ }
-            Err(e) => warn!("MCP action lookup failed; falling back to connector: {}", e),
+            Err(e) => {
+                // Never execute a cached MCP action after live validation fails.
+                // Falling through is safe only for connector-defined actions.
+                if adapter.has_cached_action(&request.action).await {
+                    return Ok(ActionResponse::failure(format!(
+                        "MCP action '{}' could not be validated: {}",
+                        request.action, e
+                    ))
+                    .into_response_with_status(StatusCode::BAD_REQUEST));
+                }
+                warn!("MCP action lookup failed; falling back to connector: {}", e);
+            }
         }
     }
 

--- a/sdk/rust/tests/mcp_adapter_test.rs
+++ b/sdk/rust/tests/mcp_adapter_test.rs
@@ -29,6 +29,13 @@ fn stdio_server() -> StdioMcpServer {
         .with_args([fixture_path().to_string_lossy().into_owned()])
 }
 
+fn tools_only_stdio_server() -> StdioMcpServer {
+    StdioMcpServer::new(python_executable()).with_args([
+        fixture_path().to_string_lossy().into_owned(),
+        "tools-only".to_string(),
+    ])
+}
+
 struct HttpFixture {
     child: Child,
     url: String,
@@ -184,6 +191,33 @@ async fn stdio_caches_after_discover() {
     assert_eq!(resources.len(), 1);
     let prompts = adapter.get_prompt_definitions(None, None).await.unwrap();
     assert_eq!(prompts.len(), 1);
+}
+
+#[tokio::test]
+async fn discover_keeps_tools_when_optional_methods_are_unsupported() {
+    let adapter = McpAdapter::new(McpServer::Stdio(tools_only_stdio_server()));
+    adapter
+        .discover(Some(HashMap::new()), None)
+        .await
+        .expect("tool discovery should not depend on optional MCP methods");
+
+    let actions = adapter.get_action_definitions(None, None).await.unwrap();
+    assert_eq!(actions.len(), 1);
+    assert_eq!(actions[0].name, "greet");
+    assert!(
+        adapter
+            .get_resource_definitions(None, None)
+            .await
+            .unwrap()
+            .is_empty()
+    );
+    assert!(
+        adapter
+            .get_prompt_definitions(None, None)
+            .await
+            .unwrap()
+            .is_empty()
+    );
 }
 
 #[tokio::test]

--- a/sdk/typescript/src/connector.ts
+++ b/sdk/typescript/src/connector.ts
@@ -145,8 +145,16 @@ export abstract class Connector<
       return manualActions;
     }
     const mcpActions = await adapter.getActionDefinitions();
+    const inheritedActions = mcpActions.map((action) =>
+      action.source_types.length === 0
+        ? { ...action, source_types: this.sourceTypes }
+        : action
+    );
     const manualNames = new Set(manualActions.map((a) => a.name));
-    return [...manualActions, ...mcpActions.filter((a) => !manualNames.has(a.name))];
+    return [
+      ...manualActions,
+      ...inheritedActions.filter((a) => !manualNames.has(a.name)),
+    ];
   }
 
   async getManifest(connectorUrl: string): Promise<ConnectorManifest> {
@@ -218,12 +226,28 @@ export abstract class Connector<
   ): Promise<Response> {
     const adapter = await this.getMcpAdapter();
     if (adapter) {
-      const { env, headers } = this.prepareMcpAuth(credentials);
-      const mcpActions = await adapter.getActionDefinitions(env, headers);
-      const mcpToolNames = new Set(mcpActions.map((a) => a.name));
-      if (mcpToolNames.has(action)) {
-        const response = await adapter.executeTool(action, params, env, headers);
-        return response.toResponse();
+      try {
+        const { env, headers } = this.prepareMcpAuth(credentials);
+        const mcpActions = await adapter.getActionDefinitionsLive(env, headers);
+        const mcpAction = mcpActions.find((definition) => definition.name === action);
+        if (mcpAction) {
+          const sourceReadOnly = source?.config?.read_only === true;
+          if (sourceReadOnly && mcpAction.mode === 'write') {
+            return ActionResponse.failure(
+              `Action '${action}' is not allowed: source is read-only`
+            ).toResponse(400);
+          }
+          const response = await adapter.executeTool(action, params, env, headers);
+          return response.toResponse();
+        }
+      } catch (err) {
+        if (adapter.hasCachedAction(action)) {
+          const message = err instanceof Error ? err.message : String(err);
+          return ActionResponse.failure(
+            `MCP action '${action}' could not be validated: ${message}`
+          ).toResponse(400);
+        }
+        logger.warn({ err }, `MCP action lookup failed for ${action}`);
       }
     }
     return ActionResponse.notSupported(action).toResponse(404);

--- a/sdk/typescript/src/mcp-adapter.ts
+++ b/sdk/typescript/src/mcp-adapter.ts
@@ -63,6 +63,10 @@ export class McpAdapter {
     );
   }
 
+  hasCachedAction(name: string): boolean {
+    return this.cachedActions?.some((action) => action.name === name) ?? false;
+  }
+
   clearCachedCatalog(): void {
     this.cachedActions = null;
     this.cachedResources = null;
@@ -135,6 +139,17 @@ export class McpAdapter {
         `${catalog.resources.length} resources, ` +
         `${catalog.prompts.length} prompts`
     );
+  }
+
+  async getActionDefinitionsLive(
+    env?: Record<string, string>,
+    headers?: Record<string, string>
+  ): Promise<ActionDefinition[]> {
+    const actions = await this.withSession(env, headers, (c) =>
+      this.fetchActions(c)
+    );
+    this.cachedActions = actions;
+    return actions;
   }
 
   async getActionDefinitions(

--- a/sdk/typescript/src/models.ts
+++ b/sdk/typescript/src/models.ts
@@ -198,7 +198,7 @@ export const OAuthManifestConfigSchema = z.object({
   provider: z.string(),
   auth_endpoint: z.string(),
   token_endpoint: z.string(),
-  userinfo_endpoint: z.string(),
+  userinfo_endpoint: z.string().optional(),
   userinfo_email_field: z.string().default('email'),
   identity_scopes: z.array(z.string()).default([]),
   scopes: z.record(OAuthScopeSetSchema).default({}),

--- a/sdk/typescript/tests/mcp-adapter.test.ts
+++ b/sdk/typescript/tests/mcp-adapter.test.ts
@@ -242,6 +242,9 @@ describe('Connector MCP integration', () => {
     const actionNames = manifest.actions.map((a) => a.name);
     expect(actionNames).toContain('greet');
     expect(actionNames).toContain('add');
+    expect(manifest.actions.find((action) => action.name === 'greet')?.source_types).toEqual([
+      'mcp_test',
+    ]);
     expect(manifest.resources).toHaveLength(1);
     expect(manifest.prompts).toHaveLength(1);
   });

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -609,6 +609,16 @@ pub async fn execute_action(
         let action_admin_only = action_def.admin_only;
         let action_mode = action_def.mode;
 
+        // Native MCP tools are always user-authorized. Keep admin-only
+        // connector actions (such as Atlassian indexing helpers) on their
+        // existing org-credential path, but never dispatch an MCP action with
+        // an org service-account credential when there is no actor.
+        if manifest.mcp_enabled && !action_admin_only && request.user_id.is_none() {
+            return Err(ApiError::BadRequest(
+                "user_id is required for native MCP actions".to_string(),
+            ));
+        }
+
         // Generic read_only enforcement — the source config is the authority.
         let source_read_only = db_source
             .config
@@ -1201,17 +1211,61 @@ pub async fn read_resource(
             ))
         })?;
 
-    let cred_service = CredentialService::new(state.db_pool.clone());
-    let creds = cred_service
-        .get_owner_credential(&source)
+    let native_manifest = get_registered_manifests(&state.redis_client)
         .await
-        .map_err(|e| ApiError::Internal(e.to_string()))?
-        .ok_or_else(|| {
-            ApiError::NotFound(format!(
-                "Credentials not found for source: {}",
-                request.source_id
-            ))
-        })?;
+        .into_iter()
+        .find(|manifest| {
+            manifest.integration_type == IntegrationType::Connector
+                && manifest.source_types.contains(&source.source_type)
+        });
+    let native_mcp = native_manifest
+        .as_ref()
+        .is_some_and(|manifest| manifest.mcp_enabled);
+    if native_mcp && request.user_id.is_none() {
+        return Err(ApiError::BadRequest(
+            "user_id is required for native MCP resources".to_string(),
+        ));
+    }
+
+    let cred_service = CredentialService::new(state.db_pool.clone());
+    let creds = if native_mcp {
+        match resolve_credentials(
+            &cred_service,
+            &source.id,
+            request.user_id.as_deref(),
+            false,
+            true,
+        )
+        .await?
+        {
+            CredentialResolution::Resolved(credentials) => credentials,
+            CredentialResolution::NeedsUserAuth { provider } => {
+                return Err(ApiError::PreconditionFailedJson(json!({
+                    "error": "needs_user_auth",
+                    "source_id": source.id,
+                    "source_type": source.source_type,
+                    "provider": provider,
+                })));
+            }
+            CredentialResolution::NoCredentials => {
+                return Err(ApiError::NotFound(format!(
+                    "Credentials not found for source: {}",
+                    request.source_id
+                )));
+            }
+        }
+    } else {
+        cred_service
+            .get_owner_credential(&source)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?
+            .ok_or_else(|| {
+                ApiError::NotFound(format!(
+                    "Credentials not found for source: {}",
+                    request.source_id
+                ))
+            })?
+    };
 
     let client = ConnectorClient::new();
     let resource_request = ResourceRequest {
@@ -1286,17 +1340,61 @@ pub async fn get_prompt(
             ))
         })?;
 
-    let cred_service = CredentialService::new(state.db_pool.clone());
-    let creds = cred_service
-        .get_owner_credential(&source)
+    let native_manifest = get_registered_manifests(&state.redis_client)
         .await
-        .map_err(|e| ApiError::Internal(e.to_string()))?
-        .ok_or_else(|| {
-            ApiError::NotFound(format!(
-                "Credentials not found for source: {}",
-                request.source_id
-            ))
-        })?;
+        .into_iter()
+        .find(|manifest| {
+            manifest.integration_type == IntegrationType::Connector
+                && manifest.source_types.contains(&source.source_type)
+        });
+    let native_mcp = native_manifest
+        .as_ref()
+        .is_some_and(|manifest| manifest.mcp_enabled);
+    if native_mcp && request.user_id.is_none() {
+        return Err(ApiError::BadRequest(
+            "user_id is required for native MCP prompts".to_string(),
+        ));
+    }
+
+    let cred_service = CredentialService::new(state.db_pool.clone());
+    let creds = if native_mcp {
+        match resolve_credentials(
+            &cred_service,
+            &source.id,
+            request.user_id.as_deref(),
+            false,
+            true,
+        )
+        .await?
+        {
+            CredentialResolution::Resolved(credentials) => credentials,
+            CredentialResolution::NeedsUserAuth { provider } => {
+                return Err(ApiError::PreconditionFailedJson(json!({
+                    "error": "needs_user_auth",
+                    "source_id": source.id,
+                    "source_type": source.source_type,
+                    "provider": provider,
+                })));
+            }
+            CredentialResolution::NoCredentials => {
+                return Err(ApiError::NotFound(format!(
+                    "Credentials not found for source: {}",
+                    request.source_id
+                )));
+            }
+        }
+    } else {
+        cred_service
+            .get_owner_credential(&source)
+            .await
+            .map_err(|e| ApiError::Internal(e.to_string()))?
+            .ok_or_else(|| {
+                ApiError::NotFound(format!(
+                    "Credentials not found for source: {}",
+                    request.source_id
+                ))
+            })?
+    };
 
     let client = ConnectorClient::new();
     let prompt_request = PromptRequest {
@@ -1816,6 +1914,60 @@ fn validate_connector_manifest_action_schemas(manifest: &ConnectorManifest) -> R
     Ok(())
 }
 
+async fn preserve_native_mcp_catalog(
+    conn: &mut redis::aio::MultiplexedConnection,
+    manifest: ConnectorManifest,
+) -> Result<ConnectorManifest, ApiError> {
+    if !manifest.mcp_enabled || manifest.mcp_catalog_loaded {
+        return Ok(manifest);
+    }
+
+    let key = format!("connector:manifest:{}", manifest.connector_id);
+    let Some(existing_json) = conn
+        .get::<_, Option<String>>(&key)
+        .await
+        .map_err(|e| ApiError::Internal(format!("Redis read error: {}", e)))?
+    else {
+        return Ok(manifest);
+    };
+    let Ok(existing) = serde_json::from_str::<ConnectorManifest>(&existing_json) else {
+        return Ok(manifest);
+    };
+    if existing.integration_type != IntegrationType::Connector
+        || !existing.mcp_catalog_loaded
+        || existing.connector_id != manifest.connector_id
+    {
+        return Ok(manifest);
+    }
+
+    Ok(merge_native_mcp_catalog(manifest, existing))
+}
+
+fn merge_native_mcp_catalog(
+    mut manifest: ConnectorManifest,
+    existing: ConnectorManifest,
+) -> ConnectorManifest {
+    let names: std::collections::HashSet<String> = manifest
+        .actions
+        .iter()
+        .map(|action| action.name.clone())
+        .collect();
+    manifest.actions.extend(
+        existing
+            .actions
+            .into_iter()
+            .filter(|action| !names.contains(&action.name)),
+    );
+    if manifest.resources.is_empty() {
+        manifest.resources = existing.resources;
+    }
+    if manifest.prompts.is_empty() {
+        manifest.prompts = existing.prompts;
+    }
+    manifest.mcp_catalog_loaded = true;
+    manifest
+}
+
 pub async fn sdk_register(
     State(state): State<AppState>,
     Json(manifest): Json<ConnectorManifest>,
@@ -1841,7 +1993,17 @@ pub async fn sdk_register(
         )));
     }
 
-    let connector_id = &manifest.connector_id;
+    // Native MCP discovery needs per-user OAuth. On connector restart the
+    // first unauthenticated heartbeat is necessarily catalog-less; retain a
+    // previously authenticated catalog until live discovery replaces it.
+    let needs_mcp_catalog_recovery = manifest.mcp_enabled && !manifest.mcp_catalog_loaded;
+    let mut preserve_conn = state
+        .redis_client
+        .get_multiplexed_async_connection()
+        .await
+        .map_err(|e| ApiError::Internal(format!("Redis connection error: {}", e)))?;
+    let manifest = preserve_native_mcp_catalog(&mut preserve_conn, manifest).await?;
+    let connector_id = manifest.connector_id.clone();
 
     info!(
         "SDK: Registered connector '{}' (source_types: {:?}, url: {})",
@@ -1886,7 +2048,7 @@ pub async fn sdk_register(
     // to find an existing OAuth credential for one of its source types and
     // replay the credential-ready notification. This covers the case where the
     // connector was unavailable when OAuth completed.
-    if manifest.mcp_enabled && !manifest.mcp_catalog_loaded {
+    if needs_mcp_catalog_recovery {
         if let Some(provider) = manifest
             .oauth
             .as_ref()
@@ -3278,6 +3440,35 @@ mod tests {
             skills: Vec::new(),
             oauth: None,
         }
+    }
+
+    #[test]
+    fn native_mcp_registration_preserves_authenticated_catalog() {
+        let mut existing = manifest_with_action_schema(json!({}));
+        existing.mcp_enabled = true;
+        existing.mcp_catalog_loaded = true;
+        existing.actions[0].name = "rovo_search".to_string();
+        existing
+            .resources
+            .push(shared::models::McpResourceDefinition {
+                uri_template: "rovo://issue/{id}".to_string(),
+                name: "Issue".to_string(),
+                description: None,
+                mime_type: None,
+            });
+
+        let mut restarted = manifest_with_action_schema(json!({}));
+        restarted.mcp_enabled = true;
+        let merged = merge_native_mcp_catalog(restarted, existing);
+
+        assert!(merged.mcp_catalog_loaded);
+        assert!(
+            merged
+                .actions
+                .iter()
+                .any(|action| action.name == "rovo_search")
+        );
+        assert_eq!(merged.resources[0].name, "Issue");
     }
 
     #[test]

--- a/services/connector-manager/src/handlers.rs
+++ b/services/connector-manager/src/handlers.rs
@@ -2088,7 +2088,6 @@ pub async fn sdk_register(
                             &recovery_creds,
                         )) {
                             Ok(credentials) => {
-                                // Fire and forget: replay the notification best-effort.
                                 let recovery_request = OAuthCredentialReadyRequest {
                                     source_id,
                                     user_id: Some(user_id),
@@ -2096,14 +2095,67 @@ pub async fn sdk_register(
                                     flow: "user_read".to_string(),
                                     credentials,
                                 };
-                                if let Err(e) = client
+                                match client
                                     .oauth_credential_ready(
                                         &manifest.connector_url,
                                         &recovery_request,
                                     )
                                     .await
                                 {
-                                    warn!("Recovery credential-ready delivery failed: {}", e);
+                                    Ok(Some(refreshed_manifest)) => {
+                                        if let Err(error) =
+                                            validate_connector_manifest_action_schemas(
+                                                &refreshed_manifest,
+                                            )
+                                        {
+                                            warn!(
+                                                "Recovery returned invalid connector manifest: {}",
+                                                error
+                                            );
+                                        } else {
+                                            let refreshed_key = format!(
+                                                "connector:manifest:{}",
+                                                refreshed_manifest.connector_id
+                                            );
+                                            match serde_json::to_string(&refreshed_manifest) {
+                                                Ok(refreshed_json) => {
+                                                    let store_result: redis::RedisResult<()> = conn
+                                                        .set_ex(
+                                                            &refreshed_key,
+                                                            refreshed_json,
+                                                            REGISTRATION_TTL_SECONDS,
+                                                        )
+                                                        .await;
+                                                    if let Err(error) = store_result {
+                                                        warn!(
+                                                            "Recovery failed to store refreshed connector manifest: {}",
+                                                            error
+                                                        );
+                                                    } else {
+                                                        info!(
+                                                            "Recovery updated MCP catalog for {}",
+                                                            refreshed_manifest.connector_id
+                                                        );
+                                                    }
+                                                }
+                                                Err(error) => warn!(
+                                                    "Recovery failed to serialize refreshed connector manifest: {}",
+                                                    error
+                                                ),
+                                            }
+                                        }
+                                    }
+                                    Ok(None) => {
+                                        warn!(
+                                            "Recovery credential-ready returned no refreshed manifest"
+                                        );
+                                    }
+                                    Err(error) => {
+                                        warn!(
+                                            "Recovery credential-ready delivery failed: {}",
+                                            error
+                                        );
+                                    }
                                 }
                             }
                             Err(e) => {

--- a/web/src/lib/server/mcp/client.ts
+++ b/web/src/lib/server/mcp/client.ts
@@ -483,12 +483,6 @@ export async function discoverRemoteMcpOAuthConfig(args: {
                 asMetadata.token_endpoint,
             ).catch(() => null)
             if (!authEndpoint || !tokenEndpoint) continue
-            const userinfoEndpoint =
-                typeof asMetadata.userinfo_endpoint === 'string'
-                    ? await validateRemoteMcpUrlForCredentialUse(
-                          asMetadata.userinfo_endpoint,
-                      ).catch(() => null)
-                    : endpoint.origin
             const registrationEndpoint =
                 typeof asMetadata.registration_endpoint === 'string'
                     ? await validateRemoteMcpUrlForCredentialUse(
@@ -499,11 +493,7 @@ export async function discoverRemoteMcpOAuthConfig(args: {
                 typeof prm.resource === 'string'
                     ? await validateRemoteMcpUrlForCredentialUse(prm.resource).catch(() => null)
                     : endpoint.toString()
-            if (
-                !userinfoEndpoint ||
-                (asMetadata.registration_endpoint && !registrationEndpoint) ||
-                !resource
-            ) {
+            if ((asMetadata.registration_endpoint && !registrationEndpoint) || !resource) {
                 continue
             }
             const scopes = Array.isArray(asMetadata.scopes_supported)
@@ -519,8 +509,6 @@ export async function discoverRemoteMcpOAuthConfig(args: {
                 credential_provider: 'remote_mcp',
                 auth_endpoint: authEndpoint,
                 token_endpoint: tokenEndpoint,
-                userinfo_endpoint: userinfoEndpoint,
-                userinfo_email_field: 'email',
                 identity_scopes: [],
                 scopes: { [args.sourceType]: { read: scopes, write: scopes } },
                 extra_auth_params: {},

--- a/web/src/lib/server/oauth/connectorOAuth.test.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.test.ts
@@ -127,6 +127,18 @@ describe('OAuth connector helpers', () => {
             client_name: 'Omni ClickUp MCP',
             grant_types: ['authorization_code'],
         })
+
+        expect(
+            dynamicRegistrationPayload(
+                'atlassian',
+                'https://omni.example/api/oauth/callback',
+                'read:jira-work',
+            ),
+        ).toMatchObject({
+            client_name: 'Omni Atlassian MCP',
+            grant_types: ['authorization_code', 'refresh_token'],
+            token_endpoint_auth_method: 'none',
+        })
     })
 
     it('checks configured state based on token endpoint auth method', () => {

--- a/web/src/lib/server/oauth/connectorOAuth.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.ts
@@ -31,7 +31,7 @@ export interface OAuthManifestConfig {
     provider: string
     auth_endpoint: string
     token_endpoint: string
-    userinfo_endpoint: string
+    userinfo_endpoint?: string
     userinfo_email_field: string
     identity_scopes: string[]
     scopes: Record<string, { read: string[]; write: string[] }>
@@ -273,7 +273,8 @@ async function readCredentialText(_provider: string, response: Response): Promis
 async function validateRemoteMcpOAuthConfigUrls(config: OAuthManifestConfig): Promise<void> {
     if (!isAdminConfiguredEndpointProvider(config.provider)) return
     const internalOrigin = windshiftInternalOrigin(config)
-    const endpoints = [config.auth_endpoint, config.token_endpoint, config.userinfo_endpoint]
+    const endpoints = [config.auth_endpoint, config.token_endpoint]
+    if (config.userinfo_endpoint) endpoints.push(config.userinfo_endpoint)
     if (config.registration_endpoint) endpoints.push(config.registration_endpoint)
     if (config.resource) endpoints.push(config.resource)
     if (config.protected_resource_metadata_url) {
@@ -354,7 +355,7 @@ export function dynamicRegistrationPayload(provider: string, redirectUri: string
         client_name: `Omni ${providerName} MCP`,
         redirect_uris: [redirectUri],
         grant_types:
-            provider === 'windshift'
+            provider === 'windshift' || provider === 'atlassian'
                 ? ['authorization_code', 'refresh_token']
                 : ['authorization_code'],
         response_types: ['code'],
@@ -785,6 +786,12 @@ export async function exchangeCodeAndIdentify(
             flow: state.metadata.flow.type,
         })
         return { tokens, state, config, principalEmail: principalEmailOverride, clientCreds: creds }
+    }
+
+    if (!config.userinfo_endpoint) {
+        throw new Error(
+            `OAuth provider ${config.provider} does not advertise userinfo; a trusted principal identity override is required`,
+        )
     }
 
     const userinfoResp = await remoteMcpCredentialFetch(

--- a/web/src/lib/server/oauth/connectorOAuth.ts
+++ b/web/src/lib/server/oauth/connectorOAuth.ts
@@ -666,14 +666,13 @@ export interface ExchangeResult {
 }
 
 export interface ExchangeCodeOptions {
-    /// Provider-scoped identity overrides for providers whose OAuth token cannot
-    /// be used with their REST userinfo endpoint. Values must come from an
-    /// already-authenticated Omni user, never from request input.
-    principalEmailOverrides?: Record<string, string>
+    /// Identity for manifests without a userinfo endpoint. This must come from
+    /// the already-authenticated Omni session, never from request input.
+    authenticatedUserEmail?: string
 }
 
-/// Exchange an authorization code for tokens, validate state, fetch
-/// principal email unless a trusted provider-specific override is supplied.
+/// Exchange an authorization code for tokens, validate state, and identify the
+/// principal using the provider's userinfo endpoint or the authenticated Omni user.
 export async function exchangeCodeAndIdentify(
     code: string,
     stateToken: string,
@@ -779,19 +778,18 @@ export async function exchangeCodeAndIdentify(
         grantedScope: tokens.scope ?? null,
     })
 
-    const principalEmailOverride = options.principalEmailOverrides?.[config.provider]
-    if (principalEmailOverride) {
+    if (!config.userinfo_endpoint) {
+        const authenticatedUserEmail = options.authenticatedUserEmail
+        if (!authenticatedUserEmail) {
+            throw new Error(
+                `OAuth provider ${config.provider} does not advertise userinfo; an authenticated Omni user is required`,
+            )
+        }
         logger.info('Using authenticated Omni user as connector OAuth principal', {
             provider: config.provider,
             flow: state.metadata.flow.type,
         })
-        return { tokens, state, config, principalEmail: principalEmailOverride, clientCreds: creds }
-    }
-
-    if (!config.userinfo_endpoint) {
-        throw new Error(
-            `OAuth provider ${config.provider} does not advertise userinfo; a trusted principal identity override is required`,
-        )
+        return { tokens, state, config, principalEmail: authenticatedUserEmail, clientCreds: creds }
     }
 
     const userinfoResp = await remoteMcpCredentialFetch(

--- a/web/src/routes/api/oauth/callback/+server.ts
+++ b/web/src/routes/api/oauth/callback/+server.ts
@@ -70,6 +70,9 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
         exchange = await exchangeCodeAndIdentify(code, stateToken, {
             principalEmailOverrides: {
                 clickup: user.email,
+                // Rovo has no userinfo endpoint. This value is the signed-in
+                // Omni user's identity, not callback-provided provider data.
+                atlassian: user.email,
                 ...(pendingProvider?.startsWith('remote_mcp:')
                     ? { [pendingProvider]: user.email }
                     : {}),

--- a/web/src/routes/api/oauth/callback/+server.ts
+++ b/web/src/routes/api/oauth/callback/+server.ts
@@ -54,12 +54,10 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
     }
 
     let failureReturnTo: string | null = null
-    let pendingProvider: string | null = null
     try {
         const pendingState = await OAuthStateManager.getState(stateToken)
         if (pendingState?.user_id === user.id) {
             failureReturnTo = returnToFromStateMetadata(pendingState.metadata)
-            pendingProvider = pendingState.metadata?.provider ?? null
         }
     } catch (err) {
         logger.warn('Failed to read OAuth state for failure redirect', { err: String(err) })
@@ -68,15 +66,7 @@ export const GET: RequestHandler = async ({ url, locals, fetch }) => {
     let exchange
     try {
         exchange = await exchangeCodeAndIdentify(code, stateToken, {
-            principalEmailOverrides: {
-                clickup: user.email,
-                // Rovo has no userinfo endpoint. This value is the signed-in
-                // Omni user's identity, not callback-provided provider data.
-                atlassian: user.email,
-                ...(pendingProvider?.startsWith('remote_mcp:')
-                    ? { [pendingProvider]: user.email }
-                    : {}),
-            },
+            authenticatedUserEmail: user.email,
         })
     } catch (err) {
         logger.error('OAuth exchange failed', { err: String(err) })


### PR DESCRIPTION
- Add Rovo MCP to the native Atlassian connector so workplace actions run with each user’s OAuth identity rather than the indexing service account.
- Discover and retain the authenticated MCP catalog so Rovo tools become source-scoped Omni actions after user authorization.
- Enforce live tool validation, user credentials, write approvals, and source read-only policy for MCP-backed actions.
- Support Rovo’s public OAuth client registration and trusted Omni-session identity binding because its OAuth flow has no userinfo endpoint.