### PR TITLE
feat(web): redesign project workspace and project list

### DIFF
--- a/web/src/lib/components/project-chat-input.svelte
+++ b/web/src/lib/components/project-chat-input.svelte
@@ -1,0 +1,156 @@
+<script lang="ts">
+    import { goto } from '$app/navigation'
+    import { resolve } from '$app/paths'
+    import { z } from 'zod'
+    import { toast } from 'svelte-sonner'
+    import UserInput, { type ModelOption } from '$lib/components/user-input.svelte'
+    import UploadChip from '$lib/components/upload-chip.svelte'
+    import { resolvePreferredModelId, setPreferredModelId } from '$lib/preferences'
+    import type { MentionedDocument } from '$lib/types/message'
+
+    let {
+        projectId,
+        models,
+        disabled = false,
+    }: {
+        projectId: string
+        models: ModelOption[]
+        disabled?: boolean
+    } = $props()
+
+    const chatResponse = z.object({ chatId: z.string().min(1) })
+    const uploadResponse = z.object({ id: z.string().min(1), filename: z.string().min(1) })
+    const messageResponse = z.object({ messageId: z.string().min(1) })
+    type PendingUpload = { id: string; filename: string; uploading: boolean }
+
+    let value = $state('')
+    let mentionedDocs = $state<MentionedDocument[]>([])
+    let uploads = $state<PendingUpload[]>([])
+    let uploadInput = $state<HTMLInputElement>()
+    let submitting = $state(false)
+    let createdChatId = $state<string | null>(null)
+    let messageSent = $state(false)
+    let selectedModelId = $state<string | null>(resolvePreferredModelId(models))
+    const canSubmit = $derived(
+        !disabled &&
+            !submitting &&
+            !uploads.some((u) => u.uploading) &&
+            (value.trim().length > 0 || mentionedDocs.length > 0 || uploads.length > 0),
+    )
+
+    async function attachFiles(files: FileList | null) {
+        if (!files || disabled || submitting || messageSent) return
+        for (const file of Array.from(files)) {
+            const placeholderId = crypto.randomUUID()
+            uploads.push({ id: placeholderId, filename: file.name, uploading: true })
+            try {
+                const body = new FormData()
+                body.append('file', file)
+                const response = await fetch('/api/uploads', { method: 'POST', body })
+                if (!response.ok) throw new Error('Upload failed')
+                const uploaded = uploadResponse.parse(await response.json())
+                uploads = uploads.map((u) =>
+                    u.id === placeholderId ? { ...uploaded, uploading: false } : u,
+                )
+            } catch {
+                uploads = uploads.filter((u) => u.id !== placeholderId)
+                toast.error(`Failed to upload ${file.name}`)
+            }
+        }
+        if (uploadInput) uploadInput.value = ''
+    }
+
+    async function submit() {
+        if (!canSubmit) return
+        submitting = true
+        try {
+            // Reuse the chat if sending its first message failed, rather than creating duplicates.
+            if (!createdChatId) {
+                const response = await fetch('/api/chat', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ projectId, modelId: selectedModelId }),
+                })
+                if (!response.ok) throw new Error('Failed to create chat. Please try again.')
+                createdChatId = chatResponse.parse(await response.json()).chatId
+            }
+            if (!messageSent) {
+                const response = await fetch(`/api/chat/${createdChatId}/messages`, {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({
+                        content: value.trim(),
+                        attachmentIds: uploads.map((u) => u.id),
+                        mentionedDocuments: mentionedDocs,
+                    }),
+                })
+                if (!response.ok)
+                    throw new Error(
+                        'Failed to send message. Your draft is saved here; please try again.',
+                    )
+                messageResponse.parse(await response.json())
+                messageSent = true
+            }
+            await goto(resolve(`/chat/${createdChatId}`), {
+                invalidateAll: true,
+                state: { stream: true },
+            })
+        } catch (error) {
+            toast.error(error instanceof Error ? error.message : 'Failed to start chat')
+        } finally {
+            submitting = false
+        }
+    }
+</script>
+
+<input
+    bind:this={uploadInput}
+    type="file"
+    multiple
+    class="hidden"
+    aria-label="Attach files"
+    onchange={(event) => attachFiles(event.currentTarget.files)} />
+
+{#snippet attachments()}
+    {#if uploads.length > 0}
+        <div class="flex flex-wrap gap-2">
+            {#each uploads as upload (upload.id)}
+                <UploadChip
+                    filename={upload.filename}
+                    uploading={upload.uploading}
+                    onRemove={() => {
+                        if (!submitting && !messageSent)
+                            uploads = uploads.filter((u) => u.id !== upload.id)
+                    }} />
+            {/each}
+        </div>
+    {/if}
+{/snippet}
+
+<div inert={disabled || submitting || messageSent} class:opacity-60={disabled}>
+    <UserInput
+        bind:value
+        bind:mentionedDocs
+        inputMode="chat"
+        modeSelectorEnabled={false}
+        onSubmit={submit}
+        onInput={(input) => (value = input)}
+        onAttachClick={() => uploadInput?.click()}
+        onFilesDropped={attachFiles}
+        {attachments}
+        {models}
+        {selectedModelId}
+        {canSubmit}
+        disabled={disabled || submitting || messageSent}
+        isLoading={submitting}
+        placeholders={{ chat: 'Ask anything about this project...', search: 'Search...' }}
+        maxWidth="max-w-none"
+        onModelChange={(id) => {
+            selectedModelId = id
+            setPreferredModelId(id)
+        }} />
+</div>
+{#if messageSent && !submitting && createdChatId}
+    <a href={resolve(`/chat/${createdChatId}`)} class="mt-2 inline-block text-sm underline"
+        >Open your chat</a>
+{/if}

--- a/web/src/routes/(app)/projects/+page.svelte
+++ b/web/src/routes/(app)/projects/+page.svelte
@@ -8,6 +8,7 @@
     import * as Dialog from '$lib/components/ui/dialog/index.js'
     import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
     import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js'
+    import * as Tabs from '$lib/components/ui/tabs/index.js'
     import {
         Plus,
         Folder,
@@ -16,8 +17,11 @@
         Archive,
         ArchiveRestore,
         MoreVertical,
+        Search,
+        MessageSquare,
     } from '@lucide/svelte'
     import { invalidateAll } from '$app/navigation'
+    import { resolve } from '$app/paths'
     import { toast } from 'svelte-sonner'
     import { formatDateTime } from '$lib/utils/datetime'
     import type { PageData } from './$types.js'
@@ -40,12 +44,22 @@
     let showDeleteConfirm = $state(false)
     let deletingProject = $state<Project | null>(null)
 
-    let showArchived = $state(false)
+    type ProjectTab = 'active' | 'archived'
+    let activeTab = $state<ProjectTab>('active')
+    let showArchived = $derived(activeTab === 'archived')
+    let query = $state('')
 
     let visibleProjects = $derived(
-        data.projects.filter((project) => showArchived || !project.isArchived),
+        data.projects.filter(
+            (project) =>
+                project.isArchived === showArchived &&
+                `${project.name} ${project.description ?? ''}`
+                    .toLowerCase()
+                    .includes(query.trim().toLowerCase()),
+        ),
     )
     let archivedCount = $derived(data.projects.filter((p) => p.isArchived).length)
+    let activeCount = $derived(data.projects.filter((p) => !p.isArchived).length)
 
     function resetNewForm() {
         newName = ''
@@ -163,127 +177,177 @@
     }
 </script>
 
-<div class="mx-auto max-w-4xl p-6">
-    <div class="mb-6 flex items-center justify-between">
-        <div>
-            <h1 class="text-2xl font-bold">Projects</h1>
-            <p class="text-muted-foreground text-sm">
-                Organize related chats, instructions, and context in one place
+<svelte:head><title>Projects · Omni</title></svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6 sm:px-8 sm:py-10">
+    <div class="mb-8 flex flex-wrap items-center justify-between gap-4">
+        <div class="min-w-0 flex-1">
+            <h1 class="text-2xl font-semibold tracking-tight sm:text-3xl">Projects</h1>
+            <p class="text-muted-foreground mt-2 text-sm">
+                Pick up where you left off, with everything in one place.
             </p>
         </div>
-        <Button onclick={() => (showNewForm = true)} class="cursor-pointer">
-            <Plus class="mr-2 h-4 w-4" />
-            New Project
+        <Button
+            onclick={() => (showNewForm = true)}
+            aria-label="New project"
+            class="h-9 w-9 shrink-0 cursor-pointer p-0 sm:h-10 sm:w-auto sm:px-4">
+            <Plus class="h-4 w-4 sm:mr-2" />
+            <span class="hidden sm:inline">New project</span>
         </Button>
     </div>
 
-    {#if data.projects.length > 0}
-        <label class="text-muted-foreground mb-4 flex cursor-pointer items-center gap-2 text-sm">
-            <input
-                type="checkbox"
-                bind:checked={showArchived}
-                class="accent-primary h-4 w-4 cursor-pointer" />
-            Show archived ({archivedCount})
-        </label>
-    {/if}
-
-    {#if visibleProjects.length === 0}
+    <Tabs.Root
+        value={activeTab}
+        onValueChange={(value) => (activeTab = value as ProjectTab)}
+        class="w-full">
         <div
-            class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
-            <Folder class="text-muted-foreground mb-4 h-12 w-12" />
-            <h3 class="mb-2 text-lg font-medium">No projects yet</h3>
-            <p class="text-muted-foreground mb-4 text-sm">
-                Create a project to group chats, share standing instructions, and keep key documents
-                at hand.
-            </p>
-            <Button onclick={() => (showNewForm = true)} class="cursor-pointer">
-                <Plus class="mr-2 h-4 w-4" />
-                Create your first project
-            </Button>
+            class="mb-6 flex flex-col gap-2 border-b pb-2 sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+            <Tabs.List
+                variant="line"
+                class="order-2 gap-6 p-0 sm:order-1"
+                aria-label="Project status">
+                <Tabs.Trigger
+                    value="active"
+                    class="data-[state=active]:text-foreground data-[state=active]:after:bg-foreground text-muted-foreground h-11 cursor-pointer rounded-none px-1 data-[state=active]:font-semibold data-[state=active]:after:bottom-[-10px] data-[state=active]:after:opacity-100">
+                    Active <span class="text-muted-foreground text-xs font-normal"
+                        >{activeCount}</span>
+                </Tabs.Trigger>
+                <Tabs.Trigger
+                    value="archived"
+                    class="data-[state=active]:text-foreground data-[state=active]:after:bg-foreground text-muted-foreground h-11 cursor-pointer rounded-none px-1 data-[state=active]:font-semibold data-[state=active]:after:bottom-[-10px] data-[state=active]:after:opacity-100">
+                    Archived <span class="text-muted-foreground text-xs font-normal"
+                        >{archivedCount}</span>
+                </Tabs.Trigger>
+            </Tabs.List>
+            <div
+                class="bg-card order-1 flex h-10 w-full items-center gap-2 rounded-lg border px-3 pb-0 sm:order-2 sm:w-64 sm:pb-0">
+                <Search class="text-muted-foreground h-4 w-4 shrink-0" />
+                <Input
+                    bind:value={query}
+                    aria-label="Search projects"
+                    placeholder="Search projects..."
+                    class="h-9 min-w-0 flex-1 border-0 bg-transparent px-0 shadow-none focus-visible:ring-0" />
+            </div>
         </div>
-    {:else}
-        <div class="grid gap-4 sm:grid-cols-2">
-            {#each visibleProjects as project (project.id)}
-                <Card.Root>
-                    <Card.Header>
-                        <div class="flex items-start justify-between gap-2">
-                            <a href={`/projects/${project.id}`} class="hover:underline">
-                                <Card.Title class="flex items-center gap-2">
-                                    <Folder class="text-muted-foreground h-4 w-4" />
-                                    {project.name}
+
+        <Tabs.Content value={activeTab} class="mt-0">
+            {#if visibleProjects.length === 0}
+                <div
+                    class="flex flex-col items-center justify-center rounded-lg border border-dashed p-12 text-center">
+                    <Folder class="text-muted-foreground mb-4 h-12 w-12" />
+                    <h2 class="mb-2 text-lg font-medium">
+                        {query.trim()
+                            ? 'No matching projects'
+                            : showArchived
+                              ? 'No archived projects'
+                              : 'Give your work a home'}
+                    </h2>
+                    <p class="text-muted-foreground mb-4 max-w-sm text-sm">
+                        {query.trim()
+                            ? 'Try a different name or description.'
+                            : showArchived
+                              ? 'Projects you archive will appear here.'
+                              : 'Bring related chats, instructions, and key documents together in your first project.'}
+                    </p>
+                    {#if query.trim()}
+                        <Button
+                            variant="outline"
+                            onclick={() => (query = '')}
+                            class="cursor-pointer">Clear search</Button>
+                    {:else if !showArchived}
+                        <Button onclick={() => (showNewForm = true)} class="cursor-pointer">
+                            <Plus class="mr-2 h-4 w-4" /> Create project
+                        </Button>
+                    {/if}
+                </div>
+            {:else}
+                <div class="grid gap-5 md:grid-cols-2">
+                    {#each visibleProjects as project (project.id)}
+                        <Card.Root
+                            class="group hover:border-primary/30 relative flex min-h-[214px] gap-0 shadow-none transition-all hover:shadow-sm sm:min-h-[214px]">
+                            <Card.Header class="flex-1 pb-4">
+                                <div class="flex items-start justify-between gap-2">
+                                    <div class="bg-muted text-muted-foreground rounded-lg p-2.5">
+                                        <Folder class="h-5 w-5" />
+                                    </div>
+                                    <DropdownMenu.Root>
+                                        <DropdownMenu.Trigger>
+                                            {#snippet child({ props })}
+                                                <Button
+                                                    variant="ghost"
+                                                    size="icon"
+                                                    class="relative z-10 cursor-pointer"
+                                                    {...props}>
+                                                    <MoreVertical class="h-4 w-4" />
+                                                    <span class="sr-only">Project actions</span>
+                                                </Button>
+                                            {/snippet}
+                                        </DropdownMenu.Trigger>
+                                        <DropdownMenu.Content align="end">
+                                            <DropdownMenu.Item
+                                                class="cursor-pointer"
+                                                onclick={() => openEdit(project)}>
+                                                <Pencil class="mr-2 h-4 w-4" />
+                                                Edit
+                                            </DropdownMenu.Item>
+                                            <DropdownMenu.Item
+                                                class="cursor-pointer"
+                                                onclick={() => toggleArchive(project)}>
+                                                {#if project.isArchived}
+                                                    <ArchiveRestore class="mr-2 h-4 w-4" />
+                                                    Unarchive
+                                                {:else}
+                                                    <Archive class="mr-2 h-4 w-4" />
+                                                    Archive
+                                                {/if}
+                                            </DropdownMenu.Item>
+                                            <DropdownMenu.Item
+                                                class="text-destructive cursor-pointer"
+                                                onclick={() => {
+                                                    deletingProject = project
+                                                    showDeleteConfirm = true
+                                                }}>
+                                                <Trash2 class="mr-2 h-4 w-4" />
+                                                Delete
+                                            </DropdownMenu.Item>
+                                        </DropdownMenu.Content>
+                                    </DropdownMenu.Root>
+                                </div>
+                                <Card.Title class="mt-4 text-lg leading-snug">
+                                    <a
+                                        href={resolve(`/projects/${project.id}`)}
+                                        class="focus-visible:after:ring-ring after:absolute after:inset-0 after:rounded-xl focus-visible:outline-none focus-visible:after:ring-2">
+                                        <span class="break-words">{project.name}</span>
+                                    </a>
                                 </Card.Title>
-                            </a>
-                            <DropdownMenu.Root>
-                                <DropdownMenu.Trigger>
-                                    {#snippet child({ props })}
-                                        <Button
-                                            variant="ghost"
-                                            size="icon"
-                                            class="cursor-pointer"
-                                            {...props}>
-                                            <MoreVertical class="h-4 w-4" />
-                                            <span class="sr-only">Project actions</span>
-                                        </Button>
-                                    {/snippet}
-                                </DropdownMenu.Trigger>
-                                <DropdownMenu.Content align="end">
-                                    <DropdownMenu.Item
-                                        class="cursor-pointer"
-                                        onclick={() => openEdit(project)}>
-                                        <Pencil class="mr-2 h-4 w-4" />
-                                        Edit
-                                    </DropdownMenu.Item>
-                                    <DropdownMenu.Item
-                                        class="cursor-pointer"
-                                        onclick={() => toggleArchive(project)}>
-                                        {#if project.isArchived}
-                                            <ArchiveRestore class="mr-2 h-4 w-4" />
-                                            Unarchive
-                                        {:else}
-                                            <Archive class="mr-2 h-4 w-4" />
-                                            Archive
-                                        {/if}
-                                    </DropdownMenu.Item>
-                                    <DropdownMenu.Item
-                                        class="text-destructive cursor-pointer"
-                                        onclick={() => {
-                                            deletingProject = project
-                                            showDeleteConfirm = true
-                                        }}>
-                                        <Trash2 class="mr-2 h-4 w-4" />
-                                        Delete
-                                    </DropdownMenu.Item>
-                                </DropdownMenu.Content>
-                            </DropdownMenu.Root>
-                        </div>
-                        <Card.Description>
-                            {project.description || 'No description'}
-                        </Card.Description>
-                    </Card.Header>
-                    <Card.Content>
-                        <a href={`/projects/${project.id}`} class="text-sm hover:underline">
-                            View project
-                        </a>
-                    </Card.Content>
-                    <Card.Footer class="flex items-center justify-between text-xs">
-                        <Badge variant="secondary">
-                            {project.chatCount}
-                            {project.chatCount === 1 ? 'chat' : 'chats'}
-                        </Badge>
-                        {#if project.isArchived}
-                            <Badge variant="outline">Archived</Badge>
-                        {/if}
-                        <span class="text-muted-foreground">
-                            Updated {formatDateTime(
-                                project.updatedAt,
-                                data.user.configuration?.timezone,
-                            )}
-                        </span>
-                    </Card.Footer>
-                </Card.Root>
-            {/each}
-        </div>
-    {/if}
+                                <Card.Description class="mt-2 line-clamp-2 min-h-10 leading-5">
+                                    {project.description ??
+                                        'Add instructions and documents to give your chats shared context.'}
+                                </Card.Description>
+                            </Card.Header>
+                            <Card.Footer
+                                class="text-muted-foreground mt-auto flex flex-wrap items-center gap-x-4 gap-y-2 pt-3 text-xs">
+                                <span class="inline-flex items-center gap-1.5">
+                                    <MessageSquare class="h-3.5 w-3.5" />
+                                    {project.chatCount}
+                                    {project.chatCount === 1 ? 'chat' : 'chats'}
+                                </span>
+                                {#if project.isArchived}
+                                    <Badge variant="outline">Archived</Badge>
+                                {/if}
+                                <span class="text-muted-foreground">
+                                    Updated {formatDateTime(
+                                        project.updatedAt,
+                                        data.user.configuration?.timezone,
+                                    )}
+                                </span>
+                            </Card.Footer>
+                        </Card.Root>
+                    {/each}
+                </div>
+            {/if}
+        </Tabs.Content>
+    </Tabs.Root>
 </div>
 
 <Dialog.Root bind:open={showNewForm}>

--- a/web/src/routes/(app)/projects/[projectId]/+page.svelte
+++ b/web/src/routes/(app)/projects/[projectId]/+page.svelte
@@ -1,39 +1,45 @@
 <script lang="ts">
-    import { Button } from '$lib/components/ui/button/index.js'
-    import { Badge } from '$lib/components/ui/badge/index.js'
-    import { Label } from '$lib/components/ui/label/index.js'
-    import { Textarea } from '$lib/components/ui/textarea/index.js'
-    import { Input } from '$lib/components/ui/input/index.js'
-    import * as Card from '$lib/components/ui/card/index.js'
-    import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
+    import { goto, invalidateAll } from '$app/navigation'
+    import { resolve } from '$app/paths'
+    import { toast } from 'svelte-sonner'
     import {
-        MessageSquare,
-        Save,
-        Trash2,
-        Plus,
-        Search,
-        X,
         Archive,
         ArchiveRestore,
+        ArrowLeft,
+        ChevronRight,
+        Ellipsis,
+        FileText,
+        Folder,
+        Layers,
+        MessageSquare,
+        Pencil,
+        Plus,
+        Search,
+        Save,
+        Trash2,
+        X,
     } from '@lucide/svelte'
-    import { goto, invalidateAll } from '$app/navigation'
-    import { toast } from 'svelte-sonner'
-    import { resolvePreferredModelId } from '$lib/preferences'
+    import ProjectChatInput from '$lib/components/project-chat-input.svelte'
+    import { Badge } from '$lib/components/ui/badge/index.js'
+    import { Button } from '$lib/components/ui/button/index.js'
+    import { Input } from '$lib/components/ui/input/index.js'
+    import { Textarea } from '$lib/components/ui/textarea/index.js'
+    import { Label } from '$lib/components/ui/label/index.js'
+    import * as AlertDialog from '$lib/components/ui/alert-dialog/index.js'
+    import * as Dialog from '$lib/components/ui/dialog/index.js'
+    import * as DropdownMenu from '$lib/components/ui/dropdown-menu/index.js'
     import { formatDateTime } from '$lib/utils/datetime'
-    import type { PageData } from './$types.js'
     import type { TypeaheadResult } from '$lib/types/search.js'
+    import type { PageData } from './$types.js'
 
     let { data }: { data: PageData } = $props()
 
-    let instructions = $state(data.project.instructions ?? '')
+    let instructions = $derived(data.project.instructions ?? '')
     let savingInstructions = $state(false)
-    let instructionsDirty = $derived(instructions !== (data.project.instructions ?? ''))
-
+    let showInstructionsDialog = $state(false)
+    let showContextDialog = $state(false)
     let showDeleteConfirm = $state(false)
 
-    let addingChat = $state(false)
-
-    // Document attachment search (reuses the permission-enforced typeahead).
     let docQuery = $state('')
     let docResults = $state<TypeaheadResult[]>([])
     let searching = $state(false)
@@ -52,7 +58,7 @@
             try {
                 const res = await fetch(`/api/typeahead?q=${encodeURIComponent(query)}&limit=8`)
                 if (res.ok) {
-                    const body = await res.json()
+                    const body: { results?: TypeaheadResult[] } = await res.json()
                     docResults = body.results ?? []
                 }
             } finally {
@@ -70,10 +76,11 @@
                 body: JSON.stringify({ instructions: instructions.trim() || null }),
             })
             if (res.ok) {
+                showInstructionsDialog = false
                 toast.success('Instructions saved')
                 invalidateAll()
             } else {
-                const body = await res.json()
+                const body: { error?: string } = await res.json()
                 toast.error(body.error || 'Failed to save instructions')
             }
         } catch {
@@ -83,23 +90,25 @@
         }
     }
 
+    function cancelInstructions() {
+        instructions = data.project.instructions ?? ''
+        showInstructionsDialog = false
+    }
+
     async function attachDocument(result: TypeaheadResult) {
         const res = await fetch(`/api/projects/${data.project.id}/attachments`, {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({
-                attachmentType: 'document',
-                documentId: result.document_id,
-            }),
+            body: JSON.stringify({ attachmentType: 'document', documentId: result.document_id }),
         })
         if (res.ok) {
-            const body = await res.json()
+            const body: { alreadyAttached?: boolean } = await res.json()
             toast.success(body.alreadyAttached ? 'Already attached' : 'Document attached')
             docQuery = ''
             docResults = []
             invalidateAll()
         } else {
-            const body = await res.json()
+            const body: { error?: string } = await res.json()
             toast.error(body.error || 'Failed to attach document')
         }
     }
@@ -114,33 +123,8 @@
             toast.success('Attachment removed')
             invalidateAll()
         } else {
-            const body = await res.json()
+            const body: { error?: string } = await res.json()
             toast.error(body.error || 'Failed to remove attachment')
-        }
-    }
-
-    async function newChat() {
-        addingChat = true
-        try {
-            const modelId = resolvePreferredModelId(data.models)
-            const res = await fetch('/api/chat', {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ projectId: data.project.id, modelId }),
-            })
-            if (res.ok) {
-                const { chatId } = await res.json()
-                // No message has been sent yet, so there is no run to stream.
-                // Requesting a stream on an empty regular chat fails with 404.
-                await goto(`/chat/${chatId}`)
-            } else {
-                const body = await res.json()
-                toast.error(body.error || 'Failed to create chat')
-            }
-        } catch {
-            toast.error('Failed to create chat')
-        } finally {
-            addingChat = false
         }
     }
 
@@ -154,7 +138,7 @@
             toast.success(data.project.isArchived ? 'Project unarchived' : 'Project archived')
             invalidateAll()
         } else {
-            const body = await res.json()
+            const body: { error?: string } = await res.json()
             toast.error(body.error || 'Failed to update project')
         }
     }
@@ -163,186 +147,305 @@
         const res = await fetch(`/api/projects/${data.project.id}`, { method: 'DELETE' })
         if (res.ok) {
             toast.success('Project deleted. Its chats were kept and moved to unorganized.')
-            await goto('/projects')
+            await goto(resolve('/projects'))
         } else {
-            const body = await res.json()
+            const body: { error?: string } = await res.json()
             toast.error(body.error || 'Failed to delete project')
         }
     }
 </script>
 
-<div class="mx-auto max-w-4xl p-6">
-    <div class="mb-6 flex items-start justify-between gap-4">
-        <div>
-            <div class="flex items-center gap-3">
-                <h1 class="text-2xl font-bold">{data.project.name}</h1>
-                {#if data.project.isArchived}
-                    <Badge variant="outline">Archived</Badge>
-                {/if}
+{#snippet projectContext(searchId: string)}
+    <div class="space-y-7">
+        <section class="border-t pt-6">
+            <div class="flex items-center justify-between gap-3">
+                <div>
+                    <h3 class="text-sm font-semibold">Instructions</h3>
+                    <p class="text-muted-foreground mt-1 text-xs">
+                        Guide how Omni responds in every chat.
+                    </p>
+                </div>
+                <Button
+                    variant="ghost"
+                    size="icon"
+                    class="text-muted-foreground cursor-pointer"
+                    aria-label="Edit project instructions"
+                    disabled={data.project.isArchived}
+                    onclick={() => (showInstructionsDialog = true)}>
+                    <Pencil class="h-4 w-4" />
+                </Button>
             </div>
-            {#if data.project.description}
-                <p class="text-muted-foreground mt-1 text-sm">{data.project.description}</p>
+            {#if instructions.trim()}
+                <p class="text-muted-foreground mt-4 line-clamp-4 text-sm leading-6">
+                    {instructions}
+                </p>
+            {:else}
+                <p class="text-muted-foreground mt-4 text-sm italic">
+                    Add instructions to guide every conversation.
+                </p>
             {/if}
-        </div>
-        <div class="flex shrink-0 items-center gap-2">
-            <Button onclick={newChat} disabled={addingChat} class="cursor-pointer">
-                <MessageSquare class="mr-2 h-4 w-4" />
-                {addingChat ? 'Starting...' : 'New chat'}
-            </Button>
-            <Button variant="outline" onclick={toggleArchive} class="cursor-pointer">
-                {#if data.project.isArchived}
-                    <ArchiveRestore class="mr-2 h-4 w-4" />
-                    Unarchive
-                {:else}
-                    <Archive class="mr-2 h-4 w-4" />
-                    Archive
-                {/if}
-            </Button>
-            <Button
-                variant="outline"
-                class="text-destructive hover:text-destructive cursor-pointer"
-                onclick={() => (showDeleteConfirm = true)}>
-                <Trash2 class="mr-2 h-4 w-4" />
-                Delete
-            </Button>
+        </section>
+
+        <section class="border-t pt-6">
+            <div class="flex items-center justify-between gap-3">
+                <div class="flex items-center gap-2">
+                    <FileText class="h-4 w-4" />
+                    <h3 class="text-sm font-semibold">Documents</h3>
+                    <span class="text-muted-foreground text-xs">{data.attachments.length}</span>
+                </div>
+                <button
+                    type="button"
+                    class="text-muted-foreground hover:text-foreground cursor-pointer rounded-md p-1"
+                    aria-label="Add documents"
+                    onclick={() => document.getElementById(searchId)?.focus()}>
+                    <Plus class="h-4 w-4" />
+                </button>
+            </div>
+            <p class="text-muted-foreground mt-1 text-xs">
+                Standing context for every conversation.
+            </p>
+
+            {#if data.attachments.length > 0}
+                <ul class="mt-3 divide-y">
+                    {#each data.attachments as attachment (attachment.id)}
+                        <li class="flex items-center gap-2 py-2.5">
+                            <span
+                                class="bg-muted flex h-8 w-8 shrink-0 items-center justify-center rounded-md">
+                                <FileText class="text-muted-foreground h-4 w-4" />
+                            </span>
+                            <span class="min-w-0 flex-1 truncate text-xs font-medium">
+                                {attachment.title ?? 'Attachment'}
+                            </span>
+                            <button
+                                type="button"
+                                class="text-muted-foreground hover:text-foreground shrink-0 cursor-pointer p-1"
+                                aria-label="Remove {attachment.title}"
+                                disabled={data.project.isArchived}
+                                onclick={() => removeAttachment(attachment.id)}>
+                                <X class="h-3.5 w-3.5" />
+                            </button>
+                        </li>
+                    {/each}
+                </ul>
+            {:else}
+                <p class="text-muted-foreground mt-4 text-sm">No documents attached yet.</p>
+            {/if}
+
+            {#if !data.project.isArchived}
+                <div class="mt-4 grid gap-2">
+                    <Label for={searchId} class="text-muted-foreground text-xs font-normal"
+                        >Add documents</Label>
+                    <div class="relative">
+                        <Search
+                            class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
+                        <Input
+                            id={searchId}
+                            bind:value={docQuery}
+                            placeholder="Search documents..."
+                            class="h-9 pl-9 text-xs" />
+                    </div>
+                    {#if docQuery.trim().length >= 2}
+                        <div class="bg-background rounded-lg border">
+                            {#if searching}
+                                <p class="text-muted-foreground p-3 text-xs">Searching...</p>
+                            {:else if docResults.length === 0}
+                                <p class="text-muted-foreground p-3 text-xs">No documents found.</p>
+                            {:else}
+                                {#each docResults as result (result.document_id)}
+                                    <button
+                                        type="button"
+                                        class="hover:bg-muted flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-xs"
+                                        onclick={() => attachDocument(result)}>
+                                        <span class="truncate">{result.title}</span>
+                                        <Plus class="text-muted-foreground h-4 w-4 shrink-0" />
+                                    </button>
+                                {/each}
+                            {/if}
+                        </div>
+                    {/if}
+                </div>
+            {/if}
+        </section>
+    </div>
+{/snippet}
+
+<svelte:head><title>{data.project.name} · Projects · Omni</title></svelte:head>
+
+<div class="mx-auto w-full max-w-6xl px-4 py-6 sm:px-8 sm:py-10">
+    <div class="mb-8 flex items-center justify-between gap-4">
+        <a
+            href={resolve('/projects')}
+            class="text-muted-foreground hover:text-foreground hover:bg-muted inline-flex items-center gap-2 rounded-md px-2 py-1.5 text-sm leading-5 font-medium transition-colors">
+            <ArrowLeft class="h-4 w-4 shrink-0" />
+            <span>All projects</span>
+        </a>
+        <div class="flex items-center gap-2">
+            <Dialog.Root bind:open={showContextDialog}>
+                <Dialog.Trigger class="lg:hidden">
+                    {#snippet child({ props })}
+                        <Button variant="outline" class="cursor-pointer" {...props}>
+                            <Layers class="mr-2 h-4 w-4" /> Context
+                        </Button>
+                    {/snippet}
+                </Dialog.Trigger>
+                <Dialog.Content class="max-h-[calc(100dvh-2rem)] overflow-y-auto sm:max-w-lg">
+                    {@render projectContext('mobile-doc-search')}
+                </Dialog.Content>
+            </Dialog.Root>
+            <DropdownMenu.Root>
+                <DropdownMenu.Trigger>
+                    {#snippet child({ props })}
+                        <Button variant="outline" size="icon" class="cursor-pointer" {...props}>
+                            <Ellipsis class="h-4 w-4" />
+                            <span class="sr-only">Project actions</span>
+                        </Button>
+                    {/snippet}
+                </DropdownMenu.Trigger>
+                <DropdownMenu.Content align="end">
+                    <DropdownMenu.Item class="cursor-pointer" onclick={toggleArchive}>
+                        {#if data.project.isArchived}
+                            <ArchiveRestore class="mr-2 h-4 w-4" /> Unarchive
+                        {:else}
+                            <Archive class="mr-2 h-4 w-4" /> Archive
+                        {/if}
+                    </DropdownMenu.Item>
+                    <DropdownMenu.Item
+                        class="text-destructive cursor-pointer"
+                        onclick={() => (showDeleteConfirm = true)}>
+                        <Trash2 class="mr-2 h-4 w-4" /> Delete
+                    </DropdownMenu.Item>
+                </DropdownMenu.Content>
+            </DropdownMenu.Root>
         </div>
     </div>
 
-    <div class="grid gap-6">
-        <!-- Instructions -->
-        <Card.Root>
-            <Card.Header>
-                <Card.Title>Project instructions</Card.Title>
-                <Card.Description>
-                    Automatically included in every chat in this project.
-                </Card.Description>
-            </Card.Header>
-            <Card.Content class="grid gap-3">
-                <Textarea
-                    bind:value={instructions}
-                    rows={5}
-                    placeholder="e.g. This project is about the Q3 launch. Prefer German responses and reference the roadmap."
-                    disabled={data.project.isArchived} />
-            </Card.Content>
-            <Card.Footer class="justify-end">
-                <Button
-                    onclick={saveInstructions}
-                    disabled={!instructionsDirty || savingInstructions || data.project.isArchived}
-                    class="cursor-pointer">
-                    <Save class="mr-2 h-4 w-4" />
-                    {savingInstructions ? 'Saving...' : 'Save instructions'}
-                </Button>
-            </Card.Footer>
-        </Card.Root>
+    <div class="mb-10 flex items-start gap-3 sm:gap-4">
+        <div class="bg-muted shrink-0 rounded-xl p-2.5 sm:p-3">
+            <Folder class="text-muted-foreground h-5 w-5 sm:h-6 sm:w-6" />
+        </div>
+        <div class="min-w-0">
+            <div class="flex flex-wrap items-center gap-3">
+                <h1 class="text-2xl font-semibold tracking-tight break-words sm:text-3xl">
+                    {data.project.name}
+                </h1>
+                {#if data.project.isArchived}<Badge variant="outline">Archived</Badge>{/if}
+            </div>
+            {#if data.project.description}
+                <p class="text-muted-foreground mt-2 text-sm">{data.project.description}</p>
+            {:else}
+                <p class="text-muted-foreground mt-2 text-sm">
+                    A shared home for conversations and context.
+                </p>
+            {/if}
+        </div>
+    </div>
 
-        <!-- Attachments -->
-        <Card.Root>
-            <Card.Header>
-                <Card.Title>Context documents</Card.Title>
-                <Card.Description>
-                    Attached documents are available as standing context in every chat in this
-                    project.
-                </Card.Description>
-            </Card.Header>
-            <Card.Content class="grid gap-4">
-                {#if data.attachments.length > 0}
-                    <div class="flex flex-wrap gap-2">
-                        {#each data.attachments as attachment (attachment.id)}
-                            <Badge
-                                variant="secondary"
-                                class="flex max-w-full items-center gap-1 py-1 pl-2">
-                                <span class="truncate">{attachment.title ?? 'Attachment'}</span>
-                                <button
-                                    type="button"
-                                    class="hover:text-destructive ml-1 cursor-pointer"
-                                    aria-label="Remove {attachment.title}"
-                                    onclick={() => removeAttachment(attachment.id)}>
-                                    <X class="h-3 w-3" />
-                                </button>
-                            </Badge>
-                        {/each}
-                    </div>
-                {:else}
-                    <p class="text-muted-foreground text-sm">No documents attached yet.</p>
-                {/if}
+    <div class="grid items-start gap-10 lg:grid-cols-[minmax(0,1fr)_17rem] lg:gap-14">
+        <section class="min-w-0" aria-label="Project conversations">
+            <h2 class="text-lg font-medium tracking-tight">Start a conversation</h2>
+            <div class="mt-4">
+                {#key data.project.id}
+                    <ProjectChatInput
+                        projectId={data.project.id}
+                        models={data.models}
+                        disabled={data.project.isArchived} />
+                {/key}
+            </div>
+            <p class="text-muted-foreground mt-3 flex items-center gap-1.5 text-xs">
+                <Layers class="h-3.5 w-3.5" />
+                {data.project.isArchived
+                    ? 'This project is archived. Unarchive it to start a new chat.'
+                    : 'Your project context is included in every chat.'}
+            </p>
 
-                {#if !data.project.isArchived}
-                    <div class="grid gap-2">
-                        <Label for="doc-search">Add documents</Label>
-                        <div class="relative">
-                            <Search
-                                class="text-muted-foreground pointer-events-none absolute top-1/2 left-3 h-4 w-4 -translate-y-1/2" />
-                            <Input
-                                id="doc-search"
-                                bind:value={docQuery}
-                                placeholder="Search indexed documents to attach..."
-                                class="pl-9" />
-                        </div>
-                        {#if docQuery.trim().length >= 2}
-                            <div class="rounded-md border">
-                                {#if searching}
-                                    <p class="text-muted-foreground p-3 text-sm">Searching...</p>
-                                {:else if docResults.length === 0}
-                                    <p class="text-muted-foreground p-3 text-sm">
-                                        No documents found. Try a different search.
-                                    </p>
-                                {:else}
-                                    {#each docResults as result (result.document_id)}
-                                        <button
-                                            type="button"
-                                            class="hover:bg-accent flex w-full cursor-pointer items-center justify-between gap-2 px-3 py-2 text-left text-sm"
-                                            onclick={() => attachDocument(result)}>
-                                            <span class="truncate">{result.title}</span>
-                                            <Plus class="text-muted-foreground h-4 w-4 shrink-0" />
-                                        </button>
-                                    {/each}
-                                {/if}
-                            </div>
-                        {/if}
-                    </div>
-                {/if}
-            </Card.Content>
-        </Card.Root>
-
-        <!-- Chats -->
-        <Card.Root>
-            <Card.Header>
-                <Card.Title>Chats</Card.Title>
-                <Card.Description>Conversations in this project.</Card.Description>
-            </Card.Header>
-            <Card.Content>
+            <div class="mt-10">
+                <div class="mb-3 flex items-center gap-3">
+                    <h2 class="text-sm font-semibold">Chats</h2>
+                    <span class="text-muted-foreground text-xs">{data.chats.length}</span>
+                    <div class="flex-1"></div>
+                </div>
                 {#if data.chats.length === 0}
-                    <p class="text-muted-foreground text-sm">No chats yet.</p>
+                    <div class="rounded-xl border border-dashed px-6 py-10 text-center">
+                        <MessageSquare class="text-muted-foreground mx-auto mb-3 h-6 w-6" />
+                        <h3 class="text-sm font-medium">Start something here</h3>
+                        <p class="text-muted-foreground mt-1 text-sm">
+                            Send a message above and your project conversations will appear here.
+                        </p>
+                    </div>
                 {:else}
-                    <ul class="divide-y">
+                    <ul class="divide-y border-y">
                         {#each data.chats as chat (chat.id)}
                             <li>
                                 <a
-                                    href={`/chat/${chat.id}`}
-                                    class="hover:bg-accent flex items-center justify-between gap-4 px-2 py-3">
-                                    <span class="truncate text-sm">
-                                        {chat.title ?? 'Untitled chat'}
-                                    </span>
-                                    <span class="text-muted-foreground shrink-0 text-xs">
-                                        {formatDateTime(
-                                            chat.updatedAt,
-                                            data.user.configuration?.timezone,
-                                        )}
-                                    </span>
+                                    href={resolve(`/chat/${chat.id}`)}
+                                    class="hover:bg-muted/60 group flex items-center gap-3 rounded-lg px-2 py-4 transition-colors">
+                                    <MessageSquare class="text-muted-foreground h-4 w-4 shrink-0" />
+                                    <div class="min-w-0 flex-1">
+                                        <p class="truncate text-sm font-medium">
+                                            {chat.title ?? 'Untitled chat'}
+                                        </p>
+                                        <p class="text-muted-foreground mt-1 text-xs">
+                                            {formatDateTime(
+                                                chat.updatedAt,
+                                                data.user.configuration?.timezone,
+                                            )}
+                                        </p>
+                                    </div>
+                                    <ChevronRight class="text-muted-foreground h-4 w-4 shrink-0" />
                                 </a>
                             </li>
                         {/each}
                     </ul>
                 {/if}
-            </Card.Content>
-        </Card.Root>
+            </div>
+        </section>
+
+        <aside class="hidden min-w-0 border-l pl-6 lg:block" aria-label="Project context">
+            {@render projectContext('desktop-doc-search')}
+        </aside>
     </div>
 </div>
+
+<Dialog.Root bind:open={showInstructionsDialog}>
+    <Dialog.Content class="sm:max-w-lg">
+        <Dialog.Header>
+            <Dialog.Title>Project instructions</Dialog.Title>
+            <Dialog.Description>
+                Set the direction once. Omni will use these instructions in every chat in {data
+                    .project.name}.
+            </Dialog.Description>
+        </Dialog.Header>
+        <div class="grid gap-2">
+            <Label for="instructions-editor">Instructions</Label>
+            <Textarea
+                id="instructions-editor"
+                bind:value={instructions}
+                rows={7}
+                autofocus
+                placeholder="Include goals, tone, or details you don’t want to repeat."
+                disabled={data.project.isArchived} />
+            <p class="text-muted-foreground text-xs">
+                Include goals, tone, or details you don’t want to repeat.
+            </p>
+        </div>
+        <Dialog.Footer>
+            <Button variant="outline" onclick={cancelInstructions} class="cursor-pointer"
+                >Cancel</Button>
+            <Button
+                onclick={saveInstructions}
+                disabled={savingInstructions || data.project.isArchived}
+                class="cursor-pointer">
+                <Save class="mr-2 h-4 w-4" />
+                {savingInstructions ? 'Saving...' : 'Save instructions'}
+            </Button>
+        </Dialog.Footer>
+    </Dialog.Content>
+</Dialog.Root>
 
 <AlertDialog.Root bind:open={showDeleteConfirm}>
     <AlertDialog.Content>
         <AlertDialog.Header>
-            <AlertDialog.Title>Delete "{data.project.name}"?</AlertDialog.Title>
+            <AlertDialog.Title>Delete “{data.project.name}”?</AlertDialog.Title>
             <AlertDialog.Description>
                 This permanently removes the project, its instructions, and its attachments. Chats
                 in this project are kept and moved back to unorganized.


### PR DESCRIPTION
- Redesign the projects overview with shadcn active/archived tabs, project search, responsive cards, and clearer empty states
- Redesign the project workspace around a project-scoped UserInput composer, conversation history, and a quieter context panel
- Add responsive mobile context and instruction editing dialogs while preserving project attachments and archive/delete actions
- Create the first chat and user message with the selected projectId, model preference, attachments, and document mentions
