### PR TITLE
feat(projects): add projects to organize chats, context, and agent work

### DIFF
--- a/services/ai/db/__init__.py
+++ b/services/ai/db/__init__.py
@@ -8,7 +8,18 @@ from .embedding_queue import EmbeddingQueueItem, EmbeddingQueueRepository, Queue
 from .embeddings import Embedding, EmbeddingsRepository
 from .messages import MessagesRepository
 from .model_providers import ModelProviderRecord, ModelProvidersRepository, ModelsRepository
-from .models import Chat, ChatMessage, ChatSearchHit, ModelRecord, Source, User
+from .models import (
+    Chat,
+    ChatMessage,
+    ChatSearchHit,
+    ModelRecord,
+    Project,
+    ProjectAttachment,
+    ProjectAttachmentType,
+    Source,
+    User,
+)
+from .projects import ProjectAttachmentsRepository, ProjectsRepository
 from .skills import Skill, SkillsRepository
 from .task_queue import (
     ClaimOptions,
@@ -78,4 +89,9 @@ __all__ = [
     "TaskQueueRepository",
     "TaskStats",
     "TaskStatus",
+    "Project",
+    "ProjectAttachment",
+    "ProjectAttachmentType",
+    "ProjectAttachmentsRepository",
+    "ProjectsRepository",
 ]

--- a/services/ai/db/chats.py
+++ b/services/ai/db/chats.py
@@ -6,7 +6,7 @@ from .models import Chat, ChatSearchHit
 from .connection import get_db_pool
 
 
-_CHAT_COLUMNS = "id, user_id, title, model_id, agent_id, created_at, updated_at"
+_CHAT_COLUMNS = "id, user_id, title, model_id, agent_id, project_id, created_at, updated_at"
 
 
 class ChatsRepository:
@@ -25,6 +25,7 @@ class ChatsRepository:
         title: Optional[str] = None,
         model_id: Optional[str] = None,
         agent_id: Optional[str] = None,
+        project_id: Optional[str] = None,
     ) -> Chat:
         """Create a new chat"""
         pool = await self._get_pool()
@@ -32,14 +33,14 @@ class ChatsRepository:
         chat_id = str(ULID())
 
         query = f"""
-            INSERT INTO chats (id, user_id, title, model_id, agent_id, created_at, updated_at)
-            VALUES ($1, $2, $3, $4, $5, NOW(), NOW())
+            INSERT INTO chats (id, user_id, title, model_id, agent_id, project_id, created_at, updated_at)
+            VALUES ($1, $2, $3, $4, $5, $6, NOW(), NOW())
             RETURNING {_CHAT_COLUMNS}
         """
 
         async with pool.acquire() as conn:
             row = await conn.fetchrow(
-                query, chat_id, user_id, title, model_id, agent_id
+                query, chat_id, user_id, title, model_id, agent_id, project_id
             )
 
         return Chat.from_row(dict(row))
@@ -67,8 +68,13 @@ class ChatsRepository:
         query: str,
         limit: int,
         exclude_chat_id: str | None = None,
+        project_id: str | None = None,
     ) -> list[ChatSearchHit]:
-        """Search a user's non-deleted chats by title or message content."""
+        """Search a user's non-deleted chats by title or message content.
+
+        When project_id is given, results are scoped to that project's chats;
+        the project must still belong to user_id (enforced by the user_id match).
+        """
         pool = await self._get_pool()
 
         search_query = """
@@ -92,6 +98,7 @@ class ChatsRepository:
                   AND c.user_id = $1
                   AND c.is_deleted = FALSE
                   AND ($3::varchar IS NULL OR c.id <> $3::varchar)
+                  AND ($5::char(26) IS NULL OR c.project_id = $5::char(26))
             ),
             message_matches AS (
                 SELECT DISTINCT ON (c.id)
@@ -114,6 +121,7 @@ class ChatsRepository:
                   AND c.user_id = $1
                   AND c.is_deleted = FALSE
                   AND ($3::varchar IS NULL OR c.id <> $3::varchar)
+                  AND ($5::char(26) IS NULL OR c.project_id = $5::char(26))
                 ORDER BY c.id, score DESC, cm.id
             ),
             ranked_matches AS (
@@ -175,6 +183,7 @@ class ChatsRepository:
                 query,
                 exclude_chat_id,
                 limit,
+                project_id,
             )
 
         return [ChatSearchHit.from_row(dict(row)) for row in rows]

--- a/services/ai/db/models.py
+++ b/services/ai/db/models.py
@@ -332,6 +332,79 @@ class ChatRole(str, Enum):
     SYSTEM = "system"
 
 
+class ProjectAttachmentType(str, Enum):
+    UPLOAD = "upload"
+    DOCUMENT = "document"
+
+
+@dataclass
+class Project:
+    id: str
+    user_id: str
+    name: str
+    description: str | None
+    instructions: str | None
+    is_archived: bool
+    created_at: datetime
+    updated_at: datetime
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, object]) -> "Project":
+        return cls(
+            id=cast(str, row["id"]),
+            user_id=cast(str, row["user_id"]),
+            name=cast(str, row["name"]),
+            description=cast(str | None, row.get("description")),
+            instructions=cast(str | None, row.get("instructions")),
+            is_archived=cast(bool, row["is_archived"]),
+            created_at=cast(datetime, row["created_at"]),
+            updated_at=cast(datetime, row["updated_at"]),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "name": self.name,
+            "description": self.description,
+            "instructions": self.instructions,
+            "isArchived": self.is_archived,
+            "createdAt": self.created_at.isoformat(),
+            "updatedAt": self.updated_at.isoformat(),
+        }
+
+
+@dataclass
+class ProjectAttachment:
+    id: str
+    project_id: str
+    attachment_type: ProjectAttachmentType
+    upload_id: str | None
+    document_id: str | None
+    added_at: datetime
+
+    @classmethod
+    def from_row(cls, row: Mapping[str, object]) -> "ProjectAttachment":
+        return cls(
+            id=cast(str, row["id"]),
+            project_id=cast(str, row["project_id"]),
+            attachment_type=ProjectAttachmentType(cast(str, row["attachment_type"])),
+            upload_id=cast(str | None, row.get("upload_id")),
+            document_id=cast(str | None, row.get("document_id")),
+            added_at=cast(datetime, row["added_at"]),
+        )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "projectId": self.project_id,
+            "attachmentType": self.attachment_type.value,
+            "uploadId": self.upload_id,
+            "documentId": self.document_id,
+            "addedAt": self.added_at.isoformat(),
+        }
+
+
 @dataclass
 class Chat:
     id: str
@@ -341,6 +414,7 @@ class Chat:
     created_at: datetime
     updated_at: datetime
     agent_id: str | None = None
+    project_id: str | None = None
 
     @classmethod
     def from_row(cls, row: dict) -> "Chat":
@@ -356,6 +430,7 @@ class Chat:
             created_at=row["created_at"],
             updated_at=row["updated_at"],
             agent_id=row.get("agent_id"),
+            project_id=row.get("project_id"),
         )
 
     def to_dict(self) -> dict:
@@ -366,6 +441,7 @@ class Chat:
             "title": self.title,
             "model_id": self.model_id,
             "agent_id": self.agent_id,
+            "project_id": self.project_id,
             "created_at": self.created_at.isoformat(),
             "updated_at": self.updated_at.isoformat(),
         }

--- a/services/ai/db/projects.py
+++ b/services/ai/db/projects.py
@@ -1,0 +1,63 @@
+"""Read-only access to projects for the chat stream.
+
+Projects and their attachments are written by omni-web (drizzle) — the
+established pattern for user-owned resources (chats, agents, skills).
+omni-ai only reads them to enrich chat system prompts.
+"""
+
+import logging
+from typing import Optional
+
+from asyncpg import Pool
+
+from .connection import get_db_pool
+from .models import Project, ProjectAttachment
+
+logger = logging.getLogger(__name__)
+
+_PROJECT_COLUMNS = (
+    "id, user_id, name, description, instructions, is_archived, created_at, updated_at"
+)
+
+
+class ProjectsRepository:
+    def __init__(self, pool: Optional[Pool] = None):
+        self.pool = pool
+
+    async def _get_pool(self) -> Pool:
+        if self.pool:
+            return self.pool
+        return await get_db_pool()
+
+    async def get(self, project_id: str) -> Optional[Project]:
+        pool = await self._get_pool()
+        row = await pool.fetchrow(
+            f"SELECT {_PROJECT_COLUMNS} FROM projects WHERE id = $1 AND is_deleted = FALSE",
+            project_id,
+        )
+        return Project.from_row(dict(row)) if row else None
+
+
+class ProjectAttachmentsRepository:
+    def __init__(self, pool: Optional[Pool] = None):
+        self.pool = pool
+
+    async def _get_pool(self) -> Pool:
+        if self.pool:
+            return self.pool
+        return await get_db_pool()
+
+    async def list_for_project(self, project_id: str) -> list[ProjectAttachment]:
+        pool = await self._get_pool()
+        rows = await pool.fetch(
+            """
+            SELECT pa.id, pa.project_id, pa.attachment_type, pa.upload_id,
+                   pa.document_id, pa.added_at
+            FROM project_attachments pa
+            JOIN projects p ON p.id = pa.project_id
+            WHERE pa.project_id = $1 AND p.is_deleted = FALSE
+            ORDER BY pa.added_at ASC
+            """,
+            project_id,
+        )
+        return [ProjectAttachment.from_row(dict(row)) for row in rows]

--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -229,6 +229,32 @@ def _format_trusted_memory_block(memories: list[str], heading: str) -> str:
     return f"\n\n## {heading}\n{_build_memory_bullets(memories)}"
 
 
+def _format_project_instructions_block(instructions: str) -> str:
+    """Render project-level instructions as a trusted system-prompt section.
+
+    Only the project's owner can write them (same trust level as agent
+    instructions), so no untrusted fence is applied.
+    """
+    return (
+        "\n\n# Project instructions\n"
+        "The user wrote the following instructions for this project. Apply them "
+        "to every conversation in this project, in addition to the guidance above.\n"
+        f"{instructions}"
+    )
+
+
+def _format_project_context_block(lines: list[str]) -> str:
+    """Render project context attachments as pointers the model can resolve."""
+    bullet_list = "\n".join(f"- {line}" for line in lines)
+    return (
+        "\n\n# Project context\n"
+        "The following documents are attached to this project as standing context:\n"
+        f"{bullet_list}\n"
+        "- Use `read_document` with the [_ref:ULID] id when you need an attached "
+        "document's content beyond its title. Do not display _ref values to the user."
+    )
+
+
 def _available_skill_names() -> set[str]:
     if not _SKILLS_DIR.exists():
         return set()
@@ -380,6 +406,8 @@ def build_chat_system_prompt(
     user_configuration: UserConfiguration | None = None,
     include_web_search: bool = False,
     include_fetch_web_page: bool = False,
+    project_instructions: str | None = None,
+    project_context_lines: list[str] | None = None,
 ) -> str:
     """Build system prompt from active sources and available toolsets.
 
