### PR TITLE
fix(salesforce): keep first-run deletion window inside the 30-day limit

### DIFF
--- a/connectors/salesforce/salesforce_connector/config.py
+++ b/connectors/salesforce/salesforce_connector/config.py
@@ -24,6 +24,12 @@ CHECKPOINT_INTERVAL = 500
 # cover deletions older than the provider's reported `earliestDateAvailable`.
 DELETION_RETENTION_DAYS = 30
 
+# Salesforce rejects a /deleted startDate older than 30 days, and the
+# unbounded first-run window is derived from the run-start timestamp. Trim the
+# requested window so a pass that starts later (or a clock that drifts) stays
+# inside the provider's limit instead of failing with INVALID_REPLICATION_DATE.
+DELETION_WINDOW_MARGIN_DAYS = 1
+
 # Maximum number of shared parents persisted in the checkpoint share snapshot.
 # Beyond this the connector cannot safely diff share grants from checkpoint
 # state, so it reconciles every share-enabled object on every pass instead.

--- a/connectors/salesforce/salesforce_connector/connector.py
+++ b/connectors/salesforce/salesforce_connector/connector.py
@@ -41,6 +41,7 @@ from .client import (
 from .config import (
     CHECKPOINT_INTERVAL,
     DELETION_RETENTION_DAYS,
+    DELETION_WINDOW_MARGIN_DAYS,
     DELTA_OVERLAP_SECONDS,
     MAX_SHARE_SNAPSHOT_ENTRIES,
     PAGE_SIZE,
@@ -1718,7 +1719,9 @@ class SalesforceConnector(Connector):
         elif state.watermark is not None:
             base = datetime.fromisoformat(state.watermark)
         else:
-            base = window_end - timedelta(days=DELETION_RETENTION_DAYS)
+            base = window_end - timedelta(
+                days=DELETION_RETENTION_DAYS - DELETION_WINDOW_MARGIN_DAYS
+            )
             bounded = False
         requested_start = (
             base - timedelta(seconds=DELTA_OVERLAP_SECONDS) if bounded else base


### PR DESCRIPTION
Trims the unbounded first-run /deleted window by a day so Salesforce stops rejecting it with INVALID_REPLICATION_DATE.