### PR TITLE
feat(sandbox): first-class file creation, edit_file tool, and git file versioning

### DIFF
--- a/services/ai/prompts.py
+++ b/services/ai/prompts.py
@@ -82,7 +82,9 @@ Connected apps: {connected_apps}
 - When a task requires multiple steps, execute them sequentially. Do not ask the user to confirm intermediate steps unless a decision is genuinely ambiguous.
 
 # Sandbox (code execution)
-- Use sandbox tools (`run_python`, `run_bash`, `write_file`, `read_file`) when the user needs data processing, analysis, or transformation that cannot be done with search alone.
+- Use sandbox tools (`run_python`, `run_bash`, `write_file`, `edit_file`, `read_file`) when the user needs data processing, analysis, or transformation that cannot be done with search alone.
+- To create a new file, use `write_file` or generate it with code. To modify an existing file, prefer `edit_file` (exact string replacement) — read the file first if needed, then edit only the parts that change instead of rewriting the whole file. `write_file` overwrites the entire file and should only be used for new files or complete rewrites.
+- Office files and PDFs can be created with Python in the sandbox: `python-docx` for Word documents, `python-pptx` for PowerPoint presentations, `openpyxl`/`xlsxwriter` for Excel spreadsheets, `reportlab` for PDFs. For PDFs with formatted text, use reportlab's Platypus flowables (Paragraph, Table, Image).
 - Use the `run_python` tool for quick one-liners; for more complex tasks, use `write_file` to create a Python script and then `run_bash` to execute it.
 - To analyze a full document, use `read_document` to fetch it into the workspace, then process with `run_python` or `run_bash`. `read_document` returns the indexed extracted text for text-extractable formats (PDFs, Word docs, presentations) — small results inline, large results as a `.txt` in the workspace. For spreadsheets and images it saves the original binary to the workspace so you can load it with pandas / Pillow.
 - Use a connector's `fetch_file` tool only when you specifically need the original binary (e.g., a spreadsheet for pandas). If you already pulled a PDF or document binary into the workspace via `fetch_file` and only need its text, switch to `read_document` instead of writing a sandbox script to extract text.

--- a/services/ai/routers/chat.py
+++ b/services/ai/routers/chat.py
@@ -1237,12 +1237,16 @@ async def download_artifact(
     request: Request,
     chat_id: str = Path(..., description="Chat thread ID"),
     path: str = Path(..., description="Relative file path in the sandbox"),
+    v: str | None = Query(None, description="Optional git SHA pinning the file version"),
 ):
     try:
+        params = {"chat_id": chat_id, "path": path}
+        if v:
+            params["version"] = v
         async with httpx.AsyncClient(timeout=30.0) as client:
             resp = await client.get(
                 f"{SANDBOX_URL}/files/download",
-                params={"chat_id": chat_id, "path": path},
+                params=params,
             )
 
             if resp.status_code == 404:
@@ -1251,11 +1255,16 @@ async def download_artifact(
             resp.raise_for_status()
 
             content_type = resp.headers.get("content-type", "application/octet-stream")
+            # Version-pinned responses never change, so browsers can cache them
+            # indefinitely; unpinned URLs always serve the latest file content.
+            cache_control = (
+                "private, max-age=31536000, immutable" if v else "private, max-age=3600"
+            )
             return Response(
                 content=resp.content,
                 media_type=content_type,
                 headers={
-                    "Cache-Control": "private, max-age=3600",
+                    "Cache-Control": cache_control,
                     # Artifact bytes may be read by sandboxed iframe previews
                     # (unique origin), so allow cross-origin reads.
                     "Access-Control-Allow-Origin": "*",

--- a/services/ai/tests/unit/test_sandbox_handler.py
+++ b/services/ai/tests/unit/test_sandbox_handler.py
@@ -1,0 +1,134 @@
+import json
+
+import httpx
+import pytest
+import respx
+
+from tools.registry import ToolContext
+from tools.sandbox_handler import SandboxToolHandler
+
+
+@pytest.fixture
+def context() -> ToolContext:
+    return ToolContext(chat_id="chat-1", user_id="user-1")
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_edit_file_returns_success_message(context: ToolContext):
+    respx.post("http://sandbox.test/files/edit").mock(
+        return_value=httpx.Response(
+            200, json={"content": "File edited successfully (1 replacement).", "path": "doc.md"}
+        )
+    )
+
+    handler = SandboxToolHandler("http://sandbox.test")
+    result = await handler.execute(
+        "edit_file",
+        {"path": "doc.md", "old_string": "old", "new_string": "new"},
+        context,
+    )
+
+    assert result.is_error is False
+    assert "File edited successfully" in result.content[0]["text"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_edit_file_surfaces_sandbox_error(context: ToolContext):
+    respx.post("http://sandbox.test/files/edit").mock(
+        return_value=httpx.Response(
+            400,
+            json={
+                "detail": "old_string matches 3 locations. Either include more surrounding "
+                "context to make it unique, or pass replace_all=true."
+            },
+        )
+    )
+
+    handler = SandboxToolHandler("http://sandbox.test")
+    result = await handler.execute(
+        "edit_file",
+        {"path": "doc.md", "old_string": "old", "new_string": "new"},
+        context,
+    )
+
+    assert result.is_error is True
+    assert "3 locations" in result.content[0]["text"]
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_edit_file_sends_replace_all(context: ToolContext):
+    route = respx.post("http://sandbox.test/files/edit").mock(
+        return_value=httpx.Response(200, json={"content": "ok", "path": "doc.md"})
+    )
+
+    handler = SandboxToolHandler("http://sandbox.test")
+    await handler.execute(
+        "edit_file",
+        {"path": "doc.md", "old_string": "old", "new_string": "new", "replace_all": True},
+        context,
+    )
+
+    sent = json.loads(route.calls.last.request.content)
+    assert sent["replace_all"] is True
+    assert sent["chat_id"] == "chat-1"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_present_artifact_pins_versioned_url(context: ToolContext):
+    respx.post("http://sandbox.test/files/stat").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "path": "report.docx",
+                "size_bytes": 1234,
+                "content_type": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+                "exists": True,
+                "version": "abc123",
+            },
+        )
+    )
+
+    handler = SandboxToolHandler("http://sandbox.test")
+    result = await handler.execute(
+        "present_artifact",
+        {"path": "report.docx", "title": "Report"},
+        context,
+    )
+
+    assert result.is_error is False
+    info = json.loads(result.content[0]["text"])
+    assert info["url"] == f"/api/chat/{context.chat_id}/artifacts/report.docx?v=abc123"
+    assert info["version"] == "abc123"
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_present_artifact_without_version_keeps_plain_url(context: ToolContext):
+    respx.post("http://sandbox.test/files/stat").mock(
+        return_value=httpx.Response(
+            200,
+            json={
+                "path": "chart.png",
+                "size_bytes": 2048,
+                "content_type": "image/png",
+                "exists": True,
+                "version": None,
+            },
+        )
+    )
+
+    handler = SandboxToolHandler("http://sandbox.test")
+    result = await handler.execute(
+        "present_artifact",
+        {"path": "chart.png", "title": "Chart"},
+        context,
+    )
+
+    assert result.is_error is False
+    info = json.loads(result.content[0]["text"])
+    assert info["url"] == f"/api/chat/{context.chat_id}/artifacts/chart.png"
+    assert info["version"] is None

--- a/services/ai/tools/sandbox_handler.py
+++ b/services/ai/tools/sandbox_handler.py
@@ -55,6 +55,32 @@ SANDBOX_TOOLS: list[ToolParam] = [
         },
     },
     {
+        "name": "edit_file",
+        "description": "Make an exact string replacement in an existing text file in the scratch workspace. Prefer this over write_file when modifying an existing file — it preserves the rest of the content. old_string must match the file content exactly (including whitespace). If it matches multiple locations, either include more surrounding context to make it unique or pass replace_all=true.",
+        "input_schema": {
+            "type": "object",
+            "properties": {
+                "path": {
+                    "type": "string",
+                    "description": "Relative file path of the existing file within the scratch workspace",
+                },
+                "old_string": {
+                    "type": "string",
+                    "description": "The exact text to replace",
+                },
+                "new_string": {
+                    "type": "string",
+                    "description": "The replacement text",
+                },
+                "replace_all": {
+                    "type": "boolean",
+                    "description": "Replace every occurrence of old_string instead of failing when it matches multiple locations (default: false)",
+                },
+            },
+            "required": ["path", "old_string", "new_string"],
+        },
+    },
+    {
         "name": "run_bash",
         "description": "Run a bash command in the scratch workspace. The `excel` CLI is available for spreadsheet operations (run `excel --help` for usage). Use for file operations, data processing with standard unix tools, etc.",
         "input_schema": {
@@ -70,7 +96,7 @@ SANDBOX_TOOLS: list[ToolParam] = [
     },
     {
         "name": "run_python",
-        "description": "Run Python code in the scratch workspace. Pre-installed libraries: pandas, numpy, openpyxl, matplotlib, seaborn, json, csv. Use for data analysis, processing, transformation, and visualization.",
+        "description": "Run Python code in the scratch workspace. Pre-installed libraries: pandas, numpy, openpyxl, xlsxwriter, matplotlib, seaborn, python-docx, python-pptx, reportlab, pypdf, json, csv. Use for data analysis, processing, transformation, visualization, and creating office files (docx via python-docx, pptx via python-pptx, xlsx via openpyxl/xlsxwriter) and PDFs (via reportlab).",
         "input_schema": {
             "type": "object",
             "properties": {
@@ -102,7 +128,7 @@ SANDBOX_TOOLS: list[ToolParam] = [
     },
 ]
 
-_TOOL_NAMES = {"write_file", "read_file", "run_bash", "run_python", "present_artifact"}
+_TOOL_NAMES = {"write_file", "read_file", "edit_file", "run_bash", "run_python", "present_artifact"}
 _UNSAFE_CONTROL_CHARS_RE = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
 
 
@@ -156,6 +182,17 @@ class SandboxToolHandler:
                         f"{self._sandbox_url}/files/read",
                         json={k: v for k, v in body.items() if v is not None},
                     )
+                elif tool_name == "edit_file":
+                    resp = await client.post(
+                        f"{self._sandbox_url}/files/edit",
+                        json={
+                            "path": tool_input["path"],
+                            "old_string": tool_input["old_string"],
+                            "new_string": tool_input["new_string"],
+                            "replace_all": tool_input.get("replace_all", False),
+                            "chat_id": context.chat_id,
+                        },
+                    )
                 elif tool_name == "run_bash":
                     resp = await client.post(
                         f"{self._sandbox_url}/execute/bash",
@@ -203,14 +240,18 @@ class SandboxToolHandler:
                             is_error=True,
                         )
 
-                    artifact_url = (
-                        f"/api/chat/{context.chat_id}/artifacts/{tool_input['path']}"
-                    )
+                    artifact_url = f"/api/chat/{context.chat_id}/artifacts/{tool_input['path']}"
+                    # Pin the artifact to the committed version it was presented
+                    # at, so later edits never change what this card shows.
+                    version = stat.get("version")
+                    if version:
+                        artifact_url = f"{artifact_url}?v={version}"
                     artifact_info = {
                         "url": artifact_url,
                         "title": tool_input["title"],
                         "content_type": stat["content_type"],
                         "size_bytes": stat["size_bytes"],
+                        "version": version,
                     }
                     return ToolResult(
                         content=[
@@ -255,7 +296,7 @@ class SandboxToolHandler:
             )
 
         # Format the result
-        if tool_name in ("write_file", "read_file"):
+        if tool_name in ("write_file", "read_file", "edit_file"):
             return ToolResult(
                 content=[
                     {

--- a/services/sandbox/Dockerfile
+++ b/services/sandbox/Dockerfile
@@ -28,9 +28,10 @@ RUN if [ "$BUILD_MODE" = "debug" ]; then \
 FROM python:3.12-slim-bookworm AS runtime
 ARG BUILD_MODE=release
 
-# Install curl for healthcheck and common data processing libraries for user code
+# Install curl for healthcheck, git for per-chat file versioning, and common
+# data processing libraries for user code
 RUN apt-get update && \
-    apt-get install -y --no-install-recommends curl && \
+    apt-get install -y --no-install-recommends curl git && \
     rm -rf /var/lib/apt/lists/*
 
 ENV MPLBACKEND=Agg
@@ -39,8 +40,13 @@ RUN pip install --no-cache-dir \
     pandas>=2.2.0 \
     numpy>=1.26.0 \
     openpyxl>=3.1.0 \
+    xlsxwriter>=3.2.0 \
     matplotlib>=3.9.0 \
-    seaborn>=0.13.0
+    seaborn>=0.13.0 \
+    python-docx>=1.1.0 \
+    python-pptx>=1.0.0 \
+    reportlab>=4.2.0 \
+    pypdf>=5.0.0
 
 COPY services/sandbox/scripts/excel /usr/local/bin/excel
 RUN chmod +x /usr/local/bin/excel

--- a/services/sandbox/src/handlers.rs
+++ b/services/sandbox/src/handlers.rs
@@ -1,14 +1,15 @@
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
+use axum::Json;
 use axum::extract::{Query, State};
 use axum::http::header;
 use axum::response::Response;
-use axum::Json;
 use tokio::fs;
 
 use crate::executor::{run_command, truncate_output};
 use crate::models::*;
+use crate::versioning;
 use crate::{AppState, SandboxError};
 
 fn get_chat_dir(scratch_dir: &Path, chat_id: &str) -> Result<PathBuf, SandboxError> {
@@ -85,6 +86,14 @@ pub async fn execute_bash(
         .await
         .map_err(|e| SandboxError::Internal(e))?;
 
+    versioning::commit(
+        &chat_dir,
+        &req.chat_id,
+        &state.git_locks,
+        &versioning::commit_message("run_bash", None),
+    )
+    .await;
+
     Ok(Json(result))
 }
 
@@ -110,6 +119,14 @@ pub async fn execute_python(
     // Clean up script file (best effort)
     let _ = fs::remove_file(&script_path).await;
 
+    versioning::commit(
+        &chat_dir,
+        &req.chat_id,
+        &state.git_locks,
+        &versioning::commit_message("run_python", None),
+    )
+    .await;
+
     Ok(Json(result))
 }
 
@@ -134,6 +151,14 @@ pub async fn write_file(
     fs::write(&file_path, &req.content)
         .await
         .map_err(|e| SandboxError::Internal(format!("Cannot write file: {e}")))?;
+
+    versioning::commit(
+        &chat_dir,
+        &req.chat_id,
+        &state.git_locks,
+        &versioning::commit_message("write_file", Some(&req.path)),
+    )
+    .await;
 
     Ok(Json(FileResult {
         content: format!("File written successfully ({byte_count} bytes)"),
@@ -169,8 +194,90 @@ pub async fn write_file_binary(
         .await
         .map_err(|e| SandboxError::Internal(format!("Cannot write file: {e}")))?;
 
+    versioning::commit(
+        &chat_dir,
+        &req.chat_id,
+        &state.git_locks,
+        &versioning::commit_message("write_file", Some(&req.path)),
+    )
+    .await;
+
     Ok(Json(FileResult {
         content: format!("Binary file written successfully ({byte_count} bytes)"),
+        path: req.path,
+    }))
+}
+
+pub async fn edit_file(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<FileEditRequest>,
+) -> Result<Json<FileResult>, SandboxError> {
+    let chat_dir = get_chat_dir(&state.config.scratch_dir, &req.chat_id)?;
+
+    let file_path = validate_path(&chat_dir, &req.path)?;
+
+    if !file_path.exists() {
+        return Err(SandboxError::NotFound(format!(
+            "File not found: {}",
+            req.path
+        )));
+    }
+
+    let raw = fs::read(&file_path)
+        .await
+        .map_err(|e| SandboxError::Internal(format!("Cannot read file: {e}")))?;
+
+    let content = String::from_utf8(raw).map_err(|_| {
+        SandboxError::BadRequest(format!(
+            "File {} is binary and cannot be edited with edit_file. Use run_python or run_bash to modify it.",
+            req.path
+        ))
+    })?;
+
+    if req.old_string.is_empty() {
+        return Err(SandboxError::BadRequest(
+            "old_string must not be empty".into(),
+        ));
+    }
+
+    let match_count = content.matches(&req.old_string).count();
+    if match_count == 0 {
+        return Err(SandboxError::BadRequest(
+            "old_string not found in file. Use read_file to check the exact content, then retry."
+                .into(),
+        ));
+    }
+    let replace_all = req.replace_all.unwrap_or(false);
+    if match_count > 1 && !replace_all {
+        return Err(SandboxError::BadRequest(format!(
+            "old_string matches {match_count} locations. Either include more surrounding context to make it unique, or pass replace_all=true to replace every occurrence."
+        )));
+    }
+
+    let replacements = if replace_all { match_count } else { 1 };
+    let updated = if replace_all {
+        content.replace(&req.old_string, &req.new_string)
+    } else {
+        content.replacen(&req.old_string, &req.new_string, 1)
+    };
+
+    fs::write(&file_path, updated)
+        .await
+        .map_err(|e| SandboxError::Internal(format!("Cannot write file: {e}")))?;
+
+    versioning::commit(
+        &chat_dir,
+        &req.chat_id,
+        &state.git_locks,
+        &versioning::commit_message("edit_file", Some(&req.path)),
+    )
+    .await;
+
+    Ok(Json(FileResult {
+        content: format!(
+            "File edited successfully ({replacements} replacement{}). Call present_artifact if the user should see the updated file.",
+            if replacements == 1 { "" } else { "s" }
+        ),
         path: req.path,
     }))
 }
@@ -247,6 +354,7 @@ pub async fn file_stat(
             size_bytes: 0,
             content_type: String::new(),
             exists: false,
+            version: None,
         }));
     }
 
@@ -258,6 +366,7 @@ pub async fn file_stat(
             size_bytes: 0,
             content_type: String::new(),
             exists: false,
+            version: None,
         }));
     }
 
@@ -269,12 +378,52 @@ pub async fn file_stat(
         .first_or_octet_stream()
         .to_string();
 
+    // present_artifact pins the artifact to the version being presented, so a
+    // later edit never changes what an earlier artifact card shows.
+    versioning::ensure_repo(&chat_dir).await;
+    let version = versioning::head_version(&chat_dir, &req.path).await;
+
     Ok(Json(FileStatResponse {
         path: req.path,
         size_bytes: metadata.len(),
         content_type,
         exists: true,
+        version,
     }))
+}
+
+pub async fn file_versions(
+    State(state): State<Arc<AppState>>,
+    Json(req): Json<FileVersionsRequest>,
+) -> Result<Json<Vec<FileVersionResponse>>, SandboxError> {
+    let chat_dir = get_chat_dir(&state.config.scratch_dir, &req.chat_id)?;
+
+    if !chat_dir.exists() {
+        return Err(SandboxError::NotFound("Chat directory not found".into()));
+    }
+
+    let file_path = validate_path(&chat_dir, &req.path)?;
+    if !file_path.exists() {
+        return Err(SandboxError::NotFound(format!(
+            "File not found: {}",
+            req.path
+        )));
+    }
+
+    let versions = versioning::list_versions(&chat_dir, &req.path)
+        .await
+        .map_err(SandboxError::Internal)?;
+
+    Ok(Json(
+        versions
+            .into_iter()
+            .map(|v| FileVersionResponse {
+                sha: v.sha,
+                timestamp: v.timestamp,
+                message: v.message,
+            })
+            .collect(),
+    ))
 }
 
 pub async fn download_file(
@@ -289,20 +438,25 @@ pub async fn download_file(
 
     let file_path = validate_path(&chat_dir, &req.path)?;
 
-    if !file_path.exists() {
-        return Err(SandboxError::NotFound(format!(
-            "File not found: {}",
-            req.path
-        )));
-    }
+    let body = if let Some(version) = &req.version {
+        versioning::read_version(&chat_dir, version, &req.path)
+            .await
+            .map_err(SandboxError::NotFound)?
+    } else {
+        if !file_path.exists() {
+            return Err(SandboxError::NotFound(format!(
+                "File not found: {}",
+                req.path
+            )));
+        }
+        fs::read(&file_path)
+            .await
+            .map_err(|e| SandboxError::Internal(format!("Cannot read file: {e}")))?
+    };
 
     let content_type = mime_guess::from_path(&file_path)
         .first_or_octet_stream()
         .to_string();
-
-    let body = fs::read(&file_path)
-        .await
-        .map_err(|e| SandboxError::Internal(format!("Cannot read file: {e}")))?;
 
     Ok(Response::builder()
         .header(header::CONTENT_TYPE, content_type)

--- a/services/sandbox/src/lib.rs
+++ b/services/sandbox/src/lib.rs
@@ -1,15 +1,16 @@
 pub mod executor;
 pub mod handlers;
 pub mod models;
+pub mod versioning;
 
 use std::path::PathBuf;
 use std::sync::Arc;
 
+use axum::Router;
 use axum::extract::DefaultBodyLimit;
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Json};
 use axum::routing::{get, post};
-use axum::Router;
 use tower_http::trace::TraceLayer;
 
 #[derive(Debug, Clone)]
@@ -47,6 +48,7 @@ impl SandboxConfig {
 #[derive(Debug)]
 pub struct AppState {
     pub config: SandboxConfig,
+    pub git_locks: versioning::GitLocks,
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -91,6 +93,8 @@ pub fn create_app(state: Arc<AppState>) -> Router {
             post(handlers::write_file_binary).layer(DefaultBodyLimit::max(400 * 1024 * 1024)),
         )
         .route("/files/read", post(handlers::read_file))
+        .route("/files/edit", post(handlers::edit_file))
+        .route("/files/versions", post(handlers::file_versions))
         .route("/files/stat", post(handlers::file_stat))
         .route("/files/download", get(handlers::download_file))
         .layer(TraceLayer::new_for_http())
@@ -161,6 +165,7 @@ pub async fn run_server() -> anyhow::Result<()> {
 
     let state = Arc::new(AppState {
         config: config.clone(),
+        git_locks: versioning::GitLocks::new(),
     });
     let app = create_app(state);
 

--- a/services/sandbox/src/models.rs
+++ b/services/sandbox/src/models.rs
@@ -28,6 +28,15 @@ pub struct FileReadRequest {
 }
 
 #[derive(Debug, Deserialize)]
+pub struct FileEditRequest {
+    pub path: String,
+    pub old_string: String,
+    pub new_string: String,
+    pub replace_all: Option<bool>,
+    pub chat_id: String,
+}
+
+#[derive(Debug, Deserialize)]
 pub struct BinaryFileWriteRequest {
     pub path: String,
     pub content_base64: String,
@@ -59,12 +68,30 @@ pub struct FileStatResponse {
     pub size_bytes: u64,
     pub content_type: String,
     pub exists: bool,
+    /// SHA of the latest commit covering this file, for version-pinned
+    /// artifact URLs. Null when the file has no committed version.
+    pub version: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+pub struct FileVersionsRequest {
+    pub path: String,
+    pub chat_id: String,
+}
+
+#[derive(Debug, Serialize)]
+pub struct FileVersionResponse {
+    pub sha: String,
+    pub timestamp: String,
+    pub message: String,
 }
 
 #[derive(Debug, Deserialize)]
 pub struct FileDownloadQuery {
     pub path: String,
     pub chat_id: String,
+    /// Optional git SHA — serve the file's content as of that version.
+    pub version: Option<String>,
 }
 
 #[derive(Debug, Serialize)]

--- a/services/sandbox/src/versioning.rs
+++ b/services/sandbox/src/versioning.rs
@@ -1,0 +1,204 @@
+//! Git-based per-chat file versioning.
+//!
+//! Each chat directory is its own git repository. Every mutating request
+//! (write, edit, bash, python) ends with an auto-commit so that artifacts can
+//! be pinned to the exact version that was presented, and history can be
+//! listed/restored later. Git failures are logged but never fail the request —
+//! versioning is best-effort around the primary operation.
+
+use std::collections::HashMap;
+use std::path::Path;
+use std::sync::Arc;
+use std::time::Duration;
+
+use tokio::process::Command;
+use tokio::sync::{Mutex, Semaphore};
+use tracing::debug;
+
+const GIT_TIMEOUT: Duration = Duration::from_secs(15);
+const GIT_AUTHOR_NAME: &str = "omni-sandbox";
+const GIT_AUTHOR_EMAIL: &str = "sandbox@omni.local";
+const GIT_IGNORE: &str = "_script.py\n";
+
+/// Serializes git operations per chat directory. Concurrent requests for the
+/// same chat would otherwise race on git's index.lock and lose commits.
+#[derive(Default, Debug)]
+pub struct GitLocks {
+    locks: Mutex<HashMap<String, Arc<Semaphore>>>,
+}
+
+impl GitLocks {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    async fn lock(&self, chat_id: &str) -> OwnedPermit {
+        let sema = {
+            let mut map = self.locks.lock().await;
+            map.entry(chat_id.to_string())
+                .or_insert_with(|| Arc::new(Semaphore::new(1)))
+                .clone()
+        };
+        // Unwrap is safe: each semaphore has one permit and is never closed.
+        OwnedPermit(sema.acquire_owned().await.unwrap())
+    }
+}
+
+// Held across the critical section purely for its Drop guard effect.
+struct OwnedPermit(#[allow(dead_code)] tokio::sync::OwnedSemaphorePermit);
+
+fn git_command(chat_dir: &Path) -> Command {
+    let mut cmd = Command::new("git");
+    cmd.current_dir(chat_dir)
+        .arg("-c")
+        .arg(format!("user.name={GIT_AUTHOR_NAME}"))
+        .arg("-c")
+        .arg(format!("user.email={GIT_AUTHOR_EMAIL}"))
+        .arg("-c")
+        .arg("commit.gpgsign=false")
+        .arg("-c")
+        .arg("core.autocrlf=false")
+        .env("HOME", chat_dir)
+        .env("GIT_CONFIG_GLOBAL", "/dev/null")
+        .env("GIT_CONFIG_SYSTEM", "/dev/null")
+        .env("GIT_TERMINAL_PROMPT", "0");
+    cmd
+}
+
+async fn run_git(chat_dir: &Path, args: &[&str]) -> Result<Vec<u8>, String> {
+    let output = tokio::time::timeout(GIT_TIMEOUT, async {
+        git_command(chat_dir)
+            .args(args)
+            .output()
+            .await
+            .map_err(|e| format!("git spawn failed: {e}"))
+    })
+    .await
+    .map_err(|_| "git command timed out".to_string())?
+    .map_err(|e| format!("git failed: {e}"))?;
+
+    if !output.status.success() {
+        return Err(format!(
+            "git {} failed: {}",
+            args.first().unwrap_or(&""),
+            String::from_utf8_lossy(&output.stderr).trim()
+        ));
+    }
+    Ok(output.stdout)
+}
+
+/// Ensure the chat directory is an initialized git repo with a .gitignore for
+/// internal files. Does not create the directory.
+pub async fn ensure_repo(chat_dir: &Path) {
+    if !chat_dir.exists() || chat_dir.join(".git").exists() {
+        return;
+    }
+
+    if let Err(e) = run_git(chat_dir, &["init", "-q"]).await {
+        debug!(error = %e, "git init failed for chat dir");
+        return;
+    }
+    let _ = tokio::fs::write(chat_dir.join(".gitignore"), GIT_IGNORE).await;
+}
+
+/// Commit all changes in the chat directory. No-op when nothing changed.
+pub async fn commit(chat_dir: &Path, chat_id: &str, locks: &GitLocks, message: &str) {
+    ensure_repo(chat_dir).await;
+    let _guard = locks.lock(chat_id).await;
+
+    if let Err(e) = run_git(chat_dir, &["add", "-A", "--", "."]).await {
+        debug!(error = %e, "git add failed for chat dir");
+        return;
+    }
+
+    // Exit code 1 with "nothing to commit" is expected and surfaces here as an
+    // error string — treat it as success.
+    if let Err(e) = run_git(chat_dir, &["commit", "-q", "-m", message, "--allow-empty"]).await
+        && !e.contains("nothing to commit")
+    {
+        debug!(error = %e, "git commit failed for chat dir");
+    }
+}
+
+/// SHA of the latest commit that touched `rel_path`, or None when the file has
+/// no committed version yet.
+pub async fn head_version(chat_dir: &Path, rel_path: &str) -> Option<String> {
+    let output = run_git(
+        chat_dir,
+        &[
+            "log",
+            "-1",
+            "--format=%H",
+            "--",
+            &sanitize_git_path(rel_path),
+        ],
+    )
+    .await
+    .ok()?;
+    let sha = String::from_utf8_lossy(&output).trim().to_string();
+    if sha.is_empty() { None } else { Some(sha) }
+}
+
+pub struct FileVersion {
+    pub sha: String,
+    pub timestamp: String,
+    pub message: String,
+}
+
+/// Commit history for one file, newest first.
+pub async fn list_versions(chat_dir: &Path, rel_path: &str) -> Result<Vec<FileVersion>, String> {
+    let output = run_git(
+        chat_dir,
+        &[
+            "log",
+            "--format=%H%x1f%aI%x1f%s",
+            "--",
+            &sanitize_git_path(rel_path),
+        ],
+    )
+    .await?;
+
+    let text = String::from_utf8_lossy(&output);
+    Ok(text
+        .lines()
+        .filter(|line| !line.trim().is_empty())
+        .filter_map(|line| {
+            let mut parts = line.split('\x1f');
+            Some(FileVersion {
+                sha: parts.next()?.to_string(),
+                timestamp: parts.next()?.to_string(),
+                message: parts.next().unwrap_or("").to_string(),
+            })
+        })
+        .collect())
+}
+
+/// File content at a specific commit. Empty history means git itself erred or
+/// the repo is missing — callers turn that into a 404/502 upstream.
+pub async fn read_version(chat_dir: &Path, sha: &str, rel_path: &str) -> Result<Vec<u8>, String> {
+    if !sha.chars().all(|c| c.is_ascii_hexdigit()) {
+        return Err("Invalid version ref".into());
+    }
+    run_git(
+        chat_dir,
+        &["show", &format!("{sha}:{}", sanitize_git_path(rel_path))],
+    )
+    .await
+}
+
+/// Refuse paths git would interpret as options; callers already validated the
+/// path stays inside the chat dir.
+fn sanitize_git_path(rel_path: &str) -> String {
+    if rel_path.starts_with('-') {
+        format!("./{rel_path}")
+    } else {
+        rel_path.to_string()
+    }
+}
+
+pub fn commit_message(tool: &str, path: Option<&str>) -> String {
+    match path {
+        Some(p) => format!("{tool}: {p}"),
+        None => tool.to_string(),
+    }
+}

--- a/services/sandbox/tests/integration_tests.rs
+++ b/services/sandbox/tests/integration_tests.rs
@@ -187,6 +187,223 @@ async fn test_file_read_line_range() {
 }
 
 #[tokio::test]
+async fn test_file_edit_exact_match() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "file-edit-basic";
+
+    f.client
+        .post(f.url("/files/write"))
+        .json(&json!({
+            "path": "doc.md",
+            "content": "# Title\n\nOld paragraph.\n\nAnother section.\n",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = f
+        .client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "doc.md",
+            "old_string": "Old paragraph.",
+            "new_string": "New paragraph.",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["content"].as_str().unwrap().contains("1 replacement"));
+
+    let resp = f
+        .client
+        .post(f.url("/files/read"))
+        .json(&json!({ "path": "doc.md", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    let content = body["content"].as_str().unwrap();
+    assert!(content.contains("New paragraph."));
+    assert!(!content.contains("Old paragraph."));
+    assert!(content.contains("Another section."));
+}
+
+#[tokio::test]
+async fn test_file_edit_errors() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "file-edit-errors";
+
+    let content = "repeat\nrepeat\nunique\n";
+    f.client
+        .post(f.url("/files/write"))
+        .json(&json!({ "path": "doc.txt", "content": content, "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+
+    // No match
+    let resp = f
+        .client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "doc.txt",
+            "old_string": "does not exist",
+            "new_string": "x",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // Ambiguous match without replace_all
+    let resp = f
+        .client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "doc.txt",
+            "old_string": "repeat",
+            "new_string": "x",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["detail"].as_str().unwrap().contains("2 locations"));
+
+    // Empty old_string
+    let resp = f
+        .client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "doc.txt",
+            "old_string": "",
+            "new_string": "x",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+
+    // Missing file
+    let resp = f
+        .client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "missing.txt",
+            "old_string": "a",
+            "new_string": "b",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // File should be unchanged after all failures
+    let resp = f
+        .client
+        .post(f.url("/files/read"))
+        .json(&json!({ "path": "doc.txt", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["content"].as_str().unwrap(),
+        "1 | repeat\n2 | repeat\n3 | unique"
+    );
+}
+
+#[tokio::test]
+async fn test_file_edit_replace_all() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "file-edit-replace-all";
+
+    f.client
+        .post(f.url("/files/write"))
+        .json(&json!({
+            "path": "doc.txt",
+            "content": "foo bar foo\nfoo\n",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = f
+        .client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "doc.txt",
+            "old_string": "foo",
+            "new_string": "baz",
+            "replace_all": true,
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["content"].as_str().unwrap().contains("3 replacements"));
+
+    let resp = f
+        .client
+        .post(f.url("/files/read"))
+        .json(&json!({ "path": "doc.txt", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    assert_eq!(
+        body["content"].as_str().unwrap(),
+        "1 | baz bar baz\n2 | baz"
+    );
+}
+
+#[tokio::test]
+async fn test_file_edit_binary_rejected() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "file-edit-binary";
+
+    let raw_bytes: Vec<u8> = vec![0x00, 0xFF, 0xFE, 0x01];
+    f.client
+        .post(f.url("/files/write_binary"))
+        .json(&json!({
+            "path": "data.bin",
+            "content_base64": BASE64.encode(&raw_bytes),
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = f
+        .client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "data.bin",
+            "old_string": "x",
+            "new_string": "y",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 400);
+    let body: Value = resp.json().await.unwrap();
+    assert!(body["detail"].as_str().unwrap().contains("binary"));
+}
+
+#[tokio::test]
 async fn test_binary_write_and_download() {
     let f = SandboxTestFixture::shared().await;
     let chat_id = "binary-test";
@@ -256,6 +473,234 @@ async fn test_file_stat() {
     assert_eq!(resp.status(), 200);
     let body: Value = resp.json().await.unwrap();
     assert_eq!(body["exists"], false);
+}
+
+// ---------------------------------------------------------------------------
+// Versioning tests
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_versioning_write_edit_and_history() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "versioning-basic";
+
+    f.client
+        .post(f.url("/files/write"))
+        .json(&json!({
+            "path": "report.md",
+            "content": "version one\n",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    // stat exposes the version that present_artifact pins to
+    let resp = f
+        .client
+        .post(f.url("/files/stat"))
+        .json(&json!({ "path": "report.md", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    let v1 = body["version"]
+        .as_str()
+        .expect("stat should expose version")
+        .to_string();
+    assert!(!v1.is_empty());
+
+    // edit_file creates a second version
+    f.client
+        .post(f.url("/files/edit"))
+        .json(&json!({
+            "path": "report.md",
+            "old_string": "version one",
+            "new_string": "version two",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = f
+        .client
+        .post(f.url("/files/versions"))
+        .json(&json!({ "path": "report.md", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let versions: Vec<Value> = resp.json().await.unwrap();
+    assert_eq!(versions.len(), 2, "expected one commit per mutation");
+    assert!(
+        versions[0]["message"]
+            .as_str()
+            .unwrap()
+            .starts_with("edit_file:")
+    );
+    assert!(
+        versions[1]["message"]
+            .as_str()
+            .unwrap()
+            .starts_with("write_file:")
+    );
+    assert!(versions[1]["timestamp"].as_str().is_some());
+    assert_ne!(versions[0]["sha"], versions[1]["sha"]);
+
+    // The version-1 sha still serves the original content (version pinning)
+    let resp = f
+        .client
+        .get(f.url("/files/download"))
+        .query(&[
+            ("path", "report.md"),
+            ("chat_id", chat_id),
+            ("version", v1.as_str()),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let bytes = resp.bytes().await.unwrap();
+    assert_eq!(bytes.as_ref(), b"version one\n");
+
+    // Default download keeps serving the latest content
+    let resp = f
+        .client
+        .get(f.url("/files/download"))
+        .query(&[("path", "report.md"), ("chat_id", chat_id)])
+        .send()
+        .await
+        .unwrap();
+    let bytes = resp.bytes().await.unwrap();
+    assert_eq!(bytes.as_ref(), b"version two\n");
+}
+
+#[tokio::test]
+async fn test_versioning_bash_writes_are_committed() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "versioning-bash";
+
+    f.client
+        .post(f.url("/execute/bash"))
+        .json(&json!({
+            "command": "echo from-bash > out.txt",
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = f
+        .client
+        .post(f.url("/files/versions"))
+        .json(&json!({ "path": "out.txt", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let versions: Vec<Value> = resp.json().await.unwrap();
+    assert!(!versions.is_empty(), "bash mutations should be committed");
+    assert!(
+        versions[0]["message"]
+            .as_str()
+            .unwrap()
+            .starts_with("run_bash")
+    );
+}
+
+#[tokio::test]
+async fn test_versioning_binary_content_roundtrip() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "versioning-binary";
+
+    let raw_bytes: Vec<u8> = vec![0x00, 0xFF, 0xFE, 0x01, 0x02];
+    f.client
+        .post(f.url("/files/write_binary"))
+        .json(&json!({
+            "path": "file.bin",
+            "content_base64": BASE64.encode(&raw_bytes),
+            "chat_id": chat_id
+        }))
+        .send()
+        .await
+        .unwrap();
+
+    let resp = f
+        .client
+        .post(f.url("/files/stat"))
+        .json(&json!({ "path": "file.bin", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    let body: Value = resp.json().await.unwrap();
+    let v1 = body["version"].as_str().unwrap().to_string();
+
+    let resp = f
+        .client
+        .get(f.url("/files/download"))
+        .query(&[
+            ("path", "file.bin"),
+            ("chat_id", chat_id),
+            ("version", v1.as_str()),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 200);
+    let bytes = resp.bytes().await.unwrap();
+    assert_eq!(bytes.as_ref(), &raw_bytes[..]);
+}
+
+#[tokio::test]
+async fn test_versioning_errors() {
+    let f = SandboxTestFixture::shared().await;
+    let chat_id = "versioning-errors";
+
+    // No history at all for an untouched chat
+    let resp = f
+        .client
+        .post(f.url("/files/versions"))
+        .json(&json!({ "path": "nope.txt", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    f.client
+        .post(f.url("/files/write"))
+        .json(&json!({ "path": "a.txt", "content": "x", "chat_id": chat_id }))
+        .send()
+        .await
+        .unwrap();
+
+    // Unknown version ref
+    let resp = f
+        .client
+        .get(f.url("/files/download"))
+        .query(&[
+            ("path", "a.txt"),
+            ("chat_id", chat_id),
+            ("version", "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
+
+    // Non-hex ref is rejected
+    let resp = f
+        .client
+        .get(f.url("/files/download"))
+        .query(&[
+            ("path", "a.txt"),
+            ("chat_id", chat_id),
+            ("version", "; rm -rf"),
+        ])
+        .send()
+        .await
+        .unwrap();
+    assert_eq!(resp.status(), 404);
 }
 
 // ---------------------------------------------------------------------------

--- a/web/src/lib/components/tool-message.svelte
+++ b/web/src/lib/components/tool-message.svelte
@@ -8,6 +8,7 @@
         FileCode,
         Terminal,
         Pencil,
+        FilePen,
         Image,
         Users,
         BookOpen,
@@ -56,6 +57,7 @@
         fetch_web_page: { loading: 'Fetching web page', loaded: 'Fetched web page' },
         read_document: { loading: 'Reading', loaded: 'Read' },
         write_file: { loading: 'Writing', loaded: 'Wrote' },
+        edit_file: { loading: 'Editing', loaded: 'Edited' },
         read_file: { loading: 'Reading', loaded: 'Read' },
         run_bash: { loading: 'Running', loaded: 'Ran' },
         run_python: { loading: 'Running', loaded: 'Ran' },
@@ -78,6 +80,7 @@
         fetch_web_page: 'url',
         read_document: 'name',
         write_file: 'path',
+        edit_file: 'path',
         read_file: 'path',
         run_bash: 'command',
         run_python: 'code',
@@ -336,6 +339,8 @@
                         <Users class="h-4 w-4 shrink-0 text-blue-600" />
                     {:else if toolName === 'write_file'}
                         <Pencil class="h-4 w-4 shrink-0 text-amber-600" />
+                    {:else if toolName === 'edit_file'}
+                        <FilePen class="h-4 w-4 shrink-0 text-amber-600" />
                     {:else if toolName === 'present_artifact'}
                         <Image class="h-4 w-4 shrink-0 text-violet-600" />
                     {:else if isSkillTool}

--- a/web/src/routes/api/chat/[chatId]/artifacts/[...path]/+server.ts
+++ b/web/src/routes/api/chat/[chatId]/artifacts/[...path]/+server.ts
@@ -3,7 +3,7 @@ import { error } from '@sveltejs/kit'
 import type { RequestHandler } from './$types.js'
 import { chatRepository } from '$lib/server/db/chats.js'
 
-export const GET: RequestHandler = async ({ params, locals }) => {
+export const GET: RequestHandler = async ({ params, url, locals }) => {
     const { chatId, path } = params
     const logger = locals.logger.child('artifacts')
 
@@ -21,8 +21,13 @@ export const GET: RequestHandler = async ({ params, locals }) => {
         throw error(403, 'Forbidden')
     }
 
+    const version = url.searchParams.get('v')
+    const versionSuffix = version ? `?v=${encodeURIComponent(version)}` : ''
+
     try {
-        const response = await fetch(`${env.AI_SERVICE_URL}/chat/${chatId}/artifacts/${path}`)
+        const response = await fetch(
+            `${env.AI_SERVICE_URL}/chat/${chatId}/artifacts/${path}${versionSuffix}`,
+        )
 
         if (!response.ok) {
             logger.warn('Artifact proxy failed', undefined, {
@@ -35,11 +40,16 @@ export const GET: RequestHandler = async ({ params, locals }) => {
 
         const contentType = response.headers.get('content-type') || 'application/octet-stream'
         const body = await response.arrayBuffer()
+        // Version-pinned artifact URLs are immutable; unpinned ones track the
+        // latest file content and must not be cached long.
+        const cacheControl = version
+            ? 'private, max-age=31536000, immutable'
+            : 'private, max-age=3600'
 
         return new Response(body, {
             headers: {
                 'Content-Type': contentType,
-                'Cache-Control': 'private, max-age=3600',
+                'Cache-Control': cacheControl,
                 // Artifact bytes may be read by sandboxed iframe previews (unique
                 // origin), so allow cross-origin reads.
                 'Access-Control-Allow-Origin': '*',


### PR DESCRIPTION
- First-class creation of Word, PowerPoint, Excel, and PDF files in the sandbox, with the right Python libraries pre-installed
- New edit_file tool so the agent can modify an existing file in place instead of rewriting it
- Automatic per-chat file versioning in the sandbox, so older versions of a file are preserved
- Artifact cards stay pinned to the version shown when they were created, so later edits never change what the user sees