### PR TITLE
fix(web): start project chats with a model

### DIFF
--- a/web/src/lib/preferences/index.ts
+++ b/web/src/lib/preferences/index.ts
@@ -1,2 +1,7 @@
-export { preferencesStorage as userPreferences } from './storage.svelte'
+export {
+    preferencesStorage as userPreferences,
+    getPreferredModelId,
+    setPreferredModelId,
+    resolvePreferredModelId,
+} from './storage.svelte'
 export type { UserPreferences } from './user-preferences'

--- a/web/src/lib/preferences/storage.svelte.ts
+++ b/web/src/lib/preferences/storage.svelte.ts
@@ -1,4 +1,5 @@
 import { browser } from '$app/environment'
+import type { ModelOption } from '$lib/components/user-input.svelte'
 import {
     DEFAULT_PREFERENCES,
     STORAGE_KEY,
@@ -82,3 +83,24 @@ class PreferencesStorage {
 }
 
 export const preferencesStorage = new PreferencesStorage()
+
+export function getPreferredModelId(): string | null {
+    return preferencesStorage.get('preferredModelId')
+}
+
+export function setPreferredModelId(modelId: string | null): void {
+    preferencesStorage.set('preferredModelId', modelId)
+}
+
+/**
+ * Resolve the model a new chat should start with: the user's saved preference
+ * when it is still available, otherwise the configured default, otherwise the
+ * first available model. Returns null when no models are configured.
+ */
+export function resolvePreferredModelId(models: ModelOption[]): string | null {
+    const preferredModelId = getPreferredModelId()
+    if (preferredModelId && models.some((model) => model.id === preferredModelId)) {
+        return preferredModelId
+    }
+    return models.find((model) => model.isDefault)?.id ?? models[0]?.id ?? null
+}

--- a/web/src/routes/(app)/+page.svelte
+++ b/web/src/routes/(app)/+page.svelte
@@ -7,7 +7,7 @@
     import UploadChip from '$lib/components/upload-chip.svelte'
     import { themeStore } from '$lib/themes/store.svelte'
     import type { MentionedDocument } from '$lib/types/message'
-    import { userPreferences } from '$lib/preferences'
+    import { resolvePreferredModelId, setPreferredModelId, userPreferences } from '$lib/preferences'
     import { toast } from 'svelte-sonner'
 
     let { data }: PageProps = $props()
@@ -91,14 +91,7 @@
 
     const models = $derived(data.models)
 
-    const savedModelId = userPreferences.get('preferredModelId')
-    const initialModelId = $derived.by(() => {
-        if (savedModelId && models.find((m) => m.id === savedModelId)) {
-            return savedModelId
-        }
-        const defaultModel = models.find((m) => m.isDefault)
-        return defaultModel?.id ?? models[0]?.id ?? null
-    })
+    const initialModelId = $derived(resolvePreferredModelId(models))
     let selectedModelId = $state<string | null>(null)
     $effect(() => {
         selectedModelId = initialModelId
@@ -268,7 +261,7 @@
                 {selectedModelId}
                 onModelChange={(id) => {
                     selectedModelId = id
-                    userPreferences.set('preferredModelId', id)
+                    setPreferredModelId(id)
                 }} />
         </div>
 

--- a/web/src/routes/(app)/projects/[projectId]/+page.server.ts
+++ b/web/src/routes/(app)/projects/[projectId]/+page.server.ts
@@ -4,6 +4,7 @@ import { error } from '@sveltejs/kit'
 import { sql } from 'drizzle-orm'
 import { db } from '$lib/server/db/index.js'
 import { ChatRepository } from '$lib/server/db/chats.js'
+import { listAllActiveModels } from '$lib/server/db/model-providers.js'
 import { ProjectAttachmentRepository, ProjectRepository } from '$lib/server/db/projects.js'
 
 export const load: PageServerLoad = async ({ locals, params }) => {
@@ -14,10 +15,17 @@ export const load: PageServerLoad = async ({ locals, params }) => {
         error(404, 'Project not found')
     }
 
-    const [attachments, chats] = await Promise.all([
+    const [attachments, chats, allModels] = await Promise.all([
         new ProjectAttachmentRepository().listForProject(project.id),
         new ChatRepository().getByUserId(user.id, { projectId: project.id, limit: 50 }),
+        listAllActiveModels(),
     ])
+    const models = allModels.map((model) => ({
+        id: model.id,
+        displayName: model.displayName,
+        providerType: model.providerType,
+        isDefault: model.isDefault,
+    }))
 
     // Resolve document titles for display. Content/permission enforcement stays
     // with search/read_document; here we only need a human-readable label.
@@ -60,6 +68,7 @@ export const load: PageServerLoad = async ({ locals, params }) => {
         user,
         project,
         chats,
+        models,
         attachments: attachments.map((attachment) => ({
             id: attachment.id,
             attachmentType: attachment.attachmentType,

--- a/web/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/web/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -18,6 +18,7 @@
     } from '@lucide/svelte'
     import { goto, invalidateAll } from '$app/navigation'
     import { toast } from 'svelte-sonner'
+    import { resolvePreferredModelId } from '$lib/preferences'
     import { formatDateTime } from '$lib/utils/datetime'
     import type { PageData } from './$types.js'
     import type { TypeaheadResult } from '$lib/types/search.js'
@@ -121,14 +122,17 @@
     async function newChat() {
         addingChat = true
         try {
+            const modelId = resolvePreferredModelId(data.models)
             const res = await fetch('/api/chat', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ projectId: data.project.id }),
+                body: JSON.stringify({ projectId: data.project.id, modelId }),
             })
             if (res.ok) {
                 const { chatId } = await res.json()
-                await goto(`/chat/${chatId}`, { state: { stream: true } })
+                // No message has been sent yet, so there is no run to stream.
+                // Requesting a stream on an empty regular chat fails with 404.
+                await goto(`/chat/${chatId}`)
             } else {
                 const body = await res.json()
                 toast.error(body.error || 'Failed to create chat')

--- a/web/src/routes/(app)/settings/profile/+page.svelte
+++ b/web/src/routes/(app)/settings/profile/+page.svelte
@@ -16,7 +16,7 @@
     import * as Popover from '$lib/components/ui/popover/index.js'
     import * as Select from '$lib/components/ui/select/index.js'
     import * as ToggleGroup from '$lib/components/ui/toggle-group/index.js'
-    import { userPreferences } from '$lib/preferences'
+    import { getPreferredModelId, setPreferredModelId, userPreferences } from '$lib/preferences'
     import type { InputMode } from '$lib/components/user-input.svelte'
     import type { ThemePreference } from '$lib/preferences/user-preferences'
     import { themeStore } from '$lib/themes/store.svelte'
@@ -45,7 +45,7 @@
     let timezoneOpen = $state(false)
     let timezoneTriggerRef = $state<HTMLButtonElement>(null!)
     let inputMode = $state<InputMode>(userPreferences.get('inputMode'))
-    let preferredModelId = $state<string>(userPreferences.get('preferredModelId') ?? '')
+    let preferredModelId = $state<string>(getPreferredModelId() ?? '')
     let isSubmitting = $state(false)
     const timezones = $derived(timezoneOptions())
     const defaultModel = $derived(data.models.find((model) => model.isDefault))
@@ -95,7 +95,7 @@
 
     function savePreferredModel(value: string) {
         preferredModelId = value
-        userPreferences.set('preferredModelId', value || null)
+        setPreferredModelId(value || null)
     }
 </script>
 


### PR DESCRIPTION
- Start chats created from a project page with the user's saved model preference, the configured default, or the first available model, so the first stream no longer fails with `Chat has no model configured`.
- Centralize the preferred-model localStorage access in `$lib/preferences` behind `getPreferredModelId` / `setPreferredModelId` / `resolvePreferredModelId`, so the storage key and the resolution fallback live in one place instead of being duplicated across the home page, project page, and profile settings.
- Stop requesting a stream for a brand-new chat: the project page navigated with `state: { stream: true }`, which opened a stream for an empty regular chat and returned `No messages found for chat`. The chat page now resumes an existing run instead. Agent chats keep streaming on open because the proxy injects `auto_start=true` for them.

Checks:
- `cd web && npm run check`
- `cd web && npx prettier --check .`
- Project → New chat manually verified against the local stack