@@ -391,6 +419,8 @@ def build_chat_system_prompt(
         user_name: display name of the current user
         user_email: email of the current user
         memories: list of memory strings to inject as remembered context
+        project_instructions: standing instructions of the chat's project, if any
+        project_context_lines: rendered pointers to the project's attached documents
     """
     seen = set()
     display_names = []
@@ -416,11 +446,17 @@ def build_chat_system_prompt(
         web_tool_lines=_web_tool_lines(include_web_search, include_fetch_web_page),
     )
 
+    sections: list[str] = [base_prompt]
+
+    if project_instructions:
+        sections.append(_format_project_instructions_block(project_instructions))
+    if project_context_lines:
+        sections.append(_format_project_context_block(project_context_lines))
     if memories:
-        return base_prompt + _format_memory_block(
-            memories, heading="Remembered context about this user"
+        sections.append(
+            _format_memory_block(memories, heading="Remembered context about this user")
         )
-    return base_prompt
+    return "".join(sections)
 
 
 def _format_execution_log(execution_log: list[dict], max_chars: int = 5000) -> str:

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -39,12 +39,14 @@ from db import (
     ChatsRepository,
     CompactionsRepository,
     MessagesRepository,
+    ProjectAttachmentsRepository,
+    ProjectsRepository,
     SkillsRepository,
 )
 from db.groups import GroupRepository
 from db.configuration import ConfigurationRepository
 from db.documents import DocumentsRepository
-from db.models import Chat, Source, UserConfiguration
+from db.models import Chat, ProjectAttachmentType, Source, UserConfiguration
 from db.tool_approvals import (
     ToolApproval,
     ToolApprovalsRepository,
@@ -388,6 +390,40 @@ async def _build_registry(
         sources=sources,
         search_operators=search_operators,
     )
+
+
+async def _load_project_context(
+    chat: Chat,
+) -> tuple[str | None, list[str] | None]:
+    """Resolve project instructions and context pointers for a project chat.
+
+    Returns (instructions, context_lines); both None when the chat has no
+    project or the project is inaccessible — the chat still proceeds without
+    project context rather than failing.
+    """
+    if not chat.project_id:
+        return None, None
+
+    project = await ProjectsRepository().get(chat.project_id)
+    if not project or project.user_id != chat.user_id:
+        return None, None
+
+    attachments = await ProjectAttachmentsRepository().list_for_project(project.id)
+    document_ids = [
+        a.document_id
+        for a in attachments
+        if a.attachment_type == ProjectAttachmentType.DOCUMENT and a.document_id
+    ]
+    context_lines: list[str] = []
+    if document_ids:
+        documents = await DocumentsRepository().get_by_ids(document_ids)
+        for document_id in document_ids:
+            document = documents.get(document_id)
+            if document:
+                title = document.title or "Untitled document"
+                context_lines.append(f"{title} [_ref:{document.id}]")
+
+    return project.instructions, (context_lines or None)
 
 
 async def _build_agent_chat_registry(
@@ -870,6 +906,9 @@ class StreamChatHandler:
             loaded_source_ids = _loaded_source_ids(
                 loaded_toolsets, build_result.connector_handler
             )
+            project_instructions, project_context_lines = await _load_project_context(
+                chat
+            )
             system_prompt = build_chat_system_prompt(
                 active_sources,
                 toolsets=build_result.toolsets,
@@ -886,6 +925,8 @@ class StreamChatHandler:
                     request.app.state, "web_fetch_provider", None
                 )
                 is not None,
+                project_instructions=project_instructions,
+                project_context_lines=project_context_lines,
             )
 
         # ---- Common setup (repair, compaction, etc.) ----

--- a/services/ai/tests/integration/test_projects_repository.py
+++ b/services/ai/tests/integration/test_projects_repository.py
@@ -1,0 +1,136 @@
+"""Integration tests for omni-ai's read-only view of projects.
+
+Projects and their attachments are written by omni-web; the CRUD coverage
+lives in web/src/lib/server/db/projects.test.ts. Here we create rows via SQL
+and assert the read paths used by the chat stream: live-project lookup,
+deleted-project filtering, and project-scoped chat search.
+"""
+
+import asyncpg
+import pytest
+from ulid import ULID
+
+from db import ChatsRepository, ProjectAttachmentsRepository, ProjectsRepository, UsersRepository
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+async def project_user(db_pool):
+    return await UsersRepository(pool=db_pool).create(
+        email=f"{ULID()}@test.local",
+        password_hash="not-a-real-hash",
+        full_name="Project User",
+    )
+
+
+async def _insert_project(db_pool, user_id: str, name: str) -> str:
+    project_id = str(ULID())
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO projects (id, user_id, name, description, instructions)
+            VALUES ($1, $2, $3, $4, $5)
+            """,
+            project_id,
+            user_id,
+            name,
+            "Project description",
+            "Always answer in German.",
+        )
+    return project_id
+
+
+async def _insert_document_attachment(db_pool, project_id: str) -> str:
+    attachment_id = str(ULID())
+    async with db_pool.acquire() as conn:
+        await conn.execute(
+            """
+            INSERT INTO project_attachments
+                (id, project_id, attachment_type, upload_id, document_id)
+            VALUES ($1, $2, 'document', NULL, $3)
+            """,
+            attachment_id,
+            project_id,
+            str(ULID()),
+        )
+    return attachment_id
+
+
+@pytest.mark.asyncio
+async def test_get_returns_live_project_and_hides_deleted(db_pool, project_user):
+    projects = ProjectsRepository(pool=db_pool)
+
+    project_id = await _insert_project(db_pool, project_user.id, "Visible")
+    fetched = await projects.get(project_id)
+    assert fetched is not None
+    assert fetched.name == "Visible"
+    assert fetched.instructions == "Always answer in German."
+    assert fetched.is_archived is False
+
+    async with db_pool.acquire() as conn:
+        await conn.execute("UPDATE projects SET is_deleted = TRUE WHERE id = $1", project_id)
+    assert await projects.get(project_id) is None
+
+
+@pytest.mark.asyncio
+async def test_list_attachments_joins_live_projects_only(db_pool, project_user):
+    attachments = ProjectAttachmentsRepository(pool=db_pool)
+
+    project_id = await _insert_project(db_pool, project_user.id, "With docs")
+    first = await _insert_document_attachment(db_pool, project_id)
+    second = await _insert_document_attachment(db_pool, project_id)
+
+    listed = await attachments.list_for_project(project_id)
+    assert {a.id for a in listed} == {first, second}
+    assert all(a.attachment_type.value == "document" for a in listed)
+
+    # Deleted projects yield no attachments.
+    async with db_pool.acquire() as conn:
+        await conn.execute("UPDATE projects SET is_deleted = TRUE WHERE id = $1", project_id)
+    assert await attachments.list_for_project(project_id) == []
+
+    # The DB shape check still rejects mixed payloads (defense in depth).
+    with pytest.raises(asyncpg.CheckViolationError):
+        async with db_pool.acquire() as conn:
+            await conn.execute(
+                """
+                INSERT INTO project_attachments
+                    (id, project_id, attachment_type, upload_id, document_id)
+                VALUES ($1, $2, 'document', $3, NULL)
+                """,
+                str(ULID()),
+                project_id,
+                first,
+            )
+
+
+@pytest.mark.asyncio
+async def test_chat_search_scopes_to_project(db_pool, project_user):
+    projects = ProjectsRepository(pool=db_pool)
+    chats = ChatsRepository(pool=db_pool)
+
+    project = await projects.get(
+        await _insert_project(db_pool, project_user.id, "Scoped")
+    )
+    in_project = await chats.create(
+        project_user.id, title="Zebra roadmap", project_id=project.id
+    )
+    outside = await chats.create(project_user.id, title="Zebra outside")
+    other_project = await projects.get(
+        await _insert_project(db_pool, project_user.id, "Other scope")
+    )
+    other_project_chat = await chats.create(
+        project_user.id, title="Zebra elsewhere", project_id=other_project.id
+    )
+
+    hits = await chats.search(project_user.id, "zebra", limit=10, project_id=project.id)
+    hit_ids = {hit.chat_id for hit in hits}
+    assert hit_ids == {in_project.id}
+
+    unscoped = await chats.search(project_user.id, "zebra", limit=10)
+    assert {hit.chat_id for hit in unscoped} >= {
+        in_project.id,
+        outside.id,
+        other_project_chat.id,
+    }

--- a/services/ai/tests/unit/test_project_prompts.py
+++ b/services/ai/tests/unit/test_project_prompts.py
@@ -1,0 +1,51 @@
+"""Unit tests for project instructions/context injection in chat system prompts."""
+
+import prompts
+
+
+def _sources():
+    return []
+
+
+def test_chat_prompt_without_project_is_unchanged():
+    without_project = prompts.build_chat_system_prompt(_sources())
+    assert "Project instructions" not in without_project
+    assert "Project context" not in without_project
+
+
+def test_chat_prompt_includes_project_instructions():
+    prompt = prompts.build_chat_system_prompt(
+        _sources(), project_instructions="Always answer in German."
+    )
+    assert "# Project instructions" in prompt
+    assert "Always answer in German." in prompt
+    assert "Apply them" in prompt
+
+
+def test_chat_prompt_includes_project_context_lines():
+    lines = ["Q3 Roadmap [_ref:01HXXXXXX]"]
+    prompt = prompts.build_chat_system_prompt(_sources(), project_context_lines=lines)
+    assert "# Project context" in prompt
+    assert "- Q3 Roadmap [_ref:01HXXXXXX]" in prompt
+    assert "read_document" in prompt
+
+
+def test_chat_prompt_orders_project_sections_before_memories():
+    prompt = prompts.build_chat_system_prompt(
+        _sources(),
+        project_instructions="Be terse.",
+        project_context_lines=["Spec [_ref:01HYYYYYY]"],
+        memories=["User prefers email."],
+    )
+    instructions_at = prompt.index("# Project instructions")
+    context_at = prompt.index("# Project context")
+    memory_at = prompt.index("<untrusted-memory>")
+    assert instructions_at < context_at < memory_at
+
+
+def test_chat_prompt_empty_context_lines_renders_no_section():
+    prompt = prompts.build_chat_system_prompt(
+        _sources(), project_instructions=None, project_context_lines=[]
+    )
+    assert "Project instructions" not in prompt
+    assert "Project context" not in prompt

