### PR TITLE
feat(indexer): migrate document embeddings to task queue

### DIFF
--- a/benchmarks/src/indexer/mod.rs
+++ b/benchmarks/src/indexer/mod.rs
@@ -76,7 +76,7 @@ impl BenchmarkIndexer {
             "users",
             "sync_runs",
             "connector_events_queue",
-            "embedding_queue",
+            "tasks",
             "service_credentials",
         ];
 
@@ -493,11 +493,12 @@ impl BenchmarkIndexer {
             let embedding_stats: (i64, i64) = sqlx::query_as(
                 r#"
                 SELECT
-                    COUNT(*) FILTER (WHERE eq.status = 'pending') as pending,
-                    COUNT(*) FILTER (WHERE eq.status = 'processing') as processing
-                FROM embedding_queue eq
-                JOIN documents d ON eq.document_id = d.id
-                WHERE d.source_id = $1
+                    COUNT(*) FILTER (WHERE t.status = 'pending') as pending,
+                    COUNT(*) FILTER (WHERE t.status = 'running') as processing
+                FROM tasks t
+                JOIN documents d ON t.deduplication_key = d.id
+                WHERE t.task_type = 'document_embedding'
+                  AND d.source_id = $1
                 "#,
             )
             .bind(source_id)

--- a/services/ai/db/__init__.py
+++ b/services/ai/db/__init__.py
@@ -4,7 +4,15 @@ from .configuration import ConfigurationRepository
 from .connection import close_db_pool, get_db_pool
 from .documents import ContentBlob, Document, DocumentsRepository
 from .embedding_providers import EmbeddingProviderRecord, EmbeddingProvidersRepository
-from .embedding_queue import EmbeddingQueueItem, EmbeddingQueueRepository, QueueStatus
+from .embedding_queue import (
+    DOCUMENT_EMBEDDING_MAX_ATTEMPTS,
+    DOCUMENT_EMBEDDING_PAYLOAD_VERSION,
+    DOCUMENT_EMBEDDING_TASK_TYPE,
+    EmbeddingQueueItem,
+    EmbeddingQueueRepository,
+    QueueStatus,
+    embedding_task,
+)
 from .embeddings import Embedding, EmbeddingsRepository
 from .messages import MessagesRepository
 from .model_providers import ModelProviderRecord, ModelProvidersRepository, ModelsRepository
@@ -59,6 +67,10 @@ __all__ = [
     "EmbeddingQueueRepository",
     "EmbeddingQueueItem",
     "QueueStatus",
+    "DOCUMENT_EMBEDDING_TASK_TYPE",
+    "DOCUMENT_EMBEDDING_PAYLOAD_VERSION",
+    "DOCUMENT_EMBEDDING_MAX_ATTEMPTS",
+    "embedding_task",
     "EmbeddingsRepository",
     "Embedding",
     "ModelProvidersRepository",

--- a/services/ai/db/documents.py
+++ b/services/ai/db/documents.py
@@ -182,9 +182,9 @@ class DocumentsRepository:
         """Find embedded donor documents for content IDs.
 
         Returns content_id -> donor_document_id for donors that already have embeddings for
-        the current model. Donors with pending/processing work, or failed work newer than
-        their embeddings, are excluded because their embeddings may be stale relative to
-        their current content_id.
+        the current model. Donors with active embedding tasks, or dead-letter work newer
+        than their embeddings, are excluded because their embeddings may be stale relative
+        to their current content_id.
         """
         if not content_ids:
             return {}
@@ -205,17 +205,18 @@ class DocumentsRepository:
               AND d.id <> ALL($2::text[])
               AND NOT EXISTS (
                   SELECT 1
-                  FROM embedding_queue q
-                  WHERE q.document_id = d.id
-                    AND q.status IN ('pending', 'processing')
+                  FROM tasks q
+                  WHERE q.task_type = 'document_embedding'
+                    AND q.deduplication_key = d.id
+                    AND q.status IN ('pending', 'running')
               )
               AND NOT EXISTS (
                   SELECT 1
-                  FROM embedding_queue q
-                  WHERE q.document_id = d.id
-                    AND q.status = 'failed'
-                    AND GREATEST(q.created_at, q.updated_at, COALESCE(q.processed_at, q.updated_at))
-                        > ed.latest_embedding_at
+                  FROM tasks q
+                  WHERE q.task_type = 'document_embedding'
+                    AND q.deduplication_key = d.id
+                    AND q.status = 'dead_letter'
+                    AND q.updated_at > ed.latest_embedding_at
               )
             ORDER BY d.content_id, d.id
             """,

--- a/services/ai/db/embedding_queue.py
+++ b/services/ai/db/embedding_queue.py
@@ -1,151 +1,217 @@
-"""Repository for embedding queue database operations."""
+"""Embedding workload adapter over the generic task queue."""
 
-import logging
-from enum import StrEnum
-from typing import Optional, List
 from dataclasses import dataclass
-from datetime import datetime
-from asyncpg import Pool
+from datetime import UTC, datetime, timedelta
+from enum import StrEnum
+
+from asyncpg import Connection, Pool
 
 from .connection import get_db_pool
+from .task_queue import (
+    ClaimOptions,
+    EnqueueTaskRequest,
+    Task,
+    TaskClaim,
+    TaskQueueRepository,
+    TaskStatus,
+)
+
+DOCUMENT_EMBEDDING_TASK_TYPE = "document_embedding"
+DOCUMENT_EMBEDDING_PAYLOAD_VERSION = 1
+DOCUMENT_EMBEDDING_MAX_ATTEMPTS = 5
 
 
 class QueueStatus(StrEnum):
     PENDING = "pending"
-    PROCESSING = "processing"
+    PROCESSING = "running"
     COMPLETED = "completed"
-    FAILED = "failed"
-
-
-logger = logging.getLogger(__name__)
+    FAILED = "dead_letter"
 
 
 @dataclass
 class EmbeddingQueueItem:
-    """Represents an embedding_queue item"""
+    """Validated document embedding task payload and generic task metadata."""
 
     id: str
     document_id: str
-    status: str
-    error_message: Optional[str]
+    status: QueueStatus
+    error_message: str | None
     retry_count: int
     created_at: datetime
+    updated_at: datetime
+    processed_at: datetime | None
+    claim_token: str | None
+
+    @classmethod
+    def from_task(cls, task: Task) -> "EmbeddingQueueItem":
+        if task.task_type != DOCUMENT_EMBEDDING_TASK_TYPE:
+            raise ValueError(f"unexpected embedding task type: {task.task_type!r}")
+        if task.payload_version != DOCUMENT_EMBEDDING_PAYLOAD_VERSION:
+            raise ValueError(
+                f"unsupported embedding payload version: {task.payload_version}"
+            )
+        document_id = task.payload.get("document_id")
+        if not isinstance(document_id, str) or not document_id:
+            raise ValueError("embedding task payload requires document_id")
+        status = {
+            TaskStatus.PENDING: QueueStatus.PENDING,
+            TaskStatus.RUNNING: QueueStatus.PROCESSING,
+            TaskStatus.COMPLETED: QueueStatus.COMPLETED,
+            TaskStatus.DEAD_LETTER: QueueStatus.FAILED,
+        }[task.status]
+        return cls(
+            id=task.id,
+            document_id=document_id,
+            status=status,
+            error_message=task.last_error,
+            retry_count=task.attempt_count,
+            created_at=task.created_at,
+            updated_at=task.updated_at,
+            processed_at=task.completed_at,
+            claim_token=task.claim_token,
+        )
 
 
 class EmbeddingQueueRepository:
-    """Repository for embedding queue database operations."""
+    """Provider-gated adapter for document embedding tasks."""
 
-    def __init__(self, pool: Optional[Pool] = None):
+    def __init__(self, pool: Pool | None = None):
         self.pool = pool
+        self.task_queue = TaskQueueRepository(pool)
 
     async def _get_pool(self) -> Pool:
-        """Get database pool"""
         if self.pool:
             return self.pool
         return await get_db_pool()
 
-    async def get_by_id(self, item_id: str) -> Optional[EmbeddingQueueItem]:
-        """Get a queue item by ID."""
-        pool = await self._get_pool()
-
-        row = await pool.fetchrow(
-            """
-            SELECT id, document_id, status, error_message, retry_count, created_at
-            FROM embedding_queue
-            WHERE id = $1
-            """,
-            item_id,
-        )
-        if row:
-            return EmbeddingQueueItem(**dict(row))
-        return None
+    async def get_by_id(self, item_id: str) -> EmbeddingQueueItem | None:
+        task = await self.task_queue.get(item_id)
+        return EmbeddingQueueItem.from_task(task) if task else None
 
     async def get_status_counts(self) -> dict[str, int]:
-        """Get counts of queue items grouped by status."""
-        pool = await self._get_pool()
-
-        rows = await pool.fetch(
-            "SELECT status, COUNT(*) as count FROM embedding_queue GROUP BY status"
-        )
-        return {row["status"]: int(row["count"]) for row in rows}
+        stats = await self.task_queue.stats(DOCUMENT_EMBEDDING_TASK_TYPE)
+        return {str(stat.status): stat.count for stat in stats}
 
     async def get_pending_count(self, max_retries: int) -> int:
-        """Get number of pending queue items."""
         pool = await self._get_pool()
-
-        res = await pool.fetchval(
-            """
-            SELECT COUNT(*)
-            FROM embedding_queue
-            WHERE retry_count < $1
-              AND status IN ('pending', 'failed')
-            """,
-            max_retries,
+        return int(
+            await pool.fetchval(
+                """
+                SELECT COUNT(*) FROM tasks
+                WHERE task_type = $1 AND status = 'pending'
+                  AND attempt_count < LEAST(max_attempts, $2)
+                """,
+                DOCUMENT_EMBEDDING_TASK_TYPE,
+                max_retries,
+            )
         )
 
-        return int(res)
+    async def claim_batch(self, limit: int, worker: str = "embedding-worker") -> TaskClaim:
+        return await self.task_queue.claim(
+            DOCUMENT_EMBEDDING_TASK_TYPE,
+            worker,
+            ClaimOptions(limit=limit, lease_seconds=900),
+        )
 
     async def get_pending_items(
         self, limit: int, max_retries: int
-    ) -> List[EmbeddingQueueItem]:
-        """Atomically fetch and claim pending items.
+    ) -> list[EmbeddingQueueItem]:
+        claim = await self.claim_batch(limit)
+        return [EmbeddingQueueItem.from_task(task) for task in claim.tasks]
 
-        Uses FOR UPDATE SKIP LOCKED so each item is only claimed by one worker.
-        """
-        pool = await self._get_pool()
-
-        rows = await pool.fetch(
-            """
-            UPDATE embedding_queue
-            SET status = 'processing'
-            WHERE id IN (
-                SELECT id
-                FROM embedding_queue
-                WHERE retry_count < $1
-                  AND status IN ('pending', 'failed')
-                ORDER BY created_at ASC
-                LIMIT $2
-                FOR UPDATE SKIP LOCKED
+    async def mark_completed_with_token(
+        self,
+        item_ids: list[str],
+        claim_token: str,
+        *,
+        connection: Connection | None = None,
+    ) -> None:
+        if not item_ids:
+            return
+        if connection is None:
+            completed = await self.task_queue.complete(item_ids, claim_token)
+        else:
+            completed = await connection.fetchval(
+                "SELECT task_complete_bulk($1, $2)", item_ids, claim_token
             )
-            RETURNING id, document_id, status, error_message, retry_count, created_at
-            """,
-            max_retries,
-            limit,
-        )
-        return [EmbeddingQueueItem(**dict(row)) for row in rows]
+        if int(completed) != len(item_ids):
+            raise RuntimeError("embedding task completion was fenced")
 
-    async def mark_completed(self, item_ids: List[str]) -> None:
-        """Mark queue items as completed"""
+    async def mark_completed(self, item_ids: list[str]) -> None:
         if not item_ids:
             return
+        token = await self._token_for(item_ids)
+        await self.mark_completed_with_token(item_ids, token)
 
-        pool = await self._get_pool()
+    async def mark_failed_with_token(
+        self,
+        item_ids: list[str],
+        claim_token: str,
+        error: str,
+        *,
+        retryable: bool = True,
+    ) -> None:
+        if item_ids:
+            results = await self.task_queue.fail(
+                item_ids,
+                claim_token,
+                error,
+                retryable=retryable,
+                retry_delay_seconds=0,
+            )
+            if len(results) != len(item_ids):
+                raise RuntimeError("embedding task failure was fenced")
 
-        await pool.execute(
-            """
-            UPDATE embedding_queue
-            SET status = 'completed', processed_at = CURRENT_TIMESTAMP
-            WHERE id = ANY($1)
-            """,
-            item_ids,
-        )
-        logger.info(f"Marked {len(item_ids)} queue items as completed")
-
-    async def mark_failed(self, item_ids: List[str], error: str) -> None:
-        """Mark queue items as failed"""
+    async def mark_failed(self, item_ids: list[str], error: str) -> None:
         if not item_ids:
             return
+        token = await self._token_for(item_ids)
+        await self.mark_failed_with_token(item_ids, token, error)
 
+    async def heartbeat(self, task_id: str, claim_token: str, lease_seconds: int) -> bool:
+        return await self.task_queue.heartbeat(task_id, claim_token, lease_seconds)
+
+    async def recover_stale_processing_items(self, timeout_seconds: int) -> int:
+        if timeout_seconds < 1:
+            raise ValueError("recovery timeout must be >= 1")
         pool = await self._get_pool()
-
-        await pool.execute(
-            """
-            UPDATE embedding_queue
-            SET status = 'failed', error_message = $2, processed_at = CURRENT_TIMESTAMP,
-                retry_count = retry_count + 1, updated_at = CURRENT_TIMESTAMP
-            WHERE id = ANY($1)
-            """,
-            item_ids,
-            error,
+        rows = await pool.fetch(
+            "SELECT * FROM task_recover_stale_for_type($1, $2)",
+            DOCUMENT_EMBEDDING_TASK_TYPE,
+            timeout_seconds,
         )
-        logger.error(f"Marked {len(item_ids)} queue items as failed: {error}")
+        return len(rows)
+
+    async def cleanup_completed(self, days_old: int) -> int:
+        pool = await self._get_pool()
+        cutoff = datetime.now(UTC) - timedelta(days=days_old)
+        return int(
+            await pool.fetchval(
+                "SELECT task_cleanup_for_type($1, $2)",
+                DOCUMENT_EMBEDDING_TASK_TYPE,
+                cutoff,
+            )
+        )
+
+    async def cleanup_failed(self, days_old: int) -> int:
+        return await self.cleanup_completed(days_old)
+
+    async def _token_for(self, item_ids: list[str]) -> str:
+        pool = await self._get_pool()
+        token = await pool.fetchval(
+            "SELECT claim_token FROM tasks WHERE id = ANY($1) AND status = 'running' LIMIT 1",
+            item_ids,
+        )
+        if not isinstance(token, str):
+            raise RuntimeError("embedding tasks are not currently claimed")
+        return token
+
+
+def embedding_task(document_id: str) -> EnqueueTaskRequest:
+    return EnqueueTaskRequest(
+        task_type=DOCUMENT_EMBEDDING_TASK_TYPE,
+        payload={"document_id": document_id},
+        payload_version=DOCUMENT_EMBEDDING_PAYLOAD_VERSION,
+        deduplication_key=document_id,
+        max_attempts=DOCUMENT_EMBEDDING_MAX_ATTEMPTS,
+    )

--- a/services/ai/db/embeddings.py
+++ b/services/ai/db/embeddings.py
@@ -5,7 +5,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from asyncpg import Pool
+from asyncpg import Connection, Pool
 
 from .connection import get_db_pool
 
@@ -54,14 +54,15 @@ class EmbeddingsRepository:
         )
         return [Embedding(**dict(row)) for row in rows]
 
-    async def delete_for_documents(self, document_ids: List[str]) -> None:
-        """Delete existing embeddings for documents"""
+    async def delete_for_documents(
+        self, document_ids: List[str], connection: Connection | None = None
+    ) -> None:
+        """Delete existing embeddings for documents."""
         if not document_ids:
             return
 
-        pool = await self._get_pool()
-
-        await pool.execute(
+        executor = connection or await self._get_pool()
+        await executor.execute(
             """
             DELETE FROM embeddings
             WHERE document_id = ANY($1)
@@ -70,7 +71,11 @@ class EmbeddingsRepository:
         )
         logger.info(f"Deleted existing embeddings for {len(document_ids)} documents")
 
-    async def bulk_insert(self, embeddings: List[Dict[str, Any]]) -> None:
+    async def bulk_insert(
+        self,
+        embeddings: List[Dict[str, Any]],
+        connection: Connection | None = None,
+    ) -> None:
         """Bulk insert embeddings into database using COPY for efficiency.
 
         Each embedding dict should contain:
@@ -87,7 +92,7 @@ class EmbeddingsRepository:
         if not embeddings:
             return
 
-        pool = await self._get_pool()
+        executor = connection or await self._get_pool()
 
         # Prepare data for COPY
         records = [
@@ -106,7 +111,7 @@ class EmbeddingsRepository:
         ]
 
         # Use COPY for efficient bulk insert
-        await pool.copy_records_to_table(
+        await executor.copy_records_to_table(
             "embeddings",
             records=records,
             columns=[
@@ -123,14 +128,41 @@ class EmbeddingsRepository:
         )
         logger.info(f"Bulk inserted {len(embeddings)} embeddings")
 
+    async def replace_for_document_if_claimed(
+        self,
+        document_id: str,
+        embeddings: List[Dict[str, Any]],
+        task_id: str,
+        claim_token: str,
+    ) -> None:
+        """Replace a document's vectors and fence completion in one transaction.
+
+        If the lease expired while vectors were being generated, the terminal
+        update affects no rows and the transaction rolls back the vector write.
+        """
+        pool = await self._get_pool()
+        async with pool.acquire() as conn:
+            async with conn.transaction():
+                await self.delete_for_documents([document_id], connection=conn)
+                await self.bulk_insert(embeddings, connection=conn)
+                completed = await conn.fetchval(
+                    "SELECT task_complete_bulk($1, $2)", [task_id], claim_token
+                )
+                if int(completed) != 1:
+                    raise RuntimeError("embedding task completion was fenced")
+
     async def bulk_clone_for_documents(
-        self, clone_requests: list[tuple[str, str, str]], model_name: str
+        self,
+        clone_requests: list[tuple[str, str, str]],
+        model_name: str,
+        claim_token: str | None = None,
     ) -> dict[str, int]:
         """Clone current-model embeddings and complete queue items atomically.
 
-        clone_requests contains (source_document_id, target_document_id, queue_item_id).
-        Returns target_document_id -> cloned row count. Existing embeddings are replaced
-        for targets that successfully clone rows.
+        clone_requests contains (source_document_id, target_document_id, task_id).
+        When claim_token is provided, cloned tasks are completed in the same
+        transaction. Returns target_document_id -> cloned row count. Existing
+        embeddings are replaced for targets that successfully clone rows.
         """
         if not clone_requests:
             return {}
@@ -236,17 +268,14 @@ class EmbeddingsRepository:
                     list(clone_counts.keys()),
                 )
 
-                await conn.execute(
-                    """
-                    UPDATE embedding_queue
-                    SET status = 'completed',
-                        processed_at = CURRENT_TIMESTAMP,
-                        updated_at = CURRENT_TIMESTAMP
-                    WHERE id = ANY($1)
-                      AND status = 'processing'
-                    """,
-                    cloned_queue_item_ids,
-                )
+                if claim_token is not None:
+                    completed = await conn.fetchval(
+                        "SELECT task_complete_bulk($1, $2)",
+                        cloned_queue_item_ids,
+                        claim_token,
+                    )
+                    if int(completed) != len(cloned_queue_item_ids):
+                        raise RuntimeError("embedding task completion was fenced")
 
         logger.info(
             f"Cloned {sum(clone_counts.values())} embeddings for {len(clone_counts)} documents"

--- a/services/ai/db/task_queue.py
+++ b/services/ai/db/task_queue.py
@@ -14,10 +14,8 @@ Contract notes:
   write affects no rows) must stop processing the task.
 - Claim result order is not guaranteed by ``UPDATE ... RETURNING``; consumers
   that need order must sort the returned tasks.
-- Enqueue idempotency is per task id: producers retrying must reuse the same
-  ``EnqueueTaskRequest.id``. There is no generic deduplication key; logical work
-  coalescing is workload policy (enforced with task-specific indexes in the
-  workload migrations).
+- Enqueue idempotency is per task id, and an optional generic
+  ``deduplication_key`` coalesces active work for the same task type.
 - A non-null ``concurrency_key`` only serializes execution: multiple tasks may
   queue for the same key, but they run one at a time in oldest-task order.
 """
@@ -58,6 +56,7 @@ class Task:
     available_at: datetime
     weight: int
     concurrency_key: str | None
+    deduplication_key: str | None
     attempt_count: int
     max_attempts: int
     last_error: str | None
@@ -72,9 +71,12 @@ class Task:
     @classmethod
     def from_row(cls, row) -> "Task":
         data = dict(row)
+        data.setdefault("deduplication_key", None)
         data["status"] = TaskStatus(data["status"])
         if isinstance(data["payload"], str):
             data["payload"] = json.loads(data["payload"])
+        if not isinstance(data["payload"], dict):
+            raise ValueError("task payload must be a JSON object")
         return cls(**data)
 
 
@@ -91,6 +93,7 @@ class EnqueueTaskRequest:
     available_at: datetime | None = None
     weight: int = 1
     concurrency_key: str | None = None
+    deduplication_key: str | None = None
     max_attempts: int = 3
 
 
@@ -149,17 +152,28 @@ class TaskQueueRepository:
         return Task.from_row(row) if row else None
 
     async def enqueue(self, task: EnqueueTaskRequest) -> Task:
-        """Enqueue one task. Re-enqueueing an existing id is idempotent and
-        returns the already-stored task."""
+        """Enqueue one task, coalescing an active matching deduplication key."""
         created = await self.enqueue_bulk([task])
         if created:
             return created[0]
-        if task.id is None:
-            raise RuntimeError("task was not enqueued")
-        existing = await self.get(task.id)
-        if existing is None:
-            raise RuntimeError(f"task {task.id} was not enqueued")
-        return existing
+        if task.id is not None:
+            existing = await self.get(task.id)
+            if existing is not None:
+                return existing
+        if task.deduplication_key is not None:
+            pool = await self._get_pool()
+            row = await pool.fetchrow(
+                """
+                SELECT * FROM tasks
+                WHERE task_type = $1 AND deduplication_key = $2
+                  AND status IN ('pending', 'running')
+                """,
+                task.task_type,
+                task.deduplication_key,
+            )
+            if row:
+                return Task.from_row(row)
+        raise RuntimeError(f"task {task.id or '<generated>'} was not enqueued")
 
     async def enqueue_bulk(self, tasks: list[EnqueueTaskRequest]) -> list[Task]:
         """Enqueue tasks, returning only the rows actually inserted."""
@@ -170,6 +184,9 @@ class TaskQueueRepository:
             self._validate_enqueue_task_request(task)
 
         ids = [task.id or str(ULID()) for task in tasks]
+        for task, task_id in zip(tasks, ids, strict=True):
+            if task.id is None:
+                task.id = task_id
         task_types = [task.task_type for task in tasks]
         payloads = [json.dumps(task.payload) for task in tasks]
         payload_versions = [task.payload_version for task in tasks]
@@ -178,10 +195,11 @@ class TaskQueueRepository:
         weights = [task.weight for task in tasks]
         concurrency_keys = [task.concurrency_key for task in tasks]
         max_attempts = [task.max_attempts for task in tasks]
+        deduplication_keys = [task.deduplication_key for task in tasks]
 
         pool = await self._get_pool()
         rows = await pool.fetch(
-            "SELECT * FROM task_enqueue_bulk($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            "SELECT * FROM task_enqueue_bulk($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
             ids,
             task_types,
             payloads,
@@ -191,6 +209,7 @@ class TaskQueueRepository:
             weights,
             concurrency_keys,
             max_attempts,
+            deduplication_keys,
         )
         return [Task.from_row(row) for row in rows]
 
@@ -342,5 +361,7 @@ class TaskQueueRepository:
             raise ValueError("task weight must be >= 0")
         if task.max_attempts < 1:
             raise ValueError("max_attempts must be >= 1")
+        if task.deduplication_key is not None and not task.deduplication_key.strip():
+            raise ValueError("deduplication_key must not be empty")
         if task.payload_version < 1:
             raise ValueError("payload_version must be >= 1")

--- a/services/ai/embeddings/batch_processor.py
+++ b/services/ai/embeddings/batch_processor.py
@@ -1,14 +1,13 @@
 """
 Embedding processor for document indexing.
 
-Drains the embedding_queue table by chunking each document and calling the
-configured embedding provider.
+Claims document_embedding tasks, chunks each document, and calls the configured
+embedding provider.
 """
 
 import asyncio
 import logging
 import time
-from typing import Optional
 
 import ulid
 
@@ -36,10 +35,16 @@ ONLINE_POLL_INTERVAL = 5  # Seconds to wait when queue is empty
 ONLINE_BATCH_DELAY = 0.1  # Seconds to yield between batches when queue has items
 PROGRESS_LOG_INTERVAL = 30  # Seconds between progress log lines
 MAX_EMBEDDING_RETRIES = 5
+LEASE_SECONDS = 900
+HEARTBEAT_INTERVAL = 60
+
+
+class LeaseLost(RuntimeError):
+    """The worker no longer owns a task lease."""
 
 
 class EmbeddingBatchProcessor:
-    """Drains the embedding_queue table using the configured provider's online API."""
+    """Processes document_embedding tasks using the configured provider."""
 
     def __init__(
         self,
@@ -56,14 +61,14 @@ class EmbeddingBatchProcessor:
         self._embedding_semaphore = asyncio.Semaphore(1)
 
         # Progress tracking (populated at online loop start)
-        self._progress_start_time: Optional[float] = None
+        self._progress_start_time: float | None = None
         self._docs_completed = 0
         self._docs_failed = 0
         self._embeddings_written = 0
         self._embedding_time_ms: float = 0
         self._baseline_completed = 0
         self._baseline_failed = 0
-        self._last_progress_log_time: Optional[float] = None
+        self._last_progress_log_time: float | None = None
 
     @property
     def embedding_provider(self):
@@ -80,12 +85,15 @@ class EmbeddingBatchProcessor:
     async def processing_loop(self):
         """Process queue items using online API calls"""
         logger.info(f"Starting embedding processor for provider: {self.provider_type}")
+        recovered = await self.queue_repo.recover_stale_processing_items(300)
+        if recovered:
+            logger.info("Recovered %d expired embedding task leases", recovered)
 
         status_counts = await self.queue_repo.get_status_counts()
-        self._baseline_completed = status_counts.get(QueueStatus.COMPLETED, 0)
-        self._baseline_failed = status_counts.get(QueueStatus.FAILED, 0)
-        pending = status_counts.get(QueueStatus.PENDING, 0) + status_counts.get(
-            QueueStatus.PROCESSING, 0
+        self._baseline_completed = status_counts.get(str(QueueStatus.COMPLETED), 0)
+        self._baseline_failed = status_counts.get(str(QueueStatus.FAILED), 0)
+        pending = status_counts.get(str(QueueStatus.PENDING), 0) + status_counts.get(
+            str(QueueStatus.PROCESSING), 0
         )
         logger.info(
             f"Embedding queue: {pending} pending, "
@@ -112,45 +120,102 @@ class EmbeddingBatchProcessor:
         Returns:
             True if any items were processed, False if queue was empty.
         """
-        items = await self.queue_repo.get_pending_items(
-            limit=ONLINE_BATCH_SIZE, max_retries=MAX_EMBEDDING_RETRIES
-        )
+        claim = await self.queue_repo.claim_batch(ONLINE_BATCH_SIZE)
+        items: list[EmbeddingQueueItem] = []
+        for task in claim.tasks:
+            try:
+                items.append(EmbeddingQueueItem.from_task(task))
+            except ValueError as error:
+                logger.error("Invalid embedding task %s: %s", task.id, error)
+                await self.queue_repo.mark_failed_with_token(
+                    [task.id],
+                    claim.claim_token,
+                    str(error),
+                    retryable=False,
+                )
+                self._docs_failed += 1
 
         if not items:
             await asyncio.sleep(ONLINE_POLL_INTERVAL)
             return False
 
         logger.info(f"Processing {len(items)} documents via online embedding API")
-
-        documents_by_id = await self.documents_repo.get_by_ids(
-            [item.document_id for item in items]
+        lease_lost = asyncio.Event()
+        active_task_ids = {item.id for item in items}
+        heartbeat_task = asyncio.create_task(
+            self._heartbeat_claim(
+                items, claim.claim_token, lease_lost, active_task_ids
+            )
         )
-        items_to_process = await self._clone_same_content_embeddings(
-            items, documents_by_id
-        )
+        try:
+            documents_by_id = await self.documents_repo.get_by_ids(
+                [item.document_id for item in items]
+            )
+            items_to_process = await self._clone_same_content_embeddings(
+                items, documents_by_id, claim.claim_token, lease_lost
+            )
+            active_task_ids.intersection_update(item.id for item in items_to_process)
 
-        for item in items_to_process:
-            try:
-                await self._process_single_document(
-                    item, documents_by_id.get(item.document_id)
-                )
-            except Exception as e:
-                logger.error(
-                    f"Failed to process document {item.document_id}: {e}", exc_info=True
-                )
-                await self.queue_repo.mark_failed([item.id], str(e))
-                self._docs_failed += 1
-            finally:
-                # Yield to allow higher-priority tasks (stream requests) to run
-                await asyncio.sleep(0)
-                await self._maybe_log_progress()
+            for item in items_to_process:
+                if lease_lost.is_set():
+                    break
+                try:
+                    await self._process_single_document(
+                        item,
+                        documents_by_id.get(item.document_id),
+                        claim.claim_token,
+                        lease_lost,
+                    )
+                except LeaseLost:
+                    logger.warning("Lost lease for embedding task %s", item.id)
+                    lease_lost.set()
+                except Exception as e:
+                    logger.error(
+                        f"Failed to process document {item.document_id}: {e}",
+                        exc_info=True,
+                    )
+                    await self.queue_repo.mark_failed_with_token(
+                        [item.id], claim.claim_token, str(e)
+                    )
+                    self._docs_failed += 1
+                finally:
+                    active_task_ids.discard(item.id)
+                    await asyncio.sleep(0)
+                    await self._maybe_log_progress()
+        finally:
+            heartbeat_task.cancel()
+            await asyncio.gather(heartbeat_task, return_exceptions=True)
 
         return True
+
+    async def _heartbeat_claim(
+        self,
+        items: list[EmbeddingQueueItem],
+        claim_token: str,
+        lease_lost: asyncio.Event,
+        active_task_ids: set[str],
+    ) -> None:
+        """Keep active shared leases alive while provider calls run."""
+        try:
+            while not lease_lost.is_set():
+                await asyncio.sleep(HEARTBEAT_INTERVAL)
+                for item in items:
+                    if item.id not in active_task_ids:
+                        continue
+                    if not await self.queue_repo.heartbeat(
+                        item.id, claim_token, LEASE_SECONDS
+                    ):
+                        lease_lost.set()
+                        return
+        except asyncio.CancelledError:
+            raise
 
     async def _clone_same_content_embeddings(
         self,
         items: list[EmbeddingQueueItem],
         documents_by_id: dict[str, Document],
+        claim_token: str,
+        lease_lost: asyncio.Event,
     ) -> list[EmbeddingQueueItem]:
         docs_with_content = [
             doc for doc in documents_by_id.values() if doc.content_id is not None
@@ -184,8 +249,10 @@ class EmbeddingBatchProcessor:
         if not clone_requests:
             return items
 
+        if lease_lost.is_set():
+            raise LeaseLost("embedding lease expired before cloning")
         clone_counts = await self.embeddings_repo.bulk_clone_for_documents(
-            clone_requests, model_name
+            clone_requests, model_name, claim_token
         )
         if not clone_counts:
             return items
@@ -202,9 +269,17 @@ class EmbeddingBatchProcessor:
         return [item for item in items if item.document_id not in cloned_document_ids]
 
     async def _process_single_document(
-        self, item: EmbeddingQueueItem, doc: Document | None = None
+        self,
+        item: EmbeddingQueueItem,
+        doc: Document | None = None,
+        claim_token: str | None = None,
+        lease_lost: asyncio.Event | None = None,
     ):
-        """Process a single document using the embedding provider"""
+        """Process a single document using the embedding provider."""
+        if claim_token is None:
+            raise ValueError("claim_token is required for embedding processing")
+        if lease_lost is not None and lease_lost.is_set():
+            raise LeaseLost("embedding lease expired")
         if item.retry_count > 0:
             logger.debug(
                 f"Retrying document {item.document_id} (attempt {item.retry_count + 1})"
@@ -219,8 +294,8 @@ class EmbeddingBatchProcessor:
                 logger.warning(
                     f"Document {item.document_id} has no content_id, skipping"
                 )
-                await self.queue_repo.mark_failed(
-                    [item.id], "Document has no content_id"
+                await self.queue_repo.mark_failed_with_token(
+                    [item.id], claim_token, "Document has no content_id"
                 )
                 self._docs_failed += 1
                 return
@@ -234,12 +309,15 @@ class EmbeddingBatchProcessor:
                     doc.external_id, item.document_id
                 )
                 if donor_id:
-                    await self.embeddings_repo.delete_for_documents([item.document_id])
-                    cloned = await self.embeddings_repo.clone_for_document(
-                        donor_id, item.document_id
+                    if lease_lost is not None and lease_lost.is_set():
+                        raise LeaseLost("embedding lease expired before clone")
+                    clone_counts = await self.embeddings_repo.bulk_clone_for_documents(
+                        [(donor_id, item.document_id, item.id)],
+                        self.embedding_provider.get_model_name(),
+                        claim_token,
                     )
+                    cloned = clone_counts.get(item.document_id, 0)
                     if cloned > 0:
-                        await self.queue_repo.mark_completed([item.id])
                         self._docs_completed += 1
                         self._embeddings_written += cloned
                         logger.info(
@@ -253,8 +331,8 @@ class EmbeddingBatchProcessor:
                 logger.warning(
                     f"Document {item.document_id} has empty content, skipping"
                 )
-                await self.queue_repo.mark_failed(
-                    [item.id], "Document has empty content"
+                await self.queue_repo.mark_failed_with_token(
+                    [item.id], claim_token, "Document has empty content"
                 )
                 self._docs_failed += 1
                 return
@@ -302,13 +380,14 @@ class EmbeddingBatchProcessor:
                     logger.warning(
                         f"No embeddings generated for document {item.document_id}"
                     )
-                    await self.queue_repo.mark_failed(
-                        [item.id], "No embeddings generated"
+                    await self.queue_repo.mark_failed_with_token(
+                        [item.id], claim_token, "No embeddings generated"
                     )
                     self._docs_failed += 1
                     return
 
-                await self.embeddings_repo.delete_for_documents([item.document_id])
+                if lease_lost is not None and lease_lost.is_set():
+                    raise LeaseLost("embedding lease expired before vector write")
 
                 embeddings_to_insert = []
                 for chunk_idx, chunk in enumerate(chunks):
@@ -325,9 +404,12 @@ class EmbeddingBatchProcessor:
                         }
                     )
 
-                await self.embeddings_repo.bulk_insert(embeddings_to_insert)
-
-                await self.queue_repo.mark_completed([item.id])
+                await self.embeddings_repo.replace_for_document_if_claimed(
+                    item.document_id,
+                    embeddings_to_insert,
+                    item.id,
+                    claim_token,
+                )
 
                 self._docs_completed += 1
                 self._embeddings_written += len(chunks)
@@ -340,7 +422,11 @@ class EmbeddingBatchProcessor:
                     f"Embedding generation failed for {item.document_id}: {e}",
                     exc_info=True,
                 )
-                await self.queue_repo.mark_failed([item.id], str(e))
+                if isinstance(e, LeaseLost):
+                    raise
+                await self.queue_repo.mark_failed_with_token(
+                    [item.id], claim_token, str(e)
+                )
                 self._docs_failed += 1
 
     async def _maybe_log_progress(self):

--- a/services/ai/tests/helpers.py
+++ b/services/ai/tests/helpers.py
@@ -140,13 +140,19 @@ async def create_test_document(
 
 
 async def enqueue_document(db_pool, document_id: str) -> str:
-    """Add document to embedding queue. Returns queue item ID."""
+    """Add a document_embedding task. Returns its task ID."""
     item_id = str(ULID())
     async with db_pool.acquire() as conn:
         await conn.execute(
-            """INSERT INTO embedding_queue (id, document_id, status)
-               VALUES ($1, $2, 'pending')""",
+            """
+            INSERT INTO tasks (
+                id, task_type, payload, payload_version,
+                deduplication_key, max_attempts
+            ) VALUES ($1, 'document_embedding', $2::jsonb, 1, $3, 5)
+            ON CONFLICT DO NOTHING
+            """,
             item_id,
+            json.dumps({"document_id": document_id}),
             document_id,
         )
     return item_id

--- a/services/ai/tests/integration/test_batch_processor.py
+++ b/services/ai/tests/integration/test_batch_processor.py
@@ -3,6 +3,7 @@
 Tests the embedding processor with real database and a mocked embedding provider.
 """
 
+import json
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -226,11 +227,16 @@ async def test_online_does_not_clone_from_donor_with_unresolved_embedding_work(
         )
         await conn.execute(
             """
-            INSERT INTO embedding_queue (id, document_id, status)
-            VALUES ($1, $2, 'processing')
+            INSERT INTO tasks (
+                id, task_type, payload, payload_version, status,
+                deduplication_key, claim_token, claimed_by, lease_expires_at
+            ) VALUES ($1, 'document_embedding', $2::jsonb, 1, 'running',
+                      $3, $4, 'test-worker', clock_timestamp() + interval '10 minutes')
             """,
             str(ulid.ULID()),
+            json.dumps({"document_id": donor_doc_id}),
             donor_doc_id,
+            str(ulid.ULID()),
         )
 
     await embeddings_repo.bulk_insert(
@@ -272,7 +278,8 @@ async def test_online_handles_empty_content(
     await online_processor._process_online_batch()
 
     queue_item = await queue_repo.get_by_id(queue_id)
-    assert queue_item.status == "failed"
+    assert queue_item.status == "pending"
+    assert queue_item.retry_count == 1
     assert queue_item.error_message is not None
 
     embeddings = await embeddings_repo.get_for_document(doc_id)
@@ -489,7 +496,7 @@ async def test_failed_items_are_retried(
     await online_processor._process_online_batch()
 
     item = await queue_repo.get_by_id(queue_id)
-    assert item.status == "failed"
+    assert item.status == "pending"
     assert item.retry_count == 1
 
     # 2) Immediate retry — should succeed now
@@ -523,14 +530,20 @@ async def test_max_retries_exhausted_items_are_not_retried(
     queue_id = str(ulid.ULID())
     async with db_pool.acquire() as conn:
         await conn.execute(
-            """INSERT INTO embedding_queue (id, document_id, status, retry_count)
-               VALUES ($1, $2, 'failed', 5)""",
+            """
+            INSERT INTO tasks (
+                id, task_type, payload, payload_version, status,
+                deduplication_key, attempt_count, max_attempts, completed_at
+            ) VALUES ($1, 'document_embedding', $2::jsonb, 1, 'dead_letter',
+                      $3, 5, 5, clock_timestamp())
+            """,
             queue_id,
+            json.dumps({"document_id": doc_id}),
             doc_id,
         )
 
     await online_processor._process_online_batch()
 
     item = await queue_repo.get_by_id(queue_id)
-    assert item.status == "failed"
+    assert item.status == "dead_letter"
     assert item.retry_count == 5

--- a/services/ai/tests/integration/test_task_queue.py
+++ b/services/ai/tests/integration/test_task_queue.py
@@ -71,6 +71,38 @@ async def test_enqueue_round_trip_generated_id_and_idempotent_retry(db_pool):
 
 
 @pytest.mark.asyncio
+async def test_active_deduplication_is_per_type_and_requeues_after_completion(db_pool):
+    repo = TaskQueueRepository(pool=db_pool)
+    task_type = _unique_task_type("dedup")
+    first = await repo.enqueue(
+        EnqueueTaskRequest(
+            task_type=task_type,
+            payload={"n": 1},
+            deduplication_key="logical-work-1",
+        )
+    )
+    duplicate = await repo.enqueue(
+        EnqueueTaskRequest(
+            task_type=task_type,
+            payload={"n": 2},
+            deduplication_key="logical-work-1",
+        )
+    )
+    assert duplicate.id == first.id
+
+    claim = await repo.claim(task_type, "dedup-worker", ClaimOptions())
+    assert await repo.complete([first.id], claim.claim_token) == 1
+    replacement = await repo.enqueue(
+        EnqueueTaskRequest(
+            task_type=task_type,
+            payload={"n": 3},
+            deduplication_key="logical-work-1",
+        )
+    )
+    assert replacement.id != first.id
+
+
+@pytest.mark.asyncio
 async def test_claim_uses_provided_transaction(db_pool):
     repo = TaskQueueRepository(pool=db_pool)
     task_type = _unique_task_type("claim_transaction")

--- a/services/ai/tests/unit/test_batch_processor_chunk_translation.py
+++ b/services/ai/tests/unit/test_batch_processor_chunk_translation.py
@@ -12,6 +12,7 @@ source document during retrieval, so they must point at clean boundaries in the
 original text.
 """
 
+import asyncio
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -92,9 +93,36 @@ class TestBatchProcessorChunkIndexTranslation:
         item.document_id = doc.id
         item.retry_count = 0
 
-        await processor._process_single_document(item, doc)
+        await processor._process_single_document(
+            item, doc, "01J00000000000000000000001", asyncio.Event()
+        )
 
-        return embeddings_repo.bulk_insert.await_args.args[0]
+        return embeddings_repo.replace_for_document_if_claimed.await_args.args[1]
+
+    async def test_heartbeat_loss_stops_batch_regardless_of_current_status(self, monkeypatch):
+        monkeypatch.setattr(bp, "HEARTBEAT_INTERVAL", 0)
+        processor = EmbeddingBatchProcessor(
+            documents_repo=AsyncMock(),
+            queue_repo=AsyncMock(),
+            embeddings_repo=AsyncMock(),
+            app_state=AppState(),
+        )
+        processor.queue_repo.heartbeat.return_value = False
+        item = MagicMock()
+        item.id = "task-1"
+        lease_lost = asyncio.Event()
+        heartbeat_task = asyncio.create_task(
+            processor._heartbeat_claim(
+                [item], "claim-token", lease_lost, {item.id}
+            )
+        )
+        try:
+            await asyncio.sleep(0)
+            await asyncio.sleep(0)
+            assert lease_lost.is_set()
+        finally:
+            heartbeat_task.cancel()
+            await asyncio.gather(heartbeat_task, return_exceptions=True)
 
     async def test_translated_offsets_match_window_chunk_spans(self, monkeypatch):
         """Control: the persisted offsets must be exactly the piece-relative

--- a/services/ai/tests/unit/test_embedding_queue.py
+++ b/services/ai/tests/unit/test_embedding_queue.py
@@ -1,0 +1,68 @@
+"""Unit tests for the document embedding task adapter."""
+
+from datetime import UTC, datetime
+
+import pytest
+
+from db.embedding_queue import (
+    DOCUMENT_EMBEDDING_MAX_ATTEMPTS,
+    DOCUMENT_EMBEDDING_PAYLOAD_VERSION,
+    DOCUMENT_EMBEDDING_TASK_TYPE,
+    EmbeddingQueueItem,
+    QueueStatus,
+    embedding_task,
+)
+from db.task_queue import Task
+
+pytestmark = pytest.mark.unit
+
+
+NOW = datetime.now(UTC)
+
+
+def _task(payload: dict, **overrides) -> Task:
+    row = {
+        "id": "01J00000000000000000000000",
+        "task_type": DOCUMENT_EMBEDDING_TASK_TYPE,
+        "payload": payload,
+        "payload_version": DOCUMENT_EMBEDDING_PAYLOAD_VERSION,
+        "status": "running",
+        "priority": 0,
+        "available_at": NOW,
+        "weight": 1,
+        "concurrency_key": None,
+        "deduplication_key": "doc-1",
+        "attempt_count": 1,
+        "max_attempts": DOCUMENT_EMBEDDING_MAX_ATTEMPTS,
+        "last_error": None,
+        "claim_token": "01J00000000000000000000001",
+        "claimed_by": "worker",
+        "lease_expires_at": NOW,
+        "created_at": NOW,
+        "updated_at": NOW,
+        "last_started_at": NOW,
+        "completed_at": None,
+    }
+    row.update(overrides)
+    return Task.from_row(row)
+
+
+def test_embedding_enqueue_request_has_versioned_payload_and_deduplication():
+    request = embedding_task("doc-1")
+
+    assert request.task_type == DOCUMENT_EMBEDDING_TASK_TYPE
+    assert request.payload_version == DOCUMENT_EMBEDDING_PAYLOAD_VERSION
+    assert request.payload == {"document_id": "doc-1"}
+    assert request.deduplication_key == "doc-1"
+    assert request.max_attempts == DOCUMENT_EMBEDDING_MAX_ATTEMPTS
+
+
+def test_embedding_payload_is_validated_at_adapter_boundary():
+    item = EmbeddingQueueItem.from_task(_task({"document_id": "doc-1"}))
+    assert item.document_id == "doc-1"
+    assert item.status == QueueStatus.PROCESSING
+
+    with pytest.raises(ValueError, match="requires document_id"):
+        EmbeddingQueueItem.from_task(_task({"document_id": 123}))
+    with pytest.raises(ValueError, match="payload version"):
+        EmbeddingQueueItem.from_task(_task({"document_id": "doc-1"}, payload_version=2))

--- a/services/ai/tests/unit/test_task_queue.py
+++ b/services/ai/tests/unit/test_task_queue.py
@@ -31,6 +31,7 @@ def _task_row(**overrides) -> dict:
         "available_at": NOW,
         "weight": 1,
         "concurrency_key": None,
+        "deduplication_key": None,
         "attempt_count": 0,
         "max_attempts": 3,
         "last_error": None,
@@ -58,6 +59,7 @@ def test_from_row_parses_string_payload_and_status():
 
     assert task.payload == {"n": 1}
     assert task.status == TaskStatus.RUNNING
+    assert task.deduplication_key is None
 
 
 @pytest.mark.asyncio
@@ -85,6 +87,10 @@ async def test_enqueue_validation_raises_before_database_access():
     with pytest.raises(ValueError, match="payload_version"):
         await repo.enqueue_bulk(
             [EnqueueTaskRequest(task_type="test", payload={}, payload_version=0)]
+        )
+    with pytest.raises(ValueError, match="deduplication_key"):
+        await repo.enqueue_bulk(
+            [EnqueueTaskRequest(task_type="test", payload={}, deduplication_key=" ")]
         )
 
 

--- a/services/indexer/tests/common/mod.rs
+++ b/services/indexer/tests/common/mod.rs
@@ -267,7 +267,10 @@ pub async fn wait_for_embedding_queue_entry(
     let result = timeout(timeout_duration, async {
         loop {
             let row: Option<(i64,)> =
-                sqlx::query_as("SELECT COUNT(*) FROM embedding_queue WHERE document_id = $1")
+                sqlx::query_as("SELECT COUNT(*) FROM tasks
+                     WHERE task_type = 'document_embedding'
+                       AND deduplication_key = $1
+                       AND status IN ('pending', 'running')")
                     .bind(document_id)
                     .fetch_optional(pool)
                     .await

--- a/services/indexer/tests/integration_tests.rs
+++ b/services/indexer/tests/integration_tests.rs
@@ -292,7 +292,7 @@ async fn test_unchanged_content_upsert_does_not_requeue_existing_embeddings() {
             .expect("Document should be created");
     common::wait_for_completed(fixture.state.db_pool.pool(), 1, Duration::from_secs(5)).await;
 
-    sqlx::query("UPDATE embedding_queue SET status = 'completed' WHERE document_id = $1")
+    sqlx::query("UPDATE tasks SET status = 'completed', completed_at = clock_timestamp() WHERE task_type = 'document_embedding' AND deduplication_key = $1")
         .bind(&document.id)
         .execute(fixture.state.db_pool.pool())
         .await
@@ -352,7 +352,7 @@ async fn test_unchanged_content_upsert_does_not_requeue_existing_embeddings() {
     common::wait_for_completed(fixture.state.db_pool.pool(), 2, Duration::from_secs(5)).await;
 
     let queue_rows_after_metadata_update: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM embedding_queue WHERE document_id = $1")
+        sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE task_type = 'document_embedding' AND deduplication_key = $1")
             .bind(&document.id)
             .fetch_one(fixture.state.db_pool.pool())
             .await
@@ -402,7 +402,7 @@ async fn test_unchanged_content_upsert_does_not_requeue_existing_embeddings() {
     common::wait_for_completed(fixture.state.db_pool.pool(), 3, Duration::from_secs(5)).await;
 
     let queue_rows_after_content_update: (i64,) =
-        sqlx::query_as("SELECT COUNT(*) FROM embedding_queue WHERE document_id = $1")
+        sqlx::query_as("SELECT COUNT(*) FROM tasks WHERE task_type = 'document_embedding' AND deduplication_key = $1")
             .bind(&document.id)
             .fetch_one(fixture.state.db_pool.pool())
             .await
@@ -935,7 +935,7 @@ async fn test_recovery_and_dead_letter() {
         .unwrap();
 
     sqlx::query(
-        "UPDATE embedding_queue SET status = 'processing', processing_started_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes' WHERE id = $1"
+        "UPDATE tasks SET status = 'running', claim_token = '01J00000000000000000000001', claimed_by = 'test', lease_expires_at = CURRENT_TIMESTAMP - INTERVAL '10 minutes' WHERE id = $1"
     )
     .bind(&queue_id)
     .execute(pool)
@@ -952,7 +952,7 @@ async fn test_recovery_and_dead_letter() {
     );
 
     // Verify our specific item was recovered back to pending
-    let row: (String,) = sqlx::query_as("SELECT status FROM embedding_queue WHERE id = $1")
+    let row: (String,) = sqlx::query_as("SELECT status FROM tasks WHERE id = $1")
         .bind(&queue_id)
         .fetch_one(pool)
         .await

--- a/services/migrations/114_migrate_embedding_queue_to_tasks.sql
+++ b/services/migrations/114_migrate_embedding_queue_to_tasks.sql
@@ -1,0 +1,209 @@
+-- Add generic active-work deduplication and move document embedding work to tasks.
+-- The tasks table remains workload-agnostic: document_id is carried only in the
+-- versioned embedding payload and in the generic deduplication key.
+
+ALTER TABLE tasks
+    ADD COLUMN deduplication_key TEXT;
+
+ALTER TABLE tasks
+    ADD CONSTRAINT tasks_deduplication_key_check
+    CHECK (deduplication_key IS NULL OR btrim(deduplication_key) <> '');
+
+CREATE UNIQUE INDEX idx_tasks_active_deduplication_key
+    ON tasks (task_type, deduplication_key)
+    WHERE deduplication_key IS NOT NULL
+      AND status IN ('pending', 'running');
+
+COMMENT ON COLUMN tasks.deduplication_key IS
+    'Optional opaque key that prevents duplicate pending or running work within a task type.';
+
+-- Changing the argument list creates an overload in PostgreSQL. Remove the
+-- migration-112 function first so an old nine-argument enqueue path cannot be
+-- selected ambiguously by clients.
+DROP FUNCTION task_enqueue_bulk(
+    TEXT[], TEXT[], JSONB[], INTEGER[], INTEGER[], BIGINT[], BIGINT[], TEXT[], INTEGER[]
+);
+
+CREATE FUNCTION task_enqueue_bulk(
+    p_ids TEXT[],
+    p_task_types TEXT[],
+    p_payloads JSONB[],
+    p_payload_versions INTEGER[],
+    p_priorities INTEGER[],
+    p_available_at_ms BIGINT[],
+    p_weights BIGINT[],
+    p_concurrency_keys TEXT[],
+    p_max_attempts INTEGER[],
+    p_deduplication_keys TEXT[]
+) RETURNS SETOF tasks AS $$
+BEGIN
+    RETURN QUERY
+    INSERT INTO tasks (
+        id, task_type, payload, payload_version,
+        priority, available_at, weight, concurrency_key, max_attempts,
+        deduplication_key
+    )
+    SELECT
+        ids.id,
+        ids.task_type,
+        ids.payload,
+        ids.payload_version,
+        ids.priority,
+        to_timestamp(ids.available_at_ms::double precision / 1000.0),
+        ids.weight,
+        ids.concurrency_key,
+        ids.max_attempts,
+        ids.deduplication_key
+    FROM UNNEST(
+        p_ids,
+        p_task_types,
+        p_payloads,
+        p_payload_versions,
+        p_priorities,
+        p_available_at_ms,
+        p_weights,
+        p_concurrency_keys,
+        p_max_attempts,
+        p_deduplication_keys
+    ) AS ids(
+        id, task_type, payload, payload_version,
+        priority, available_at_ms, weight, concurrency_key, max_attempts,
+        deduplication_key
+    )
+    ON CONFLICT DO NOTHING
+    RETURNING *;
+END;
+$$ LANGUAGE plpgsql;
+
+-- A scoped form is used by adapters that own one workload. Keeping the
+-- unscoped function from migration 112 preserves the generic recovery API.
+CREATE FUNCTION task_recover_expired_for_type(p_task_type TEXT)
+RETURNS SETOF tasks AS $$
+DECLARE
+    v_now TIMESTAMPTZ;
+BEGIN
+    IF p_task_type IS NULL OR btrim(p_task_type) = '' THEN
+        RAISE EXCEPTION 'task_recover_expired_for_type: task_type must not be empty';
+    END IF;
+    v_now := statement_timestamp();
+
+    RETURN QUERY
+    UPDATE tasks t
+    SET status = CASE
+            WHEN t.attempt_count < t.max_attempts THEN 'pending'
+            ELSE 'dead_letter'
+        END,
+        available_at = CASE
+            WHEN t.attempt_count < t.max_attempts THEN v_now
+            ELSE t.available_at
+        END,
+        completed_at = CASE
+            WHEN t.attempt_count < t.max_attempts THEN NULL
+            ELSE v_now
+        END,
+        last_error = CASE
+            WHEN t.attempt_count < t.max_attempts THEN 'task lease expired; requeued'
+            ELSE 'task lease expired; retries exhausted'
+        END,
+        claim_token = NULL,
+        claimed_by = NULL,
+        lease_expires_at = NULL,
+        updated_at = v_now
+    WHERE t.task_type = p_task_type
+      AND t.status = 'running'
+      AND t.lease_expires_at <= v_now
+    RETURNING t.*;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE FUNCTION task_cleanup_for_type(
+    p_task_type TEXT,
+    p_before TIMESTAMPTZ
+) RETURNS BIGINT AS $$
+DECLARE
+    v_deleted BIGINT;
+BEGIN
+    IF p_task_type IS NULL OR btrim(p_task_type) = '' THEN
+        RAISE EXCEPTION 'task_cleanup_for_type: task_type must not be empty';
+    END IF;
+    DELETE FROM tasks
+    WHERE task_type = p_task_type
+      AND status IN ('completed', 'dead_letter')
+      AND completed_at < p_before;
+    GET DIAGNOSTICS v_deleted = ROW_COUNT;
+    RETURN v_deleted;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Backfill deterministically. Processing rows cannot retain their old worker
+-- ownership, so they are requeued. Failed rows with five or more failures are
+-- represented as dead letters; all other rows retain their failure count as
+-- attempt_count. Only the oldest active row per document is retained because
+-- the new generic active deduplication index intentionally rejects duplicates.
+WITH mapped AS (
+    SELECT
+        CASE
+            WHEN char_length(q.id) = 26 THEN q.id
+            ELSE substring(md5('embedding_queue:' || q.id), 1, 26)
+        END AS task_id,
+        q.document_id,
+        q.status AS legacy_status,
+        q.retry_count,
+        q.error_message,
+        q.created_at,
+        q.updated_at,
+        q.processed_at,
+        CASE
+            WHEN q.status = 'completed' THEN 'completed'
+            WHEN q.status = 'failed' AND q.retry_count >= 5 THEN 'dead_letter'
+            ELSE 'pending'
+        END AS task_status,
+        LEAST(GREATEST(q.retry_count, 0), 5) AS attempt_count
+    FROM embedding_queue q
+), ranked AS (
+    SELECT mapped.*,
+           row_number() OVER (
+               PARTITION BY document_id
+               ORDER BY CASE WHEN task_status = 'pending' THEN 0 ELSE 1 END,
+                        created_at, task_id
+           ) AS active_rank
+    FROM mapped
+)
+INSERT INTO tasks (
+    id, task_type, payload, payload_version, status,
+    priority, available_at, weight, max_attempts, attempt_count,
+    last_error, created_at, updated_at, completed_at, deduplication_key
+)
+SELECT
+    r.task_id,
+    'document_embedding',
+    jsonb_build_object('document_id', r.document_id),
+    1,
+    r.task_status,
+    0,
+    CASE
+        WHEN r.task_status = 'pending' THEN COALESCE(r.updated_at, r.created_at, NOW())
+        ELSE COALESCE(r.created_at, NOW())
+    END,
+    1,
+    5,
+    r.attempt_count,
+    CASE
+        WHEN r.legacy_status = 'failed' THEN COALESCE(r.error_message, 'migrated from embedding_queue')
+        WHEN r.legacy_status = 'processing' THEN 'migrated from processing embedding_queue item'
+        ELSE NULL
+    END,
+    COALESCE(r.created_at, NOW()),
+    COALESCE(r.updated_at, r.created_at, NOW()),
+    CASE
+        WHEN r.task_status IN ('completed', 'dead_letter')
+            THEN COALESCE(r.processed_at, r.updated_at, r.created_at, NOW())
+        ELSE NULL
+    END,
+    r.document_id
+FROM ranked r
+WHERE r.task_status <> 'pending' OR r.active_rank = 1
+ON CONFLICT DO NOTHING;
+
+DROP TABLE embedding_queue;
+DROP FUNCTION IF EXISTS notify_embedding_queue();

--- a/services/migrations/115_add_scoped_task_recovery.sql
+++ b/services/migrations/115_add_scoped_task_recovery.sql
@@ -1,0 +1,52 @@
+-- Generic type-scoped stale recovery for workers that own one task type.
+-- Heartbeats update updated_at, so healthy long-running tasks are not recovered
+-- merely because they have been running longer than the stale threshold.
+
+DROP FUNCTION task_recover_expired_for_type(TEXT);
+
+CREATE FUNCTION task_recover_stale_for_type(
+    p_task_type TEXT,
+    p_timeout_seconds INTEGER
+) RETURNS SETOF tasks AS $$
+DECLARE
+    v_now TIMESTAMPTZ;
+BEGIN
+    IF p_task_type IS NULL OR btrim(p_task_type) = '' THEN
+        RAISE EXCEPTION 'task_recover_stale_for_type: task_type must not be empty';
+    END IF;
+    IF p_timeout_seconds IS NULL OR p_timeout_seconds < 1 THEN
+        RAISE EXCEPTION 'task_recover_stale_for_type: timeout_seconds must be >= 1';
+    END IF;
+    v_now := clock_timestamp();
+
+    RETURN QUERY
+    UPDATE tasks t
+    SET status = CASE
+            WHEN t.attempt_count < t.max_attempts THEN 'pending'
+            ELSE 'dead_letter'
+        END,
+        available_at = CASE
+            WHEN t.attempt_count < t.max_attempts THEN v_now
+            ELSE t.available_at
+        END,
+        completed_at = CASE
+            WHEN t.attempt_count < t.max_attempts THEN NULL
+            ELSE v_now
+        END,
+        last_error = CASE
+            WHEN t.attempt_count < t.max_attempts THEN 'task lease expired; requeued'
+            ELSE 'task lease expired; retries exhausted'
+        END,
+        claim_token = NULL,
+        claimed_by = NULL,
+        lease_expires_at = NULL,
+        updated_at = v_now
+    WHERE t.task_type = p_task_type
+      AND t.status = 'running'
+      AND (
+          t.lease_expires_at <= v_now
+          OR t.updated_at <= v_now - make_interval(secs => p_timeout_seconds)
+      )
+    RETURNING t.*;
+END;
+$$ LANGUAGE plpgsql;

--- a/shared/src/db/repositories/document.rs
+++ b/shared/src/db/repositories/document.rs
@@ -1,7 +1,7 @@
 use crate::{
-    SourceType,
     db::error::DatabaseError,
     models::{AttributeFilter, DateFilter, Document},
+    SourceType,
 };
 use serde_json::Value as JsonValue;
 use sqlx::{FromRow, PgPool};
@@ -585,10 +585,18 @@ impl DocumentRepository {
     }
 
     pub async fn delete(&self, id: &str) -> Result<bool, DatabaseError> {
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
+            "DELETE FROM tasks WHERE task_type = 'document_embedding' AND deduplication_key = $1",
+        )
+        .bind(id)
+        .execute(&mut *tx)
+        .await?;
         let result = sqlx::query("DELETE FROM documents WHERE id = $1")
             .bind(id)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
+        tx.commit().await?;
 
         Ok(result.rows_affected() > 0)
     }
@@ -752,10 +760,18 @@ impl DocumentRepository {
             return Ok(0);
         }
 
+        let mut tx = self.pool.begin().await?;
+        sqlx::query(
+            "DELETE FROM tasks WHERE task_type = 'document_embedding' AND deduplication_key = ANY($1)",
+        )
+        .bind(&document_ids)
+        .execute(&mut *tx)
+        .await?;
         let result = sqlx::query("DELETE FROM documents WHERE id = ANY($1)")
             .bind(&document_ids)
-            .execute(&self.pool)
+            .execute(&mut *tx)
             .await?;
+        tx.commit().await?;
 
         Ok(result.rows_affected() as i64)
     }

--- a/shared/src/embedding_queue.rs
+++ b/shared/src/embedding_queue.rs
@@ -1,9 +1,22 @@
-use anyhow::Result;
-use serde::{Deserialize, Serialize};
-use sqlx::{PgPool, Row};
-use ulid::Ulid;
+//! Embedding workload adapter for the generic task queue.
+//!
+//! Document identifiers are encoded in the versioned task payload. This module
+//! owns provider gating and the current-model eligibility query, while lease,
+//! retry, fencing, and deduplication remain generic task-queue behavior.
 
-use crate::{db::repositories::EmbeddingProviderRepository, utils::generate_ulid};
+use anyhow::{bail, Result};
+use serde::{Deserialize, Serialize};
+use sqlx::PgPool;
+use time::Duration;
+
+use crate::{
+    db::repositories::EmbeddingProviderRepository,
+    task_queue::{ClaimOptions, EnqueueTaskRequest, Task, TaskClaim, TaskQueue, TaskStatus},
+};
+
+pub const DOCUMENT_EMBEDDING_TASK_TYPE: &str = "document_embedding";
+pub const DOCUMENT_EMBEDDING_PAYLOAD_VERSION: i32 = 1;
+pub const DOCUMENT_EMBEDDING_MAX_ATTEMPTS: i32 = 5;
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -17,24 +30,10 @@ pub enum EmbeddingQueueStatus {
 impl std::fmt::Display for EmbeddingQueueStatus {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
-            EmbeddingQueueStatus::Pending => write!(f, "pending"),
-            EmbeddingQueueStatus::Processing => write!(f, "processing"),
-            EmbeddingQueueStatus::Completed => write!(f, "completed"),
-            EmbeddingQueueStatus::Failed => write!(f, "failed"),
-        }
-    }
-}
-
-impl std::str::FromStr for EmbeddingQueueStatus {
-    type Err = anyhow::Error;
-
-    fn from_str(s: &str) -> Result<Self> {
-        match s {
-            "pending" => Ok(EmbeddingQueueStatus::Pending),
-            "processing" => Ok(EmbeddingQueueStatus::Processing),
-            "completed" => Ok(EmbeddingQueueStatus::Completed),
-            "failed" => Ok(EmbeddingQueueStatus::Failed),
-            _ => Err(anyhow::anyhow!("Invalid embedding queue status: {}", s)),
+            Self::Pending => write!(f, "pending"),
+            Self::Processing => write!(f, "processing"),
+            Self::Completed => write!(f, "completed"),
+            Self::Failed => write!(f, "failed"),
         }
     }
 }
@@ -49,111 +48,44 @@ pub struct EmbeddingQueueItem {
     pub created_at: sqlx::types::time::OffsetDateTime,
     pub updated_at: sqlx::types::time::OffsetDateTime,
     pub processed_at: Option<sqlx::types::time::OffsetDateTime>,
-}
-
-impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for EmbeddingQueueItem {
-    fn from_row(row: &sqlx::postgres::PgRow) -> Result<Self, sqlx::Error> {
-        use sqlx::Row;
-
-        let status_str: String = row.try_get("status")?;
-        let status =
-            status_str
-                .parse::<EmbeddingQueueStatus>()
-                .map_err(|e| sqlx::Error::ColumnDecode {
-                    index: "status".to_string(),
-                    source: e.into(),
-                })?;
-
-        Ok(EmbeddingQueueItem {
-            id: row.try_get("id")?,
-            document_id: row.try_get("document_id")?,
-            status,
-            retry_count: row.try_get("retry_count")?,
-            error_message: row.try_get("error_message")?,
-            created_at: row.try_get("created_at")?,
-            updated_at: row.try_get("updated_at")?,
-            processed_at: row.try_get("processed_at")?,
-        })
-    }
+    /// Fencing token for the claim that produced this adapter item.
+    pub claim_token: Option<String>,
 }
 
 #[derive(Clone)]
 pub struct EmbeddingQueue {
     pool: PgPool,
     provider_repo: EmbeddingProviderRepository,
+    task_queue: TaskQueue,
 }
 
 impl EmbeddingQueue {
     pub fn new(pool: PgPool) -> Self {
         let provider_repo = EmbeddingProviderRepository::new(&pool);
+        let task_queue = TaskQueue::new(pool.clone());
         Self {
             pool,
             provider_repo,
+            task_queue,
         }
     }
 
     pub async fn enqueue(&self, document_id: String) -> Result<Option<String>> {
-        if !self.provider_repo.has_active_provider().await? {
-            return Ok(None);
-        }
-
-        let id = Ulid::new().to_string();
-
-        let result = sqlx::query(
-            r#"
-            INSERT INTO embedding_queue (id, document_id)
-            SELECT $1, $2
-            WHERE NOT EXISTS (
-                SELECT 1 FROM embedding_queue
-                WHERE document_id = $2 AND status IN ('pending', 'processing')
-            )
-            "#,
-        )
-        .bind(&id)
-        .bind(&document_id)
-        .execute(&self.pool)
-        .await?;
-
-        if result.rows_affected() > 0 {
-            Ok(Some(id))
-        } else {
-            Ok(None)
-        }
+        let ids = self.enqueue_batch(vec![document_id]).await?;
+        Ok(ids.into_iter().next())
     }
 
     pub async fn enqueue_batch(&self, document_ids: Vec<String>) -> Result<Vec<String>> {
-        if !self.provider_repo.has_active_provider().await? {
-            return Ok(vec![]);
+        if document_ids.is_empty() || !self.provider_repo.has_active_provider().await? {
+            return Ok(Vec::new());
         }
 
-        let mut tx = self.pool.begin().await?;
-        let mut ids = Vec::new();
-
-        for document_id in document_ids {
-            let id = Ulid::new().to_string();
-
-            let result = sqlx::query(
-                r#"
-                INSERT INTO embedding_queue (id, document_id)
-                SELECT $1, $2
-                WHERE NOT EXISTS (
-                    SELECT 1 FROM embedding_queue
-                    WHERE document_id = $2 AND status IN ('pending', 'processing')
-                )
-                "#,
-            )
-            .bind(&id)
-            .bind(&document_id)
-            .execute(&mut *tx)
-            .await?;
-
-            if result.rows_affected() > 0 {
-                ids.push(id);
-            }
-        }
-
-        tx.commit().await?;
-        Ok(ids)
+        let tasks: Vec<EnqueueTaskRequest> = document_ids
+            .into_iter()
+            .map(|document_id| embedding_task(document_id))
+            .collect();
+        let inserted = self.task_queue.enqueue_bulk(&tasks).await?;
+        Ok(inserted.into_iter().map(|task| task.id).collect())
     }
 
     pub async fn enqueue_batch_missing_current_embeddings(
@@ -161,231 +93,222 @@ impl EmbeddingQueue {
         document_ids: Vec<String>,
     ) -> Result<Vec<String>> {
         if document_ids.is_empty() || !self.provider_repo.has_active_provider().await? {
-            return Ok(vec![]);
+            return Ok(Vec::new());
         }
 
-        let ids: Vec<String> = document_ids.iter().map(|_| generate_ulid()).collect();
-        let rows = sqlx::query(
+        let candidates: Vec<String> = sqlx::query_scalar(
             r#"
             WITH active_provider AS (
                 SELECT config->>'model' AS model_name
                 FROM embedding_providers
                 WHERE is_current = TRUE AND is_deleted = FALSE
                 LIMIT 1
-            ),
-            input_rows AS (
-                SELECT id, document_id, ordinality
-                FROM UNNEST($1::text[], $2::text[]) WITH ORDINALITY AS t(id, document_id, ordinality)
-            ),
-            deduped_input AS (
-                SELECT DISTINCT ON (document_id) id, document_id
-                FROM input_rows
-                ORDER BY document_id, ordinality
             )
-            INSERT INTO embedding_queue (id, document_id)
-            SELECT input.id, input.document_id
-            FROM deduped_input input
+            SELECT DISTINCT d.id
+            FROM UNNEST($1::text[]) AS input(document_id)
+            JOIN documents d ON d.id = input.document_id
             CROSS JOIN active_provider provider
             WHERE NOT EXISTS (
-                SELECT 1
-                FROM embedding_queue q
-                WHERE q.document_id = input.document_id
-                  AND q.status IN ('pending', 'processing')
+                SELECT 1 FROM tasks q
+                WHERE q.task_type = $2
+                  AND q.deduplication_key = d.id
+                  AND q.status IN ('pending', 'running')
             )
             AND NOT EXISTS (
-                SELECT 1
-                FROM embeddings e
-                WHERE e.document_id = input.document_id
+                SELECT 1 FROM embeddings e
+                WHERE e.document_id = d.id
                   AND e.model_name = provider.model_name
             )
-            RETURNING id
+            ORDER BY d.id
             "#,
         )
-        .bind(&ids)
         .bind(&document_ids)
+        .bind(DOCUMENT_EMBEDDING_TASK_TYPE)
         .fetch_all(&self.pool)
         .await?;
 
-        Ok(rows.into_iter().map(|row| row.get("id")).collect())
+        self.enqueue_batch(candidates).await
     }
 
-    pub async fn dequeue_batch(&self, batch_size: i32) -> Result<Vec<EmbeddingQueueItem>> {
-        let items = sqlx::query_as::<_, EmbeddingQueueItem>(
-            r#"
-            UPDATE embedding_queue
-            SET status = $2,
-                updated_at = CURRENT_TIMESTAMP,
-                processing_started_at = CURRENT_TIMESTAMP
-            WHERE id IN (
-                SELECT id
-                FROM embedding_queue
-                WHERE status = $3
-                   OR (status = $4 AND retry_count < 3)
-                ORDER BY created_at
-                LIMIT $1
-                FOR UPDATE SKIP LOCKED
+    /// Claim embedding tasks with a fencing token. The old queue's five retry
+    /// attempts are represented by each task's generic max_attempts field.
+    pub async fn claim_batch(&self, batch_size: i32, worker: &str) -> Result<TaskClaim> {
+        self.task_queue
+            .claim_bulk(
+                &self.pool,
+                DOCUMENT_EMBEDDING_TASK_TYPE,
+                worker,
+                &ClaimOptions {
+                    limit: batch_size,
+                    lease_seconds: 900,
+                    ..Default::default()
+                },
             )
-            RETURNING *
-            "#,
-        )
-        .bind(batch_size)
-        .bind(EmbeddingQueueStatus::Processing.to_string())
-        .bind(EmbeddingQueueStatus::Pending.to_string())
-        .bind(EmbeddingQueueStatus::Failed.to_string())
-        .fetch_all(&self.pool)
-        .await?;
+            .await
+    }
 
-        Ok(items)
+    /// Compatibility-shaped method for callers that only need claimed items.
+    pub async fn dequeue_batch(&self, batch_size: i32) -> Result<Vec<EmbeddingQueueItem>> {
+        let claim = self.claim_batch(batch_size, "embedding-adapter").await?;
+        claim.tasks.into_iter().map(task_to_item).collect()
+    }
+
+    pub async fn get_by_id(&self, id: &str) -> Result<Option<EmbeddingQueueItem>> {
+        let task = self.task_queue.get(id).await?;
+        task.map(task_to_item).transpose()
+    }
+
+    pub async fn get_queue_stats(&self) -> Result<QueueStats> {
+        let stats = self
+            .task_queue
+            .stats(Some(DOCUMENT_EMBEDDING_TASK_TYPE))
+            .await?;
+        let mut result = QueueStats::default();
+        for stat in stats {
+            match stat.status {
+                TaskStatus::Pending => result.pending = stat.count,
+                TaskStatus::Running => result.processing = stat.count,
+                TaskStatus::Completed => result.completed = stat.count,
+                TaskStatus::DeadLetter => result.failed = stat.count,
+            }
+        }
+        Ok(result)
     }
 
     pub async fn mark_completed(&self, ids: &[String]) -> Result<()> {
-        sqlx::query(
-            r#"
-            UPDATE embedding_queue
-            SET status = $2,
-                processed_at = CURRENT_TIMESTAMP,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = ANY($1)
-            "#,
-        )
-        .bind(ids)
-        .bind(EmbeddingQueueStatus::Completed.to_string())
-        .execute(&self.pool)
-        .await?;
+        let token = self.claim_token_for(ids).await?;
+        self.mark_completed_with_token(ids, &token).await
+    }
 
+    pub async fn mark_completed_with_token(&self, ids: &[String], token: &str) -> Result<()> {
+        let completed = self.task_queue.complete_bulk(ids, token).await?;
+        if completed != ids.len() as i64 {
+            bail!(
+                "embedding task completion was fenced for {} tasks",
+                ids.len() - completed as usize
+            );
+        }
         Ok(())
     }
 
     pub async fn mark_failed(&self, id: &str, error: &str) -> Result<()> {
-        sqlx::query(
-            r#"
-            UPDATE embedding_queue
-            SET status = $3,
-                error_message = $2,
-                retry_count = retry_count + 1,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = $1
-            "#,
-        )
-        .bind(id)
-        .bind(error)
-        .bind(EmbeddingQueueStatus::Failed.to_string())
-        .execute(&self.pool)
-        .await?;
-
-        Ok(())
+        self.mark_failed_batch(std::slice::from_ref(&id.to_string()), error)
+            .await
     }
 
     pub async fn mark_failed_batch(&self, ids: &[String], error: &str) -> Result<()> {
-        sqlx::query(
-            r#"
-            UPDATE embedding_queue
-            SET status = $3,
-                error_message = $2,
-                retry_count = retry_count + 1,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE id = ANY($1)
-            "#,
-        )
-        .bind(ids)
-        .bind(error)
-        .bind(EmbeddingQueueStatus::Failed.to_string())
-        .execute(&self.pool)
-        .await?;
+        let token = self.claim_token_for(ids).await?;
+        self.mark_failed_batch_with_token(ids, &token, error).await
+    }
 
+    pub async fn mark_failed_batch_with_token(
+        &self,
+        ids: &[String],
+        token: &str,
+        error: &str,
+    ) -> Result<()> {
+        let failed = self
+            .task_queue
+            .fail_bulk(ids, token, error, true, 0)
+            .await?;
+        if failed.len() != ids.len() {
+            bail!(
+                "embedding task failure was fenced for {} tasks",
+                ids.len() - failed.len()
+            );
+        }
         Ok(())
     }
 
     pub async fn recover_stale_processing_items(&self, timeout_seconds: i32) -> Result<i64> {
-        let result = sqlx::query(
-            r#"
-            UPDATE embedding_queue
-            SET status = $2,
-                processing_started_at = NULL,
-                updated_at = CURRENT_TIMESTAMP
-            WHERE status = $3
-            AND processing_started_at < CURRENT_TIMESTAMP - INTERVAL '1 second' * $1
-            "#,
-        )
-        .bind(timeout_seconds)
-        .bind(EmbeddingQueueStatus::Pending.to_string())
-        .bind(EmbeddingQueueStatus::Processing.to_string())
-        .execute(&self.pool)
-        .await?;
-
-        let recovered_count = result.rows_affected() as i64;
-        if recovered_count > 0 {
-            tracing::info!(
-                "Recovered {} stale embedding processing items (timeout: {}s)",
-                recovered_count,
-                timeout_seconds
-            );
+        if timeout_seconds < 1 {
+            bail!("recovery timeout must be >= 1");
         }
-
-        Ok(recovered_count)
+        let rows = sqlx::query("SELECT * FROM task_recover_stale_for_type($1, $2)")
+            .bind(DOCUMENT_EMBEDDING_TASK_TYPE)
+            .bind(timeout_seconds)
+            .fetch_all(&self.pool)
+            .await?;
+        Ok(rows.len() as i64)
     }
 
     pub async fn cleanup_completed(&self, days_old: i32) -> Result<i64> {
-        let result = sqlx::query(
-            r#"
-            DELETE FROM embedding_queue
-            WHERE status = $2
-              AND processed_at < CURRENT_TIMESTAMP - INTERVAL '1 day' * $1
-            "#,
-        )
-        .bind(days_old)
-        .bind(EmbeddingQueueStatus::Completed.to_string())
-        .execute(&self.pool)
-        .await?;
-
-        Ok(result.rows_affected() as i64)
+        let cutoff =
+            sqlx::types::time::OffsetDateTime::now_utc() - Duration::days(i64::from(days_old));
+        sqlx::query_scalar("SELECT task_cleanup_for_type($1, $2)")
+            .bind(DOCUMENT_EMBEDDING_TASK_TYPE)
+            .bind(cutoff)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(Into::into)
     }
 
     pub async fn cleanup_failed(&self, days_old: i32) -> Result<i64> {
-        let result = sqlx::query(
-            r#"
-            DELETE FROM embedding_queue
-            WHERE status = $2
-              AND retry_count >= 3
-              AND updated_at < CURRENT_TIMESTAMP - INTERVAL '1 day' * $1
-            "#,
-        )
-        .bind(days_old)
-        .bind(EmbeddingQueueStatus::Failed.to_string())
-        .execute(&self.pool)
-        .await?;
-
-        Ok(result.rows_affected() as i64)
+        self.cleanup_completed(days_old).await
     }
 
-    pub async fn get_queue_stats(&self) -> Result<QueueStats> {
-        let row = sqlx::query(
-            r#"
-            SELECT 
-                COUNT(*) FILTER (WHERE status = $1) as pending,
-                COUNT(*) FILTER (WHERE status = $2) as processing,
-                COUNT(*) FILTER (WHERE status = $3) as completed,
-                COUNT(*) FILTER (WHERE status = $4) as failed
-            FROM embedding_queue
-            "#,
+    async fn claim_token_for(&self, ids: &[String]) -> Result<String> {
+        let token: Option<String> = sqlx::query_scalar(
+            "SELECT claim_token FROM tasks WHERE id = ANY($1) AND status = 'running' LIMIT 1",
         )
-        .bind(EmbeddingQueueStatus::Pending.to_string())
-        .bind(EmbeddingQueueStatus::Processing.to_string())
-        .bind(EmbeddingQueueStatus::Completed.to_string())
-        .bind(EmbeddingQueueStatus::Failed.to_string())
-        .fetch_one(&self.pool)
+        .bind(ids)
+        .fetch_optional(&self.pool)
         .await?;
-
-        Ok(QueueStats {
-            pending: row.try_get::<i64, _>("pending").unwrap_or(0),
-            processing: row.try_get::<i64, _>("processing").unwrap_or(0),
-            completed: row.try_get::<i64, _>("completed").unwrap_or(0),
-            failed: row.try_get::<i64, _>("failed").unwrap_or(0),
-        })
+        token.ok_or_else(|| anyhow::anyhow!("embedding tasks are not currently claimed"))
     }
 }
 
-#[derive(Debug, Serialize)]
+fn embedding_task(document_id: String) -> EnqueueTaskRequest {
+    let mut task = EnqueueTaskRequest::new(
+        DOCUMENT_EMBEDDING_TASK_TYPE,
+        serde_json::json!({ "document_id": document_id }),
+    );
+    task.payload_version = DOCUMENT_EMBEDDING_PAYLOAD_VERSION;
+    task.deduplication_key = Some(document_id);
+    task.max_attempts = DOCUMENT_EMBEDDING_MAX_ATTEMPTS;
+    task
+}
+
+fn task_to_item(task: Task) -> Result<EmbeddingQueueItem> {
+    if task.task_type != DOCUMENT_EMBEDDING_TASK_TYPE {
+        bail!(
+            "unexpected task type for embedding item: {}",
+            task.task_type
+        );
+    }
+    if task.payload_version != DOCUMENT_EMBEDDING_PAYLOAD_VERSION {
+        bail!(
+            "unsupported embedding payload version: {}",
+            task.payload_version
+        );
+    }
+    let document_id = task
+        .payload
+        .get("document_id")
+        .and_then(serde_json::Value::as_str)
+        .filter(|value| !value.is_empty())
+        .ok_or_else(|| anyhow::anyhow!("embedding task payload requires document_id"))?
+        .to_string();
+    let status = match task.status {
+        TaskStatus::Pending => EmbeddingQueueStatus::Pending,
+        TaskStatus::Running => EmbeddingQueueStatus::Processing,
+        TaskStatus::Completed => EmbeddingQueueStatus::Completed,
+        TaskStatus::DeadLetter => EmbeddingQueueStatus::Failed,
+    };
+    Ok(EmbeddingQueueItem {
+        id: task.id,
+        document_id,
+        status,
+        retry_count: task.attempt_count,
+        error_message: task.last_error,
+        created_at: task.created_at,
+        updated_at: task.updated_at,
+        processed_at: task.completed_at,
+        claim_token: task.claim_token,
+    })
+}
+
+#[derive(Debug, Default, Serialize)]
 pub struct QueueStats {
     pub pending: i64,
     pub processing: i64,

--- a/shared/src/lib.rs
+++ b/shared/src/lib.rs
@@ -31,7 +31,10 @@ pub use db::repositories::{
     PersonUpsert, ServiceCredentialsRepo, SourceRepository, TitleEntry, UserRepository,
 };
 pub use db::{DatabaseError, DatabasePool};
-pub use embedding_queue::{EmbeddingQueue, EmbeddingQueueItem};
+pub use embedding_queue::{
+    DOCUMENT_EMBEDDING_MAX_ATTEMPTS, DOCUMENT_EMBEDDING_PAYLOAD_VERSION,
+    DOCUMENT_EMBEDDING_TASK_TYPE, EmbeddingQueue, EmbeddingQueueItem,
+};
 pub use encryption::{EncryptedData, EncryptionService};
 pub use models::*;
 pub use queue::{EventQueue, QueueStats, QueueSummary};

--- a/shared/src/task_queue.rs
+++ b/shared/src/task_queue.rs
@@ -1,4 +1,4 @@
-use anyhow::{Result, bail};
+use anyhow::{bail, Result};
 use serde::{Deserialize, Serialize};
 use sqlx::{PgPool, Row};
 use time::OffsetDateTime;
@@ -61,6 +61,7 @@ pub struct Task {
     pub available_at: OffsetDateTime,
     pub weight: i64,
     pub concurrency_key: Option<String>,
+    pub deduplication_key: Option<String>,
     pub attempt_count: i32,
     pub max_attempts: i32,
     pub last_error: Option<String>,
@@ -95,6 +96,7 @@ impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for Task {
             available_at: row.try_get("available_at")?,
             weight: row.try_get("weight")?,
             concurrency_key: row.try_get("concurrency_key")?,
+            deduplication_key: row.try_get("deduplication_key")?,
             attempt_count: row.try_get("attempt_count")?,
             max_attempts: row.try_get("max_attempts")?,
             last_error: row.try_get("last_error")?,
@@ -110,7 +112,8 @@ impl sqlx::FromRow<'_, sqlx::postgres::PgRow> for Task {
 }
 
 /// A task to enqueue. `id` defaults to a fresh ULID; producers that need
-/// idempotent retries must set it explicitly and reuse it.
+/// idempotent retries must set it explicitly and reuse it. An optional
+/// `deduplication_key` coalesces active work for the same task type.
 #[derive(Debug, Clone)]
 pub struct EnqueueTaskRequest {
     pub id: String,
@@ -121,6 +124,7 @@ pub struct EnqueueTaskRequest {
     pub available_at: OffsetDateTime,
     pub weight: i64,
     pub concurrency_key: Option<String>,
+    pub deduplication_key: Option<String>,
     pub max_attempts: i32,
 }
 
@@ -135,6 +139,7 @@ impl EnqueueTaskRequest {
             available_at: OffsetDateTime::now_utc(),
             weight: 1,
             concurrency_key: None,
+            deduplication_key: None,
             max_attempts: 3,
         }
     }
@@ -189,8 +194,8 @@ pub struct TaskStats {
 }
 
 /// Thin, strongly typed facade over the canonical task queue PostgreSQL
-/// functions created by migration 112. All queue semantics live in SQL so the
-/// Rust and Python facades can never drift apart.
+/// functions created by migrations 112 and 113. All queue semantics live in
+/// SQL so the Rust and Python facades can never drift apart.
 #[derive(Clone)]
 pub struct TaskQueue {
     pool: PgPool,
@@ -199,6 +204,15 @@ pub struct TaskQueue {
 impl TaskQueue {
     pub fn new(pool: PgPool) -> Self {
         Self { pool }
+    }
+
+    pub async fn get(&self, task_id: &str) -> Result<Option<Task>> {
+        Ok(
+            sqlx::query_as::<_, Task>("SELECT * FROM tasks WHERE id = $1")
+                .bind(task_id)
+                .fetch_optional(&self.pool)
+                .await?,
+        )
     }
 
     /// Enqueue tasks, returning only the rows that were actually inserted.
@@ -222,9 +236,11 @@ impl TaskQueue {
         let concurrency_keys: Vec<Option<String>> =
             tasks.iter().map(|t| t.concurrency_key.clone()).collect();
         let max_attempts: Vec<i32> = tasks.iter().map(|t| t.max_attempts).collect();
+        let deduplication_keys: Vec<Option<String>> =
+            tasks.iter().map(|t| t.deduplication_key.clone()).collect();
 
         let rows = sqlx::query_as::<_, Task>(
-            "SELECT * FROM task_enqueue_bulk($1, $2, $3, $4, $5, $6, $7, $8, $9)",
+            "SELECT * FROM task_enqueue_bulk($1, $2, $3, $4, $5, $6, $7, $8, $9, $10)",
         )
         .bind(&ids)
         .bind(&task_types)
@@ -235,6 +251,7 @@ impl TaskQueue {
         .bind(&weights)
         .bind(&concurrency_keys)
         .bind(&max_attempts)
+        .bind(&deduplication_keys)
         .fetch_all(&self.pool)
         .await?;
 
@@ -242,7 +259,8 @@ impl TaskQueue {
     }
 
     /// Convenience wrapper around [`TaskQueue::enqueue_bulk`]. Re-enqueueing
-    /// an existing id is idempotent and returns the already-stored task.
+    /// an existing id, or an active matching deduplication key, returns the
+    /// already-stored task.
     pub async fn enqueue(&self, task: EnqueueTaskRequest) -> Result<Task> {
         let created = self.enqueue_bulk(std::slice::from_ref(&task)).await?;
         if let Some(row) = created.into_iter().next() {
@@ -252,7 +270,22 @@ impl TaskQueue {
             .bind(&task.id)
             .fetch_optional(&self.pool)
             .await?;
-        existing.ok_or_else(|| anyhow::anyhow!("task {} was not enqueued", task.id))
+        if let Some(existing) = existing {
+            return Ok(existing);
+        }
+        if let Some(deduplication_key) = &task.deduplication_key {
+            let existing = sqlx::query_as::<_, Task>(
+                "SELECT * FROM tasks WHERE task_type = $1 AND deduplication_key = $2 AND status IN ('pending', 'running')",
+            )
+            .bind(&task.task_type)
+            .bind(deduplication_key)
+            .fetch_optional(&self.pool)
+            .await?;
+            if let Some(existing) = existing {
+                return Ok(existing);
+            }
+        }
+        Err(anyhow::anyhow!("task {} was not enqueued", task.id))
     }
 
     /// Atomically claim a batch of tasks. Pass a pool, connection, or
@@ -441,6 +474,13 @@ fn validate_enqueue_task_request(task: &EnqueueTaskRequest) -> Result<()> {
     }
     if task.weight < 0 {
         bail!("task weight must be >= 0");
+    }
+    if task
+        .deduplication_key
+        .as_deref()
+        .is_some_and(|key| key.trim().is_empty())
+    {
+        bail!("deduplication_key must not be empty");
     }
     if task.max_attempts < 1 {
         bail!("max_attempts must be >= 1");

--- a/shared/tests/embedding_queue_test.rs
+++ b/shared/tests/embedding_queue_test.rs
@@ -50,6 +50,17 @@ mod tests {
 
         let queue_id = queue.enqueue(doc_id.clone()).await.unwrap().unwrap();
         assert!(!queue_id.is_empty());
+        let task: (String, i32, serde_json::Value, Option<String>) = sqlx::query_as(
+            "SELECT task_type, payload_version, payload, deduplication_key FROM tasks WHERE id = $1",
+        )
+        .bind(&queue_id)
+        .fetch_one(&pool)
+        .await
+        .unwrap();
+        assert_eq!(task.0, "document_embedding");
+        assert_eq!(task.1, 1);
+        assert_eq!(task.2["document_id"], doc_id);
+        assert_eq!(task.3.as_deref(), Some(doc_id.as_str()));
 
         let batch = queue.dequeue_batch(10).await.unwrap();
         assert_eq!(batch.len(), 1);
@@ -124,8 +135,9 @@ mod tests {
         let queued_missing_doc_count: (i64,) = sqlx::query_as(
             r#"
             SELECT COUNT(*)
-            FROM embedding_queue
-            WHERE document_id = ANY($1)
+            FROM tasks
+            WHERE task_type = 'document_embedding'
+              AND deduplication_key = ANY($1)
             "#,
         )
         .bind(vec![missing_doc_1, missing_doc_2])
@@ -137,8 +149,9 @@ mod tests {
         let skipped_doc_count: (i64,) = sqlx::query_as(
             r#"
             SELECT COUNT(*)
-            FROM embedding_queue
-            WHERE document_id = $1
+            FROM tasks
+            WHERE task_type = 'document_embedding'
+              AND deduplication_key = $1
             "#,
         )
         .bind(&doc_with_embedding)
@@ -150,8 +163,9 @@ mod tests {
         let existing_active_queue_count: (i64,) = sqlx::query_as(
             r#"
             SELECT COUNT(*)
-            FROM embedding_queue
-            WHERE document_id = $1
+            FROM tasks
+            WHERE task_type = 'document_embedding'
+              AND deduplication_key = $1
             "#,
         )
         .bind(&doc_with_active_queue)
@@ -195,8 +209,8 @@ mod tests {
         let doc_id = create_document(&pool).await;
         let queue_id = queue.enqueue(doc_id.clone()).await.unwrap().unwrap();
 
-        // Fail 3 times to exhaust retries
-        for i in 0..3 {
+        // Fail five times to exhaust the embedding task retry budget.
+        for i in 0..5 {
             let batch = queue.dequeue_batch(10).await.unwrap();
             assert_eq!(batch.len(), 1, "Should dequeue on attempt {}", i);
             queue
@@ -205,7 +219,7 @@ mod tests {
                 .unwrap();
         }
 
-        // retry_count is now 3 (>= 3), dequeue should skip it
+        // retry_count is now 5 and the task is dead-lettered.
         let batch = queue.dequeue_batch(10).await.unwrap();
         assert!(batch.is_empty());
     }
@@ -252,7 +266,7 @@ mod tests {
             .unwrap();
 
         let stats = queue.get_queue_stats().await.unwrap();
-        assert_eq!(stats.failed, 2);
+        assert_eq!(stats.pending, 2);
     }
 
     #[tokio::test]
@@ -263,13 +277,21 @@ mod tests {
         insert_active_embedding_provider(&pool).await;
 
         let doc_id = create_document(&pool).await;
-        queue.enqueue(doc_id).await.unwrap().unwrap();
+        queue.enqueue(doc_id.clone()).await.unwrap().unwrap();
 
-        // Dequeue sets processing + processing_started_at
+        // Claim the task with a 900-second lease, then make its last update
+        // older than the requested 300-second stale threshold. Recovery must
+        // honor the threshold rather than waiting for lease expiry.
         queue.dequeue_batch(10).await.unwrap();
+        sqlx::query(
+            "UPDATE tasks SET updated_at = clock_timestamp() - INTERVAL '10 minutes', lease_expires_at = clock_timestamp() + INTERVAL '10 minutes' WHERE deduplication_key = $1",
+        )
+        .bind(&doc_id)
+        .execute(&pool)
+        .await
+        .unwrap();
 
-        // Recover with timeout=0 treats all processing items as stale
-        let recovered = queue.recover_stale_processing_items(0).await.unwrap();
+        let recovered = queue.recover_stale_processing_items(300).await.unwrap();
         assert_eq!(recovered, 1);
 
         // Should be pending again and dequeue-able

--- a/shared/tests/task_queue_test.rs
+++ b/shared/tests/task_queue_test.rs
@@ -114,6 +114,32 @@ async fn test_enqueue_bulk_and_caller_id_idempotency() {
 }
 
 #[tokio::test]
+async fn test_active_deduplication_is_per_type_and_allows_terminal_requeue() {
+    let (_env, pool, queue) = new_queue().await;
+
+    let mut first = EnqueueTaskRequest::new("test", serde_json::json!({"n": 1}));
+    first.deduplication_key = Some("document-1".to_string());
+    let mut duplicate = EnqueueTaskRequest::new("test", serde_json::json!({"n": 2}));
+    duplicate.deduplication_key = Some("document-1".to_string());
+
+    assert_eq!(queue.enqueue_bulk(&[first.clone()]).await.unwrap().len(), 1);
+    assert!(queue.enqueue_bulk(&[duplicate.clone()]).await.unwrap().is_empty());
+
+    let claim = queue
+        .claim_bulk(&pool, "test", "worker", &claim_opts(1))
+        .await
+        .unwrap();
+    queue
+        .complete_bulk(&[first.id.clone()], &claim.claim_token)
+        .await
+        .unwrap();
+
+    let replacement = queue.enqueue(duplicate).await.unwrap();
+    assert_ne!(replacement.id, first.id);
+    assert_eq!(replacement.deduplication_key.as_deref(), Some("document-1"));
+}
+
+#[tokio::test]
 async fn test_enqueue_single_is_idempotent() {
     let (_env, _pool, queue) = new_queue().await;
 


### PR DESCRIPTION
- Move document embedding work from the legacy `embedding_queue` table to the generic `tasks` queue, with `document_embedding` payload version 1 and document-id deduplication.
- Add generic active-task deduplication support, deterministic legacy backfill/removal of `embedding_queue`, and generic timeout-aware scoped stale recovery.
- Cut over Rust indexer producers and the Python embedding consumer while preserving provider gating, current-model checks, batching, cloning, five-attempt retries, cleanup, deletion handling, lease heartbeats, and claim-token fencing.
- Keep workload-specific payload validation in the embedding adapter and make vector writes transactional with fenced task completion.
- Add focused Rust and Python coverage for queue lifecycle, deduplication, embedding payloads, retries/dead letters, cloning, stale recovery, heartbeat loss, fencing, and document deletion.

Checks:
- Rust shared task queue and embedding integration tests
- Rust indexer integration tests
- Python task queue and embedding processor integration tests
- Python unit tests, Ruff, targeted rustfmt, and Cargo checks