--- a/services/migrations/113_create_projects.sql
+++ b/services/migrations/113_create_projects.sql
@@ -1,0 +1,55 @@
+-- Projects: a user-owned organizational layer that groups chats, standing
+-- instructions, and context attachments. Personal scope only (no sharing):
+-- all access is mediated by projects.user_id, so projects never widen source
+-- permissions beyond what the owning user already has.
+
+CREATE TABLE projects (
+    id CHAR(26) PRIMARY KEY,
+    user_id CHAR(26) NOT NULL REFERENCES users(id) ON DELETE CASCADE,
+    name TEXT NOT NULL,
+    description TEXT,
+    instructions TEXT,
+    is_archived BOOLEAN NOT NULL DEFAULT FALSE,
+    is_deleted BOOLEAN NOT NULL DEFAULT FALSE,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Names are unique per user among live projects (case-insensitive).
+CREATE UNIQUE INDEX idx_projects_user_name ON projects(user_id, lower(name)) WHERE is_deleted = FALSE;
+
+CREATE INDEX idx_projects_user_active ON projects(user_id, updated_at DESC) WHERE is_deleted = FALSE;
+
+CREATE TRIGGER update_projects_updated_at
+    BEFORE UPDATE ON projects
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- Chat association. ON DELETE SET NULL keeps chat rows (and their usage
+-- history) intact when a project is hard-deleted; the soft-delete path also
+-- nulls the column explicitly so chats return to "unorganized".
+ALTER TABLE chats ADD COLUMN project_id CHAR(26) REFERENCES projects(id) ON DELETE SET NULL;
+
+CREATE INDEX idx_chats_project ON chats(project_id, updated_at DESC) WHERE is_deleted = FALSE;
+
+-- Standing context attachments for a project. Two kinds:
+--   upload:   a row in `uploads` (user-uploaded file), always owned by the
+--             project owner, cascaded on upload removal.
+--   document: a reference to a document in the unified index. Stored as TEXT
+--             without an FK: connector re-syncs can replace document rows, and
+--             a dangling reference must not cascade into project data.
+CREATE TABLE project_attachments (
+    id CHAR(26) PRIMARY KEY,
+    project_id CHAR(26) NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    attachment_type TEXT NOT NULL CHECK (attachment_type IN ('upload', 'document')),
+    upload_id CHAR(26) REFERENCES uploads(id) ON DELETE CASCADE,
+    document_id TEXT,
+    added_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT project_attachments_shape_check CHECK (
+        (attachment_type = 'upload' AND upload_id IS NOT NULL AND document_id IS NULL)
+        OR (attachment_type = 'document' AND document_id IS NOT NULL AND upload_id IS NULL)
+    ),
+    UNIQUE (project_id, upload_id),
+    UNIQUE (project_id, document_id)
+);
+
+CREATE INDEX idx_project_attachments_project ON project_attachments(project_id);

--- a/web/src/lib/server/db/chats.ts
+++ b/web/src/lib/server/db/chats.ts
@@ -92,6 +92,7 @@ export class ChatRepository {
         title?: string,
         modelId?: string,
         agentId?: string,
+        projectId?: string,
     ): Promise<Chat> {
         const chatId = ulid()
         const [newChat] = await this.db
@@ -102,6 +103,7 @@ export class ChatRepository {
                 title,
                 modelId: modelId || null,
                 agentId: agentId || null,
+                projectId: projectId || null,
             })
             .returning()
 
@@ -120,11 +122,14 @@ export class ChatRepository {
 
     async getByUserId(
         userId: string,
-        options?: { limit?: number; offset?: number; isStarred?: boolean },
+        options?: { limit?: number; offset?: number; isStarred?: boolean; projectId?: string },
     ): Promise<Chat[]> {
         const conditions = [eq(chats.userId, userId), eq(chats.isDeleted, false)]
         if (options?.isStarred !== undefined) {
             conditions.push(eq(chats.isStarred, options.isStarred))
+        }
+        if (options?.projectId !== undefined) {
+            conditions.push(eq(chats.projectId, options.projectId))
         }
 
         let query = this.db
@@ -158,6 +163,19 @@ export class ChatRepository {
         return updatedChat || null
     }
 
+    async moveChatToProject(chatId: string, projectId: string | null): Promise<Chat | null> {
+        const [updatedChat] = await this.db
+            .update(chats)
+            .set({
+                projectId,
+                updatedAt: new Date(),
+            })
+            .where(and(eq(chats.id, chatId), eq(chats.isDeleted, false)))
+            .returning()
+
+        return updatedChat || null
+    }
+
     async toggleStar(chatId: string, isStarred: boolean): Promise<Chat | null> {
         const [updatedChat] = await this.db
             .update(chats)
@@ -184,7 +202,7 @@ export class ChatRepository {
     async search(userId: string, query: string): Promise<ChatSearchHit[]> {
         const results = await this.db.execute<ChatSearchSqlRow>(sql`
             WITH title_matches AS (
-                SELECT c.id, c.user_id, c.title, c.is_starred, c.model_id, c.agent_id, c.is_deleted, c.created_at, c.updated_at,
+                SELECT c.id, c.user_id, c.title, c.is_starred, c.model_id, c.agent_id, c.project_id, c.is_deleted, c.created_at, c.updated_at,
                        NULL::varchar AS message_id, NULL::text AS content_text,
                        pdb.score(c.id) AS score, 'title'::text AS source
                 FROM chats c
@@ -206,7 +224,7 @@ export class ChatRepository {
             ),
             message_matches AS (
                 SELECT DISTINCT ON (c.id)
-                       c.id, c.user_id, c.title, c.is_starred, c.model_id, c.agent_id, c.is_deleted, c.created_at, c.updated_at,
+                       c.id, c.user_id, c.title, c.is_starred, c.model_id, c.agent_id, c.project_id, c.is_deleted, c.created_at, c.updated_at,
                        tmm.message_id, tmm.content_text, tmm.score, 'message'::text AS source
                 FROM top_message_matches tmm
                 JOIN chats c ON c.id = tmm.chat_id
@@ -214,7 +232,7 @@ export class ChatRepository {
             ),
             ranked_matches AS (
                 SELECT DISTINCT ON (id)
-                       id, user_id, title, is_starred, model_id, agent_id, is_deleted, created_at, updated_at,
+                       id, user_id, title, is_starred, model_id, agent_id, project_id, is_deleted, created_at, updated_at,
                        message_id, content_text, score, source
                 FROM (
                     SELECT * FROM title_matches
@@ -235,6 +253,7 @@ export class ChatRepository {
                    is_starred AS "isStarred",
                    model_id AS "modelId",
                    agent_id AS "agentId",
+                   project_id AS "projectId",
                    is_deleted AS "isDeleted",
                    created_at AS "createdAt",
                    updated_at AS "updatedAt",

--- a/web/src/lib/server/db/projects.test.ts
+++ b/web/src/lib/server/db/projects.test.ts
@@ -1,0 +1,177 @@
+import { describe, it, expect, beforeAll, afterAll, beforeEach } from 'vitest'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import { eq } from 'drizzle-orm'
+import { ulid } from 'ulid'
+import { startTestDb, stopTestDb, createTestUser } from './test-setup'
+import { ChatRepository } from './chats'
+import { ProjectAttachmentRepository, ProjectNameTakenError, ProjectRepository } from './projects'
+import * as schema from './schema'
+
+let db: PostgresJsDatabase<typeof schema>
+let projectRepo: ProjectRepository
+let attachmentRepo: ProjectAttachmentRepository
+let chatRepo: ChatRepository
+let userId: string
+
+beforeAll(async () => {
+    db = await startTestDb()
+    projectRepo = new ProjectRepository(db)
+    attachmentRepo = new ProjectAttachmentRepository(db)
+    chatRepo = new ChatRepository(db)
+})
+
+afterAll(async () => {
+    await stopTestDb()
+})
+
+beforeEach(async () => {
+    userId = await createTestUser(db)
+})
+
+describe('ProjectRepository CRUD', () => {
+    it('creates, reads and lists projects', async () => {
+        const created = await projectRepo.create(userId, 'Q3 Launch', 'desc', 'Be terse.')
+        expect(created.name).toBe('Q3 Launch')
+        expect(created.isArchived).toBe(false)
+
+        const fetched = await projectRepo.get(created.id)
+        expect(fetched?.instructions).toBe('Be terse.')
+
+        const list = await projectRepo.getByUserId(userId)
+        expect(list.map((p) => p.id)).toEqual([created.id])
+    })
+
+    it('enforces per-user unique live names case-insensitively', async () => {
+        await projectRepo.create(userId, 'Launch')
+        await expect(projectRepo.create(userId, 'launch')).rejects.toThrow(ProjectNameTakenError)
+
+        const otherUserId = await createTestUser(db)
+        const other = await projectRepo.create(otherUserId, 'Launch')
+        expect(other.name).toBe('Launch')
+    })
+
+    it('updates fields and allows clearing nullable ones', async () => {
+        const project = await projectRepo.create(userId, 'P1', 'd', 'i')
+        const updated = await projectRepo.update(project.id, {
+            name: 'P1 renamed',
+            description: null,
+            isArchived: true,
+        })
+        expect(updated?.name).toBe('P1 renamed')
+        expect(updated?.description).toBeNull()
+        expect(updated?.instructions).toBe('i')
+        expect(updated?.isArchived).toBe(true)
+    })
+
+    it('soft-deletes and detaches chats', async () => {
+        const project = await projectRepo.create(userId, 'Doomed')
+        const chat = await chatRepo.create(userId, undefined, undefined, undefined, project.id)
+        expect(chat.projectId).toBe(project.id)
+
+        expect(await projectRepo.delete(project.id)).toBe(true)
+
+        expect(await projectRepo.get(project.id)).toBeNull()
+        const stillThere = await chatRepo.get(chat.id)
+        expect(stillThere).not.toBeNull()
+        expect(stillThere?.projectId).toBeNull()
+    })
+
+    it('listWithChatCounts counts live chats per project', async () => {
+        const project = await projectRepo.create(userId, 'Counted')
+        const other = await projectRepo.create(userId, 'Empty')
+        await chatRepo.create(userId, undefined, undefined, undefined, project.id)
+        const deletedChat = await chatRepo.create(
+            userId,
+            undefined,
+            undefined,
+            undefined,
+            project.id,
+        )
+        await db
+            .update(schema.chats)
+            .set({ isDeleted: true })
+            .where(eq(schema.chats.id, deletedChat.id))
+
+        const counts = await projectRepo.listWithChatCounts(userId)
+        const byId = Object.fromEntries(counts.map((p) => [p.id, p.chatCount]))
+        expect(byId[project.id]).toBe(1)
+        expect(byId[other.id]).toBe(0)
+    })
+})
+
+describe('ProjectAttachmentRepository', () => {
+    it('adds, lists and removes attachments idempotently', async () => {
+        const project = await projectRepo.create(userId, 'With attachments')
+
+        const doc = await attachmentRepo.add(project.id, {
+            type: 'document',
+            documentId: ulid(),
+        })
+        expect(doc?.attachmentType).toBe('document')
+        expect(doc?.uploadId).toBeNull()
+
+        const duplicate = await attachmentRepo.add(project.id, {
+            type: 'document',
+            documentId: doc?.documentId ?? undefined,
+        })
+        expect(duplicate).toBeNull()
+
+        const listed = await attachmentRepo.listForProject(project.id)
+        expect(listed.map((a) => a.id)).toEqual([doc?.id])
+
+        expect(await attachmentRepo.remove(doc!.id)).toBe(true)
+        expect(await attachmentRepo.remove(doc!.id)).toBe(false)
+        expect(await attachmentRepo.listForProject(project.id)).toEqual([])
+    })
+
+    it("getOwned only returns attachments of the owner's live projects", async () => {
+        const project = await projectRepo.create(userId, 'Owned')
+        const doc = await attachmentRepo.add(project.id, {
+            type: 'document',
+            documentId: ulid(),
+        })
+
+        const otherUserId = await createTestUser(db)
+        expect(await attachmentRepo.getOwned(doc!.id, otherUserId)).toBeNull()
+        expect(await attachmentRepo.getOwned(doc!.id, userId)).not.toBeNull()
+
+        await projectRepo.delete(project.id)
+        expect(await attachmentRepo.getOwned(doc!.id, userId)).toBeNull()
+    })
+
+    it('cascades attachments when a project is hard-deleted', async () => {
+        const project = await projectRepo.create(userId, 'Cascade')
+        const doc = await attachmentRepo.add(project.id, {
+            type: 'document',
+            documentId: ulid(),
+        })
+        expect(doc).not.toBeNull()
+        await db.delete(schema.projects).where(eq(schema.projects.id, project.id))
+        expect(await attachmentRepo.listForProject(project.id)).toEqual([])
+    })
+})
+
+describe('ChatRepository project scoping', () => {
+    it('filters history by project', async () => {
+        const project = await projectRepo.create(userId, 'Scoped history')
+        const inProject = await chatRepo.create(userId, 'Inside', undefined, undefined, project.id)
+        await chatRepo.create(userId, 'Outside')
+
+        const scoped = await chatRepo.getByUserId(userId, { projectId: project.id })
+        expect(scoped.map((c) => c.id)).toEqual([inProject.id])
+
+        const all = await chatRepo.getByUserId(userId)
+        expect(all.length).toBe(2)
+    })
+
+    it('moves a chat into and out of a project', async () => {
+        const project = await projectRepo.create(userId, 'Move target')
+        const chat = await chatRepo.create(userId, 'Movable')
+
+        const moved = await chatRepo.moveChatToProject(chat.id, project.id)
+        expect(moved?.projectId).toBe(project.id)
+
+        const removed = await chatRepo.moveChatToProject(chat.id, null)
+        expect(removed?.projectId).toBeNull()
+    })
+})

--- a/web/src/lib/server/db/projects.ts
+++ b/web/src/lib/server/db/projects.ts
@@ -1,0 +1,215 @@
+import { and, desc, eq, sql } from 'drizzle-orm'
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js'
+import { ulid } from 'ulid'
+import { db } from './index'
+import * as schema from './schema'
+import { chats, projectAttachments, projects } from './schema'
+import type { Project, ProjectAttachment } from './schema'
+
+export type ProjectWithChatCount = Project & { chatCount: number }
+
+export class ProjectNameTakenError extends Error {
+    constructor(name: string) {
+        super(`A project named "${name}" already exists`)
+        this.name = 'ProjectNameTakenError'
+    }
+}
+
+export class ProjectRepository {
+    private db: PostgresJsDatabase<typeof schema>
+
+    constructor(private dbInstance: PostgresJsDatabase<typeof schema> = db) {
+        this.db = dbInstance
+    }
+
+    async create(
+        userId: string,
+        name: string,
+        description?: string,
+        instructions?: string,
+    ): Promise<Project> {
+        try {
+            const [project] = await this.db
+                .insert(projects)
+                .values({
+                    id: ulid(),
+                    userId,
+                    name,
+                    description: description ?? null,
+                    instructions: instructions ?? null,
+                })
+                .returning()
+            return project
+        } catch (error) {
+            if (isUniqueViolation(error)) {
+                throw new ProjectNameTakenError(name)
+            }
+            throw error
+        }
+    }
+
+    async get(projectId: string): Promise<Project | null> {
+        const [project] = await this.db
+            .select()
+            .from(projects)
+            .where(and(eq(projects.id, projectId), eq(projects.isDeleted, false)))
+            .limit(1)
+        return project || null
+    }
+
+    async getByUserId(userId: string, includeArchived = true): Promise<Project[]> {
+        const conditions = [eq(projects.userId, userId), eq(projects.isDeleted, false)]
+        if (!includeArchived) {
+            conditions.push(eq(projects.isArchived, false))
+        }
+        return await this.db
+            .select()
+            .from(projects)
+            .where(and(...conditions))
+            .orderBy(desc(projects.updatedAt))
+    }
+
+    async listWithChatCounts(
+        userId: string,
+        includeArchived = true,
+    ): Promise<ProjectWithChatCount[]> {
+        const rows = await this.db
+            .select({
+                project: projects,
+                chatCount: sql<number>`(
+                    SELECT count(*)::int
+                    FROM "chats" c
+                    WHERE c.project_id = projects.id
+                      AND c.is_deleted = FALSE
+                )`,
+            })
+            .from(projects)
+            .where(
+                and(
+                    eq(projects.userId, userId),
+                    eq(projects.isDeleted, false),
+                    ...(includeArchived ? [] : [eq(projects.isArchived, false)]),
+                ),
+            )
+            .orderBy(desc(projects.updatedAt))
+        return rows.map((row) => ({ ...row.project, chatCount: row.chatCount }))
+    }
+
+    async update(
+        projectId: string,
+        updates: {
+            name?: string
+            description?: string | null
+            instructions?: string | null
+            isArchived?: boolean
+        },
+    ): Promise<Project | null> {
+        try {
+            const [updated] = await this.db
+                .update(projects)
+                .set({ ...updates, updatedAt: new Date() })
+                .where(and(eq(projects.id, projectId), eq(projects.isDeleted, false)))
+                .returning()
+            return updated || null
+        } catch (error) {
+            if (updates.name !== undefined && isUniqueViolation(error)) {
+                throw new ProjectNameTakenError(updates.name)
+            }
+            throw error
+        }
+    }
+
+    async delete(projectId: string): Promise<boolean> {
+        const deleted = await this.db.transaction(async (tx) => {
+            const rows = await tx
+                .update(projects)
+                .set({ isDeleted: true, updatedAt: new Date() })
+                .where(and(eq(projects.id, projectId), eq(projects.isDeleted, false)))
+                .returning({ id: projects.id })
+            if (rows.length === 0) return false
+            // Chats survive project deletion; they return to "unorganized".
+            await tx
+                .update(chats)
+                .set({ projectId: null, updatedAt: new Date() })
+                .where(eq(chats.projectId, projectId))
+            return true
+        })
+        return deleted
+    }
+}
+
+export type ProjectAttachmentType = 'upload' | 'document'
+
+export class ProjectAttachmentRepository {
+    private db: PostgresJsDatabase<typeof schema>
+
+    constructor(private dbInstance: PostgresJsDatabase<typeof schema> = db) {
+        this.db = dbInstance
+    }
+
+    async add(
+        projectId: string,
+        attachment: { type: ProjectAttachmentType; uploadId?: string; documentId?: string },
+    ): Promise<ProjectAttachment | null> {
+        const values =
+            attachment.type === 'upload'
+                ? { uploadId: attachment.uploadId ?? null, documentId: null }
+                : { documentId: attachment.documentId ?? null, uploadId: null }
+
+        const [row] = await this.db
+            .insert(projectAttachments)
+            .values({
+                id: ulid(),
+                projectId,
+                attachmentType: attachment.type,
+                ...values,
+            })
+            .onConflictDoNothing()
+            .returning()
+        return row || null
+    }
+
+    async listForProject(projectId: string): Promise<ProjectAttachment[]> {
+        return await this.db
+            .select()
+            .from(projectAttachments)
+            .where(eq(projectAttachments.projectId, projectId))
+            .orderBy(projectAttachments.addedAt)
+    }
+
+    async getOwned(attachmentId: string, userId: string): Promise<ProjectAttachment | null> {
+        const [row] = await this.db
+            .select({ attachment: projectAttachments })
+            .from(projectAttachments)
+            .innerJoin(projects, eq(projectAttachments.projectId, projects.id))
+            .where(
+                and(
+                    eq(projectAttachments.id, attachmentId),
+                    eq(projects.userId, userId),
+                    eq(projects.isDeleted, false),
+                ),
+            )
+            .limit(1)
+        return row?.attachment || null
+    }
+
+    async remove(attachmentId: string): Promise<boolean> {
+        const removed = await this.db
+            .delete(projectAttachments)
+            .where(eq(projectAttachments.id, attachmentId))
+            .returning({ id: projectAttachments.id })
+        return removed.length > 0
+    }
+}
+
+function isUniqueViolation(error: unknown): boolean {
+    // Drizzle wraps driver errors; the Postgres code lives on the cause.
+    const candidates = [error, (error as { cause?: unknown })?.cause]
+    return candidates.some(
+        (candidate) =>
+            typeof candidate === 'object' &&
+            candidate !== null &&
+            'code' in candidate &&
+            (candidate as { code?: string }).code === '23505',
+    )
+}

--- a/web/src/lib/server/db/schema.ts
+++ b/web/src/lib/server/db/schema.ts
@@ -181,6 +181,20 @@ export const models = pgTable('models', {
     updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 })
 
+export const projects = pgTable('projects', {
+    id: text('id').primaryKey(),
+    userId: text('user_id')
+        .notNull()
+        .references(() => user.id, { onDelete: 'cascade' }),
+    name: text('name').notNull(),
+    description: text('description'),
+    instructions: text('instructions'),
+    isArchived: boolean('is_archived').notNull().default(false),
+    isDeleted: boolean('is_deleted').notNull().default(false),
+    createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+})
+
 export const chats = pgTable('chats', {
     id: text('id').primaryKey(),
     userId: text('user_id')
@@ -192,9 +206,23 @@ export const chats = pgTable('chats', {
         onDelete: 'set null',
     }),
     agentId: text('agent_id').references(() => agents.id, { onDelete: 'set null' }),
+    projectId: text('project_id').references(() => projects.id, { onDelete: 'set null' }),
     isDeleted: boolean('is_deleted').notNull().default(false),
     createdAt: timestamp('created_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
     updatedAt: timestamp('updated_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
+})
+
+// Standing context attachments for a project. `uploadId` has a DB-level FK to
+// the `uploads` table (owned by omni-ai, not modeled in this drizzle schema).
+export const projectAttachments = pgTable('project_attachments', {
+    id: text('id').primaryKey(),
+    projectId: text('project_id')
+        .notNull()
+        .references(() => projects.id, { onDelete: 'cascade' }),
+    attachmentType: text('attachment_type').notNull(),
+    uploadId: text('upload_id'),
+    documentId: text('document_id'),
+    addedAt: timestamp('added_at', { withTimezone: true, mode: 'date' }).notNull().defaultNow(),
 })
 
 export const chatMessages = pgTable('chat_messages', {
@@ -430,6 +458,8 @@ export type ModelProvider = typeof modelProviders.$inferSelect
 export type Model = typeof models.$inferSelect
 export type Chat = typeof chats.$inferSelect
 export type ChatMessage = typeof chatMessages.$inferSelect
+export type Project = typeof projects.$inferSelect
+export type ProjectAttachment = typeof projectAttachments.$inferSelect
 export type Compaction = typeof compactions.$inferSelect
 export type ResponseFeedback = typeof responseFeedback.$inferSelect
 export type AuthProvider = typeof authProviders.$inferSelect

--- a/web/src/routes/(app)/+layout.svelte
+++ b/web/src/routes/(app)/+layout.svelte
@@ -36,6 +36,7 @@
         Trash2,
         Bot,
         BookOpen,
+        Folder,
     } from '@lucide/svelte'
     import { onMount, type Snippet } from 'svelte'
     import { cn } from '$lib/utils'
@@ -384,6 +385,13 @@
                 variant="ghost">
                 <BookOpen />
                 <span class="group-data-[collapsible=icon]:hidden">Skills</span>
+            </Button>
+            <Button
+                href="/projects"
+                class="mb-2 flex w-full cursor-pointer items-center justify-start has-[>svg]:px-2"
+                variant="ghost">
+                <Folder />
+                <span class="group-data-[collapsible=icon]:hidden">Projects</span>
             </Button>
             <hr />
 

--- a/web/src/routes/(app)/chat/[chatId]/+page.server.ts
+++ b/web/src/routes/(app)/chat/[chatId]/+page.server.ts
@@ -2,6 +2,7 @@ import { chatRepository, chatMessageRepository } from '$lib/server/db/chats.js'
 import { getModel } from '$lib/server/db/model-providers.js'
 import { getAgent } from '$lib/server/db/agents.js'
 import { toolApprovalRepository } from '$lib/server/db/tool-approvals.js'
+import { ProjectRepository } from '$lib/server/db/projects.js'
 import { error } from '@sveltejs/kit'
 import type { ChatMessage } from '$lib/server/db/schema.js'
 
@@ -114,6 +115,7 @@ export const load = async ({ params, locals, fetch, depends }) => {
 
     const uploadIds = collectUploadIds(messages)
     const uploadFilenames = await resolveUploadFilenames(uploadIds, fetch)
+    const projects = await new ProjectRepository().getByUserId(locals.user.id)
     const activePathMessages = await chatMessageRepository.getActivePath(chat.id)
     const activePathToolCallIds = collectActiveUnansweredToolCallIds(activePathMessages)
     const allPendingApprovals = await toolApprovalRepository.getPendingForChatAll(
@@ -146,5 +148,6 @@ export const load = async ({ params, locals, fetch, depends }) => {
         pendingApprovals,
         pendingOAuth,
         approvedOAuth,
+        projects,
     }
 }

--- a/web/src/routes/(app)/chat/[chatId]/+page.svelte
+++ b/web/src/routes/(app)/chat/[chatId]/+page.svelte
@@ -30,7 +30,9 @@
         ArrowDown,
         BookOpen,
         X,
+        ChevronsUpDown,
     } from '@lucide/svelte'
+    import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js'
     import { marked } from 'marked'
     import { onDestroy, onMount } from 'svelte'
     import type { PageProps } from './$types'
@@ -93,6 +95,31 @@
     let { data }: PageProps = $props()
     let chatMessages = $state<ChatMessage[]>([...data.messages])
     let uploadFilenames = $state<Record<string, string>>({ ...data.uploadFilenames })
+
+    let chatProject = $derived(
+        data.chat.projectId
+            ? (data.projects.find((p) => p.id === data.chat.projectId) ?? null)
+            : null,
+    )
+
+    async function moveToProject(projectId: string | null) {
+        const res = await fetch(`/api/chat/${data.chat.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ projectId }),
+        })
+        if (res.ok) {
+            toast.success(
+                projectId
+                    ? (data.projects.find((p) => p.id === projectId)?.name ?? 'Chat') + ' updated'
+                    : 'Chat removed from project',
+            )
+            await invalidateAll()
+        } else {
+            const body = await res.json()
+            toast.error(body.error || 'Failed to move chat')
+        }
+    }
 
     onDestroy(() => {
         eventSource?.close()
@@ -2717,6 +2744,50 @@
                             </a>
                         </div>
                         <span class="text-muted-foreground text-xs">Read-only session</span>
+                    </div>
+                {/if}
+                {#if chatProject}
+                    <div
+                        class="bg-muted/50 mb-4 flex items-center justify-between rounded-lg border px-4 py-2">
+                        <div class="flex min-w-0 items-center gap-2 text-sm">
+                            <span class="text-muted-foreground shrink-0">Project:</span>
+                            <a
+                                href="/projects/{chatProject.id}"
+                                class="cursor-pointer truncate font-medium hover:underline">
+                                {chatProject.name}
+                            </a>
+                        </div>
+                        <DropdownMenu.Root>
+                            <DropdownMenu.Trigger>
+                                {#snippet child({ props })}
+                                    <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        class="h-6 shrink-0 cursor-pointer px-2 text-xs"
+                                        {...props}>
+                                        Move
+                                        <ChevronsUpDown class="ml-1 h-3 w-3" />
+                                    </Button>
+                                {/snippet}
+                            </DropdownMenu.Trigger>
+                            <DropdownMenu.Content align="end">
+                                {#if data.chat.projectId}
+                                    <DropdownMenu.Item
+                                        class="cursor-pointer"
+                                        onclick={() => moveToProject(null)}>
+                                        Remove from project
+                                    </DropdownMenu.Item>
+                                    <DropdownMenu.Separator />
+                                {/if}
+                                {#each data.projects.filter((p) => p.id !== data.chat.projectId) as project (project.id)}
+                                    <DropdownMenu.Item
+                                        class="cursor-pointer"
+                                        onclick={() => moveToProject(project.id)}>
+                                        {project.name}
+                                    </DropdownMenu.Item>
+                                {/each}
+                            </DropdownMenu.Content>
+                        </DropdownMenu.Root>
                     </div>
                 {/if}
                 {#if data.modelDisplayName}

--- a/web/src/routes/(app)/projects/+page.server.ts
+++ b/web/src/routes/(app)/projects/+page.server.ts
@@ -1,0 +1,13 @@
+import type { PageServerLoad } from './$types.js'
+import { requireActiveUser } from '$lib/server/authHelpers.js'
+import { ProjectRepository } from '$lib/server/db/projects.js'
+
+export const load: PageServerLoad = async ({ locals }) => {
+    const { user } = requireActiveUser(locals)
+    const projects = await new ProjectRepository().listWithChatCounts(user.id)
+
+    return {
+        user,
+        projects,
+    }
+}

--- a/web/src/routes/(app)/projects/+page.svelte
+++ b/web/src/routes/(app)/projects/+page.svelte
@@ -1,0 +1,381 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button/index.js'
+    import { Badge } from '$lib/components/ui/badge/index.js'
+    import { Input } from '$lib/components/ui/input/index.js'
+    import { Label } from '$lib/components/ui/label/index.js'
+    import { Textarea } from '$lib/components/ui/textarea/index.js'
+    import * as Card from '$lib/components/ui/card/index.js'
+    import * as Dialog from '$lib/components/ui/dialog/index.js'
+    import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
+    import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js'
+    import {
+        Plus,
+        Folder,
+        Pencil,
+        Trash2,
+        Archive,
+        ArchiveRestore,
+        MoreVertical,
+    } from '@lucide/svelte'
+    import { invalidateAll } from '$app/navigation'
+    import { toast } from 'svelte-sonner'
+    import { formatDateTime } from '$lib/utils/datetime'
+    import type { PageData } from './$types.js'
+    import type { Project } from '$lib/server/db/schema.js'
+
+    let { data }: { data: PageData } = $props()
+
+    let showNewForm = $state(false)
+    let newName = $state('')
+    let newDescription = $state('')
+    let newInstructions = $state('')
+    let saving = $state(false)
+
+    let showEditForm = $state(false)
+    let editingProject = $state<Project | null>(null)
+    let editName = $state('')
+    let editDescription = $state('')
+    let editInstructions = $state('')
+
+    let showDeleteConfirm = $state(false)
+    let deletingProject = $state<Project | null>(null)
+
+    let showArchived = $state(false)
+
+    let visibleProjects = $derived(
+        data.projects.filter((project) => showArchived || !project.isArchived),
+    )
+    let archivedCount = $derived(data.projects.filter((p) => p.isArchived).length)
+
+    function resetNewForm() {
+        newName = ''
+        newDescription = ''
+        newInstructions = ''
+    }
+
+    function openEdit(project: Project) {
+        editingProject = project
+        editName = project.name
+        editDescription = project.description ?? ''
+        editInstructions = project.instructions ?? ''
+        showEditForm = true
+    }
+
+    async function handleCreate() {
+        if (!newName.trim()) {
+            toast.error('Name is required')
+            return
+        }
+        saving = true
+        try {
+            const res = await fetch('/api/projects', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: newName.trim(),
+                    description: newDescription.trim() || null,
+                    instructions: newInstructions.trim() || null,
+                }),
+            })
+            if (res.ok) {
+                showNewForm = false
+                resetNewForm()
+                toast.success('Project created')
+                invalidateAll()
+            } else {
+                const body = await res.json()
+                toast.error(body.error || 'Failed to create project')
+            }
+        } catch {
+            toast.error('Failed to create project')
+        } finally {
+            saving = false
+        }
+    }
+
+    async function handleUpdate() {
+        if (!editingProject) return
+        if (!editName.trim()) {
+            toast.error('Name is required')
+            return
+        }
+        saving = true
+        try {
+            const res = await fetch(`/api/projects/${editingProject.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({
+                    name: editName.trim(),
+                    description: editDescription.trim() || null,
+                    instructions: editInstructions.trim() || null,
+                }),
+            })
+            if (res.ok) {
+                showEditForm = false
+                editingProject = null
+                toast.success('Project updated')
+                invalidateAll()
+            } else {
+                const body = await res.json()
+                toast.error(body.error || 'Failed to update project')
+            }
+        } catch {
+            toast.error('Failed to update project')
+        } finally {
+            saving = false
+        }
+    }
+
+    async function toggleArchive(project: Project) {
+        const res = await fetch(`/api/projects/${project.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ isArchived: !project.isArchived }),
+        })
+        if (res.ok) {
+            toast.success(project.isArchived ? 'Project unarchived' : 'Project archived')
+            invalidateAll()
+        } else {
+            const body = await res.json()
+            toast.error(body.error || 'Failed to update project')
+        }
+    }
+
+    async function handleDelete() {
+        if (!deletingProject) return
+        try {
+            const res = await fetch(`/api/projects/${deletingProject.id}`, {
+                method: 'DELETE',
+            })
+            if (res.ok) {
+                toast.success('Project deleted. Its chats were kept and moved to unorganized.')
+                invalidateAll()
+            } else {
+                const body = await res.json()
+                toast.error(body.error || 'Failed to delete project')
+            }
+        } catch {
+            toast.error('Failed to delete project')
+        } finally {
+            showDeleteConfirm = false
+            deletingProject = null
+        }
+    }
+</script>
+
+<div class="mx-auto max-w-4xl p-6">
+    <div class="mb-6 flex items-center justify-between">
+        <div>
+            <h1 class="text-2xl font-bold">Projects</h1>
+            <p class="text-muted-foreground text-sm">
+                Organize related chats, instructions, and context in one place
+            </p>
+        </div>
+        <Button onclick={() => (showNewForm = true)} class="cursor-pointer">
+            <Plus class="mr-2 h-4 w-4" />
+            New Project
+        </Button>
+    </div>
+
+    {#if data.projects.length > 0}
+        <label class="text-muted-foreground mb-4 flex cursor-pointer items-center gap-2 text-sm">
+            <input
+                type="checkbox"
+                bind:checked={showArchived}
+                class="accent-primary h-4 w-4 cursor-pointer" />
+            Show archived ({archivedCount})
+        </label>
+    {/if}
+
+    {#if visibleProjects.length === 0}
+        <div
+            class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+            <Folder class="text-muted-foreground mb-4 h-12 w-12" />
+            <h3 class="mb-2 text-lg font-medium">No projects yet</h3>
+            <p class="text-muted-foreground mb-4 text-sm">
+                Create a project to group chats, share standing instructions, and keep key documents
+                at hand.
+            </p>
+            <Button onclick={() => (showNewForm = true)} class="cursor-pointer">
+                <Plus class="mr-2 h-4 w-4" />
+                Create your first project
+            </Button>
+        </div>
+    {:else}
+        <div class="grid gap-4 sm:grid-cols-2">
+            {#each visibleProjects as project (project.id)}
+                <Card.Root>
+                    <Card.Header>
+                        <div class="flex items-start justify-between gap-2">
+                            <a href={`/projects/${project.id}`} class="hover:underline">
+                                <Card.Title class="flex items-center gap-2">
+                                    <Folder class="text-muted-foreground h-4 w-4" />
+                                    {project.name}
+                                </Card.Title>
+                            </a>
+                            <DropdownMenu.Root>
+                                <DropdownMenu.Trigger>
+                                    {#snippet child({ props })}
+                                        <Button
+                                            variant="ghost"
+                                            size="icon"
+                                            class="cursor-pointer"
+                                            {...props}>
+                                            <MoreVertical class="h-4 w-4" />
+                                            <span class="sr-only">Project actions</span>
+                                        </Button>
+                                    {/snippet}
+                                </DropdownMenu.Trigger>
+                                <DropdownMenu.Content align="end">
+                                    <DropdownMenu.Item
+                                        class="cursor-pointer"
+                                        onclick={() => openEdit(project)}>
+                                        <Pencil class="mr-2 h-4 w-4" />
+                                        Edit
+                                    </DropdownMenu.Item>
+                                    <DropdownMenu.Item
+                                        class="cursor-pointer"
+                                        onclick={() => toggleArchive(project)}>
+                                        {#if project.isArchived}
+                                            <ArchiveRestore class="mr-2 h-4 w-4" />
+                                            Unarchive
+                                        {:else}
+                                            <Archive class="mr-2 h-4 w-4" />
+                                            Archive
+                                        {/if}
+                                    </DropdownMenu.Item>
+                                    <DropdownMenu.Item
+                                        class="text-destructive cursor-pointer"
+                                        onclick={() => {
+                                            deletingProject = project
+                                            showDeleteConfirm = true
+                                        }}>
+                                        <Trash2 class="mr-2 h-4 w-4" />
+                                        Delete
+                                    </DropdownMenu.Item>
+                                </DropdownMenu.Content>
+                            </DropdownMenu.Root>
+                        </div>
+                        <Card.Description>
+                            {project.description || 'No description'}
+                        </Card.Description>
+                    </Card.Header>
+                    <Card.Content>
+                        <a href={`/projects/${project.id}`} class="text-sm hover:underline">
+                            View project
+                        </a>
+                    </Card.Content>
+                    <Card.Footer class="flex items-center justify-between text-xs">
+                        <Badge variant="secondary">
+                            {project.chatCount}
+                            {project.chatCount === 1 ? 'chat' : 'chats'}
+                        </Badge>
+                        {#if project.isArchived}
+                            <Badge variant="outline">Archived</Badge>
+                        {/if}
+                        <span class="text-muted-foreground">
+                            Updated {formatDateTime(
+                                project.updatedAt,
+                                data.user.configuration?.timezone,
+                            )}
+                        </span>
+                    </Card.Footer>
+                </Card.Root>
+            {/each}
+        </div>
+    {/if}
+</div>
+
+<Dialog.Root bind:open={showNewForm}>
+    <Dialog.Content class="sm:max-w-lg">
+        <Dialog.Header>
+            <Dialog.Title>New project</Dialog.Title>
+            <Dialog.Description>
+                Group chats, standing instructions, and context documents.
+            </Dialog.Description>
+        </Dialog.Header>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-2">
+                <Label for="project-name">Name</Label>
+                <Input id="project-name" bind:value={newName} placeholder="Q3 Launch" />
+            </div>
+            <div class="grid gap-2">
+                <Label for="project-description">Description (optional)</Label>
+                <Input
+                    id="project-description"
+                    bind:value={newDescription}
+                    placeholder="What is this project about?" />
+            </div>
+            <div class="grid gap-2">
+                <Label for="project-instructions">Instructions (optional)</Label>
+                <Textarea
+                    id="project-instructions"
+                    bind:value={newInstructions}
+                    placeholder="Standing instructions applied to every chat in this project"
+                    rows={4} />
+            </div>
+        </div>
+        <Dialog.Footer>
+            <Button variant="outline" onclick={() => (showNewForm = false)} class="cursor-pointer">
+                Cancel
+            </Button>
+            <Button onclick={handleCreate} disabled={saving} class="cursor-pointer">
+                {saving ? 'Creating...' : 'Create project'}
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>
+
+<Dialog.Root bind:open={showEditForm}>
+    <Dialog.Content class="sm:max-w-lg">
+        <Dialog.Header>
+            <Dialog.Title>Edit project</Dialog.Title>
+        </Dialog.Header>
+        <div class="grid gap-4 py-4">
+            <div class="grid gap-2">
+                <Label for="edit-project-name">Name</Label>
+                <Input id="edit-project-name" bind:value={editName} />
+            </div>
+            <div class="grid gap-2">
+                <Label for="edit-project-description">Description</Label>
+                <Input id="edit-project-description" bind:value={editDescription} />
+            </div>
+            <div class="grid gap-2">
+                <Label for="edit-project-instructions">Instructions</Label>
+                <Textarea
+                    id="edit-project-instructions"
+                    bind:value={editInstructions}
+                    placeholder="Standing instructions applied to every chat in this project"
+                    rows={4} />
+            </div>
+        </div>
+        <Dialog.Footer>
+            <Button variant="outline" onclick={() => (showEditForm = false)} class="cursor-pointer">
+                Cancel
+            </Button>
+            <Button onclick={handleUpdate} disabled={saving} class="cursor-pointer">
+                {saving ? 'Saving...' : 'Save changes'}
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>
+
+<AlertDialog.Root bind:open={showDeleteConfirm}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>Delete "{deletingProject?.name}"?</AlertDialog.Title>
+            <AlertDialog.Description>
+                This permanently removes the project, its instructions, and its attachments. Chats
+                in this project are kept and moved back to unorganized.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel class="cursor-pointer">Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action
+                class="bg-destructive hover:bg-destructive/90 cursor-pointer text-white"
+                onclick={handleDelete}>
+                Delete project
+            </AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/web/src/routes/(app)/projects/[projectId]/+page.server.ts
+++ b/web/src/routes/(app)/projects/[projectId]/+page.server.ts
@@ -1,0 +1,75 @@
+import type { PageServerLoad } from './$types.js'
+import { requireActiveUser } from '$lib/server/authHelpers.js'
+import { error } from '@sveltejs/kit'
+import { sql } from 'drizzle-orm'
+import { db } from '$lib/server/db/index.js'
+import { ChatRepository } from '$lib/server/db/chats.js'
+import { ProjectAttachmentRepository, ProjectRepository } from '$lib/server/db/projects.js'
+
+export const load: PageServerLoad = async ({ locals, params }) => {
+    const { user } = requireActiveUser(locals)
+
+    const project = await new ProjectRepository().get(params.projectId)
+    if (!project || project.userId !== user.id) {
+        error(404, 'Project not found')
+    }
+
+    const [attachments, chats] = await Promise.all([
+        new ProjectAttachmentRepository().listForProject(project.id),
+        new ChatRepository().getByUserId(user.id, { projectId: project.id, limit: 50 }),
+    ])
+
+    // Resolve document titles for display. Content/permission enforcement stays
+    // with search/read_document; here we only need a human-readable label.
+    const documentIds = attachments
+        .filter((a) => a.attachmentType === 'document' && a.documentId)
+        .map((a) => a.documentId as string)
+
+    let documentsByUlid: Record<string, { title: string | null; contentId: string | null }> = {}
+    if (documentIds.length > 0) {
+        const rows = await db.execute<{
+            id: string
+            title: string | null
+            content_id: string | null
+        }>(
+            sql`SELECT d.id, d.title, d.content_id
+                FROM documents d
+                JOIN sources s ON d.source_id = s.id
+                WHERE d.id = ANY(${documentIds})
+                  AND s.is_deleted = FALSE`,
+        )
+        documentsByUlid = Object.fromEntries(
+            rows.map((row) => [row.id, { title: row.title, contentId: row.content_id }]),
+        )
+    }
+
+    const uploadIds = attachments
+        .filter((a) => a.attachmentType === 'upload' && a.uploadId)
+        .map((a) => a.uploadId as string)
+    let uploadsById: Record<string, { filename: string }> = {}
+    if (uploadIds.length > 0) {
+        const rows = await db.execute<{ id: string; filename: string }>(
+            sql`SELECT id, filename FROM uploads WHERE id = ANY(${uploadIds})`,
+        )
+        uploadsById = Object.fromEntries(rows.map((row) => [row.id, { filename: row.filename }]))
+    }
+
+    return {
+        user,
+        project,
+        chats,
+        attachments: attachments.map((attachment) => ({
+            id: attachment.id,
+            attachmentType: attachment.attachmentType,
+            uploadId: attachment.uploadId,
+            documentId: attachment.documentId,
+            addedAt: attachment.addedAt,
+            title:
+                attachment.attachmentType === 'document' && attachment.documentId
+                    ? (documentsByUlid[attachment.documentId]?.title ?? 'Unavailable document')
+                    : attachment.uploadId
+                      ? (uploadsById[attachment.uploadId]?.filename ?? 'Unavailable file')
+                      : null,
+        })),
+    }
+}

--- a/web/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/web/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -1,0 +1,356 @@
+<script lang="ts">
+    import { Button } from '$lib/components/ui/button/index.js'
+    import { Badge } from '$lib/components/ui/badge/index.js'
+    import { Label } from '$lib/components/ui/label/index.js'
+    import { Textarea } from '$lib/components/ui/textarea/index.js'
+    import { Input } from '$lib/components/ui/input/index.js'
+    import * as Card from '$lib/components/ui/card/index.js'
+    import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
+    import {
+        MessageSquare,
+        Save,
+        Trash2,
+        Plus,
+        Search,
+        X,
+        Archive,
+        ArchiveRestore,
+    } from '@lucide/svelte'
+    import { goto, invalidateAll } from '$app/navigation'
+    import { toast } from 'svelte-sonner'
+    import { formatDateTime } from '$lib/utils/datetime'
+    import type { PageData } from './$types.js'
+    import type { TypeaheadResult } from '$lib/types/search.js'
+
+    let { data }: { data: PageData } = $props()
+
+    let instructions = $state(data.project.instructions ?? '')
+    let savingInstructions = $state(false)
+    let instructionsDirty = $derived(instructions !== (data.project.instructions ?? ''))
+
+    let showDeleteConfirm = $state(false)
+
+    let addingChat = $state(false)
+
+    // Document attachment search (reuses the permission-enforced typeahead).
+    let docQuery = $state('')
+    let docResults = $state<TypeaheadResult[]>([])
+    let searching = $state(false)
+    let searchTimer: ReturnType<typeof setTimeout> | undefined
+
+    $effect(() => {
+        const query = docQuery.trim()
+        if (searchTimer) clearTimeout(searchTimer)
+        if (query.length < 2) {
+            docResults = []
+            searching = false
+            return
+        }
+        searching = true
+        searchTimer = setTimeout(async () => {
+            try {
+                const res = await fetch(`/api/typeahead?q=${encodeURIComponent(query)}&limit=8`)
+                if (res.ok) {
+                    const body = await res.json()
+                    docResults = body.results ?? []
+                }
+            } finally {
+                searching = false
+            }
+        }, 200)
+    })
+
+    async function saveInstructions() {
+        savingInstructions = true
+        try {
+            const res = await fetch(`/api/projects/${data.project.id}`, {
+                method: 'PATCH',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ instructions: instructions.trim() || null }),
+            })
+            if (res.ok) {
+                toast.success('Instructions saved')
+                invalidateAll()
+            } else {
+                const body = await res.json()
+                toast.error(body.error || 'Failed to save instructions')
+            }
+        } catch {
+            toast.error('Failed to save instructions')
+        } finally {
+            savingInstructions = false
+        }
+    }
+
+    async function attachDocument(result: TypeaheadResult) {
+        const res = await fetch(`/api/projects/${data.project.id}/attachments`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({
+                attachmentType: 'document',
+                documentId: result.document_id,
+            }),
+        })
+        if (res.ok) {
+            const body = await res.json()
+            toast.success(body.alreadyAttached ? 'Already attached' : 'Document attached')
+            docQuery = ''
+            docResults = []
+            invalidateAll()
+        } else {
+            const body = await res.json()
+            toast.error(body.error || 'Failed to attach document')
+        }
+    }
+
+    async function removeAttachment(attachmentId: string) {
+        const res = await fetch(`/api/projects/${data.project.id}/attachments`, {
+            method: 'DELETE',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ attachmentId }),
+        })
+        if (res.ok) {
+            toast.success('Attachment removed')
+            invalidateAll()
+        } else {
+            const body = await res.json()
+            toast.error(body.error || 'Failed to remove attachment')
+        }
+    }
+
+    async function newChat() {
+        addingChat = true
+        try {
+            const res = await fetch('/api/chat', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ projectId: data.project.id }),
+            })
+            if (res.ok) {
+                const { chatId } = await res.json()
+                await goto(`/chat/${chatId}`, { state: { stream: true } })
+            } else {
+                const body = await res.json()
+                toast.error(body.error || 'Failed to create chat')
+            }
+        } catch {
+            toast.error('Failed to create chat')
+        } finally {
+            addingChat = false
+        }
+    }
+
+    async function toggleArchive() {
+        const res = await fetch(`/api/projects/${data.project.id}`, {
+            method: 'PATCH',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ isArchived: !data.project.isArchived }),
+        })
+        if (res.ok) {
+            toast.success(data.project.isArchived ? 'Project unarchived' : 'Project archived')
+            invalidateAll()
+        } else {
+            const body = await res.json()
+            toast.error(body.error || 'Failed to update project')
+        }
+    }
+
+    async function handleDelete() {
+        const res = await fetch(`/api/projects/${data.project.id}`, { method: 'DELETE' })
+        if (res.ok) {
+            toast.success('Project deleted. Its chats were kept and moved to unorganized.')
+            await goto('/projects')
+        } else {
+            const body = await res.json()
+            toast.error(body.error || 'Failed to delete project')
+        }
+    }
+</script>
+
+<div class="mx-auto max-w-4xl p-6">
+    <div class="mb-6 flex items-start justify-between gap-4">
+        <div>
+            <div class="flex items-center gap-3">
+                <h1 class="text-2xl font-bold">{data.project.name}</h1>
+                {#if data.project.isArchived}
+                    <Badge variant="outline">Archived</Badge>
+                {/if}
+            </div>
+            {#if data.project.description}
+                <p class="text-muted-foreground mt-1 text-sm">{data.project.description}</p>
+            {/if}
+        </div>
+        <div class="flex shrink-0 items-center gap-2">
+            <Button onclick={newChat} disabled={addingChat} class="cursor-pointer">
+                <MessageSquare class="mr-2 h-4 w-4" />
+                {addingChat ? 'Starting...' : 'New chat'}
+            </Button>
+            <Button variant="outline" onclick={toggleArchive} class="cursor-pointer">
+                {#if data.project.isArchived}
+                    <ArchiveRestore class="mr-2 h-4 w-4" />
+                    Unarchive
+                {:else}
+                    <Archive class="mr-2 h-4 w-4" />
+                    Archive
+                {/if}
+            </Button>
+            <Button
+                variant="outline"
+                class="text-destructive hover:text-destructive cursor-pointer"
+                onclick={() => (showDeleteConfirm = true)}>
+                <Trash2 class="mr-2 h-4 w-4" />
+                Delete
+            </Button>
+        </div>
+    </div>
+
+    <div class="grid gap-6">
+        <!-- Instructions -->
+        <Card.Root>
+            <Card.Header>
+                <Card.Title>Project instructions</Card.Title>
+                <Card.Description>
+                    Automatically included in every chat in this project.
+                </Card.Description>
+            </Card.Header>
+            <Card.Content class="grid gap-3">
+                <Textarea
+                    bind:value={instructions}
+                    rows={5}
+                    placeholder="e.g. This project is about the Q3 launch. Prefer German responses and reference the roadmap."
+                    disabled={data.project.isArchived} />
+            </Card.Content>
+            <Card.Footer class="justify-end">
+                <Button
+                    onclick={saveInstructions}
+                    disabled={!instructionsDirty || savingInstructions || data.project.isArchived}
+                    class="cursor-pointer">
+                    <Save class="mr-2 h-4 w-4" />
+                    {savingInstructions ? 'Saving...' : 'Save instructions'}
+                </Button>
+            </Card.Footer>
+        </Card.Root>
+
+        <!-- Attachments -->
+        <Card.Root>
+            <Card.Header>
+                <Card.Title>Context documents</Card.Title>
+                <Card.Description>
+                    Attached documents are available as standing context in every chat in this
+                    project.
+                </Card.Description>
+            </Card.Header>
+            <Card.Content class="grid gap-4">
+                {#if data.attachments.length > 0}
+                    <div class="flex flex-wrap gap-2">
+                        {#each data.attachments as attachment (attachment.id)}
+                            <Badge
+                                variant="secondary"
+                                class="flex max-w-full items-center gap-1 py-1 pl-2">
+                                <span class="truncate">{attachment.title ?? 'Attachment'}</span>
+                                <button
+                                    type="button"
+                                    class="hover:text-destructive ml-1 cursor-pointer"
+                                    aria-label="Remove {attachment.title}"
+                                    onclick={() => removeAttachment(attachment.id)}>
+                                    <X class="h-3 w-3" />
+                                </button>
+                            </Badge>
+                        {/each}
+                    </div>
+                {:else}
+                    <p class="text-muted-foreground text-sm">No documents attached yet.</p>
+                {/if}
+
+                {#if !data.project.isArchived}
+                    <div class="grid gap-2">
+                        <Label for="doc-search">Add documents</Label>
+                        <div class="relative">
+                            <Search
+                                class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+                            <Input
+                                id="doc-search"
+                                bind:value={docQuery}
+                                placeholder="Search indexed documents to attach..."
+                                class="pl-9" />
+                        </div>
+                        {#if docQuery.trim().length >= 2}
+                            <div class="rounded-md border">
+                                {#if searching}
+                                    <p class="text-muted-foreground p-3 text-sm">Searching...</p>
+                                {:else if docResults.length === 0}
+                                    <p class="text-muted-foreground p-3 text-sm">
+                                        No documents found. Try a different search.
+                                    </p>
+                                {:else}
+                                    {#each docResults as result (result.document_id)}
+                                        <button
+                                            type="button"
+                                            class="hover:bg-accent flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-sm"
+                                            onclick={() => attachDocument(result)}>
+                                            <span class="truncate">{result.title}</span>
+                                            <Plus class="text-muted-foreground h-4 w-4 shrink-0" />
+                                        </button>
+                                    {/each}
+                                {/if}
+                            </div>
+                        {/if}
+                    </div>
+                {/if}
+            </Card.Content>
+        </Card.Root>
+
+        <!-- Chats -->
+        <Card.Root>
+            <Card.Header>
+                <Card.Title>Chats</Card.Title>
+                <Card.Description>Conversations in this project.</Card.Description>
+            </Card.Header>
+            <Card.Content>
+                {#if data.chats.length === 0}
+                    <p class="text-muted-foreground text-sm">No chats yet.</p>
+                {:else}
+                    <ul class="divide-y">
+                        {#each data.chats as chat (chat.id)}
+                            <li>
+                                <a
+                                    href={`/chat/${chat.id}`}
+                                    class="hover:bg-accent flex items-center justify-between gap-4 px-2 py-3">
+                                    <span class="truncate text-sm">
+                                        {chat.title ?? 'Untitled chat'}
+                                    </span>
+                                    <span class="text-muted-foreground shrink-0 text-xs">
+                                        {formatDateTime(
+                                            chat.updatedAt,
+                                            data.user.configuration?.timezone,
+                                        )}
+                                    </span>
+                                </a>
+                            </li>
+                        {/each}
+                    </ul>
+                {/if}
+            </Card.Content>
+        </Card.Root>
+    </div>
+</div>
+
+<AlertDialog.Root bind:open={showDeleteConfirm}>
+    <AlertDialog.Content>
+        <AlertDialog.Header>
+            <AlertDialog.Title>Delete "{data.project.name}"?</AlertDialog.Title>
+            <AlertDialog.Description>
+                This permanently removes the project, its instructions, and its attachments. Chats
+                in this project are kept and moved back to unorganized.
+            </AlertDialog.Description>
+        </AlertDialog.Header>
+        <AlertDialog.Footer>
+            <AlertDialog.Cancel class="cursor-pointer">Cancel</AlertDialog.Cancel>
+            <AlertDialog.Action
+                class="bg-destructive hover:bg-destructive/90 cursor-pointer text-white"
+                onclick={handleDelete}>
+                Delete project
+            </AlertDialog.Action>
+        </AlertDialog.Footer>
+    </AlertDialog.Content>
+</AlertDialog.Root>

--- a/web/src/routes/api/chat/+server.ts
+++ b/web/src/routes/api/chat/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types.js'
 import { chatRepository } from '$lib/server/db/chats'
+import { ProjectRepository } from '$lib/server/db/projects.js'
 
 export const POST: RequestHandler = async ({ request, locals }) => {
     const logger = locals.logger.child('chat')
@@ -13,17 +14,26 @@ export const POST: RequestHandler = async ({ request, locals }) => {
     const userId = locals.user.id
 
     let modelId: string | undefined
+    let projectId: string | undefined
     try {
         const body = await request.json()
         modelId = body.modelId || undefined
+        projectId = body.projectId || undefined
     } catch {
-        // No body or invalid JSON is fine — modelId stays undefined
+        // No body or invalid JSON is fine — modelId/projectId stay undefined
     }
 
-    logger.debug('Creating new chat', { userId, modelId })
+    if (projectId) {
+        const project = await new ProjectRepository().get(projectId)
+        if (!project || project.userId !== userId) {
+            return json({ error: 'Project not found' }, { status: 404 })
+        }
+    }
+
+    logger.debug('Creating new chat', { userId, modelId, projectId })
 
     try {
-        const chat = await chatRepository.create(userId, undefined, modelId)
+        const chat = await chatRepository.create(userId, undefined, modelId, undefined, projectId)
 
         logger.info('Chat created successfully', {
             userId,

--- a/web/src/routes/api/chat/[chatId]/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types.js'
 import { chatRepository } from '$lib/server/db/chats'
+import { ProjectRepository } from '$lib/server/db/projects.js'
 
 export const GET: RequestHandler = async ({ params, locals }) => {
     const logger = locals.logger.child('chat')
@@ -52,6 +53,9 @@ export const PATCH: RequestHandler = async ({ params, locals, request }) => {
     if (!chatId) {
         return json({ error: 'chatId parameter is required' }, { status: 400 })
     }
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
 
     const chat = await chatRepository.get(chatId)
     if (!chat) {
@@ -72,6 +76,20 @@ export const PATCH: RequestHandler = async ({ params, locals, request }) => {
 
         if (typeof body.isStarred === 'boolean') {
             const result = await chatRepository.toggleStar(chatId, body.isStarred)
+            if (result) updatedChat = result
+        }
+
+        if (body.projectId !== undefined) {
+            if (body.projectId !== null && typeof body.projectId !== 'string') {
+                return json({ error: 'Invalid projectId' }, { status: 400 })
+            }
+            if (body.projectId !== null) {
+                const project = await new ProjectRepository().get(body.projectId)
+                if (!project || project.userId !== locals.user.id) {
+                    return json({ error: 'Project not found' }, { status: 404 })
+                }
+            }
+            const result = await chatRepository.moveChatToProject(chatId, body.projectId)
             if (result) updatedChat = result
         }
 

--- a/web/src/routes/api/chat/history/+server.ts
+++ b/web/src/routes/api/chat/history/+server.ts
@@ -1,6 +1,7 @@
 import { json } from '@sveltejs/kit'
 import type { RequestHandler } from './$types.js'
 import { chatRepository } from '$lib/server/db/chats'
+import { ProjectRepository } from '$lib/server/db/projects.js'
 
 const DEFAULT_LIMIT = 20
 const MAX_LIMIT = 50
@@ -29,12 +30,20 @@ export const GET: RequestHandler = async ({ url, locals }) => {
     const limit = Math.min(Math.max(requestedLimit, 1), MAX_LIMIT)
     const offset = parseNonNegativeInteger(url.searchParams.get('offset'), 0)
     const isStarred = parseOptionalBoolean(url.searchParams.get('isStarred'))
+    const projectId = url.searchParams.get('projectId')
+    if (projectId) {
+        const project = await new ProjectRepository().get(projectId)
+        if (!project || project.userId !== locals.user.id) {
+            return json({ error: 'Project not found' }, { status: 404 })
+        }
+    }
 
     try {
         const rows = await chatRepository.getByUserId(locals.user.id, {
             limit: limit + 1,
             offset,
             isStarred,
+            projectId: projectId || undefined,
         })
         const hasMore = rows.length > limit
         const items = hasMore ? rows.slice(0, limit) : rows

--- a/web/src/routes/api/projects/+server.ts
+++ b/web/src/routes/api/projects/+server.ts
@@ -1,0 +1,62 @@
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types.js'
+import { ProjectNameTakenError, ProjectRepository } from '$lib/server/db/projects.js'
+
+function parseOptionalString(value: unknown): string | undefined {
+    if (value === undefined) return undefined
+    if (typeof value !== 'string') return undefined
+    const trimmed = value.trim()
+    return trimmed.length > 0 ? trimmed : undefined
+}
+
+export const GET: RequestHandler = async ({ url, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const includeArchived = url.searchParams.get('includeArchived') !== 'false'
+    const projects = await new ProjectRepository().listWithChatCounts(
+        locals.user.id,
+        includeArchived,
+    )
+    return json({ projects })
+}
+
+export const POST: RequestHandler = async ({ request, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    let body: { name?: unknown; description?: unknown; instructions?: unknown }
+    try {
+        body = await request.json()
+    } catch {
+        return json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    const name = parseOptionalString(body.name)
+    if (!name) {
+        return json({ error: 'Project name is required' }, { status: 400 })
+    }
+    if (name.length > 200) {
+        return json({ error: 'Project name is too long' }, { status: 400 })
+    }
+
+    const description = parseOptionalString(body.description)
+    const instructions = parseOptionalString(body.instructions)
+
+    try {
+        const project = await new ProjectRepository().create(
+            locals.user.id,
+            name,
+            description,
+            instructions,
+        )
+        return json({ project }, { status: 201 })
+    } catch (error) {
+        if (error instanceof ProjectNameTakenError) {
+            return json({ error: error.message }, { status: 409 })
+        }
+        throw error
+    }
+}

--- a/web/src/routes/api/projects/[projectId]/+server.ts
+++ b/web/src/routes/api/projects/[projectId]/+server.ts
@@ -1,0 +1,118 @@
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types.js'
+import { ProjectNameTakenError, ProjectRepository } from '$lib/server/db/projects.js'
+
+async function getOwnedProject(projectId: string, userId: string) {
+    const project = await new ProjectRepository().get(projectId)
+    if (!project || project.userId !== userId) {
+        return null
+    }
+    return project
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const project = await getOwnedProject(params.projectId, locals.user.id)
+    if (!project) {
+        return json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    return json({ project })
+}
+
+export const PATCH: RequestHandler = async ({ params, request, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const project = await getOwnedProject(params.projectId, locals.user.id)
+    if (!project) {
+        return json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    let body: {
+        name?: unknown
+        description?: unknown
+        instructions?: unknown
+        isArchived?: unknown
+    }
+    try {
+        body = await request.json()
+    } catch {
+        return json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    const updates: {
+        name?: string
+        description?: string | null
+        instructions?: string | null
+        isArchived?: boolean
+    } = {}
+
+    if (body.name !== undefined) {
+        if (typeof body.name !== 'string' || body.name.trim().length === 0) {
+            return json({ error: 'Project name cannot be empty' }, { status: 400 })
+        }
+        if (body.name.trim().length > 200) {
+            return json({ error: 'Project name is too long' }, { status: 400 })
+        }
+        updates.name = body.name.trim()
+    }
+    if (body.description !== undefined) {
+        if (body.description !== null && typeof body.description !== 'string') {
+            return json({ error: 'Invalid description' }, { status: 400 })
+        }
+        updates.description =
+            typeof body.description === 'string' && body.description.trim().length > 0
+                ? body.description.trim()
+                : null
+    }
+    if (body.instructions !== undefined) {
+        if (body.instructions !== null && typeof body.instructions !== 'string') {
+            return json({ error: 'Invalid instructions' }, { status: 400 })
+        }
+        updates.instructions =
+            typeof body.instructions === 'string' && body.instructions.trim().length > 0
+                ? body.instructions.trim()
+                : null
+    }
+    if (body.isArchived !== undefined) {
+        if (typeof body.isArchived !== 'boolean') {
+            return json({ error: 'Invalid isArchived' }, { status: 400 })
+        }
+        updates.isArchived = body.isArchived
+    }
+
+    try {
+        const updated = await new ProjectRepository().update(params.projectId, updates)
+        if (!updated) {
+            return json({ error: 'Project not found' }, { status: 404 })
+        }
+        return json({ project: updated })
+    } catch (error) {
+        if (error instanceof ProjectNameTakenError) {
+            return json({ error: error.message }, { status: 409 })
+        }
+        throw error
+    }
+}
+
+export const DELETE: RequestHandler = async ({ params, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const project = await getOwnedProject(params.projectId, locals.user.id)
+    if (!project) {
+        return json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    const deleted = await new ProjectRepository().delete(params.projectId)
+    if (!deleted) {
+        return json({ error: 'Project not found' }, { status: 404 })
+    }
+    return json({ success: true })
+}

--- a/web/src/routes/api/projects/[projectId]/attachments/+server.ts
+++ b/web/src/routes/api/projects/[projectId]/attachments/+server.ts
@@ -1,0 +1,106 @@
+import { json } from '@sveltejs/kit'
+import type { RequestHandler } from './$types.js'
+import { sql } from 'drizzle-orm'
+import { db } from '$lib/server/db/index.js'
+import { ProjectAttachmentRepository, ProjectRepository } from '$lib/server/db/projects.js'
+
+type AttachmentType = 'upload' | 'document'
+
+function isAttachmentType(value: unknown): value is AttachmentType {
+    return value === 'upload' || value === 'document'
+}
+
+export const GET: RequestHandler = async ({ params, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const project = await new ProjectRepository().get(params.projectId)
+    if (!project || project.userId !== locals.user.id) {
+        return json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    const attachments = await new ProjectAttachmentRepository().listForProject(params.projectId)
+    return json({ attachments })
+}
+
+export const POST: RequestHandler = async ({ params, request, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    const project = await new ProjectRepository().get(params.projectId)
+    if (!project || project.userId !== locals.user.id) {
+        return json({ error: 'Project not found' }, { status: 404 })
+    }
+
+    let body: { attachmentType?: unknown; uploadId?: unknown; documentId?: unknown }
+    try {
+        body = await request.json()
+    } catch {
+        return json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+
+    if (!isAttachmentType(body.attachmentType)) {
+        return json({ error: 'attachmentType must be "upload" or "document"' }, { status: 400 })
+    }
+
+    if (body.attachmentType === 'upload') {
+        if (typeof body.uploadId !== 'string' || body.uploadId.length === 0) {
+            return json({ error: 'uploadId is required' }, { status: 400 })
+        }
+        // uploads are user-owned; reject attachments referencing someone else's upload.
+        const owned = await db.execute(
+            sql`SELECT 1 FROM uploads WHERE id = ${body.uploadId} AND user_id = ${locals.user.id}`,
+        )
+        if (owned.length === 0) {
+            return json({ error: 'Upload not found' }, { status: 404 })
+        }
+    } else {
+        if (typeof body.documentId !== 'string' || body.documentId.length === 0) {
+            return json({ error: 'documentId is required' }, { status: 400 })
+        }
+        const exists = await db.execute(
+            sql`SELECT 1 FROM documents d JOIN sources s ON d.source_id = s.id
+                WHERE d.id = ${body.documentId} AND s.is_deleted = FALSE`,
+        )
+        if (exists.length === 0) {
+            return json({ error: 'Document not found' }, { status: 404 })
+        }
+    }
+
+    const attachment = await new ProjectAttachmentRepository().add(params.projectId, {
+        type: body.attachmentType,
+        uploadId: typeof body.uploadId === 'string' ? body.uploadId : undefined,
+        documentId: typeof body.documentId === 'string' ? body.documentId : undefined,
+    })
+
+    return json({ attachment, alreadyAttached: attachment === null }, { status: 200 })
+}
+
+export const DELETE: RequestHandler = async ({ request, locals }) => {
+    if (!locals.user?.id) {
+        return json({ error: 'User not authenticated' }, { status: 401 })
+    }
+
+    let body: { attachmentId?: unknown }
+    try {
+        body = await request.json()
+    } catch {
+        return json({ error: 'Invalid JSON body' }, { status: 400 })
+    }
+    if (typeof body.attachmentId !== 'string' || body.attachmentId.length === 0) {
+        return json({ error: 'attachmentId is required' }, { status: 400 })
+    }
+
+    const attachment = await new ProjectAttachmentRepository().getOwned(
+        body.attachmentId,
+        locals.user.id,
+    )
+    if (!attachment) {
+        return json({ error: 'Attachment not found' }, { status: 404 })
+    }
+
+    await new ProjectAttachmentRepository().remove(attachment.id)
+    return json({ success: true })
+}


### PR DESCRIPTION
Closes #358

- Add user-owned projects that group chats, standing instructions, and context documents into a durable workspace.
- Project instructions are automatically included in the system prompt of every chat in the project; attached indexed documents are provided as standing context the model can read on demand.
- Create, rename, edit, archive, and delete projects from a new /projects management page and project detail page; chats can be started inside a project and existing chats can be moved between projects. Deleting a project keeps its chats (moved back to unorganized).
- Project-scoped chat history in the web UI, and chat-history search can be scoped to a project.
- Migration 113: projects, chats.project_id, and project_attachments (uploads and indexed-document references).
- Source permissions are unchanged — projects never grant access beyond what the user already has. Designed so project-scoped agents/background runs can be added later.
